### PR TITLE
#71 Delegation-Based @LirpRepository

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,33 @@ repo.subscribe(CrudEvent.Type.CREATE) { event ->
 }
 ```
 
+## Delegation-Based Repositories
+
+When you need to wrap an existing `VolatileRepository` (or other `RegistryBase` subclass) rather than extending it — for example, to add domain-specific behaviour while keeping the repository as a field — use Kotlin's `by` delegation combined with a manual `init` block:
+
+```kotlin
+class MyCustomRepo(
+    private val delegate: VolatileRepository<Int, MyEntity>
+) : Repository<Int, MyEntity> by delegate {
+
+    init {
+        RegistryBase.registerRepository(MyEntity::class.java, delegate)
+    }
+
+    fun create(id: Int, name: String): MyEntity =
+        MyEntity(id, name).also { add(it) }
+}
+```
+
+The `by delegate` clause routes all `Repository` method calls to the underlying `VolatileRepository`. The `init` block calls `RegistryBase.registerRepository()` to register the **delegate** — not the wrapper — into `LirpContext.default`. This means `LirpContext.default.registries()` returns the `VolatileRepository` instance, which is the actual `RegistryBase` subclass.
+
+**Key behaviours:**
+
+- The delegate is what gets registered: `context.registryFor(MyEntity::class.java)` returns the `VolatileRepository`, not the wrapper.
+- Calling `delegate.close()` deregisters the repository from the context.
+- Registering the same instance twice is idempotent (safe to call from multiple wrappers sharing a delegate).
+- Registering a different instance for the same entity class throws `IllegalStateException`, consistent with the `@LirpRepository` duplicate-detection rule.
+
 ## Inner Class Support
 
 Entities and repositories declared as inner classes are fully supported. KSP generates accessor and info classes using the JVM binary name (`$`-separated), which matches the runtime `Class.forName` lookup:

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
@@ -434,6 +434,34 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
         private val refAccessorCache: ConcurrentHashMap<Class<*>, Optional<LirpRefAccessor<Any>>> = ConcurrentHashMap()
 
         /**
+         * Registers a [RegistryBase] instance for the given entity class in the default [LirpContext].
+         *
+         * Intended for delegation-based repositories that do not extend [RegistryBase] directly
+         * but wrap one via Kotlin's `by` delegation. The caller passes the delegate [RegistryBase]
+         * instance, which becomes the registry discoverable via `LirpContext.default.registries()`.
+         *
+         * @param entityClass the entity class to register under
+         * @param registry the delegate [RegistryBase] to register (must be a [RegistryBase] instance)
+         * @throws IllegalArgumentException if [registry] is not a [RegistryBase] instance or was created
+         *   outside [LirpContext.default]
+         * @throws IllegalStateException if a different repository is already registered for [entityClass]
+         */
+        @JvmStatic
+        fun registerRepository(entityClass: Class<*>, registry: Repository<*, *>) {
+            require(registry is RegistryBase<*, *>) {
+                "Only RegistryBase instances can be registered via registerRepository(). Got: ${registry::class.qualifiedName}"
+            }
+            val context = LirpContext.default
+            require(registry.context === context) {
+                "registerRepository() only supports RegistryBase instances created in LirpContext.default."
+            }
+            val registered = context.register(entityClass, registry)
+            check(registered || context.registryFor(entityClass) === registry) {
+                "A repository for ${entityClass.simpleName} is already registered. Only one @LirpRepository per entity type is allowed."
+            }
+        }
+
+        /**
          * Computes the cascade key for an entity: `"${entityClass.name}:${entityId}"`.
          * This format allows cycle detection by class and ID without requiring a live registry lookup.
          */

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/SlowSubscriberTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/SlowSubscriberTest.kt
@@ -109,8 +109,9 @@ class SlowSubscriberTest : DescribeSpec({
             // Blocked: 60 * 50ms = 3000ms; non-blocking: << 1500ms (EVENT_COUNT * SLOW_DELAY_MS / 2)
             emissionMs shouldBeLessThan EVENT_COUNT * SLOW_DELAY_MS / 2
 
-            // Wait long enough for the slow subscriber to settle on the final event's delay
-            delay((SLOW_DELAY_MS * 4).milliseconds)
+            // Wait long enough for the slow subscriber to settle on the final event's delay.
+            // On slow CI runners coroutine scheduling adds significant overhead, so use a generous wait.
+            delay((SLOW_DELAY_MS * 10).milliseconds)
 
             // Fast subscriber receives far more events than the slow subscriber during burst emission
             // because its instant handler is never cancelled by the next event

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/DelegationRegistrationIntegrationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/DelegationRegistrationIntegrationTest.kt
@@ -1,0 +1,115 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.maps.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Integration tests for the delegation-based repository registration pattern.
+ *
+ * Verifies that a repository wrapper using Kotlin's `by` delegation registers its underlying
+ * [VolatileRepository] delegate into [LirpContext.default] via [RegistryBase.registerRepository]
+ * called from an `init` block. Tests cover registration on construction, delegate identity,
+ * routing of repository operations through the delegate, deregistration on close, independent
+ * multi-type registration, and duplicate rejection.
+ */
+@DisplayName("DelegationRegistrationIntegration")
+internal class DelegationRegistrationIntegrationTest : StringSpec({
+
+    afterEach {
+        LirpContext.resetDefault()
+    }
+
+    "constructing DelegatingCustomerRepo registers the delegate VolatileRepository in LirpContext.default" {
+        val delegate = VolatileRepository<Int, Customer>("DelegatingCustomers")
+        DelegatingCustomerRepo(delegate)
+
+        val registered = LirpContext.default.registryFor(Customer::class.java)
+
+        registered.shouldNotBeNull()
+        registered shouldBe delegate
+        registered.shouldBeInstanceOf<VolatileRepository<*, *>>()
+    }
+
+    "LirpContext.default.registries() contains exactly one entry keyed by Customer after DelegatingCustomerRepo construction" {
+        val delegate = VolatileRepository<Int, Customer>("DelegatingCustomers")
+        DelegatingCustomerRepo(delegate)
+
+        val registries = LirpContext.default.registries()
+
+        registries shouldHaveSize 1
+        registries shouldContainKey Customer::class.java
+        registries[Customer::class.java] shouldBe delegate
+    }
+
+    "DelegatingCustomerRepo routes add, contains, and size to the delegate" {
+        val delegate = VolatileRepository<Int, Customer>("DelegatingCustomers")
+        val wrapper = DelegatingCustomerRepo(delegate)
+
+        val customer = wrapper.create(1, "Alice")
+
+        wrapper.contains(1) shouldBe true
+        wrapper.size() shouldBe 1
+        delegate.contains(1) shouldBe true
+        delegate.size() shouldBe 1
+        delegate.findById(1).isPresent shouldBe true
+        delegate.findById(1).get() shouldBe customer
+    }
+
+    "closing the delegate deregisters it from LirpContext.default" {
+        val delegate = VolatileRepository<Int, Customer>("DelegatingCustomers")
+        DelegatingCustomerRepo(delegate)
+
+        LirpContext.default.registryFor(Customer::class.java).shouldNotBeNull()
+
+        delegate.close()
+
+        LirpContext.default.registryFor(Customer::class.java).shouldBeNull()
+    }
+
+    "two delegation wrappers for different entity types register independently" {
+        val customerDelegate = VolatileRepository<Int, Customer>("DelegatingCustomers")
+        val orderDelegate = VolatileRepository<Long, Order>("DelegatingOrders")
+        DelegatingCustomerRepo(customerDelegate)
+        DelegatingOrderRepo(orderDelegate)
+
+        val registries = LirpContext.default.registries()
+
+        registries shouldHaveSize 2
+        registries[Customer::class.java] shouldBe customerDelegate
+        registries[Order::class.java] shouldBe orderDelegate
+    }
+
+    "constructing a second DelegatingCustomerRepo for the same entity class throws ISE" {
+        val delegate1 = VolatileRepository<Int, Customer>("DelegatingCustomers1")
+        val delegate2 = VolatileRepository<Int, Customer>("DelegatingCustomers2")
+        DelegatingCustomerRepo(delegate1)
+
+        shouldThrow<IllegalStateException> {
+            DelegatingCustomerRepo(delegate2)
+        }.message shouldBe "A repository for Customer is already registered. Only one @LirpRepository per entity type is allowed."
+    }
+})

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/LirpTestFixtures.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/LirpTestFixtures.kt
@@ -439,3 +439,39 @@ class MutableRefOrderVolatileRepo internal constructor(
 
     fun create(id: Long, customerId: Int): MutableRefOrder = MutableRefOrder(id, customerId).also { add(it) }
 }
+
+/**
+ * Delegation-based repository wrapper for [Customer] entities.
+ *
+ * Demonstrates the manual registration pattern: the `init` block calls
+ * [RegistryBase.registerRepository] to register the delegate [VolatileRepository]
+ * into [LirpContext.default]. The wrapper itself is not a [RegistryBase] subclass.
+ */
+class DelegatingCustomerRepo(
+    private val delegate: VolatileRepository<Int, Customer>
+) : Repository<Int, Customer> by delegate {
+
+    init {
+        RegistryBase.registerRepository(Customer::class.java, delegate)
+    }
+
+    fun create(id: Int, name: String): Customer = Customer(id, name).also { add(it) }
+}
+
+/**
+ * Delegation-based repository wrapper for [Order] entities.
+ *
+ * Demonstrates the manual registration pattern for a second entity type. The `init` block calls
+ * [RegistryBase.registerRepository] to register the delegate [VolatileRepository]
+ * into [LirpContext.default].
+ */
+class DelegatingOrderRepo(
+    private val delegate: VolatileRepository<Long, Order>
+) : Repository<Long, Order> by delegate {
+
+    init {
+        RegistryBase.registerRepository(Order::class.java, delegate)
+    }
+
+    fun create(id: Long, customerId: Int): Order = Order(id, customerId).also { add(it) }
+}

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegisterRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegisterRepositoryTest.kt
@@ -1,0 +1,115 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.mockk
+
+/**
+ * Unit tests for [RegistryBase.registerRepository], the public API for delegation-based
+ * repository registration into [LirpContext.default].
+ *
+ * Verifies registration succeeds, idempotent same-instance calls are allowed, different-instance
+ * duplicates throw [IllegalStateException], non-RegistryBase instances throw [IllegalArgumentException],
+ * close() deregisters, and re-registration after close succeeds.
+ */
+@DisplayName("RegistryBase.registerRepository()")
+internal class RegisterRepositoryTest : StringSpec({
+
+    afterEach {
+        LirpContext.resetDefault()
+    }
+
+    "registers delegate RegistryBase in LirpContext.default keyed by entity class" {
+        val delegate = VolatileRepository<Int, Customer>("Customers")
+
+        RegistryBase.registerRepository(Customer::class.java, delegate)
+
+        LirpContext.default.registryFor(Customer::class.java) shouldBe delegate
+    }
+
+    "registerRepository() called twice with the same instance is idempotent" {
+        val delegate = VolatileRepository<Int, Customer>("Customers")
+
+        RegistryBase.registerRepository(Customer::class.java, delegate)
+        RegistryBase.registerRepository(Customer::class.java, delegate)
+
+        LirpContext.default.registryFor(Customer::class.java) shouldBe delegate
+    }
+
+    "registerRepository() with a different instance for same entity class throws ISE" {
+        val delegate1 = VolatileRepository<Int, Customer>("Customers1")
+        val delegate2 = VolatileRepository<Int, Customer>("Customers2")
+
+        RegistryBase.registerRepository(Customer::class.java, delegate1)
+
+        shouldThrow<IllegalStateException> {
+            RegistryBase.registerRepository(Customer::class.java, delegate2)
+        }.message shouldBe "A repository for Customer is already registered. Only one @LirpRepository per entity type is allowed."
+    }
+
+    "registerRepository() with a non-RegistryBase Registry instance throws IAE" {
+        val nonRegistryBase = mockk<Repository<Int, Customer>>()
+
+        shouldThrow<IllegalArgumentException> {
+            RegistryBase.registerRepository(Customer::class.java, nonRegistryBase)
+        }.message shouldContain "Only RegistryBase instances can be registered"
+    }
+
+    "close() on delegate deregisters from LirpContext.default" {
+        val delegate = VolatileRepository<Int, Customer>("Customers")
+
+        RegistryBase.registerRepository(Customer::class.java, delegate)
+        LirpContext.default.registryFor(Customer::class.java) shouldBe delegate
+
+        delegate.close()
+
+        LirpContext.default.registryFor(Customer::class.java) shouldBe null
+    }
+
+    "registerRepository() with a delegate from a non-default context throws IAE" {
+        val customContext = LirpContext()
+        val delegate = VolatileRepository<Int, Customer>(customContext, "Customers")
+
+        try {
+            shouldThrow<IllegalArgumentException> {
+                RegistryBase.registerRepository(Customer::class.java, delegate)
+            }.message shouldContain "registerRepository() only supports RegistryBase instances created in LirpContext.default"
+        } finally {
+            delegate.close()
+        }
+    }
+
+    "registerRepository() succeeds after close() and re-registration" {
+        val delegate1 = VolatileRepository<Int, Customer>("Customers")
+
+        RegistryBase.registerRepository(Customer::class.java, delegate1)
+        delegate1.close()
+
+        LirpContext.default.registryFor(Customer::class.java) shouldBe null
+
+        val delegate2 = VolatileRepository<Int, Customer>("Customers2")
+        RegistryBase.registerRepository(Customer::class.java, delegate2)
+
+        LirpContext.default.registryFor(Customer::class.java) shouldBe delegate2
+    }
+})

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessor.kt
@@ -28,6 +28,8 @@ import com.google.devtools.ksp.validate
 
 private const val LIRP_REPOSITORY_ANNOTATION_FQN = "net.transgressoft.lirp.persistence.LirpRepository"
 
+private const val REPOSITORY_INTERFACE_FQN = "net.transgressoft.lirp.persistence.Repository"
+
 private val REPOSITORY_BASE_FQN_SET =
     setOf(
         "net.transgressoft.lirp.persistence.VolatileRepository",
@@ -61,6 +63,10 @@ class LirpRepositoryProcessor(
             }
             val entityClassFqn = findEntityClassFqn(symbol)
             if (entityClassFqn == null) {
+                if (isDelegationClass(symbol)) {
+                    logger.info("Delegation-based @LirpRepository detected on ${symbol.qualifiedName?.asString()} — use registerRepository() in init block")
+                    continue
+                }
                 logger.warn("Cannot determine entity class for @LirpRepository on ${symbol.qualifiedName?.asString()} — skipping")
                 continue
             }
@@ -91,6 +97,40 @@ class LirpRepositoryProcessor(
             if (found != null) return found
         }
         return null
+    }
+
+    /**
+     * Returns `true` if [classDecl] is a delegation-based repository: it directly implements
+     * [Repository][net.transgressoft.lirp.persistence.Repository] (not by extending a known base class)
+     * and has exactly one Repository-typed constructor parameter.
+     *
+     * If the class implements [Repository] but has zero or more than one Repository-typed constructor
+     * parameters, a warning is logged and `false` is returned so the caller proceeds to the generic
+     * warn+skip path.
+     */
+    private fun isDelegationClass(classDecl: KSClassDeclaration): Boolean {
+        val implementsRepository =
+            classDecl.superTypes.any { superTypeRef ->
+                val superDecl = superTypeRef.resolve().declaration as? KSClassDeclaration
+                superDecl?.qualifiedName?.asString() == REPOSITORY_INTERFACE_FQN
+            }
+        if (!implementsRepository) return false
+
+        // require exactly one Repository-typed constructor parameter
+        val repoParamCount =
+            classDecl.primaryConstructor?.parameters?.count { param ->
+                val paramTypeFqn = param.type.resolve().declaration.qualifiedName?.asString()
+                paramTypeFqn == REPOSITORY_INTERFACE_FQN || paramTypeFqn in REPOSITORY_BASE_FQN_SET
+            } ?: 0
+
+        if (repoParamCount != 1) {
+            logger.warn(
+                "@LirpRepository delegation class ${classDecl.qualifiedName?.asString()} " +
+                    "must have exactly one Repository-typed constructor parameter (found $repoParamCount) — skipping"
+            )
+            return false
+        }
+        return true
     }
 
     private fun generateRegistryInfo(classDecl: KSClassDeclaration, entityClassFqn: String) {

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessorTest.kt
@@ -182,4 +182,121 @@ internal class LirpRepositoryProcessorTest : FunSpec({
         content shouldContain "`Domain\$InnerRepo_LirpRegistryInfo`"
         content shouldContain "InnerEntity::class.java"
     }
+
+    test("delegation-based @LirpRepository compiles successfully and generates no _LirpRegistryInfo") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "DelegatingRepo.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.LirpRepository
+                    import net.transgressoft.lirp.persistence.Repository
+                    import net.transgressoft.lirp.persistence.VolatileRepository
+
+                    data class SomeEntity(override val id: Int) : ReactiveEntityBase<Int, SomeEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+
+                    @LirpRepository
+                    class DelegatingRepo(private val delegate: VolatileRepository<Int, SomeEntity>) :
+                        Repository<Int, SomeEntity> by delegate
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.sourcesGeneratedBySymbolProcessor
+            .filter { it.name.contains("DelegatingRepo") }
+            .toList() shouldBe emptyList()
+    }
+
+    test("delegation class with zero Repository-typed constructor params warns and generates no _LirpRegistryInfo") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "ZeroParamDelegation.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.LirpRepository
+                    import net.transgressoft.lirp.persistence.Repository
+                    import net.transgressoft.lirp.persistence.VolatileRepository
+
+                    data class SomeEntity(override val id: Int) : ReactiveEntityBase<Int, SomeEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+
+                    private val sharedDelegate = VolatileRepository<Int, SomeEntity>("shared")
+
+                    @LirpRepository
+                    class ZeroParamDelegation : Repository<Int, SomeEntity> by sharedDelegate
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.sourcesGeneratedBySymbolProcessor
+            .filter { it.name.contains("ZeroParamDelegation") }
+            .toList() shouldBe emptyList()
+        result.messages shouldContain "must have exactly one Repository-typed constructor parameter"
+    }
+
+    test("delegation class with multiple Repository-typed constructor params warns and generates no _LirpRegistryInfo") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "MultiParamDelegation.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.LirpRepository
+                    import net.transgressoft.lirp.persistence.Repository
+                    import net.transgressoft.lirp.persistence.VolatileRepository
+
+                    data class SomeEntity(override val id: Int) : ReactiveEntityBase<Int, SomeEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+
+                    @LirpRepository
+                    class MultiParamDelegation(
+                        private val delegate1: VolatileRepository<Int, SomeEntity>,
+                        private val delegate2: VolatileRepository<Int, SomeEntity>
+                    ) : Repository<Int, SomeEntity> by delegate1
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.sourcesGeneratedBySymbolProcessor
+            .filter { it.name.contains("MultiParamDelegation") }
+            .toList() shouldBe emptyList()
+        result.messages shouldContain "must have exactly one Repository-typed constructor parameter"
+    }
+
+    test("class annotated with @LirpRepository that neither extends base nor delegates gets warn-and-skip") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "NotARepo.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.persistence.LirpRepository
+
+                    @LirpRepository
+                    class NotARepo
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.sourcesGeneratedBySymbolProcessor
+            .filter { it.name.contains("NotARepo") }
+            .toList() shouldBe emptyList()
+        result.messages shouldContain "Cannot determine entity class"
+    }
 })


### PR DESCRIPTION
## Summary

**Phase 17: Delegation-Based @LirpRepository**
**Goal:** A class that delegates `Repository<K, E>` to a constructor-injected repository can self-register its delegate in `LirpContext` via a manual init block calling `registerRepository()`, making its entities discoverable via `context.registries()`
**Status:** Verified ✓ (4/4 must-haves passed)

Adds public `RegistryBase.registerRepository()` API for delegation-based repositories to register with `LirpContext.default`, updates the KSP processor to detect delegation patterns (logging info, skipping codegen per D-11), and proves the end-to-end pattern with integration tests and documentation.

## Changes

### Plan 17-01: registerRepository() API + KSP Delegation Detection
- `RegistryBase.registerRepository(entityClass, registry)` — public `@JvmStatic` companion function with `require(is RegistryBase)` validation, idempotent same-instance semantics, ISE for different-instance
- `LirpRepositoryProcessor.isDelegationClass()` — detects `Repository` supertype + validates exactly one constructor param (D-04), logs info message, skips codegen (D-11)

**Key files:**
- `lirp-core/.../persistence/RegistryBase.kt` (modified)
- `lirp-core/.../persistence/RegisterRepositoryTest.kt` (created — 6 unit tests)
- `lirp-ksp/.../ksp/LirpRepositoryProcessor.kt` (modified)
- `lirp-ksp/.../ksp/LirpRepositoryProcessorTest.kt` (modified — 4 new KSP tests)

### Plan 17-02: Integration Tests + Documentation
- `DelegatingCustomerRepo` and `DelegatingOrderRepo` test fixtures with `Repository<K,E> by delegate` + manual `init { registerRepository() }` pattern
- 6 integration tests proving end-to-end registration, delegate identity, close/deregister, multi-type
- README "Delegation-Based Repositories" section with code example
- Wiki `Persistence.md` delegation section with behaviour table

**Key files:**
- `lirp-core/.../persistence/DelegationRegistrationIntegrationTest.kt` (created — 6 integration tests)
- `lirp-core/.../persistence/LirpTestFixtures.kt` (modified)
- `README.md` (modified)

## Requirements Addressed

| ID | Description |
|----|-------------|
| DELG-01 | KSP detects `Repository<K,E>` interface in supertypes for delegation classes |
| DELG-02 | Public `registerRepository()` API in `RegistryBase` companion for delegation registration |
| DELG-03 | Manual `init` block calling `registerRepository()` auto-registers delegate at construction |
| DELG-04 | `registerRepository()` receives delegate directly; `context.registries()` returns delegate, not wrapper |

## Verification

- [x] Automated verification: **passed** (4/4 must-haves)
- [x] `gradle clean build` passes (BUILD SUCCESSFUL)
- [x] 16 new tests (6 unit + 4 KSP compilation + 6 integration)
- [x] ktlint passes
- [x] No backward-compatibility regressions

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| D-07: Always `LirpContext.default` | No custom context parameter; test isolation via `resetDefault()` |
| D-11: KSP generates nothing for delegation | User writes manual init block; KSP logs info message only |
| D-04: Exactly one Repository constructor param | Warn+skip for zero or multiple params, matching existing warn behavior |
| D-08: `require(is RegistryBase)` | Only `RegistryBase` instances can register via this API |

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API to register delegation-based repositories into the default context with idempotent re-registration, duplicate-registration protection, and deregistration on close.

* **Documentation**
  * Added a guide on delegation-based repositories covering registration, lifecycle, lookup behavior, and duplicate rules.

* **Tests**
  * Added integration and compiler-processor tests for delegation registration, lifecycle, duplicate rejection, and emitted diagnostics/warnings.

* **Bug Fixes**
  * Increased test wait in a slow-subscriber test to reduce CI flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->