### PR TITLE
KSP Inner Class Naming Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,24 @@ repo.subscribe(CrudEvent.Type.CREATE) { event ->
 }
 ```
 
+## Inner Class Support
+
+Entities and repositories declared as inner classes are fully supported. KSP generates accessor and info classes using the JVM binary name (`$`-separated), which matches the runtime `Class.forName` lookup:
+
+```kotlin
+class MusicLibrary {
+    @LirpRepository
+    class TrackRepository : VolatileRepository<Int, Track>()
+
+    data class Track(override val id: Int, var title: String) : ReactiveEntityBase<Int, Track>() {
+        override val uniqueId = "track-$id"
+        override fun clone() = copy()
+    }
+}
+```
+
+KSP generates `MusicLibrary$TrackRepository_LirpRegistryInfo`, which `RegistryBase` resolves at runtime via `Class.forName("MusicLibrary$TrackRepository_LirpRegistryInfo")`. Anonymous and local class entities are safely handled — their ref and index discovery is skipped automatically since they cannot have KSP-generated accessors.
+
 ## JSON Persistence
 
 `JsonFileRepository` persists entities to a JSON file with debounced writes — multiple rapid mutations are batched into a single file write. No manual save calls needed:

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
@@ -123,12 +123,19 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
      * The generated accessor provides [IndexEntry] descriptors with direct property getter lambdas,
      * completely avoiding `kotlin-reflect` or `java.lang.reflect` overhead for property access.
      * If no generated accessor is found (KSP not applied), the index entry list remains empty.
+     *
+     * Anonymous and local class entities are skipped early — they can never have KSP-generated
+     * accessors because they lack stable binary names.
      */
     @Suppress("UNCHECKED_CAST")
     protected fun discoverIndexes(entity: T) {
         if (indexEntries != null) return
         synchronized(this) {
             if (indexEntries != null) return
+            if (entity.javaClass.isAnonymousClass || entity.javaClass.isLocalClass) {
+                indexEntries = emptyList()
+                return
+            }
             val entries =
                 try {
                     val accessorClass = Class.forName("${entity.javaClass.name}_LirpIndexAccessor")
@@ -186,12 +193,20 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
      * completely avoiding `kotlin-reflect` or `java.lang.reflect` overhead. If no generated
      * accessor is found (KSP not applied or no [@Aggregate][Aggregate] annotations),
      * the reference entry list remains empty.
+     *
+     * Anonymous and local class entities are skipped early — they can never have KSP-generated
+     * accessors and do not require the [failFastIfDelegatePresent] check.
      */
     @Suppress("UNCHECKED_CAST")
     protected fun discoverRefs(entity: T) {
         if (refEntries != null) return
         synchronized(this) {
             if (refEntries != null) return
+            if (entity.javaClass.isAnonymousClass || entity.javaClass.isLocalClass) {
+                collectionRefEntries = emptyList()
+                refEntries = emptyList()
+                return
+            }
             try {
                 val accessorClass = Class.forName("${entity.javaClass.name}_LirpRefAccessor")
                 val accessor = accessorClass.getDeclaredConstructor().newInstance() as LirpRefAccessor<T>
@@ -432,8 +447,10 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
          */
         @JvmStatic
         @Suppress("UNCHECKED_CAST")
-        internal fun refAccessorFor(entityClass: Class<*>): LirpRefAccessor<Any>? =
-            refAccessorCache.computeIfAbsent(entityClass) {
+        internal fun refAccessorFor(entityClass: Class<*>): LirpRefAccessor<Any>? {
+            if (entityClass.isAnonymousClass || entityClass.isLocalClass)
+                return null
+            return refAccessorCache.computeIfAbsent(entityClass) {
                 try {
                     val accessorClass = Class.forName("${entityClass.name}_LirpRefAccessor")
                     Optional.of(accessorClass.getDeclaredConstructor().newInstance() as LirpRefAccessor<Any>)
@@ -441,5 +458,6 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
                     Optional.empty()
                 }
             }.orElse(null)
+        }
     }
 }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/InnerClassRegistryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/InnerClassRegistryTest.kt
@@ -1,0 +1,302 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.event.ReactiveScope
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+/**
+ * Verifies that [RegistryBase] gracefully handles anonymous, local, and nested inner class
+ * entities without throwing [ClassNotFoundException].
+ *
+ * Inner class entities lack KSP-generated accessors in this test context because no processor
+ * runs during unit tests. The defensive guards in [RegistryBase.discoverRefs] and
+ * [RegistryBase.discoverIndexes] short-circuit before the [Class.forName] lookup for anonymous
+ * and local classes, while inner class entities fall through to the normal discovery path
+ * (which finds no accessor and proceeds with empty ref/index lists).
+ */
+@DisplayName("RegistryBase inner class and anonymous entity handling")
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class InnerClassRegistryTest : StringSpec({
+
+    val testDispatcher = UnconfinedTestDispatcher()
+    val testScope = CoroutineScope(testDispatcher)
+
+    beforeSpec {
+        ReactiveScope.flowScope = testScope
+        ReactiveScope.ioScope = testScope
+    }
+
+    lateinit var repo: VolatileRepository<Int, SimpleTestEntity>
+
+    beforeEach {
+        repo = object : VolatileRepository<Int, SimpleTestEntity>("inner-class-test") {}
+    }
+
+    afterEach {
+        repo.close()
+    }
+
+    // --- Anonymous entity tests ---
+
+    "RegistryBase adds anonymous entity without throwing" {
+        val anonymousEntity =
+            object : SimpleTestEntity(1) {
+                override val uniqueId = "anon-1"
+            }
+
+        shouldNotThrow<Exception> {
+            repo.add(anonymousEntity)
+        }
+    }
+
+    "RegistryBase stores anonymous entity after add" {
+        val anonymousEntity =
+            object : SimpleTestEntity(2) {
+                override val uniqueId = "anon-2"
+            }
+
+        repo.add(anonymousEntity)
+
+        repo.size() shouldBe 1
+        repo.findById(2).get() shouldBe anonymousEntity
+    }
+
+    // --- Local class entity tests ---
+
+    "RegistryBase adds local class entity without throwing" {
+        class LocalEntity(id: Int) : SimpleTestEntity(id) {
+            override val uniqueId = "local-$id"
+        }
+
+        shouldNotThrow<Exception> {
+            repo.add(LocalEntity(3))
+        }
+    }
+
+    "RegistryBase stores local class entity after add" {
+        class LocalEntity(id: Int) : SimpleTestEntity(id) {
+            override val uniqueId = "local-$id"
+        }
+
+        repo.add(LocalEntity(4))
+
+        repo.size() shouldBe 1
+    }
+
+    // --- Single-level inner class entity tests ---
+
+    "RegistryBase adds single-level inner class entity without throwing" {
+        val entity = OuterEntity.InnerEntity(10)
+
+        shouldNotThrow<Exception> {
+            repo.add(entity)
+        }
+    }
+
+    "RegistryBase stores and retrieves single-level inner class entity" {
+        val entity = OuterEntity.InnerEntity(11)
+
+        repo.add(entity)
+
+        repo.size() shouldBe 1
+        repo.findById(11).get() shouldBe entity
+    }
+
+    // --- Two-level nested inner class entity tests ---
+
+    "RegistryBase adds two-level nested inner class entity without throwing" {
+        val entity = OuterEntity.MiddleEntity.DeepEntity(20)
+
+        shouldNotThrow<Exception> {
+            repo.add(entity)
+        }
+    }
+
+    "RegistryBase stores and retrieves two-level nested inner class entity" {
+        val entity = OuterEntity.MiddleEntity.DeepEntity(21)
+
+        repo.add(entity)
+
+        repo.size() shouldBe 1
+        repo.findById(21).get() shouldBe entity
+    }
+
+    // --- Three-level nested inner class entity tests ---
+
+    "RegistryBase adds three-level nested inner class entity without throwing" {
+        val entity = OuterEntity.MiddleEntity.DeepEntity.DeeperEntity(30)
+
+        shouldNotThrow<Exception> {
+            repo.add(entity)
+        }
+    }
+
+    "RegistryBase stores and retrieves three-level nested inner class entity" {
+        val entity = OuterEntity.MiddleEntity.DeepEntity.DeeperEntity(31)
+
+        repo.add(entity)
+
+        repo.size() shouldBe 1
+        repo.findById(31).get() shouldBe entity
+    }
+
+    // --- Mixed entity types in a single repository ---
+
+    "RegistryBase stores top-level, inner class, and anonymous entities together" {
+        val topLevel = SimpleTestEntity(100)
+        val innerEntity = OuterEntity.InnerEntity(101)
+        val deepEntity = OuterEntity.MiddleEntity.DeepEntity(102)
+        val anonymousEntity =
+            object : SimpleTestEntity(103) {
+                override val uniqueId = "anon-103"
+            }
+
+        repo.add(topLevel)
+        repo.add(innerEntity)
+        repo.add(deepEntity)
+        repo.add(anonymousEntity)
+
+        repo.size() shouldBe 4
+        repo.findById(100).get() shouldBe topLevel
+        repo.findById(101).get() shouldBe innerEntity
+        repo.findById(102).get() shouldBe deepEntity
+        repo.findById(103).get() shouldBe anonymousEntity
+    }
+
+    // --- Anonymous entity created from an inner class ---
+
+    "RegistryBase adds anonymous entity subclassing an inner class without throwing" {
+        val anonymousInner =
+            object : OuterEntity.InnerEntity(40) {
+                override val uniqueId = "anon-inner-40"
+            }
+
+        shouldNotThrow<Exception> {
+            repo.add(anonymousInner)
+        }
+        repo.size() shouldBe 1
+    }
+
+    // --- refAccessorFor companion method guards ---
+
+    "refAccessorFor returns null for anonymous class entity" {
+        val anonymousEntity =
+            object : SimpleTestEntity(50) {
+                override val uniqueId = "anon-50"
+            }
+
+        RegistryBase.refAccessorFor(anonymousEntity.javaClass).shouldBeNull()
+    }
+
+    "refAccessorFor returns null for local class entity" {
+        class LocalEntity(id: Int) : SimpleTestEntity(id) {
+            override val uniqueId = "local-$id"
+        }
+
+        RegistryBase.refAccessorFor(LocalEntity(51).javaClass).shouldBeNull()
+    }
+
+    // --- Inner class JVM binary name verification ---
+
+    "inner class entity has dollar-separated JVM binary name" {
+        val entity = OuterEntity.InnerEntity(60)
+
+        entity.javaClass.name shouldBe
+            "net.transgressoft.lirp.persistence.OuterEntity\$InnerEntity"
+    }
+
+    "two-level nested entity has multi-dollar JVM binary name" {
+        val entity = OuterEntity.MiddleEntity.DeepEntity(61)
+
+        entity.javaClass.name shouldBe
+            "net.transgressoft.lirp.persistence.OuterEntity\$MiddleEntity\$DeepEntity"
+    }
+
+    "three-level nested entity has triple-dollar JVM binary name" {
+        val entity = OuterEntity.MiddleEntity.DeepEntity.DeeperEntity(62)
+
+        entity.javaClass.name shouldBe
+            "net.transgressoft.lirp.persistence.OuterEntity\$MiddleEntity\$DeepEntity\$DeeperEntity"
+    }
+})
+
+/**
+ * Minimal entity base for [InnerClassRegistryTest] — has no [Aggregate][net.transgressoft.lirp.entity.Aggregate]
+ * delegate properties, so no KSP accessor is expected.
+ * Used to create anonymous, local, and inner class subtypes.
+ */
+internal open class SimpleTestEntity(override val id: Int) : ReactiveEntityBase<Int, SimpleTestEntity>() {
+    override val uniqueId: String get() = "simple-$id"
+
+    override fun clone() = SimpleTestEntity(id)
+}
+
+/**
+ * Outer class containing nested inner class entity hierarchies for testing [RegistryBase]
+ * discovery behavior with inner classes at various nesting depths.
+ *
+ * Mirrors real-world patterns where domain entities are organized as inner classes
+ * inside aggregate containers (e.g. `PlaylistHierarchy.Playlist`).
+ */
+internal class OuterEntity {
+
+    /**
+     * Single-level inner class entity (depth 1).
+     * JVM binary name: `OuterEntity$InnerEntity`
+     */
+    open class InnerEntity(override val id: Int) : SimpleTestEntity(id) {
+        override val uniqueId: String get() = "inner-$id"
+
+        override fun clone() = InnerEntity(id)
+    }
+
+    /**
+     * Middle-level container for deeper nesting (depth 2+).
+     */
+    class MiddleEntity {
+
+        /**
+         * Two-level nested inner class entity (depth 2).
+         * JVM binary name: `OuterEntity$MiddleEntity$DeepEntity`
+         */
+        class DeepEntity(override val id: Int) : SimpleTestEntity(id) {
+            override val uniqueId: String get() = "deep-$id"
+
+            override fun clone() = DeepEntity(id)
+
+            /**
+             * Three-level nested inner class entity (depth 3).
+             * JVM binary name: `OuterEntity$MiddleEntity$DeepEntity$DeeperEntity`
+             */
+            class DeeperEntity(override val id: Int) : SimpleTestEntity(id) {
+                override val uniqueId: String get() = "deeper-$id"
+
+                override fun clone() = DeeperEntity(id)
+            }
+        }
+    }
+}

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
@@ -1,0 +1,52 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.ksp
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+
+/**
+ * Returns the JVM binary simple name of this class declaration relative to its enclosing package.
+ *
+ * For top-level classes returns [simpleName]. For inner/nested classes, walks [parentDeclaration]
+ * recursively joining with `$` to produce the binary name that [Class.forName] expects
+ * (e.g., `Outer$Inner` for one level, `Outer$Middle$Inner` for two levels).
+ */
+internal fun KSClassDeclaration.jvmBinaryName(): String {
+    val parent = parentDeclaration as? KSClassDeclaration
+    return if (parent != null) {
+        "${parent.jvmBinaryName()}\$${simpleName.asString()}"
+    } else {
+        simpleName.asString()
+    }
+}
+
+/**
+ * Returns the Kotlin nested class name relative to the enclosing package, using `.` as separator.
+ *
+ * For top-level classes returns [simpleName]. For inner/nested classes, walks [parentDeclaration]
+ * recursively joining with `.` to produce the Kotlin-source-level name used for type references
+ * within the same package (e.g., `Outer.Inner` for one level, `Outer.Middle.Inner` for two levels).
+ */
+internal fun KSClassDeclaration.kotlinNestedName(): String {
+    val parent = parentDeclaration as? KSClassDeclaration
+    return if (parent != null) {
+        "${parent.kotlinNestedName()}.${simpleName.asString()}"
+    } else {
+        simpleName.asString()
+    }
+}

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessor.kt
@@ -95,7 +95,7 @@ class LirpRepositoryProcessor(
 
     private fun generateRegistryInfo(classDecl: KSClassDeclaration, entityClassFqn: String) {
         val packageName = classDecl.packageName.asString()
-        val className = classDecl.simpleName.asString()
+        val className = classDecl.jvmBinaryName()
         val infoName = "${className}_LirpRegistryInfo"
         val entitySimpleName = entityClassFqn.substringAfterLast('.')
 
@@ -121,7 +121,7 @@ class LirpRepositoryProcessor(
                 appendLine(" * KSP-generated registry info for [$className].")
                 appendLine(" * Exposes the entity class for zero-config self-registration.")
                 appendLine(" */")
-                appendLine("public class $infoName : LirpRegistryInfo {")
+                appendLine("public class `$infoName` : LirpRegistryInfo {")
                 appendLine("    override val entityClass: Class<*> = $entitySimpleName::class.java")
                 appendLine("}")
             }.toByteArray()

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ReactiveEntityRefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ReactiveEntityRefProcessor.kt
@@ -102,10 +102,11 @@ class ReactiveEntityRefProcessor(
      */
     private fun classifyProperties(
         properties: List<KSPropertyDeclaration>,
-        className: String,
+        ownerDecl: KSClassDeclaration,
         singleEntries: MutableList<RefPropertyMeta>,
         collectionMetas: MutableList<CollectionRefPropertyMeta>
     ) {
+        val className = ownerDecl.jvmBinaryName()
         for (prop in properties) {
             val annotation =
                 prop.annotations.firstOrNull {
@@ -195,12 +196,14 @@ class ReactiveEntityRefProcessor(
 
     private fun generateAccessor(classDecl: KSClassDeclaration, properties: List<KSPropertyDeclaration>) {
         val packageName = classDecl.packageName.asString()
-        val className = classDecl.simpleName.asString()
+        val className = classDecl.jvmBinaryName()
+        // Kotlin-level name for type references: uses dots for nesting (e.g. Outer.RefEntity)
+        val kotlinClassName = classDecl.kotlinNestedName()
         val accessorName = "${className}_LirpRefAccessor"
 
         val singleEntries = mutableListOf<RefPropertyMeta>()
         val collectionMetas = mutableListOf<CollectionRefPropertyMeta>()
-        classifyProperties(properties, className, singleEntries, collectionMetas)
+        classifyProperties(properties, classDecl, singleEntries, collectionMetas)
 
         val file =
             codeGenerator.createNewFile(
@@ -255,7 +258,7 @@ class ReactiveEntityRefProcessor(
 
         val cancelAllBubbleUpCode =
             """
-            override fun cancelAllBubbleUp(entity: $className) {
+            override fun cancelAllBubbleUp(entity: $kotlinClassName) {
                 entries.forEach { entry -> entry.delegateGetter(entity).cancelBubbleUp() }
             }
             """.trimIndent()
@@ -280,19 +283,19 @@ class ReactiveEntityRefProcessor(
                 appendLine(" * KSP-generated aggregate reference accessor for [$className].")
                 appendLine(" * Provides direct ID getter and delegate getter lambdas — no runtime reflection.")
                 appendLine(" */")
-                appendLine("public class $accessorName : LirpRefAccessor<$className> {")
+                appendLine("public class `$accessorName` : LirpRefAccessor<$kotlinClassName> {")
                 if (singleEntries.isEmpty()) {
-                    appendLine("    override val entries: List<RefEntry<*, $className>> = emptyList()")
+                    appendLine("    override val entries: List<RefEntry<*, $kotlinClassName>> = emptyList()")
                 } else {
-                    appendLine("    override val entries: List<RefEntry<*, $className>> = listOf(")
+                    appendLine("    override val entries: List<RefEntry<*, $kotlinClassName>> = listOf(")
                     appendLine("        $entriesCode")
                     appendLine("    )")
                 }
                 appendLine()
                 if (collectionMetas.isEmpty()) {
-                    appendLine("    override val collectionEntries: List<CollectionRefEntry<*, $className>> = emptyList()")
+                    appendLine("    override val collectionEntries: List<CollectionRefEntry<*, $kotlinClassName>> = emptyList()")
                 } else {
-                    appendLine("    override val collectionEntries: List<CollectionRefEntry<*, $className>> = listOf(")
+                    appendLine("    override val collectionEntries: List<CollectionRefEntry<*, $kotlinClassName>> = listOf(")
                     appendLine("        $collectionEntriesCode")
                     appendLine("    )")
                 }

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessorTest.kt
@@ -1,0 +1,185 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.ksp
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.configureKsp
+import com.tschuchort.compiletesting.sourcesGeneratedBySymbolProcessor
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.DisplayName
+
+/**
+ * KSP compilation tests for [LirpRepositoryProcessor], verifying that the processor generates
+ * correct `_LirpRegistryInfo` implementations for all repository shapes, including top-level
+ * and inner class repositories.
+ *
+ * Each test compiles a source repository in-process using kctfork and asserts on the generated
+ * file content. Test entity classes use [net.transgressoft.lirp.entity.ReactiveEntityBase] as
+ * base and test repositories extend [net.transgressoft.lirp.persistence.VolatileRepository].
+ */
+@OptIn(ExperimentalCompilerApi::class)
+@DisplayName("LirpRepositoryProcessor")
+internal class LirpRepositoryProcessorTest : FunSpec({
+
+    fun compileWithProcessor(vararg sources: SourceFile): JvmCompilationResult {
+        val compilation =
+            KotlinCompilation().apply {
+                this.sources = sources.toList()
+                inheritClassPath = true
+            }
+        compilation.configureKsp { withCompilation = true }
+        compilation.symbolProcessorProviders += LirpRepositoryProcessorProvider()
+        return compilation.compile()
+    }
+
+    fun JvmCompilationResult.generatedFileContent(name: String): String {
+        val file =
+            sourcesGeneratedBySymbolProcessor.firstOrNull { it.name == name }
+                ?: error("Generated file '$name' not found among: ${sourcesGeneratedBySymbolProcessor.map { it.name }.toList()}")
+        return file.readText()
+    }
+
+    test("generates _LirpRegistryInfo for top-level repository") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "TrackRepo.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.LirpRepository
+                    import net.transgressoft.lirp.persistence.VolatileRepository
+
+                    data class TrackEntity(override val id: Int) : ReactiveEntityBase<Int, TrackEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+
+                    @LirpRepository
+                    class TrackRepo : VolatileRepository<Int, TrackEntity>()
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("TrackRepo_LirpRegistryInfo.kt")
+        content shouldContain "`TrackRepo_LirpRegistryInfo`"
+        content shouldContain "LirpRegistryInfo"
+        content shouldContain "TrackEntity::class.java"
+    }
+
+    test("generates \$-separated info class name for 1-level inner repository") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "Outer.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.LirpRepository
+                    import net.transgressoft.lirp.persistence.VolatileRepository
+
+                    data class SomeEntity(override val id: Int) : ReactiveEntityBase<Int, SomeEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+
+                    class Outer {
+                        @LirpRepository
+                        class InnerRepo : VolatileRepository<Int, SomeEntity>()
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("Outer\$InnerRepo_LirpRegistryInfo.kt")
+        content shouldContain "`Outer\$InnerRepo_LirpRegistryInfo`"
+        content shouldContain "LirpRegistryInfo"
+        content shouldContain "SomeEntity::class.java"
+    }
+
+    test("generates \$-separated info class name for 3-level nested repository") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "A.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.LirpRepository
+                    import net.transgressoft.lirp.persistence.VolatileRepository
+
+                    data class ItemEntity(override val id: Int) : ReactiveEntityBase<Int, ItemEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+
+                    class A {
+                        class B {
+                            @LirpRepository
+                            class C : VolatileRepository<Int, ItemEntity>()
+                        }
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("A\$B\$C_LirpRegistryInfo.kt")
+        content shouldContain "`A\$B\$C_LirpRegistryInfo`"
+        content shouldContain "LirpRegistryInfo"
+        content shouldContain "ItemEntity::class.java"
+    }
+
+    test("inner repository info references inner entity with correct simple name") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "Domain.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.LirpRepository
+                    import net.transgressoft.lirp.persistence.VolatileRepository
+
+                    class Domain {
+                        data class InnerEntity(override val id: Int) : ReactiveEntityBase<Int, InnerEntity>() {
+                            override val uniqueId: String get() = "${'$'}id"
+                            override fun clone() = copy()
+                        }
+
+                        @LirpRepository
+                        class InnerRepo : VolatileRepository<Int, InnerEntity>()
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("Domain\$InnerRepo_LirpRegistryInfo.kt")
+        content shouldContain "`Domain\$InnerRepo_LirpRegistryInfo`"
+        content shouldContain "InnerEntity::class.java"
+    }
+})

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ReactiveEntityRefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ReactiveEntityRefProcessorTest.kt
@@ -410,4 +410,111 @@ internal class ReactiveEntityRefProcessorTest : FunSpec({
         content shouldContain "refName = \"annotatedRefs\""
         content shouldNotContain "ignoredRefs"
     }
+
+    test("generates \$-separated accessor name for 1-level inner class entity") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "Outer.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Aggregate
+                    import net.transgressoft.lirp.persistence.aggregate
+
+                    class Outer {
+                        data class InnerEntity(override val id: Int) : ReactiveEntityBase<Int, InnerEntity>() {
+                            override val uniqueId: String get() = "${'$'}id"
+                            override fun clone() = copy()
+                        }
+
+                        data class RefEntity(override val id: Int, var innerId: Int) : ReactiveEntityBase<Int, RefEntity>() {
+                            override val uniqueId: String get() = "${'$'}id"
+                            override fun clone() = copy()
+
+                            @Aggregate
+                            val inner by aggregate<Int, InnerEntity> { innerId }
+                        }
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("Outer\$RefEntity_LirpRefAccessor.kt")
+        content shouldContain "`Outer\$RefEntity_LirpRefAccessor`"
+        content shouldContain "LirpRefAccessor<Outer.RefEntity>"
+        content shouldContain "InnerEntity::class.java"
+    }
+
+    test("generates \$-separated accessor name for 3-level nested entity") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "A.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Aggregate
+                    import net.transgressoft.lirp.persistence.aggregate
+
+                    class A {
+                        class B {
+                            data class RefEntity(override val id: Int) : ReactiveEntityBase<Int, RefEntity>() {
+                                override val uniqueId: String get() = "${'$'}id"
+                                override fun clone() = copy()
+                            }
+                            data class C(override val id: Int, var refId: Int) : ReactiveEntityBase<Int, C>() {
+                                override val uniqueId: String get() = "${'$'}id"
+                                override fun clone() = copy()
+
+                                @Aggregate
+                                val ref by aggregate<Int, RefEntity> { refId }
+                            }
+                        }
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("A\$B\$C_LirpRefAccessor.kt")
+        content shouldContain "`A\$B\$C_LirpRefAccessor`"
+        content shouldContain "LirpRefAccessor<A.B.C>"
+        content shouldContain "RefEntity::class.java"
+    }
+
+    test("top-level entity accessor generation unchanged after inner class support") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "TopLevelEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Aggregate
+                    import net.transgressoft.lirp.persistence.aggregate
+
+                    data class TargetEntity(override val id: Int) : ReactiveEntityBase<Int, TargetEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+
+                    data class TopLevelEntity(override val id: Int, var targetId: Int) : ReactiveEntityBase<Int, TopLevelEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+
+                        @Aggregate
+                        val target by aggregate<Int, TargetEntity> { targetId }
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("TopLevelEntity_LirpRefAccessor.kt")
+        content shouldContain "`TopLevelEntity_LirpRefAccessor`"
+        content shouldContain "LirpRefAccessor<TopLevelEntity>"
+        content shouldContain "TargetEntity::class.java"
+    }
 })


### PR DESCRIPTION
## Summary

**Phase 16: KSP Inner Class Naming Fix**
**Goal:** Inner class entities and repositories annotated with `@Aggregate` and `@LirpRepository` generate accessor/info classes whose names match `RegistryBase` runtime lookups via `Class.forName`
**Status:** Verified ✓ (8/8 must-haves)

Fixed KSP processors so inner class entities and repositories generate accessor/info class files with JVM-correct `$`-separated names, enabling `Class.forName` lookups in `RegistryBase` to resolve at runtime. Added defensive guards for anonymous/local class entities.

Closes #70 

## Changes

### Plan 01: KSP Processor Inner Class Name Generation
`jvmBinaryName()` KSP utility with `$`-separated class names for inner class accessor and registry info code generation.

**Key files created:**
- `lirp-ksp/src/main/kotlin/.../KspUtils.kt` — `jvmBinaryName()` and `kotlinNestedName()` extensions
- `lirp-ksp/src/test/kotlin/.../LirpRepositoryProcessorTest.kt` — 4 new tests

**Key files modified:**
- `lirp-ksp/src/main/kotlin/.../ReactiveEntityRefProcessor.kt` — uses `jvmBinaryName()` for class naming
- `lirp-ksp/src/main/kotlin/.../LirpRepositoryProcessor.kt` — uses `jvmBinaryName()` with backtick-escaped declaration
- `lirp-ksp/src/test/kotlin/.../ReactiveEntityRefProcessorTest.kt` — 3 new inner class tests

### Plan 02: RegistryBase Defensive Guards & Documentation
Defensive guards in RegistryBase short-circuit accessor discovery for anonymous and local class entities before `Class.forName` is called.

**Key files created:**
- `lirp-core/src/test/kotlin/.../InnerClassRegistryTest.kt` — 17 tests (anonymous, local, 1/2/3-level nested inner classes)

**Key files modified:**
- `lirp-core/src/main/kotlin/.../RegistryBase.kt` — guards in `discoverRefs()`, `discoverIndexes()`, `refAccessorFor()`
- `README.md` — Inner Class Support section

## Requirements Addressed

| REQ-ID | Description |
|--------|-------------|
| KSP-01 | `ReactiveEntityRefProcessor` generates `_LirpRefAccessor` with `$`-separated names |
| KSP-02 | `LirpRepositoryProcessor` generates `_LirpRegistryInfo` with `$`-separated names |
| KSP-03 | Shared `jvmBinaryName()` utility walks `parentDeclaration` chain |
| KSP-04 | Multi-level inner class nesting (e.g. `A$B$C_LirpRefAccessor`) |
| KSP-05 | `RegistryBase.discoverRefs()` and `discoverIndexes()` skip anonymous/local classes |

## Verification

- [x] Automated verification: 8/8 must-haves passed
- [x] Full test suite: `gradle check` exits 0
- [x] No regressions across all modules
- [x] ktlint clean

## Key Decisions

- Use `kotlinNestedName()` (dot-separated) for type references in generated code body, not `jvmBinaryName()`
- Backtick-escape only the class declaration NAME; type params use Kotlin dot-notation
- Guards placed inside `synchronized` blocks, after null checks, before `Class.forName`
- `refAccessorFor()` guard placed before `computeIfAbsent` to avoid caching null for ephemeral anonymous classes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for entities and repositories declared as Kotlin inner/nested classes.

* **Documentation**
  * Added "Inner Class Support" section to README documenting inner class entity handling and JVM binary naming conventions.

* **Bug Fixes**
  * Fixed generated class naming for inner and nested entities to use correct JVM binary format.
  * Improved handling of anonymous and local class entities to prevent errors during class discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->