### PR TITLE
#74 Add explicit deregistration API for manually registered repositories

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/LirpContext.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/LirpContext.kt
@@ -66,6 +66,14 @@ internal class LirpContext : AutoCloseable {
     }
 
     /**
+     * Removes the registry registered under [entityClass] from this context.
+     * Returns silently if no registry is registered for [entityClass].
+     */
+    internal fun deregisterByClass(entityClass: Class<*>) {
+        registriesMap.remove(entityClass)
+    }
+
+    /**
      * Returns the [Registry] registered for [entityClass], or `null` if none is registered.
      */
     internal fun registryFor(entityClass: Class<*>): Registry<*, *>? = registriesMap[entityClass]

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
@@ -462,6 +462,23 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
         }
 
         /**
+         * Deregisters the repository for the given entity class from the default [LirpContext].
+         *
+         * Intended for delegation-based repositories that need to cleanly remove their
+         * registration on shutdown or close. Only removes the mapping -- does not close
+         * the repository or its publisher. Callers manage [close] separately.
+         *
+         * Calling this method for an entity class that has no registered repository
+         * completes without error (idempotent no-op).
+         *
+         * @param entityClass the entity class to deregister
+         */
+        @JvmStatic
+        fun deregisterRepository(entityClass: Class<*>) {
+            LirpContext.default.deregisterByClass(entityClass)
+        }
+
+        /**
          * Computes the cascade key for an entity: `"${entityClass.name}:${entityId}"`.
          * This format allows cycle detection by class and ID without requiring a live registry lookup.
          */

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/DelegationRegistrationIntegrationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/DelegationRegistrationIntegrationTest.kt
@@ -17,6 +17,7 @@
 
 package net.transgressoft.lirp.persistence
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -79,15 +80,17 @@ internal class DelegationRegistrationIntegrationTest : StringSpec({
         delegate.findById(1).get() shouldBe customer
     }
 
-    "closing the delegate deregisters it from LirpContext.default" {
+    "closing the wrapper deregisters from LirpContext.default and closes the delegate" {
         val delegate = VolatileRepository<Int, Customer>("DelegatingCustomers")
-        DelegatingCustomerRepo(delegate)
+        val wrapper = DelegatingCustomerRepo(delegate)
+        wrapper.create(1, "Alice")
 
         LirpContext.default.registryFor(Customer::class.java).shouldNotBeNull()
 
-        delegate.close()
+        wrapper.close()
 
         LirpContext.default.registryFor(Customer::class.java).shouldBeNull()
+        delegate.isClosed shouldBe true
     }
 
     "two delegation wrappers for different entity types register independently" {
@@ -111,5 +114,29 @@ internal class DelegationRegistrationIntegrationTest : StringSpec({
         shouldThrow<IllegalStateException> {
             DelegatingCustomerRepo(delegate2)
         }.message shouldBe "A repository for Customer is already registered. Only one @LirpRepository per entity type is allowed."
+    }
+
+    "DelegatingCustomerRepo.close() is safe to call when already deregistered" {
+        val delegate = VolatileRepository<Int, Customer>("DelegatingCustomers")
+        val wrapper = DelegatingCustomerRepo(delegate)
+
+        RegistryBase.deregisterRepository(Customer::class.java)
+
+        shouldNotThrowAny {
+            wrapper.close()
+        }
+        delegate.isClosed shouldBe true
+    }
+
+    "DelegatingOrderRepo.close() deregisters Order independently of Customer" {
+        val customerDelegate = VolatileRepository<Int, Customer>("DelegatingCustomers")
+        val orderDelegate = VolatileRepository<Long, Order>("DelegatingOrders")
+        DelegatingCustomerRepo(customerDelegate)
+        val orderWrapper = DelegatingOrderRepo(orderDelegate)
+
+        orderWrapper.close()
+
+        LirpContext.default.registryFor(Order::class.java).shouldBeNull()
+        LirpContext.default.registryFor(Customer::class.java).shouldNotBeNull()
     }
 })

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/DeregisterRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/DeregisterRepositoryTest.kt
@@ -1,0 +1,106 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Unit tests for [RegistryBase.deregisterRepository], the public API for removing
+ * manually registered repositories from [LirpContext.default].
+ *
+ * Verifies removal, idempotent no-op for unregistered classes, re-registration after
+ * deregister, non-closing semantics, and concurrent register/deregister safety.
+ */
+@DisplayName("RegistryBase.deregisterRepository()")
+internal class DeregisterRepositoryTest : StringSpec({
+
+    afterEach {
+        LirpContext.resetDefault()
+    }
+
+    "deregisterRepository() removes a registered delegate from LirpContext.default" {
+        val delegate = VolatileRepository<Int, Customer>("Customers")
+        RegistryBase.registerRepository(Customer::class.java, delegate)
+
+        LirpContext.default.registryFor(Customer::class.java).shouldNotBeNull()
+
+        RegistryBase.deregisterRepository(Customer::class.java)
+
+        LirpContext.default.registryFor(Customer::class.java).shouldBeNull()
+    }
+
+    "deregisterRepository() for an unregistered entity class completes without exception" {
+        shouldNotThrowAny {
+            RegistryBase.deregisterRepository(Customer::class.java)
+        }
+    }
+
+    "deregisterRepository() then registerRepository() with a new delegate succeeds" {
+        val delegate1 = VolatileRepository<Int, Customer>("Customers1")
+        RegistryBase.registerRepository(Customer::class.java, delegate1)
+
+        RegistryBase.deregisterRepository(Customer::class.java)
+
+        val delegate2 = VolatileRepository<Int, Customer>("Customers2")
+        RegistryBase.registerRepository(Customer::class.java, delegate2)
+
+        LirpContext.default.registryFor(Customer::class.java) shouldBe delegate2
+    }
+
+    "deregisterRepository() does not close the repository or its publisher" {
+        val delegate = VolatileRepository<Int, Customer>("Customers")
+        RegistryBase.registerRepository(Customer::class.java, delegate)
+
+        RegistryBase.deregisterRepository(Customer::class.java)
+
+        val customer = Customer(1, "Alice")
+        delegate.add(customer)
+        delegate.contains(1) shouldBe true
+        delegate.size() shouldBe 1
+    }
+
+    "concurrent register and deregister from multiple coroutines does not corrupt registriesMap" {
+        val iterations = 100
+        val delegates = mutableListOf<VolatileRepository<Int, Customer>>()
+        withContext(Dispatchers.Default) {
+            (1..iterations).map { i ->
+                launch {
+                    val delegate = VolatileRepository<Int, Customer>("Customers-$i")
+                    synchronized(delegates) { delegates.add(delegate) }
+                    try {
+                        RegistryBase.registerRepository(Customer::class.java, delegate)
+                    } catch (_: IllegalStateException) {
+                        // Expected when another coroutine already registered a different instance
+                    }
+                    RegistryBase.deregisterRepository(Customer::class.java)
+                }
+            }.forEach { it.join() }
+        }
+
+        LirpContext.default.registryFor(Customer::class.java).shouldBeNull()
+        delegates.forEach { it.close() }
+    }
+})

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/LirpTestFixtures.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/LirpTestFixtures.kt
@@ -445,17 +445,23 @@ class MutableRefOrderVolatileRepo internal constructor(
  *
  * Demonstrates the manual registration pattern: the `init` block calls
  * [RegistryBase.registerRepository] to register the delegate [VolatileRepository]
- * into [LirpContext.default]. The wrapper itself is not a [RegistryBase] subclass.
+ * into [LirpContext.default]. Calling [close] deregisters from the context first,
+ * then closes the delegate.
  */
 class DelegatingCustomerRepo(
     private val delegate: VolatileRepository<Int, Customer>
-) : Repository<Int, Customer> by delegate {
+) : Repository<Int, Customer> by delegate, AutoCloseable {
 
     init {
         RegistryBase.registerRepository(Customer::class.java, delegate)
     }
 
     fun create(id: Int, name: String): Customer = Customer(id, name).also { add(it) }
+
+    override fun close() {
+        RegistryBase.deregisterRepository(Customer::class.java)
+        delegate.close()
+    }
 }
 
 /**
@@ -463,15 +469,21 @@ class DelegatingCustomerRepo(
  *
  * Demonstrates the manual registration pattern for a second entity type. The `init` block calls
  * [RegistryBase.registerRepository] to register the delegate [VolatileRepository]
- * into [LirpContext.default].
+ * into [LirpContext.default]. Calling [close] deregisters from the context first,
+ * then closes the delegate.
  */
 class DelegatingOrderRepo(
     private val delegate: VolatileRepository<Long, Order>
-) : Repository<Long, Order> by delegate {
+) : Repository<Long, Order> by delegate, AutoCloseable {
 
     init {
         RegistryBase.registerRepository(Order::class.java, delegate)
     }
 
     fun create(id: Long, customerId: Int): Order = Order(id, customerId).also { add(it) }
+
+    override fun close() {
+        RegistryBase.deregisterRepository(Order::class.java)
+        delegate.close()
+    }
 }


### PR DESCRIPTION
## Summary

**Phase 18: Repository Deregistration**
**Goal:** Library consumers can cleanly remove manually registered repositories from LirpContext, both explicitly and automatically on close
**Status:** Verified ✓

Adds `RegistryBase.deregisterRepository(entityClass)` as the public companion method symmetrical to `registerRepository()`, backed by `LirpContext.deregisterByClass(entityClass)` using atomic `ConcurrentHashMap.remove()`. Delegation-based wrappers (`DelegatingCustomerRepo`, `DelegatingOrderRepo`) now implement `AutoCloseable` and call `deregisterRepository()` in `close()` before closing the delegate.

Closes #74

## Changes

### Plan 18-01: Repository Deregistration API

**Key files created:**
- `lirp-core/src/test/kotlin/.../DeregisterRepositoryTest.kt` — 5 unit tests

**Key files modified:**
- `lirp-core/src/main/kotlin/.../LirpContext.kt` — Added `deregisterByClass(entityClass)` internal method
- `lirp-core/src/main/kotlin/.../RegistryBase.kt` — Added `deregisterRepository(entityClass)` `@JvmStatic` companion method
- `lirp-core/src/test/kotlin/.../LirpTestFixtures.kt` — `DelegatingCustomerRepo`/`DelegatingOrderRepo` implement `AutoCloseable`
- `lirp-core/src/test/kotlin/.../DelegationRegistrationIntegrationTest.kt` — 3 new + 1 updated integration tests

## Requirements Addressed

- **LIFECYCLE-01**: Explicit `deregisterRepository(entityClass)` method for manual cleanup
- **LIFECYCLE-02**: Delegation wrappers auto-deregister on `close()`
- **LIFECYCLE-03**: Idempotent (no-op for unregistered classes) and thread-safe (ConcurrentHashMap.remove)

## Verification

- [x] Automated verification: 4/4 must-haves passed
- [x] 8 new tests (5 unit + 3 integration) — all passing
- [x] Full regression suite: lirp-api, lirp-core, lirp-ksp — no regressions

## Key Decisions

- `deregisterRepository()` only removes mapping from `LirpContext.default` — does NOT close repository or publisher (D-01)
- Idempotent no-op for unregistered entity classes (D-02)
- Delegation wrappers explicitly call `deregisterRepository()` then `delegate.close()` in `close()` (D-03)
- Companion method only — mirrors `registerRepository()` shape with `@JvmStatic` (D-05)
- Thread safety via single atomic `ConcurrentHashMap.remove()` — no additional synchronization (D-07)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API to deregister repository mappings by entity class on the default context; idempotent and does not close or alter repository instances.
  * Delegating repository wrappers now implement orderly teardown and deregister themselves when closed, ensuring clean context state.

* **Tests**
  * Added unit and integration tests for deregistration behavior, safe wrapper close semantics, preserved repository usability after deregistration, and concurrent register/deregister robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->