### PR TITLE
#27 Make RegistryBase and VolatileRepository use ConcurrentHashMap by default

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
@@ -26,6 +26,7 @@ import net.transgressoft.lirp.event.StandardCrudEvent.Update
 import net.transgressoft.lirp.event.TransEventPublisher
 import mu.KotlinLogging
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Consumer
 import java.util.function.Predicate
 import java.util.stream.Collectors
@@ -42,16 +43,23 @@ import java.util.stream.Collectors
  * - Run actions on entities that automatically detect and publish changes
  * - Rich query capabilities with predicate-based searches
  * - Event publishing for entity reads and modifications
- * - Thread-safe operation
+ * - Thread-safe operation under concurrent access when backed by a [ConcurrentHashMap]
+ *
+ * Thread-safety: the default [entitiesById] is a [ConcurrentHashMap], which makes individual
+ * get/put/remove/computeIfPresent operations atomic. Batch methods such as [runForMany],
+ * [runMatching], and [runForAll] operate on weakly-consistent views of the map — they will
+ * not throw [java.util.ConcurrentModificationException] under concurrent modification, but
+ * may or may not reflect entries added or removed after iteration starts.
  *
  * @param K The type of entity identifier, must be [Comparable]
  * @param T The type of entity being stored, must implement [IdentifiableEntity]
