### PR TITLE
#31 Fix the uneccessary serialization trigger on every entity mutation

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepository.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepository.kt
@@ -28,6 +28,7 @@ import mu.KotlinLogging
 import java.io.File
 import java.util.Objects
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
@@ -82,7 +83,7 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
                     "Provided jsonFile does not exist, is not writable, is not a json file, or is not empty"
                 }
                 field = value
-                serializationEventChannel.trySend(Unit)
+                markDirtyAndTrigger()
                 log.info { "jsonFile set to $value" }
             }
 
@@ -122,6 +123,8 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
          */
         private val subscriptionsMap: MutableMap<K, TransEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>>> = ConcurrentHashMap()
 
+        private val dirty = AtomicBoolean(false)
+
         init {
             require(jsonFile.exists().and(jsonFile.canWrite()).and(jsonFile.extension == "json")) {
                 "Provided jsonFile does not exist, is not writable or is not a json file"
@@ -143,18 +146,25 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
             decodeFromJson()?.let { loadedEntities ->
                 log.info { "${loadedEntities.size} objects deserialized from file $jsonFile" }
 
-                addOrReplaceAll(loadedEntities.values.toSet())
+                // Bypass this class's override to avoid marking dirty during disk load
+                super.addOrReplaceAll(loadedEntities.values.toSet())
 
-                // Create subscriptions for loaded entities
                 flowScope.launch {
-                    runForAll { entity ->
-                        val subscription = entity.subscribe { serializationEventChannel.trySend(Unit) }
-                        subscriptionsMap[entity.id] = subscription
-                    }
+                    runForAll { entity -> subscribeEntity(entity) }
                 }
             }
 
             activateEvents(CREATE, UPDATE)
+        }
+
+        private fun subscribeEntity(entity: R) {
+            val subscription = entity.subscribe { markDirtyAndTrigger() }
+            subscriptionsMap[entity.id] = subscription
+        }
+
+        private fun markDirtyAndTrigger() {
+            dirty.set(true)
+            serializationEventChannel.trySend(Unit)
         }
 
         @OptIn(FlowPreview::class)
@@ -168,15 +178,19 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
             }
 
         private suspend fun performSerialization() {
+            if (!dirty.compareAndSet(true, false)) {
+                log.debug { "Skipping serialization, no changes since last write" }
+                return
+            }
             try {
                 val jsonString = json.encodeToString(mapSerializer, entitiesById)
 
-                // Limit serialization to one concurrent operation
                 withContext(ioScope.coroutineContext) {
                     jsonFile.writeText(jsonString)
                 }
                 log.debug { "File updated: $jsonFile" }
             } catch (exception: Exception) {
+                dirty.set(true)
                 log.error(exception) { "Error serializing to file $jsonFile" }
             }
         }
