### PR TITLE
#24 #28 Remove run* from RegistryBase, add iterator(), update KDoc

### DIFF
--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/Registry.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/Registry.kt
@@ -21,67 +21,19 @@ import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.LirpEventPublisher
 import java.util.*
-import java.util.function.Consumer
 import java.util.function.Predicate
 
 /**
- * A registry represents a read-only collection of entities that can be queried and accessed.
+ * A read-only, iterable collection of entities that can be queried and observed.
  *
- * The Registry provides a foundation for entity management with query capabilities
- * but intentionally restricts modification operations. Entities within a Registry
- * are uniquely identified by their ID, allowing for consistent and predictable access.
+ * Registry provides query capabilities over a collection of [IdentifiableEntity] instances,
+ * with entity access by ID, predicate-based search, and iteration via [Iterable].
+ * Iteration is weakly-consistent when backed by a [java.util.concurrent.ConcurrentHashMap].
  *
  * @param K The type of the entity's identifier, which must be [Comparable]
  * @param T The type of entities in the registry, which must implement [IdentifiableEntity]
  */
-interface Registry<K, T: IdentifiableEntity<K>> : LirpEventPublisher<CrudEvent.Type, CrudEvent<K, T>> where K : Comparable<K> {
-
-    /**
-     * Applies the given action to the entity with the specified ID if present.
-     *
-     * If the action results in a different entity state (determined by hash code comparison),
-     * the entity will be replaced in the registry.
-     *
-     * @param id The ID of the entity to apply the action to
-     * @param entityAction The action to apply to the entity
-     * @return True if the entity was found and the action was applied, false otherwise
-     */
-    fun runForSingle(id: K, entityAction: Consumer<in T>): Boolean
-
-    /**
-     * Applies the given action to all entities with the specified IDs if present.
-     *
-     * If the action results in different entity states (determined by hash code comparison),
-     * the entities will be replaced in the registry.
-     *
-     * @param ids The set of IDs of entities to apply the action to
-     * @param entityAction The action to apply to the entities
-     * @return True if any entity was found and the action was applied, false otherwise
-     */
-    fun runForMany(ids: Set<K>, entityAction: Consumer<in T>): Boolean
-
-    /**
-     * Applies the given action to all entities that match the specified predicate.
-     *
-     * If the action results in different entity states (determined by hash code comparison),
-     * the entities will be replaced in the registry.
-     *
-     * @param predicate The predicate to match entities against
-     * @param entityAction The action to apply to matching entities
-     * @return True if any entity matched and the action was applied, false otherwise
-     */
-    fun runMatching(predicate: Predicate<in T>, entityAction: Consumer<in T>): Boolean
-
-    /**
-     * Applies the given action to all entities in the registry.
-     *
-     * If the action results in different entity states (determined by hash code comparison),
-     * the entities will be replaced in the registry.
-     *
-     * @param entityAction The action to apply to all entities
-     * @return True if the action was applied to any entity, false if the registry is empty
-     */
-    fun runForAll(entityAction: Consumer<in T>): Boolean
+interface Registry<K, T: IdentifiableEntity<K>> : LirpEventPublisher<CrudEvent.Type, CrudEvent<K, T>>, Iterable<T> where K : Comparable<K> {
 
     /**
      * Checks if the registry contains an entity with the specified ID.

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
@@ -23,39 +23,24 @@ import net.transgressoft.lirp.event.CrudEvent.Type.UPDATE
 import net.transgressoft.lirp.event.FlowEventPublisher
 import net.transgressoft.lirp.event.LirpEventPublisher
 import net.transgressoft.lirp.event.StandardCrudEvent.Read
-import net.transgressoft.lirp.event.StandardCrudEvent.Update
 import mu.KotlinLogging
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
-import java.util.function.Consumer
 import java.util.function.Predicate
 
 /**
  * Base class for read-only entity registries with reactive query capabilities.
  *
- * `RegistryBase` provides the foundation for entity collections that can be searched and
- * queried, with changes tracked and published to subscribers. It follows a reactive approach
- * by implementing [LirpEventPublisher], notifying subscribers of read operations
- * and entity changes.
- *
- * Key features:
- * - Run actions on entities that automatically detect and publish changes
- * - Rich query capabilities with predicate-based searches
- * - Event publishing for entity reads and modifications
- * - Thread-safe operation under concurrent access when backed by a [ConcurrentHashMap]
- *
- * Thread-safety: the default [entitiesById] is a [ConcurrentHashMap], which makes individual
- * get/put/remove/computeIfPresent operations atomic. Batch methods such as [runForMany],
- * [runMatching], and [runForAll] operate on weakly-consistent views of the map — they will
- * not throw [java.util.ConcurrentModificationException] under concurrent modification, but
+ * Provides a searchable, iterable entity collection backed by a [ConcurrentHashMap].
+ * Query results and entity reads are published to subscribers as [CrudEvent] events.
+ * Iteration via [iterator] is weakly-consistent: it will not throw
+ * [java.util.ConcurrentModificationException] under concurrent modification, but
  * may or may not reflect entries added or removed after iteration starts.
  *
  * @param K The type of entity identifier, must be [Comparable]
  * @param T The type of entity being stored, must implement [IdentifiableEntity]
- * @property entitiesById The internal map storing entities by their IDs. Must be a thread-safe
- *   map (e.g. [ConcurrentHashMap]) for safe concurrent access.
- *
- * @see [net.transgressoft.lirp.event.LirpEventSubscriber]
+ * @property entitiesById The internal map storing entities by their IDs
+ * @property publisher The event publisher for broadcasting entity operations
  */
 abstract class RegistryBase<K, T : IdentifiableEntity<K>>(
     protected val entitiesById: MutableMap<K, T> = ConcurrentHashMap(),
@@ -71,71 +56,7 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>>(
         activateEvents(UPDATE)
     }
 
-    @Suppress("UNCHECKED_CAST")
-    override fun runForSingle(id: K, entityAction: Consumer<in T>): Boolean {
-        val entity = entitiesById[id] ?: return false
-        val previousHashcode = entity.hashCode()
-        val entityBeforeUpdate = entity.clone() as T
-
-        entityAction.accept(entity)
-
-        if (previousHashcode != entity.hashCode()) {
-            log.debug { "Entity with id ${entity.id} was modified as a result of an action" }
-            publisher.emitAsync(Update(entity, entityBeforeUpdate))
-            return true
-        }
-        return false
-    }
-
-    override fun runForMany(ids: Set<K>, entityAction: Consumer<in T>): Boolean =
-        ids.mapNotNull { entitiesById[it] }.let {
-            if (it.isNotEmpty()) {
-                runActionAndReplaceModifiedEntities(it.toSet(), entityAction)
-            } else {
-                false
-            }
-        }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun runActionAndReplaceModifiedEntities(entities: Set<T>, entityAction: Consumer<in T>): Boolean {
-        val updates =
-            entities.mapNotNull { entity ->
-                val previousHashCode = entity.hashCode()
-                val entityBeforeChange = entity.clone() as T
-
-                entityAction.accept(entity)
-
-                if (previousHashCode != entity.hashCode()) {
-                    // Ensure the entity in the map is still this entity
-                    entitiesById.computeIfPresent(entity.id) { _, current ->
-                        if (current == entityBeforeChange)
-                            entity
-                        else current
-                    }
-                    log.debug { "Entity with id ${entity.id} was modified as a result of an action" }
-                    Pair(entity, entityBeforeChange)
-                } else null
-            }
-
-        if (updates.isNotEmpty()) {
-            val (modified, originals) = updates.unzip()
-            publisher.emitAsync(Update(modified, originals))
-            return true
-        }
-
-        return false
-    }
-
-    override fun runMatching(predicate: Predicate<in T>, entityAction: Consumer<in T>): Boolean =
-        search(predicate).let {
-            if (it.isNotEmpty()) {
-                runActionAndReplaceModifiedEntities(it, entityAction)
-            } else {
-                false
-            }
-        }
-
-    override fun runForAll(entityAction: Consumer<in T>) = runActionAndReplaceModifiedEntities(entitiesById.values.toSet(), entityAction)
+    override fun iterator(): Iterator<T> = entitiesById.values.iterator()
 
     override fun contains(id: K) = entitiesById.containsKey(id)
 

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/VolatileRepository.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/VolatileRepository.kt
@@ -29,25 +29,15 @@ import java.util.Objects
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Base class for mutable entity repositories with reactive behavior.
+ * In-memory entity repository with reactive event publishing.
  *
- * `RepositoryBase` extends [RegistryBase] to provide full CRUD (Create, Read, Update, Delete)
- * operations on entities. It maintains a collection of entities that can be modified through
- * add, remove, and replace operations, with all changes automatically published to subscribers.
+ * Extends [RegistryBase] with full CRUD operations. All mutations are published as
+ * [net.transgressoft.lirp.event.CrudEvent] events: [add] emits CREATE, [remove]/[removeAll]/[clear] emit DELETE,
+ * and [addOrReplace] emits CREATE for new entities or UPDATE (with the previous entity
+ * in [net.transgressoft.lirp.event.CrudEvent.oldEntities]) when replacing an existing entity. No event is emitted
+ * when the replacement entity is identical to the existing one.
  *
- * Key features:
- * - Full CRUD operations with event publishing
- * - Bulk operations for adding/replacing/removing multiple entities
- * - Optimized entity replacement with change detection
- * - Detailed logging of repository operations
- *
- * Since this repository is volatile, all data is lost when the application terminates
- * or when the repository instance is garbage collected.
- *
- * Example usage:
- * ```
- * class UserRepository : VolatileRepository("UserRepository")
- * ```
+ * Data is volatile — all entities are lost when the repository is garbage collected.
  *
  * @param K The type of entity identifier, must be [Comparable]
  * @param T The type of entity being stored, must implement [IdentifiableEntity]

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepository.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepository.kt
@@ -150,7 +150,7 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
                 super.addOrReplaceAll(loadedEntities.values.toSet())
 
                 flowScope.launch {
-                    runForAll { entity -> subscribeEntity(entity) }
+                    forEach { entity -> subscribeEntity(entity) }
                 }
             }
 

--- a/lirp-core/src/test/java/net/transgressoft/lirp/JavaInteroperabilityTest.java
+++ b/lirp-core/src/test/java/net/transgressoft/lirp/JavaInteroperabilityTest.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.Flow;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -396,49 +395,23 @@ class JavaInteroperabilityTest {
         }
 
         @Test
-        @DisplayName("runForMany applies action to entities with the given IDs")
-        void runForManyAppliesActionToEntitiesWithGivenIds() {
-            var repository = new VolatileRepository<Integer, Person>("RunForManyRepo");
-            repository.add(new Person(1, "Alice", 100L, true));
-            repository.add(new Person(2, "Bob", 200L, false));
-            repository.add(new Person(3, "Charlie", 300L, true));
+        @DisplayName("iterator returns all entities in the repository")
+        void iteratorReturnsAllEntitiesInRepository() {
+            var repository = new VolatileRepository<Integer, Person>("IteratorRepo");
+            var alice = new Person(1, "Alice", 100L, true);
+            var bob = new Person(2, "Bob", 200L, false);
+            var charlie = new Person(3, "Charlie", 300L, true);
+            repository.add(alice);
+            repository.add(bob);
+            repository.add(charlie);
 
-            repository.runForMany(Set.of(1, 2), person -> person.setName("Updated"));
-            scheduler.advanceUntilIdle();
+            var iterated = new ArrayList<Person>();
+            for (var person : repository) {
+                iterated.add(person);
+            }
 
-            assertEquals("Updated", repository.findById(1).get().getName());
-            assertEquals("Updated", repository.findById(2).get().getName());
-            assertEquals("Charlie", repository.findById(3).get().getName());
-        }
-
-        @Test
-        @DisplayName("runMatching applies action only to entities matching the predicate")
-        void runMatchingAppliesActionOnlyToMatchingEntities() {
-            var repository = new VolatileRepository<Integer, Person>("RunMatchingRepo");
-            repository.add(new Person(1, "Alice", 100L, true));
-            repository.add(new Person(2, "Bob", 200L, false));
-            repository.add(new Person(3, "Charlie", 300L, true));
-
-            repository.runMatching(Personly::getMorals, person -> person.setName("Moral"));
-            scheduler.advanceUntilIdle();
-
-            assertEquals("Moral", repository.findById(1).get().getName());
-            assertEquals("Bob", repository.findById(2).get().getName());
-            assertEquals("Moral", repository.findById(3).get().getName());
-        }
-
-        @Test
-        @DisplayName("runForAll applies action to every entity in the repository")
-        void runForAllAppliesActionToEveryEntity() {
-            var repository = new VolatileRepository<Integer, Person>("RunForAllRepo");
-            repository.add(new Person(1, "Alice", 100L, true));
-            repository.add(new Person(2, "Bob", 200L, false));
-
-            repository.runForAll(person -> person.setName("All"));
-            scheduler.advanceUntilIdle();
-
-            assertEquals("All", repository.findById(1).get().getName());
-            assertEquals("All", repository.findById(2).get().getName());
+            assertEquals(3, iterated.size());
+            assertTrue(iterated.containsAll(List.of(alice, bob, charlie)));
         }
 
         @Test
@@ -478,12 +451,12 @@ class JavaInteroperabilityTest {
         }
 
         @Test
-        @DisplayName("runForSingle mutates entity and findById reflects change")
-        void runForSingleMutatesEntityAndFindByIdReflectsChange() {
-            var repository = new VolatileRepository<Integer, Person>("RunForSingleRepo");
+        @DisplayName("addOrReplace with updated entity and findById reflects change")
+        void addOrReplaceWithUpdatedEntityAndFindByIdReflectsChange() {
+            var repository = new VolatileRepository<Integer, Person>("AddOrReplaceNameRepo");
             repository.add(new Person(1, "Alice", 0L, true));
 
-            repository.runForSingle(1, person -> person.setName("John"));
+            repository.addOrReplace(new Person(1, "John", 0L, true));
             scheduler.advanceUntilIdle();
 
             assertEquals("John", repository.findById(1).get().getName());

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryBaseConcurrencyTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryBaseConcurrencyTest.kt
@@ -31,11 +31,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 /**
- * Concurrency tests verifying that [RegistryBase] batch operations are safe under concurrent
- * modification of the underlying [java.util.concurrent.ConcurrentHashMap].
+ * Concurrency tests verifying that [RegistryBase] iteration and search operations are safe
+ * under concurrent modification of the underlying [java.util.concurrent.ConcurrentHashMap].
  *
- * These tests prove that [RegistryBase.runForMany], [RegistryBase.runMatching],
- * [RegistryBase.runForAll], and [RegistryBase.search] do not throw
+ * These tests prove that [RegistryBase.iterator] and [RegistryBase.search] do not throw
  * [java.util.ConcurrentModificationException] when entities are added or removed
  * concurrently via another coroutine.
  */
@@ -55,16 +54,14 @@ internal class RegistryBaseConcurrencyTest : StringSpec({
         ReactiveScope.resetDefaultFlowScope()
     }
 
-    "RegistryBase runForMany completes without error under concurrent entity additions" {
+    "RegistryBase iterator completes without error under concurrent entity additions" {
         val concurrentCoroutines = 50
         val iterationsPerCoroutine = 100
         val initialSize = 100
 
-        val repository = VolatileRepository<Int, Person>("runForMany-concurrency-test")
+        val repository = VolatileRepository<Int, Person>("iterator-concurrency-test")
         val initialEntities = (1..initialSize).map { arbitraryPerson(it).next() }
         initialEntities.forEach { repository.add(it) }
-
-        val targetIds = initialEntities.map { it.id }.toSet()
 
         shouldNotThrowAny {
             val writerJobs =
@@ -81,7 +78,7 @@ internal class RegistryBaseConcurrencyTest : StringSpec({
             val readerJob =
                 launch(Dispatchers.Default) {
                     repeat(iterationsPerCoroutine) {
-                        repository.runForMany(targetIds) { /* read-only action */ }
+                        repository.forEach { /* read-only iteration */ }
                     }
                 }
 
@@ -90,12 +87,12 @@ internal class RegistryBaseConcurrencyTest : StringSpec({
         }
     }
 
-    "RegistryBase runMatching completes without error under concurrent entity removals" {
+    "RegistryBase iterator completes without error under concurrent entity removals" {
         val concurrentCoroutines = 50
         val iterationsPerCoroutine = 100
         val initialSize = 100
 
-        val repository = VolatileRepository<Int, Person>("runMatching-concurrency-test")
+        val repository = VolatileRepository<Int, Person>("iterator-removal-concurrency-test")
         val allEntities =
             (1..initialSize + concurrentCoroutines * iterationsPerCoroutine)
                 .map { arbitraryPerson(it).next() }
@@ -115,7 +112,7 @@ internal class RegistryBaseConcurrencyTest : StringSpec({
             val readerJob =
                 launch(Dispatchers.Default) {
                     repeat(iterationsPerCoroutine) {
-                        repository.runMatching({ true }) { /* read-only action */ }
+                        repository.forEach { /* read-only iteration */ }
                     }
                 }
 
@@ -124,12 +121,12 @@ internal class RegistryBaseConcurrencyTest : StringSpec({
         }
     }
 
-    "RegistryBase runForAll completes without error under concurrent modifications" {
+    "RegistryBase iterator completes without error under concurrent add and remove" {
         val concurrentCoroutines = 50
         val iterationsPerCoroutine = 100
         val initialSize = 100
 
-        val repository = VolatileRepository<Int, Person>("runForAll-concurrency-test")
+        val repository = VolatileRepository<Int, Person>("iterator-mixed-concurrency-test")
         val initialEntities = (1..initialSize).map { arbitraryPerson(it).next() }
         initialEntities.forEach { repository.add(it) }
 
@@ -148,7 +145,7 @@ internal class RegistryBaseConcurrencyTest : StringSpec({
             val readerJob =
                 launch(Dispatchers.Default) {
                     repeat(iterationsPerCoroutine) {
-                        repository.runForAll { /* read-only action */ }
+                        repository.forEach { /* read-only iteration */ }
                     }
                 }
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/VolatileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/VolatileRepositoryTest.kt
@@ -2,7 +2,6 @@ package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.Person
 import net.transgressoft.lirp.arbitraryPerson
-import net.transgressoft.lirp.entity.toIds
 import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.CrudEvent.Type.CREATE
 import net.transgressoft.lirp.event.CrudEvent.Type.DELETE
@@ -105,19 +104,18 @@ internal class VolatileRepositoryTest : StringSpec({
         }
     }
 
-    "Repository run actions on events and send update events when they are modified" {
+    "Repository addOrReplace sends UPDATE event with previous entity in oldEntities" {
         val person = arbitraryPerson().next()
         repository.add(person) shouldBe true
-        val previousMoney = person.money!!
-        repository.runForSingle(person.id) { it.money = it.money?.plus(1) } shouldBe true
-        repository.findById(person.id).get().money shouldBe previousMoney + 1
+        val updatedPerson = person.copy(money = person.money!! + 1)
+        repository.addOrReplace(updatedPerson) shouldBe true
 
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertSoftly(subscriber.receivedEvents[UPDATE]) {
             it?.let {
-                this?.entities?.values?.shouldContainOnly(person)
-                this?.oldEntities?.values?.shouldContainOnly(person.copy(money = previousMoney))
+                this?.entities?.values?.shouldContainOnly(updatedPerson)
+                this?.oldEntities?.values?.shouldContainOnly(person)
             }
         }
 
@@ -125,13 +123,14 @@ internal class VolatileRepositoryTest : StringSpec({
         val previousSetMoney = set.stream().collect(Collectors.toMap({ it.id }, { it.money }))
         repository + set shouldBe true
         repository.size() shouldBe set.size + 1
-        repository.runForMany(set.toIds()) { it.money = it.money?.plus(1) } shouldBe true
+        val updatedSet = set.map { it.copy(money = it.money!! + 1) }.toSet()
+        repository.addOrReplaceAll(updatedSet) shouldBe true
 
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertSoftly(subscriber.receivedEvents[UPDATE]) {
             it?.let {
-                this?.entities?.values?.shouldContainAll(set)
+                this?.entities?.values?.shouldContainAll(updatedSet)
                 this?.oldEntities?.values?.shouldContainAll(set.map { it.copy(money = previousSetMoney[it.id]) })
             }
         }
@@ -144,16 +143,29 @@ internal class VolatileRepositoryTest : StringSpec({
         val richPerson = arbitraryPerson().next().copy(money = 1000)
         repository.addOrReplaceAll(setOf(poorPerson, richPerson)) shouldBe true
         repository.size() shouldBe set.size + 3
-        repository.runMatching({ it.money == 0L }) { it.money = it.money?.plus(1) } shouldBe true
+        val updatedPoorPerson = poorPerson.copy(money = 1)
+        repository.addOrReplace(updatedPoorPerson) shouldBe true
 
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertSoftly(subscriber.receivedEvents[UPDATE]) {
             it?.let {
-                this?.entities?.values.shouldContainOnly(poorPerson)
+                this?.entities?.values.shouldContainOnly(updatedPoorPerson)
                 this?.oldEntities?.values.shouldContainOnly(poorPerson.copy(money = 0))
             }
         }
+    }
+
+    "Registry iterates over all entities via Iterable" {
+        val people = Arb.set(arbitraryPerson(), 3..3).next()
+        repository.addOrReplaceAll(people) shouldBe true
+
+        val iterated = mutableSetOf<Person>()
+        for (person in repository) {
+            iterated.add(person)
+        }
+
+        iterated shouldContainOnly people
     }
 
     "Repository publishes CRUD events received by a subscriber" {
@@ -335,7 +347,7 @@ internal class VolatileRepositoryTest : StringSpec({
         updateEventsReceived.get() shouldBe 0
 
         // Update the person to trigger UPDATE event
-        repository.runForSingle(person.id) { it.money = it.money?.plus(100) } shouldBe true
+        repository.addOrReplace(person.copy(money = person.money!! + 100)) shouldBe true
 
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -356,7 +368,7 @@ internal class VolatileRepositoryTest : StringSpec({
         receivedPersonIds shouldContainOnly setOf(person.id) // Should not contain person2.id
 
         // But UPDATE subscription should still work
-        repository.runForSingle(person2.id) { it.money = it.money?.plus(100) } shouldBe true
+        repository.addOrReplace(person2.copy(money = person2.money!! + 100)) shouldBe true
 
         testDispatcher.scheduler.advanceUntilIdle()
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
@@ -149,7 +149,7 @@ class JsonFileRepositoryTest : DescribeSpec({
             repository.findFirst { it.name == "John Namechanged" } shouldBePresent { it shouldBe person }
         }
 
-        it("serializes on mutation inside repository action") {
+        it("serializes on addOrReplace") {
             val person = arbitraryPerson().next()
             repository.add(person) shouldBe true
             testDispatcher.scheduler.advanceUntilIdle()
@@ -166,7 +166,8 @@ class JsonFileRepositoryTest : DescribeSpec({
                 }"""
             jsonFile.readText().shouldEqualJson(expectedRepositoryJson)
 
-            repository.runForSingle(person.id) { it.name = "John Namechanged" }
+            val updatedPerson = (person as Person).copy(initialName = "John Namechanged")
+            repository.addOrReplace(updatedPerson) shouldBe true
             testDispatcher.scheduler.advanceUntilIdle()
 
             expectedRepositoryJson = """
@@ -186,16 +187,17 @@ class JsonFileRepositoryTest : DescribeSpec({
             val jsonFile = tempfile("debounce-test", ".json").also { it.deleteOnExit() }
             val repository = PersonJsonFileRepository(jsonFile)
 
-            val person: Person = arbitraryPerson(1).next()
-            repository.add(person)
-            val initialMoney = person.money!!
+            val initialPerson: Person = arbitraryPerson(1).next()
+            repository.add(initialPerson)
+            val initialMoney = initialPerson.money!!
 
             // Make many rapid changes that should be debounced
-            repeat(100) {
-                repository.runForSingle(person.id) { (it as Person).money = it.money?.plus(1) } shouldBe true
+            repeat(100) { i ->
+                val current = repository.findById(initialPerson.id).get() as Person
+                repository.addOrReplace(current.copy(money = current.money!! + 1)) shouldBe true
             }
 
-            person.money shouldBe initialMoney + 100
+            repository.findById(initialPerson.id).get().money shouldBe initialMoney + 100
 
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -203,7 +205,7 @@ class JsonFileRepositoryTest : DescribeSpec({
             val reloaded = PersonJsonFileRepository(jsonFile)
             testDispatcher.scheduler.advanceUntilIdle()
 
-            reloaded.findById(person.id).get().money shouldBe person.money
+            reloaded.findById(initialPerson.id).get().money shouldBe initialMoney + 100
             reloaded.close()
 
             repository.close()
@@ -564,7 +566,8 @@ class JsonFileRepositoryTest : DescribeSpec({
 
             // Rapid modifications
             repeat(50) { i ->
-                repository.runForSingle(person.id) { it.name = "Name-$i" }
+                val current = repository.findById(person.id).get() as Person
+                repository.addOrReplace(current.copy(initialName = "Name-$i"))
             }
 
             testDispatcher.scheduler.advanceUntilIdle()
@@ -583,8 +586,9 @@ class JsonFileRepositoryTest : DescribeSpec({
 
             // Rapid sequence
             repository.add(person)
-            repository.runForSingle(person.id) { it.name = "Modified" }
-            repository.remove(person)
+            val modified = (person as Person).copy(initialName = "Modified")
+            repository.addOrReplace(modified)
+            repository.remove(modified)
 
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -616,7 +620,7 @@ class JsonFileRepositoryTest : DescribeSpec({
             repo2.findById(person.id).isPresent shouldBe true
 
             // Modify in repo2
-            repo2.runForSingle(person.id) { it.name = "Modified in repo2" }
+            repo2.addOrReplace((repo2.findById(person.id).get() as Person).copy(initialName = "Modified in repo2"))
 
             testDispatcher.scheduler.advanceUntilIdle()
             repo2.close()
@@ -656,7 +660,7 @@ class JsonFileRepositoryTest : DescribeSpec({
             repository.add(p1)
             repository.add(p2)
             repository.add(p3)
-            repository.runForSingle(p1.id) { it.name = "Modified" }
+            repository.addOrReplace((p1 as Person).copy(initialName = "Modified"))
             repository.remove(p2)
 
             testDispatcher.scheduler.advanceUntilIdle()


### PR DESCRIPTION
- Remove runForSingle, runForMany, runMatching, runForAll, and runActionAndReplaceModifiedEntities from RegistryBase
- Remove Consumer and StandardCrudEvent.Update imports from RegistryBase
- Add override fun iterator() delegating to entitiesById.values.iterator()
- Update class-level KDoc on RegistryBase to reflect iterable design
- Update class-level KDoc on VolatileRepository to document addOrReplace event semantics
- Fix JsonFileRepository: replace runForAll with forEach for entity subscription setup
- Update VolatileRepositoryTest: replace run* tests with addOrReplace-based update tests and iterator test
- Update RegistryBaseConcurrencyTest: replace run* concurrency tests with iterator concurrency tests
- Update JsonFileRepositoryTest: replace runForSingle calls with addOrReplace calls
- Update JavaInteroperabilityTest: replace run* tests with iterator test and addOrReplace test