### PR TITLE
#26 Fix TOCTOU race condition in FlowEventPublisher emitAsync

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/event/FlowEventPublisher.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/event/FlowEventPublisher.kt
@@ -19,7 +19,6 @@ package net.transgressoft.lirp.event
 
 import net.transgressoft.lirp.entity.TransEntity
 import mu.KotlinLogging
-import java.util.concurrent.ConcurrentSkipListSet
 import java.util.concurrent.Flow
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.Job
@@ -158,7 +157,9 @@ class FlowEventPublisher<ET : EventType, E: TransEvent<ET>>
          */
         private val flowScope = ReactiveScope.flowScope
 
-        private var activatedEventTypes: MutableSet<EventType> = ConcurrentSkipListSet()
+        // Immutable snapshot replaced atomically on activate/disable — reads need no copying or locking
+        @Volatile
+        private var activatedEventTypes: Set<EventType> = emptySet()
 
         @Volatile
         private var closed = false
@@ -193,7 +194,10 @@ class FlowEventPublisher<ET : EventType, E: TransEvent<ET>>
 
         override fun emitAsync(event: E) {
             check(!isClosed) { "Publisher '$id' is closed" }
-            if (event.type in activatedEventTypes) {
+            // Read the volatile reference once to get a consistent snapshot; a concurrent disableEvents()
+            // replacing the reference after this read will not affect the check or the send
+            val activeTypes = activatedEventTypes
+            if (event.type in activeTypes) {
                 // Use trySend so we don't block the caller
                 // If the channel is full, this will return the closed/failed result
                 val result = eventChannel.trySend(event)
@@ -285,17 +289,13 @@ class FlowEventPublisher<ET : EventType, E: TransEvent<ET>>
         }
 
         override fun disableEvents(vararg types: ET) {
-            types.toSet().let {
-                activatedEventTypes.removeAll(it)
-                log.trace { "Enabled event types from $id: $activatedEventTypes" }
-            }
+            activatedEventTypes = activatedEventTypes - types.toSet()
+            log.trace { "Enabled event types from $id: $activatedEventTypes" }
         }
 
         override fun activateEvents(vararg types: ET) {
-            types.toSet().let {
-                activatedEventTypes.addAll(it)
-                log.trace { "Enabled event types from $id: $activatedEventTypes" }
-            }
+            activatedEventTypes = activatedEventTypes + types.toSet()
+            log.trace { "Enabled event types from $id: $activatedEventTypes" }
         }
 
         override fun toString() = "FlowEventPublisher(id=$id, activatedEventTypes=$activatedEventTypes)"

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/FlowEventPublisherTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/FlowEventPublisherTest.kt
@@ -36,12 +36,15 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Consumer
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.withContext
 
 @ExperimentalCoroutinesApi
 class FlowEventPublisherTest : DescribeSpec({
@@ -811,6 +814,58 @@ class FlowEventPublisherTest : DescribeSpec({
             testDispatcher.scheduler.advanceUntilIdle()
 
             receivedEvents.size shouldBe 1
+        }
+    }
+
+    describe("TOCTOU safety") {
+        it("emitAsync uses activatedEventTypes snapshot to avoid TOCTOU race") {
+            // Run on real threads so that concurrent activate/disable and emit happen in parallel
+            withContext(Dispatchers.Default) {
+                val publisher =
+                    FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>(
+                        "ToctouPublisher",
+                        PublisherConfig.DEFAULT
+                    ).apply {
+                        activateEvents(CREATE)
+                    }
+                publisher.subscribe { }
+
+                val iterations = 1000
+                val toggleJob =
+                    launch {
+                        repeat(iterations) {
+                            publisher.disableEvents(CREATE)
+                            publisher.activateEvents(CREATE)
+                        }
+                    }
+                val emitJob =
+                    launch {
+                        repeat(iterations) { i ->
+                            publisher.emitAsync(Create(TestEntity("entity-$i")))
+                        }
+                    }
+
+                joinAll(toggleJob, emitJob)
+
+                publisher.close()
+            }
+            // The test passes if no exception is thrown during concurrent operation
+        }
+
+        it("emitAsync filters events when event type is not activated") {
+            val publisher =
+                FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("FilterPublisher").apply {
+                    activateEvents(UPDATE)
+                }
+            val receivedEvents = mutableListOf<CrudEvent<String, TestEntity>>()
+            val subscription = publisher.subscribe { receivedEvents.add(it) }
+
+            publisher.emitAsync(Create(TestEntity("entity-1")))
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            receivedEvents.size shouldBe 0
+
+            subscription.cancel()
         }
     }
 


### PR DESCRIPTION
- Replace mutable ConcurrentSkipListSet with @Volatile immutable Set reference
- activateEvents/disableEvents now replace the reference atomically (copy-on-write)
- emitAsync reads the volatile reference once to get a consistent snapshot
- Add TOCTOU safety describe block in FlowEventPublisherTest with concurrent toggle/emit test