- * @property entitiesById The internal map storing entities by their IDs
+ * @property entitiesById The internal map storing entities by their IDs. Must be a thread-safe
+ *   map (e.g. [ConcurrentHashMap]) for safe concurrent access.
  *
  * @see [net.transgressoft.lirp.event.TransEventSubscriber]
  */
 abstract class RegistryBase<K, T : IdentifiableEntity<K>>(
-    protected val entitiesById: MutableMap<K, T> = hashMapOf(),
+    protected val entitiesById: MutableMap<K, T> = ConcurrentHashMap(),
     protected val publisher: TransEventPublisher<CrudEvent.Type, CrudEvent<K, T>> = FlowEventPublisher("Registry")
 ) : TransEventPublisher<CrudEvent.Type, CrudEvent<K, T>> by publisher,
     Registry<K, T> where K : Comparable<K> {

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/VolatileRepository.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/VolatileRepository.kt
@@ -26,6 +26,7 @@ import net.transgressoft.lirp.event.StandardCrudEvent.Delete
 import net.transgressoft.lirp.event.StandardCrudEvent.Update
 import mu.KotlinLogging
 import java.util.Objects
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Base class for mutable entity repositories with reactive behavior.
@@ -57,7 +58,7 @@ open class VolatileRepository<K : Comparable<K>, T : IdentifiableEntity<K>>
     @JvmOverloads
     constructor(
         name: String = "Repository",
-        initialEntities: MutableMap<K, T> = hashMapOf()
+        initialEntities: MutableMap<K, T> = ConcurrentHashMap()
     ) : RegistryBase<K, T>(initialEntities, FlowEventPublisher(name)), Repository<K, T> {
         private val log = KotlinLogging.logger(javaClass.name)
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryBaseConcurrencyTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryBaseConcurrencyTest.kt
@@ -1,0 +1,196 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import net.transgressoft.lirp.Person
+import net.transgressoft.lirp.arbitraryPerson
+import net.transgressoft.lirp.event.ReactiveScope
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.property.arbitrary.next
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+/**
+ * Concurrency tests verifying that [RegistryBase] batch operations are safe under concurrent
+ * modification of the underlying [java.util.concurrent.ConcurrentHashMap].
+ *
+ * These tests prove that [RegistryBase.runForMany], [RegistryBase.runMatching],
+ * [RegistryBase.runForAll], and [RegistryBase.search] do not throw
+ * [java.util.ConcurrentModificationException] when entities are added or removed
+ * concurrently via another coroutine.
+ */
+@ExperimentalCoroutinesApi
+internal class RegistryBaseConcurrencyTest : StringSpec({
+
+    val testDispatcher = UnconfinedTestDispatcher()
+    val testScope = CoroutineScope(testDispatcher)
+
+    beforeSpec {
+        ReactiveScope.flowScope = testScope
+        ReactiveScope.ioScope = testScope
+    }
+
+    afterSpec {
+        ReactiveScope.resetDefaultIoScope()
+        ReactiveScope.resetDefaultFlowScope()
+    }
+
+    "RegistryBase runForMany completes without error under concurrent entity additions" {
+        val concurrentCoroutines = 50
+        val iterationsPerCoroutine = 100
+        val initialSize = 100
+
+        val repository = VolatileRepository<Int, Person>("runForMany-concurrency-test")
+        val initialEntities = (1..initialSize).map { arbitraryPerson(it).next() }
+        initialEntities.forEach { repository.add(it) }
+
+        val targetIds = initialEntities.map { it.id }.toSet()
+
+        shouldNotThrowAny {
+            val writerJobs =
+                (1..concurrentCoroutines).map { coroutineIndex ->
+                    launch(Dispatchers.Default) {
+                        repeat(iterationsPerCoroutine) { i ->
+                            val id = initialSize + coroutineIndex * iterationsPerCoroutine + i
+                            val extra = arbitraryPerson(id).next()
+                            repository.add(extra)
+                        }
+                    }
+                }
+
+            val readerJob =
+                launch(Dispatchers.Default) {
+                    repeat(iterationsPerCoroutine) {
+                        repository.runForMany(targetIds) { /* read-only action */ }
+                    }
+                }
+
+            writerJobs.joinAll()
+            readerJob.join()
+        }
+    }
+
+    "RegistryBase runMatching completes without error under concurrent entity removals" {
+        val concurrentCoroutines = 50
+        val iterationsPerCoroutine = 100
+        val initialSize = 100
+
+        val repository = VolatileRepository<Int, Person>("runMatching-concurrency-test")
+        val allEntities =
+            (1..initialSize + concurrentCoroutines * iterationsPerCoroutine)
+                .map { arbitraryPerson(it).next() }
+        allEntities.forEach { repository.add(it) }
+
+        shouldNotThrowAny {
+            val removerJobs =
+                (1..concurrentCoroutines).map { coroutineIndex ->
+                    launch(Dispatchers.Default) {
+                        repeat(iterationsPerCoroutine) { i ->
+                            val entity = allEntities[coroutineIndex * iterationsPerCoroutine + i]
+                            repository.remove(entity)
+                        }
+                    }
+                }
+
+            val readerJob =
+                launch(Dispatchers.Default) {
+                    repeat(iterationsPerCoroutine) {
+                        repository.runMatching({ true }) { /* read-only action */ }
+                    }
+                }
+
+            removerJobs.joinAll()
+            readerJob.join()
+        }
+    }
+
+    "RegistryBase runForAll completes without error under concurrent modifications" {
+        val concurrentCoroutines = 50
+        val iterationsPerCoroutine = 100
+        val initialSize = 100
+
+        val repository = VolatileRepository<Int, Person>("runForAll-concurrency-test")
+        val initialEntities = (1..initialSize).map { arbitraryPerson(it).next() }
+        initialEntities.forEach { repository.add(it) }
+
+        shouldNotThrowAny {
+            val writerJobs =
+                (1..concurrentCoroutines).map { coroutineIndex ->
+                    launch(Dispatchers.Default) {
+                        repeat(iterationsPerCoroutine) { i ->
+                            val id = initialSize + coroutineIndex * iterationsPerCoroutine + i
+                            val extra = arbitraryPerson(id).next()
+                            repository.add(extra)
+                        }
+                    }
+                }
+
+            val readerJob =
+                launch(Dispatchers.Default) {
+                    repeat(iterationsPerCoroutine) {
+                        repository.runForAll { /* read-only action */ }
+                    }
+                }
+
+            writerJobs.joinAll()
+            readerJob.join()
+        }
+    }
+
+    "RegistryBase search completes without error under concurrent modifications" {
+        val concurrentCoroutines = 50
+        val iterationsPerCoroutine = 100
+        val initialSize = 100
+
+        val repository = VolatileRepository<Int, Person>("search-concurrency-test")
+        val initialEntities = (1..initialSize).map { arbitraryPerson(it).next() }
+        initialEntities.forEach { repository.add(it) }
+
+        shouldNotThrowAny {
+            val modifierJobs =
+                (1..concurrentCoroutines).map { coroutineIndex ->
+                    launch(Dispatchers.Default) {
+                        repeat(iterationsPerCoroutine) { i ->
+                            if (i % 2 == 0) {
+                                val id = initialSize + coroutineIndex * iterationsPerCoroutine + i
+                                repository.add(arbitraryPerson(id).next())
+                            } else {
+                                val entity = initialEntities[(coroutineIndex + i) % initialSize]
+                                repository.remove(entity)
+                            }
+                        }
+                    }
+                }
+
+            val searchJob =
+                launch(Dispatchers.Default) {
+                    repeat(iterationsPerCoroutine) {
+                        repository.search { true }
+                    }
+                }
+
+            modifierJobs.joinAll()
+            searchJob.join()
+        }
+    }
+})


### PR DESCRIPTION
- Change entitiesById default from hashMapOf() to ConcurrentHashMap() in RegistryBase
- Change initialEntities default from hashMapOf() to ConcurrentHashMap() in VolatileRepository
- Import java.util.concurrent.ConcurrentHashMap in both files
- Update KDoc to document thread-safety guarantees and weakly-consistent batch iteration