@@ -199,36 +213,31 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
         override fun add(entity: R) =
             super.add(entity).also { added ->
                 if (added) {
-                    serializationEventChannel.trySend(Unit)
-                    val subscription = entity.subscribe { serializationEventChannel.trySend(Unit) }
-                    subscriptionsMap[entity.id] = subscription
+                    markDirtyAndTrigger()
+                    subscribeEntity(entity)
                 }
             }
 
         override fun addOrReplace(entity: R) =
             super.addOrReplace(entity).also { added ->
                 if (added) {
-                    serializationEventChannel.trySend(Unit)
-                    val subscription = entity.subscribe { serializationEventChannel.trySend(Unit) }
-                    subscriptionsMap[entity.id] = subscription
+                    markDirtyAndTrigger()
+                    subscribeEntity(entity)
                 }
             }
 
         override fun addOrReplaceAll(entities: Set<R>) =
             super.addOrReplaceAll(entities).also { added ->
                 if (added) {
-                    serializationEventChannel.trySend(Unit)
-                    entities.forEach { entity ->
-                        val subscription = entity.subscribe { serializationEventChannel.trySend(Unit) }
-                        subscriptionsMap[entity.id] = subscription
-                    }
+                    markDirtyAndTrigger()
+                    entities.forEach { entity -> subscribeEntity(entity) }
                 }
             }
 
         override fun remove(entity: R) =
             super.remove(entity).also { removed ->
                 if (removed) {
-                    serializationEventChannel.trySend(Unit)
+                    markDirtyAndTrigger()
                     val subscription =
                         subscriptionsMap.remove(entity.id)
                             ?: error("Repository should contain a subscription for $entity")
@@ -239,7 +248,7 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
         override fun removeAll(entities: Collection<R>) =
             super.removeAll(entities).also { removed ->
                 if (removed) {
-                    serializationEventChannel.trySend(Unit)
+                    markDirtyAndTrigger()
                     entities.forEach {
                         val subscription =
                             subscriptionsMap.remove(it.id)
@@ -251,7 +260,7 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
 
         override fun clear() {
             super.clear()
-            serializationEventChannel.trySend(Unit)
+            markDirtyAndTrigger()
             subscriptionsMap.forEach { (_, subscription) ->
                 subscription.cancel()
             }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
@@ -28,6 +28,7 @@ import java.io.File
 import java.io.IOException
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.collections.forEach
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
@@ -751,6 +752,103 @@ class JsonFileRepositoryTest : DescribeSpec({
             shouldThrow<IllegalStateException> {
                 repository.removeAll(listOf(person))
             }
+        }
+    }
+
+    describe("Dirty flag optimization") {
+        // Navigates the delegation chain: PersonJsonFileRepository ->
+        // HumanGenericJsonFileRepositoryBase -> JsonFileRepository -> dirty
+        fun getDirtyFlag(repo: PersonJsonFileRepository): AtomicBoolean {
+            val delegateField =
+                repo.javaClass.superclass
+                    .getDeclaredField("repository")
+                    .also { it.isAccessible = true }
+            val jsonFileRepository = delegateField.get(repo)
+            val dirtyField =
+                jsonFileRepository.javaClass
+                    .getDeclaredField("dirty")
+                    .also { it.isAccessible = true }
+            return dirtyField.get(jsonFileRepository) as AtomicBoolean
+        }
+
+        it("skips serialization when no changes occur after last write") {
+            val person = arbitraryPerson().next()
+            repository.add(person) shouldBe true
+
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val lastModifiedAfterWrite = jsonFile.lastModified()
+            jsonFile.readText().isNotEmpty() shouldBe true
+
+            // Advance again without any mutations
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            jsonFile.lastModified() shouldBe lastModifiedAfterWrite
+        }
+
+        it("writes to new file on jsonFile switch even when state is unchanged") {
+            val person = arbitraryPerson().next()
+            repository.add(person)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            jsonFile.readText().isNotEmpty() shouldBe true
+
+            val newJsonFile = tempfile("json-repository-test", ".json").also { it.deleteOnExit() }
+            repository.jsonFile = newJsonFile
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            newJsonFile.readText().isNotEmpty() shouldBe true
+        }
+
+        it("does not write back loaded state on initialization") {
+            val person = arbitraryPerson().next()
+            repository.add(person) shouldBe true
+            testDispatcher.scheduler.advanceUntilIdle()
+            repository.close()
+
+            val contentAfterFirstWrite = jsonFile.readText()
+            contentAfterFirstWrite.isNotEmpty() shouldBe true
+
+            val lastModifiedBeforeReload = jsonFile.lastModified()
+
+            val reloadedRepo = PersonJsonFileRepository(jsonFile)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            jsonFile.lastModified() shouldBe lastModifiedBeforeReload
+            jsonFile.readText().shouldEqualJson(contentAfterFirstWrite)
+
+            val dirtyFlag = getDirtyFlag(reloadedRepo)
+            dirtyFlag.get() shouldBe false
+
+            reloadedRepo.close()
+        }
+
+        it("close() skips write when repository is clean") {
+            val person = arbitraryPerson().next()
+            repository.add(person) shouldBe true
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val lastModifiedAfterWrite = jsonFile.lastModified()
+            val contentAfterWrite = jsonFile.readText()
+
+            repository.close()
+
+            jsonFile.lastModified() shouldBe lastModifiedAfterWrite
+            jsonFile.readText() shouldBe contentAfterWrite
+        }
+
+        it("retries write after transient I/O failure") {
+            val dirtyFlag = getDirtyFlag(repository)
+
+            val person = arbitraryPerson().next()
+            repository.add(person) shouldBe true
+
+            dirtyFlag.get() shouldBe true
+
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            dirtyFlag.get() shouldBe false
+            jsonFile.readText().isNotEmpty() shouldBe true
         }
     }
 


### PR DESCRIPTION
- Extract markDirtyAndTrigger() to eliminate 8 duplicated dirty+trySend patterns
- Extract subscribeEntity() to eliminate 4 duplicated subscribe+put patterns
- Init block calls super.addOrReplaceAll to bypass dirty marking during disk load
- Remove fragile dirty.set(false) reset at end of init