### PR TITLE
#58 Add event suppression API to ReactiveEntityBase

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -82,6 +82,10 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
     @Volatile
     private var closed = false
 
+    @Volatile
+    @PublishedApi
+    internal var eventsDisabled = false
+
     override val isClosed: Boolean get() = closed
 
     /**
@@ -111,8 +115,10 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
         get() {
             while (true) {
                 val current = publisherRef.get()
-                if (current != null && !current.isClosed) return current
+                if (current != null && !current.isClosed)
+                    return current
                 check(!isClosed) { "Entity '${this::class.java.simpleName}' is closed" }
+
                 val newPublisher = publisherFactory(this::class.java.simpleName)
                 newPublisher.activateEvents(MUTATE)
                 if (publisherRef.compareAndSet(current, newPublisher)) {
@@ -166,7 +172,8 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
      */
     @Suppress("UNCHECKED_CAST")
     override fun close() {
-        if (closed) return
+        if (closed)
+            return
         closed = true
         (loadRefAccessor() as? LirpRefAccessor<R>)?.cancelAllBubbleUp(this as R)
         publisherRef.getAndSet(null)?.close()
@@ -248,6 +255,62 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
     }
 
     /**
+     * Suppresses event emission from [mutateAndPublish] and reactive property delegates.
+     * Mutations still execute, but no [ReactiveMutationEvent] is published.
+     *
+     * Pair with [enableEvents] to restore normal emission. Designed for use in [clone]
+     * implementations where property setters would otherwise trigger infinite recursion
+     * through the clone-compare change detection.
+     *
+     * @see enableEvents
+     * @see withEventsDisabled
+     */
+    protected fun disableEvents() {
+        eventsDisabled = true
+    }
+
+    /**
+     * Restores event emission after a prior [disableEvents] call.
+     *
+     * @see disableEvents
+     * @see withEventsDisabled
+     */
+    protected fun enableEvents() {
+        eventsDisabled = false
+    }
+
+    /**
+     * Executes [action] with event emission suppressed, restoring the previous state afterward.
+     *
+     * Equivalent to wrapping the action between [disableEvents] and [enableEvents], but
+     * guarantees restoration even if the action throws.
+     *
+     * ```
+     * override fun clone(): MyEntity = MyEntity(id).apply {
+     *     withEventsDisabled {
+     *         name = this@MyEntity.name
+     *         price = this@MyEntity.price
+     *     }
+     * }
+     * ```
+     *
+     * @param T The return type of the action
+     * @param action The block to execute with events disabled
+     * @return The result of the action
+     * @see disableEvents
+     * @see enableEvents
+     */
+    protected inline fun <T> withEventsDisabled(action: () -> T): T {
+        val wasDisabled = eventsDisabled
+        eventsDisabled = true
+        try {
+            return action()
+        } finally {
+            eventsDisabled = wasDisabled
+        }
+    }
+
+    /**
      * Creates a reactive property delegate that emits a [ReactiveMutationEvent] on value change.
      *
      * Usage: `var name: String by reactiveProperty(initialName)`
@@ -280,6 +343,9 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
     @Suppress("UNCHECKED_CAST")
     protected fun <T> mutateAndPublish(mutationAction: () -> T): T {
         check(!isClosed) { "Entity '${this::class.java.simpleName}' is closed" }
+        if (eventsDisabled)
+            return mutationAction()
+
         val entityBeforeChange = clone()
         val result = mutationAction()
         if (entityBeforeChange == this) {
@@ -305,7 +371,13 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
         @Suppress("UNCHECKED_CAST")
         override fun setValue(thisRef: ReactiveEntityBase<K, R>, property: KProperty<*>, value: T) {
             check(!isClosed) { "Entity '${this@ReactiveEntityBase::class.java.simpleName}' is closed" }
+
             if (value != storedValue) {
+                if (eventsDisabled) {
+                    storedValue = value
+                    return
+                }
+
                 val entityBeforeChange = clone()
                 storedValue = value
                 lastDateModified = LocalDateTime.now()
@@ -327,8 +399,13 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
         @Suppress("UNCHECKED_CAST")
         override fun setValue(thisRef: ReactiveEntityBase<K, R>, property: KProperty<*>, value: T) {
             check(!isClosed) { "Entity '${this@ReactiveEntityBase::class.java.simpleName}' is closed" }
+
             val oldValue = getter()
             if (value != oldValue) {
+                if (eventsDisabled) {
+                    setter(value)
+                    return
+                }
                 val entityBeforeChange = clone()
                 setter(value)
                 lastDateModified = LocalDateTime.now()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/ReactiveEntityLifecycleTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/ReactiveEntityLifecycleTest.kt
@@ -293,4 +293,83 @@ class ReactiveEntityLifecycleTest : StringSpec({
         subscription.cancel()
         customer.close()
     }
+
+    "disableEvents suppresses mutation events from reactiveProperty setters" {
+        val customer = Customer(1, "Alice")
+        val received = mutableListOf<MutationEvent<Int, Customer>>()
+        val subscription = customer.subscribe { event -> received.add(event) }
+
+        customer.suppressEvents()
+        customer.updateName("Bob")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        received.size shouldBe 0
+        customer.name shouldBe "Bob"
+
+        customer.restoreEvents()
+        customer.updateName("Charlie")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        received.size shouldBe 1
+        received[0].newEntity.name shouldBe "Charlie"
+
+        subscription.cancel()
+        customer.close()
+    }
+
+    "withEventsDisabled suppresses events and restores emission afterward" {
+        val customer = Customer(1, "Alice")
+        val received = mutableListOf<MutationEvent<Int, Customer>>()
+        val subscription = customer.subscribe { event -> received.add(event) }
+
+        customer.silently {
+            customer.updateName("Silent")
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+        received.size shouldBe 0
+        customer.name shouldBe "Silent"
+
+        customer.updateName("Loud")
+        testDispatcher.scheduler.advanceUntilIdle()
+        received.size shouldBe 1
+
+        subscription.cancel()
+        customer.close()
+    }
+
+    "withEventsDisabled restores state even if action throws" {
+        val customer = Customer(1, "Alice")
+        val received = mutableListOf<MutationEvent<Int, Customer>>()
+        val subscription = customer.subscribe { event -> received.add(event) }
+
+        shouldThrow<RuntimeException> {
+            customer.silently {
+                customer.updateName("BeforeError")
+                throw RuntimeException("test error")
+            }
+        }
+
+        customer.updateName("AfterError")
+        testDispatcher.scheduler.advanceUntilIdle()
+        received.size shouldBe 1
+
+        subscription.cancel()
+        customer.close()
+    }
+
+    "disableEvents suppresses mutateAndPublish block emission" {
+        val customer = Customer(1, "Alice")
+        val received = mutableListOf<MutationEvent<Int, Customer>>()
+        val subscription = customer.subscribe { event -> received.add(event) }
+
+        customer.suppressEvents()
+        customer.bulkUpdate("Silent")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        received.size shouldBe 0
+        customer.name shouldBe "Silent"
+
+        subscription.cancel()
+        customer.close()
+    }
 })

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/LirpTestFixtures.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/LirpTestFixtures.kt
@@ -41,6 +41,14 @@ data class Customer(
     fun updateName(newName: String) {
         name = newName
     }
+
+    fun bulkUpdate(newName: String) = mutateAndPublish { name = newName }
+
+    fun suppressEvents() = disableEvents()
+
+    fun restoreEvents() = enableEvents()
+
+    fun <T> silently(action: () -> T): T = withEventsDisabled(action)
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds `disableEvents()`, `enableEvents()`, and `withEventsDisabled {}` to `ReactiveEntityBase`, solving the infinite recursion problem in `clone()` when property setters trigger `mutateAndPublish`.

When events are disabled, `mutateAndPublish` and reactive property delegates still execute mutations but skip the clone-compare cycle and event emission. This eliminates the need for per-property `if (!suppressEvents)` guards in downstream entity implementations.

## Usage

```kotlin
override fun clone(): MyEntity = MyEntity(id).apply {
    withEventsDisabled {
        title = this@MyEntity.title
        artist = this@MyEntity.artist
    }
}
```

## Changes

- `ReactiveEntityBase`: three new protected methods (`disableEvents`, `enableEvents`, `withEventsDisabled`)
- Early return in `mutateAndPublish` and both property delegate `setValue` methods when `eventsDisabled` is true
- Tests: three new test cases covering suppression, restoration, and exception safety
- README: added event suppression example in Entity Reactivity section
- Wiki: documented API in Core-Concepts.md under "Event Suppression for Clone"

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event suppression controls to temporarily disable event publication during entity mutations while preserving state changes.
  * Events are automatically restored even when operations throw exceptions.

* **Tests**
  * Added comprehensive test coverage for event suppression behavior, exception handling, and state consistency during batch operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->