### PR TITLE
#87 lirp-fx FxProperty Scalar Delegates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ ctx.close()                            // closes all repositories and connection
 
 No manual saves. No ORM session flushing. Property assignment _is_ persistence.
 
-Annotations are optional — convention-over-configuration infers table and column names from the class. Use `@PersistenceMapping` and `@PersistenceProperty` when you need to customize names, lengths, or precision. See the [wiki](https://github.com/octaviospain/lirp/wiki/SQL-Persistence) for full annotation reference.
+`@PersistenceMapping` on the entity class triggers KSP table definition generation for SQL persistence. Convention-over-configuration infers table and column names from the class — use `@PersistenceProperty` on individual properties when you need to customize names, lengths, or precision. See the [wiki](https://github.com/octaviospain/lirp/wiki/SQL-Persistence) for full annotation reference. These annotations are not needed for `VolatileRepository` or `JsonFileRepository`.
 
 ### Supported Persistence Targets
 
@@ -129,7 +129,9 @@ val bySku: Optional<Product> = repo.findFirstByIndex("sku", "SKU-001")
 
 ## Aggregate References
 
-Model DDD aggregate root relationships with the `@Aggregate` annotation and the `aggregate()`, `aggregateList()`, or `aggregateSet()` property delegates. A reference holds only the referenced entity's ID and resolves it lazily from the registered repository:
+Model DDD aggregate root relationships with the `@Aggregate` annotation and the `aggregate()`, `aggregateList()`, or `aggregateSet()` property delegates. The `@Aggregate` annotation is **required** on every aggregate reference property — the KSP processor uses it to generate the `_LirpRefAccessor` that `RegistryBase` needs at runtime for reference binding and cascade resolution. Without it, `RegistryBase` throws `IllegalStateException` when the entity is added to a repository.
+
+A reference holds only the referenced entity's ID and resolves it lazily from the registered repository:
 
 ```kotlin
 data class Product(override val id: Int, var name: String, val categoryId: Int) :
@@ -568,6 +570,57 @@ dependencies {
     implementation("org.openjfx:javafx-base:21")
 }
 ```
+
+### Scalar Property Delegates
+
+`lirp-fx` provides scalar property delegates that bridge lirp's reactive properties with JavaFX property types:
+
+```kotlin
+class MyEntity(override val id: Int, name: String, age: Int) :
+    ReactiveEntityBase<Int, MyEntity>(), IdentifiableEntity<Int> {
+
+    override val uniqueId: String get() = "my-entity-$id"
+
+    val nameProperty: StringProperty by fxString(name)
+    val ageProperty: IntegerProperty by fxInteger(age)
+    val activeProperty: BooleanProperty by fxBoolean(false)
+    val scoreProperty: DoubleProperty by fxDouble(0.0)
+    val tagProperty: ObjectProperty<String?> by fxObject<String?>(null)
+
+    override fun clone(): MyEntity = MyEntity(id, nameProperty.get(), ageProperty.get())
+}
+```
+
+When the entity is in a repository, setting a scalar property fires both a lirp `MutationEvent` and JavaFX `ChangeListener` notifications:
+
+```kotlin
+entity.nameProperty.set("Updated")  // Emits MutationEvent + fires ChangeListeners
+entity.nameProperty.addListener { _, old, new -> println("$old -> $new") }
+```
+
+Available factories: `fxString()`, `fxInteger()`, `fxDouble()`, `fxFloat()`, `fxLong()`, `fxBoolean()`, `fxObject<T>()`.
+
+**Java API:** Use `FxProperties` for static factory access:
+
+```java
+LirpStringProperty name = FxProperties.fxString("default", true);
+LirpIntegerProperty age = FxProperties.fxInteger(0, true);
+FxAggregateListProxy<Integer, Track> tracks = FxProperties.fxAggregateList(List.of(), true);
+```
+
+## Annotations Reference
+
+| Annotation | Target | Required when | Not needed for |
+|-----------|--------|--------------|----------------|
+| `@Aggregate` | aggregate reference properties | any `aggregate()`, `aggregateList()`, `aggregateSet()`, `mutableAggregateList()`, `mutableAggregateSet()`, `fxAggregateList()`, `fxAggregateSet()` delegate | `reactiveProperty()`, `fxString()`, `fxInteger()`, and other scalar property delegates |
+| `@PersistenceMapping` | entity class | SQL persistence via `SqlRepository` | `VolatileRepository`, `JsonFileRepository`, `lirp-fx` delegates |
+| `@PersistenceProperty` | entity property | customizing SQL column name, length, precision, or type | uses convention defaults when absent; not needed outside `SqlRepository` |
+| `@Indexed` | entity property | O(1) equality lookups via `findByIndex` | when only key-based lookups or full-scan predicates are needed |
+| `@LirpRepository` | repository class | auto-discovery via KSP-generated `LirpContext` registration | manual repository registration via `RegistryBase.registerRepository()` |
+
+**`@Aggregate`** triggers KSP generation of `_LirpRefAccessor`, which `RegistryBase` requires at runtime for reference binding and cascade resolution. Without it on an aggregate delegate property, `RegistryBase` throws `IllegalStateException`.
+
+**`@PersistenceMapping`** triggers KSP generation of `_LirpTableDef` for SQL schema creation. Convention-over-configuration infers table name from the class name; use `@PersistenceProperty` on individual properties to customize column details.
 
 ## Key Features
 

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -271,6 +271,35 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
         publisher.emitAsync(aggregateEvent)
     }
 
+    /**
+     * Emits a [ReactiveMutationEvent] triggered by a JavaFX scalar property delegate mutation.
+     *
+     * Called by fx scalar property delegates via a callback injected by RegistryBase. The supplied
+     * [mutationBlock] contains the `super.set(newValue)` call on the underlying Simple*Property.
+     * This method wraps it in a clone-before-mutation sequence: it captures the entity state before
+     * [mutationBlock] executes, then emits a [ReactiveMutationEvent] after if subscribers are present.
+     *
+     * Respects the [eventsDisabled] flag — when events are suppressed (e.g., during [clone]),
+     * the mutation still executes but no event is published.
+     *
+     * @param mutationBlock the lambda that performs the actual property mutation (super.set call)
+     */
+    @Suppress("UNCHECKED_CAST")
+    internal fun emitFxScalarMutation(mutationBlock: () -> Unit) {
+        check(!isClosed) { "Entity '${this::class.java.simpleName}' is closed" }
+        if (eventsDisabled) {
+            mutationBlock()
+            return
+        }
+        val entityBeforeChange = clone()
+        mutationBlock()
+        lastDateModified = LocalDateTime.now()
+        if (shouldEmit) {
+            log.trace { "Firing fx scalar mutation event from $entityBeforeChange to $this" }
+            publisher.emitAsync(ReactiveMutationEvent(this as R, entityBeforeChange as R))
+        }
+    }
+
     override fun subscribe(action: suspend (MutationEvent<K, R>) -> Unit): LirpEventSubscription<in LirpEntity, MutationEvent.Type, MutationEvent<K, R>> {
         check(!isClosed) { "Entity '${this::class.java.simpleName}' is closed" }
         return publisher.subscribe(action)
@@ -386,8 +415,8 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
         val result = mutationAction()
         if (entityBeforeChange == this) {
             log.warn {
-                "Attempt to publish update event from a mutation when object comparison was false. " +
-                    "Consider implementing equals() and hashcode() that implies a mutation in instance variables affected by the mutationAction"
+                "Attempt to publish update event from a mutation when the entity state did not change. " +
+                    "Consider implementing equals() and hashCode() that reflects all mutable properties affected by the mutationAction."
             }
         } else {
             lastDateModified = LocalDateTime.now()
@@ -429,9 +458,27 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
                 @Suppress("UNCHECKED_CAST")
                 for (prop in this::class.memberProperties) {
                     val typedProp = prop as? KProperty1<ReactiveEntityBase<*, *>, *> ?: continue
-                    // isAccessible is required for private entity classes (e.g. in test files)
-                    typedProp.isAccessible = true
-                    val delegate = typedProp.getDelegate(this)
+                    // isAccessible is required for private entity classes (e.g. in test files).
+                    // Some properties (e.g. @Transient-backed properties in data classes) may throw
+                    // KotlinReflectionInternalError (an Error, not Exception) — skip them safely
+                    // since they cannot be delegate-backed.
+                    try {
+                        typedProp.isAccessible = true
+                    } catch (e: Error) {
+                        if (e is VirtualMachineError || e is LinkageError) throw e
+                        continue
+                    } catch (_: Exception) {
+                        continue
+                    }
+                    val delegate =
+                        try {
+                            typedProp.getDelegate(this)
+                        } catch (e: Error) {
+                            if (e is VirtualMachineError || e is LinkageError) throw e
+                            continue
+                        } catch (_: Exception) {
+                            continue
+                        }
                     if (delegate is LirpDelegate) {
                         map[prop.name] = delegate
                     } else if (delegate is FxObservableCollectionProxy) {

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/FxObservableCollectionProxy.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/FxObservableCollectionProxy.kt
@@ -36,4 +36,14 @@ interface FxObservableCollectionProxy {
      * Typed as [Any] to avoid importing concrete fx proxy types in lirp-core.
      */
     val innerMutableProxy: Any
+
+    /**
+     * Synchronizes the local element cache with the resolved entities from the bound registry.
+     *
+     * Called by [RegistryBase.bindEntityRefs] after the inner delegate's registry is bound,
+     * ensuring the fx proxy's local cache reflects the current backing IDs. Without this,
+     * proxies constructed from IDs only (e.g. from SQL deserialization) would have an empty
+     * local cache, causing operations like [remove] and [get] to malfunction.
+     */
+    fun syncLocalCache()
 }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/FxScalarPropertyDelegate.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/FxScalarPropertyDelegate.kt
@@ -1,0 +1,44 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+/**
+ * Marker interface for JavaFX scalar property delegates that participate in lirp's reactive mutation
+ * event system. Implemented by `Lirp*Property` classes in the `lirp-fx` module.
+ *
+ * [RegistryBase] uses this interface to detect fx scalar property delegates in
+ * [RegistryBase.bindEntityRefs] without creating a circular module dependency between
+ * `lirp-core` and `lirp-fx`. When discovered, RegistryBase injects a mutation callback
+ * that wraps each `super.set()` call in a clone-before-mutation sequence, emitting a
+ * [net.transgressoft.lirp.event.ReactiveMutationEvent] on the owning entity's publisher.
+ *
+ * The injected [callback] parameter accepts a mutation block supplied by the delegate —
+ * typically a lambda that calls `super.set(newValue)` on the underlying Simple*Property.
+ * RegistryBase wraps this block in [net.transgressoft.lirp.entity.ReactiveEntityBase.emitFxScalarMutation]
+ * to ensure clone-before-mutation ordering and correct event emission.
+ */
+fun interface FxScalarPropertyDelegate {
+    /**
+     * Binds a mutation callback injected by [RegistryBase] that wraps scalar mutations in
+     * clone-before-mutation event emission logic.
+     *
+     * @param callback a function that accepts a mutation block (the `super.set()` call) and
+     *   executes it within lirp's reactive event pipeline
+     */
+    fun bindMutationCallback(callback: (() -> Unit) -> Unit)
+}

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
@@ -25,6 +25,7 @@ import net.transgressoft.lirp.event.CrudEvent.Type.UPDATE
 import net.transgressoft.lirp.event.FlowEventPublisher
 import net.transgressoft.lirp.event.LirpEventPublisher
 import net.transgressoft.lirp.event.StandardCrudEvent.Read
+import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
 import mu.KotlinLogging
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -280,23 +281,39 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
             val typed = entry.delegateGetter(entity) as AggregateRefDelegate<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>
             typed.bindRegistry(registry as Registry<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, context)
         }
+        bindCollectionRefs(entity)
+        bindFxScalarDelegates(entity)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun bindCollectionRefs(entity: T) {
         val collEntries = collectionRefEntries ?: return
         for (entry in collEntries) {
             val registry = context.registryFor(entry.referencedClass) ?: continue
             val delegate = entry.delegateGetter(entity)
             val inner = unwrapCollectionDelegate(delegate)
             if (inner != null) {
-                @Suppress("UNCHECKED_CAST")
                 (inner as AbstractAggregateCollectionRefDelegate<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>)
                     .bindRegistry(registry as Registry<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, context)
             }
-            // Inject collection emission callback for mutable collection delegates after registry binding.
-            // The callback receives a CollectionChangeEvent and emits it wrapped in AggregateMutationEvent
-            // via ReactiveEntityBase.emitCollectionChangeEvent.
             val mutableInner = unwrapMutableDelegate(delegate)
             if (mutableInner != null && entity is ReactiveEntityBase<*, *>) {
                 mutableInner.bindCollectionEmissionCallback { event ->
                     entity.emitCollectionChangeEvent(entry.refName, event)
+                }
+            }
+            if (delegate is FxObservableCollectionProxy) {
+                delegate.syncLocalCache()
+            }
+        }
+    }
+
+    private fun bindFxScalarDelegates(entity: T) {
+        if (entity !is ReactiveEntityBase<*, *>) return
+        for ((_, delegate) in entity.delegateRegistry) {
+            if (delegate is FxScalarPropertyDelegate) {
+                delegate.bindMutationCallback { mutationBlock ->
+                    entity.emitFxScalarMutation(mutationBlock)
                 }
             }
         }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
@@ -20,11 +20,13 @@ package net.transgressoft.lirp.persistence.json
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.persistence.AbstractMutableAggregateCollectionRefDelegate
 import net.transgressoft.lirp.persistence.AggregateCollectionRef
+import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
 import net.transgressoft.lirp.persistence.MutableAggregateListProxy
 import net.transgressoft.lirp.persistence.MutableAggregateSetProxy
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
+import kotlin.reflect.full.createType
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.isAccessible
@@ -33,7 +35,6 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
-import kotlinx.serialization.descriptors.element
 import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -90,6 +91,11 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
             override val name: String,
             override val serializer: KSerializer<Any?>
         ) : DelegateInfo
+
+        data class FxScalar(
+            override val name: String,
+            override val serializer: KSerializer<Any?>
+        ) : DelegateInfo
     }
 
     private val constructorParams: List<ConstructorParamInfo>
@@ -122,25 +128,32 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
                 .filter { param -> param.name != null && param.name in delegateNames }
                 .associateBy { it.name!! }
 
-        // Collect delegate infos preserving the order from memberProperties (kotlin-reflect preserves declaration order)
+        // Collect delegate infos preserving the order from memberProperties (kotlin-reflect preserves declaration order).
         delegateInfos =
             registry.entries.map { (name, delegate) ->
                 val prop = memberProps[name]
-                if (delegate is AggregateCollectionRef<*, *>) {
-                    val idSerializer = resolveAggregateIdSerializer(delegate, prop)
-                    @Suppress("UNCHECKED_CAST")
-                    DelegateInfo.AggregateCollection(name, ListSerializer(idSerializer) as KSerializer<Any?>)
-                } else {
-                    val typedProp =
-                        requireNotNull(prop) {
-                            "Cannot find member property '$name' on ${kClass.simpleName}"
-                        }
-                    @Suppress("UNCHECKED_CAST")
-                    DelegateInfo.ReactiveProperty(
-                        name,
-                        serializer(typedProp.returnType),
-                        typedProp as KProperty1<Any, Any?>
-                    )
+                when {
+                    delegate is AggregateCollectionRef<*, *> -> {
+                        val idSerializer = resolveAggregateIdSerializer(delegate, prop)
+                        @Suppress("UNCHECKED_CAST")
+                        DelegateInfo.AggregateCollection(name, ListSerializer(idSerializer) as KSerializer<Any?>)
+                    }
+                    delegate is FxScalarPropertyDelegate -> {
+                        @Suppress("UNCHECKED_CAST")
+                        DelegateInfo.FxScalar(name, resolveFxScalarSerializer(delegate, prop) as KSerializer<Any?>)
+                    }
+                    else -> {
+                        val typedProp =
+                            requireNotNull(prop) {
+                                "Cannot find member property '$name' on ${kClass.simpleName}"
+                            }
+                        @Suppress("UNCHECKED_CAST")
+                        DelegateInfo.ReactiveProperty(
+                            name,
+                            serializer(typedProp.returnType),
+                            typedProp as KProperty1<Any, Any?>
+                        )
+                    }
                 }
             }
     }
@@ -167,6 +180,34 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
                 "Build the serializer from a sample with at least one backing ID, or expose enough type " +
                 "information to resolve the aggregate key serializer."
         )
+    }
+
+    /**
+     * Resolves the value-level serializer for an [FxScalarPropertyDelegate]. The delegate wraps a
+     * JavaFX property whose underlying value type is determined from the property return type name.
+     * Falls back to the current value's runtime type when the property type isn't recognized.
+     */
+    private fun resolveFxScalarSerializer(
+        delegate: FxScalarPropertyDelegate,
+        prop: KProperty1<E, *>?
+    ): KSerializer<*> {
+        val qualifiedName = (prop?.returnType?.classifier as? KClass<*>)?.qualifiedName ?: ""
+        return when {
+            qualifiedName.endsWith("StringProperty") -> serializer<String?>()
+            qualifiedName.endsWith("IntegerProperty") -> serializer<Int>()
+            qualifiedName.endsWith("DoubleProperty") -> serializer<Double>()
+            qualifiedName.endsWith("FloatProperty") -> serializer<Float>()
+            qualifiedName.endsWith("LongProperty") -> serializer<Long>()
+            qualifiedName.endsWith("BooleanProperty") -> serializer<Boolean>()
+            qualifiedName.endsWith("ObjectProperty") -> {
+                val typeArg = prop?.returnType?.arguments?.firstOrNull()?.type
+                if (typeArg != null) serializer(typeArg) else serializer<String?>()
+            }
+            else -> {
+                val value = delegate.javaClass.getMethod("get").invoke(delegate)
+                if (value != null) serializer(value::class.createType()) else serializer<String?>()
+            }
+        }
     }
 
     override val descriptor: SerialDescriptor =
@@ -212,6 +253,15 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
                             )
                     composite.encodeSerializableElement(descriptor, index++, info.serializer, delegate.referenceIds.toList())
                 }
+                is DelegateInfo.FxScalar -> {
+                    val delegate =
+                        registry[info.name]
+                            ?: throw IllegalStateException(
+                                "Fx scalar delegate '${info.name}' not found in registry for ${kClass.simpleName}"
+                            )
+                    val fxValue = delegate.javaClass.getMethod("get").invoke(delegate)
+                    composite.encodeSerializableElement(descriptor, index++, info.serializer, fxValue)
+                }
             }
         }
 
@@ -240,6 +290,7 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
         entity.withEventsDisabledForClone {
             restoreReactiveProperties(entity, decoded.reactiveValues)
             restoreAggregateIds(entity, decoded.aggregateIds)
+            restoreFxScalarProperties(entity, decoded.fxScalarValues)
         }
         return entity
     }
@@ -247,7 +298,8 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
     private data class DecodedFields(
         val paramValues: Map<KParameter, Any?>,
         val reactiveValues: Map<String, Any?>,
-        val aggregateIds: Map<String, List<Any?>>
+        val aggregateIds: Map<String, List<Any?>>,
+        val fxScalarValues: Map<String, Any?>
     )
 
     @Suppress("UNCHECKED_CAST")
@@ -259,6 +311,7 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
         val paramValues = mutableMapOf<KParameter, Any?>()
         val aggregateIds = mutableMapOf<String, List<Any?>>()
         val reactiveValues = mutableMapOf<String, Any?>()
+        val fxScalarValues = mutableMapOf<String, Any?>()
 
         loop@ while (true) {
             val elementIndex = composite.decodeElementIndex(descriptor)
@@ -277,10 +330,13 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
                 is DelegateInfo.AggregateCollection ->
                     aggregateIds[delegateInfo.name] =
                         composite.decodeSerializableElement(descriptor, elementIndex, delegateInfo.serializer) as List<Any?>
+                is DelegateInfo.FxScalar ->
+                    fxScalarValues[delegateInfo.name] =
+                        composite.decodeSerializableElement(descriptor, elementIndex, delegateInfo.serializer)
                 null -> composite.decodeSerializableElement(descriptor, elementIndex, serializer<Any?>())
             }
         }
-        return DecodedFields(paramValues, reactiveValues, aggregateIds)
+        return DecodedFields(paramValues, reactiveValues, aggregateIds, fxScalarValues)
     }
 
     private fun constructEntity(paramValues: Map<KParameter, Any?>): E {
@@ -316,6 +372,17 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
                     else -> continue
                 }
             mutableDelegate.setBackingIds(ids as Collection<Nothing>)
+        }
+    }
+
+    private fun restoreFxScalarProperties(entity: E, fxScalarValues: Map<String, Any?>) {
+        val registry = entity.delegateRegistry
+        for ((name, decodedValue) in fxScalarValues) {
+            val delegate = registry[name] ?: continue
+            if (delegate !is FxScalarPropertyDelegate) continue
+            val setMethod = delegate.javaClass.methods.find { it.name == "set" } ?: continue
+            setMethod.isAccessible = true
+            setMethod.invoke(delegate, decodedValue)
         }
     }
 }

--- a/lirp-fx/build.gradle
+++ b/lirp-fx/build.gradle
@@ -8,8 +8,10 @@ ktlint {
     }
 }
 
-def osName = System.getProperty('os.name').toLowerCase()
-def fxPlatform = osName.contains('mac') ? 'mac' : osName.contains('win') ? 'win' : 'linux'
+def osName = System.getProperty('os.name').toLowerCase(Locale.ROOT)
+def osArch = System.getProperty('os.arch').toLowerCase(Locale.ROOT)
+def isArm64 = osArch.contains('aarch64') || osArch.contains('arm64')
+def fxPlatform = osName.contains('mac') ? (isArm64 ? 'mac-aarch64' : 'mac') : osName.contains('win') ? 'win' : 'linux'
 
 dependencies {
     api project(path: ':lirp-core')

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateListProxy.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateListProxy.kt
@@ -63,6 +63,13 @@ class FxAggregateListProxy<K : Comparable<K>, E : IdentifiableEntity<K>>(
     // Enables snapshotting for JavaFX Change notifications without requiring registry resolution.
     private val localElements = ArrayList<E>()
 
+    override fun syncLocalCache() {
+        localElements.clear()
+        for (i in 0 until innerProxy.size) {
+            localElements.add(innerProxy[i])
+        }
+    }
+
     override fun get(index: Int): E = localElements[index]
 
     override val size: Int get() = localElements.size

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSetProxy.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSetProxy.kt
@@ -59,6 +59,11 @@ class FxAggregateSetProxy<K : Comparable<K>, E : IdentifiableEntity<K>>(
     private val invalidationListeners = CopyOnWriteArrayList<InvalidationListener>()
     private val setChangeListeners = CopyOnWriteArrayList<SetChangeListener<in E>>()
 
+    override fun syncLocalCache() {
+        localElements.clear()
+        localElements.addAll(innerProxy.resolveAll())
+    }
+
     // Local element cache maintained in parallel with the inner proxy's backing IDs.
     // Enables iteration and snapshotting without requiring registry resolution.
     private val localElements = LinkedHashSet<E>()

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxFactories.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxFactories.kt
@@ -61,3 +61,74 @@ fun <K : Comparable<K>, E : IdentifiableEntity<K>> fxAggregateSet(
     dispatchToFxThread: Boolean = true
 ): FxAggregateSetProxy<K, E> =
     FxAggregateSetProxy(mutableAggregateSet(initialIds), dispatchToFxThread)
+
+/**
+ * Creates a [LirpStringProperty] delegate with an optional initial value.
+ *
+ * @param initialValue the initial string value; defaults to `""`
+ * @param dispatchToFxThread when `true` (default), RegistryBase dispatches mutation notifications
+ *   to the JavaFX Application Thread
+ */
+fun fxString(initialValue: String = "", dispatchToFxThread: Boolean = true): LirpStringProperty =
+    LirpStringProperty(initialValue, dispatchToFxThread)
+
+/**
+ * Creates a [LirpIntegerProperty] delegate with an optional initial value.
+ *
+ * @param initialValue the initial integer value; defaults to `0`
+ * @param dispatchToFxThread when `true` (default), RegistryBase dispatches mutation notifications
+ *   to the JavaFX Application Thread
+ */
+fun fxInteger(initialValue: Int = 0, dispatchToFxThread: Boolean = true): LirpIntegerProperty =
+    LirpIntegerProperty(initialValue, dispatchToFxThread)
+
+/**
+ * Creates a [LirpDoubleProperty] delegate with an optional initial value.
+ *
+ * @param initialValue the initial double value; defaults to `0.0`
+ * @param dispatchToFxThread when `true` (default), RegistryBase dispatches mutation notifications
+ *   to the JavaFX Application Thread
+ */
+fun fxDouble(initialValue: Double = 0.0, dispatchToFxThread: Boolean = true): LirpDoubleProperty =
+    LirpDoubleProperty(initialValue, dispatchToFxThread)
+
+/**
+ * Creates a [LirpFloatProperty] delegate with an optional initial value.
+ *
+ * @param initialValue the initial float value; defaults to `0.0f`
+ * @param dispatchToFxThread when `true` (default), RegistryBase dispatches mutation notifications
+ *   to the JavaFX Application Thread
+ */
+fun fxFloat(initialValue: Float = 0.0f, dispatchToFxThread: Boolean = true): LirpFloatProperty =
+    LirpFloatProperty(initialValue, dispatchToFxThread)
+
+/**
+ * Creates a [LirpLongProperty] delegate with an optional initial value.
+ *
+ * @param initialValue the initial long value; defaults to `0L`
+ * @param dispatchToFxThread when `true` (default), RegistryBase dispatches mutation notifications
+ *   to the JavaFX Application Thread
+ */
+fun fxLong(initialValue: Long = 0L, dispatchToFxThread: Boolean = true): LirpLongProperty =
+    LirpLongProperty(initialValue, dispatchToFxThread)
+
+/**
+ * Creates a [LirpBooleanProperty] delegate with an optional initial value.
+ *
+ * @param initialValue the initial boolean value; defaults to `false`
+ * @param dispatchToFxThread when `true` (default), RegistryBase dispatches mutation notifications
+ *   to the JavaFX Application Thread
+ */
+fun fxBoolean(initialValue: Boolean = false, dispatchToFxThread: Boolean = true): LirpBooleanProperty =
+    LirpBooleanProperty(initialValue, dispatchToFxThread)
+
+/**
+ * Creates a [LirpObjectProperty] delegate with an optional nullable initial value.
+ *
+ * @param T the type of the wrapped object; nullable is supported
+ * @param initialValue the initial value; defaults to `null`
+ * @param dispatchToFxThread when `true` (default), RegistryBase dispatches mutation notifications
+ *   to the JavaFX Application Thread
+ */
+fun <T> fxObject(initialValue: T? = null, dispatchToFxThread: Boolean = true): LirpObjectProperty<T> =
+    LirpObjectProperty(initialValue, dispatchToFxThread)

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxProperties.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxProperties.kt
@@ -1,0 +1,92 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.entity.IdentifiableEntity
+import net.transgressoft.lirp.persistence.mutableAggregateList
+import net.transgressoft.lirp.persistence.mutableAggregateSet
+
+/**
+ * Java-friendly static factory methods for all lirp-fx delegate types.
+ *
+ * Kotlin callers prefer the top-level `fxString()`, `fxInteger()`, `fxAggregateList()` etc. functions.
+ * Java callers use this object's `@JvmStatic` methods to avoid Kotlin top-level function call syntax.
+ *
+ * Method names mirror the top-level Kotlin factories with the `fx` prefix, so both Kotlin and Java
+ * callers use a consistent naming convention: `FxProperties.fxString(...)`, `FxProperties.fxDouble(...)`.
+ */
+object FxProperties {
+
+    /** Creates a [LirpStringProperty] with the given initial value. */
+    @JvmStatic
+    @JvmOverloads
+    fun fxString(initialValue: String = "", dispatchToFxThread: Boolean = true): LirpStringProperty =
+        LirpStringProperty(initialValue, dispatchToFxThread)
+
+    /** Creates a [LirpIntegerProperty] with the given initial value. */
+    @JvmStatic
+    @JvmOverloads
+    fun fxInteger(initialValue: Int = 0, dispatchToFxThread: Boolean = true): LirpIntegerProperty =
+        LirpIntegerProperty(initialValue, dispatchToFxThread)
+
+    /** Creates a [LirpDoubleProperty] with the given initial value. */
+    @JvmStatic
+    @JvmOverloads
+    fun fxDouble(initialValue: Double = 0.0, dispatchToFxThread: Boolean = true): LirpDoubleProperty =
+        LirpDoubleProperty(initialValue, dispatchToFxThread)
+
+    /** Creates a [LirpFloatProperty] with the given initial value. */
+    @JvmStatic
+    @JvmOverloads
+    fun fxFloat(initialValue: Float = 0.0f, dispatchToFxThread: Boolean = true): LirpFloatProperty =
+        LirpFloatProperty(initialValue, dispatchToFxThread)
+
+    /** Creates a [LirpLongProperty] with the given initial value. */
+    @JvmStatic
+    @JvmOverloads
+    fun fxLong(initialValue: Long = 0L, dispatchToFxThread: Boolean = true): LirpLongProperty =
+        LirpLongProperty(initialValue, dispatchToFxThread)
+
+    /** Creates a [LirpBooleanProperty] with the given initial value. */
+    @JvmStatic
+    @JvmOverloads
+    fun fxBoolean(initialValue: Boolean = false, dispatchToFxThread: Boolean = true): LirpBooleanProperty =
+        LirpBooleanProperty(initialValue, dispatchToFxThread)
+
+    /** Creates a [LirpObjectProperty] with the given nullable initial value. */
+    @JvmStatic
+    @JvmOverloads
+    fun <T> fxObject(initialValue: T? = null, dispatchToFxThread: Boolean = true): LirpObjectProperty<T> =
+        LirpObjectProperty(initialValue, dispatchToFxThread)
+
+    /** Creates an [FxAggregateListProxy] for a JavaFX-observable mutable ordered aggregate collection. */
+    @JvmStatic
+    @JvmOverloads
+    fun <K : Comparable<K>, E : IdentifiableEntity<K>> fxAggregateList(
+        initialIds: List<K> = emptyList(),
+        dispatchToFxThread: Boolean = true
+    ): FxAggregateListProxy<K, E> = FxAggregateListProxy(mutableAggregateList(initialIds), dispatchToFxThread)
+
+    /** Creates an [FxAggregateSetProxy] for a JavaFX-observable mutable unique-set aggregate collection. */
+    @JvmStatic
+    @JvmOverloads
+    fun <K : Comparable<K>, E : IdentifiableEntity<K>> fxAggregateSet(
+        initialIds: Set<K> = emptySet(),
+        dispatchToFxThread: Boolean = true
+    ): FxAggregateSetProxy<K, E> = FxAggregateSetProxy(mutableAggregateSet(initialIds), dispatchToFxThread)
+}

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpBooleanProperty.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpBooleanProperty.kt
@@ -1,0 +1,69 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
+import net.transgressoft.lirp.persistence.LirpDelegate
+import javafx.beans.property.SimpleBooleanProperty
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.reflect.KProperty
+
+/**
+ * JavaFX [SimpleBooleanProperty] delegate that participates in lirp's reactive mutation event system.
+ *
+ * When registered in a [net.transgressoft.lirp.entity.ReactiveEntityBase] subclass and wired by
+ * RegistryBase, each call to [set] emits a [net.transgressoft.lirp.event.ReactiveMutationEvent]
+ * using the clone-before-mutation pattern. Use [fxBoolean] to create instances as property delegates.
+ *
+ * @param initialValue the initial boolean value; defaults to `false`
+ * @param dispatchToFxThread when `true` (default), RegistryBase may dispatch notifications to the
+ *   JavaFX Application Thread; when `false`, dispatches on
+ *   [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @see FxScalarPropertyDelegate
+ * @see fxBoolean
+ */
+class LirpBooleanProperty(initialValue: Boolean = false, val dispatchToFxThread: Boolean = true) :
+    SimpleBooleanProperty(initialValue),
+    LirpDelegate,
+    FxScalarPropertyDelegate {
+
+    private val mutationCallback = AtomicReference<((() -> Unit) -> Unit)?>(null)
+
+    override fun bindMutationCallback(callback: (() -> Unit) -> Unit) {
+        check(mutationCallback.compareAndSet(null, callback)) {
+            "Mutation callback already bound. FxScalarPropertyDelegate supports a single binding."
+        }
+    }
+
+    override fun set(value: Boolean) {
+        if (isBound) {
+            super.set(value)
+            return
+        }
+        if (get() == value) return
+        val callback = mutationCallback.get()
+        if (callback != null) {
+            callback { super.set(value) }
+        } else {
+            super.set(value)
+        }
+    }
+
+    /** Returns this instance for use as a Kotlin property delegate via `by`. */
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): LirpBooleanProperty = this
+}

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpDoubleProperty.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpDoubleProperty.kt
@@ -1,0 +1,69 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
+import net.transgressoft.lirp.persistence.LirpDelegate
+import javafx.beans.property.SimpleDoubleProperty
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.reflect.KProperty
+
+/**
+ * JavaFX [SimpleDoubleProperty] delegate that participates in lirp's reactive mutation event system.
+ *
+ * When registered in a [net.transgressoft.lirp.entity.ReactiveEntityBase] subclass and wired by
+ * RegistryBase, each call to [set] emits a [net.transgressoft.lirp.event.ReactiveMutationEvent]
+ * using the clone-before-mutation pattern. Use [fxDouble] to create instances as property delegates.
+ *
+ * @param initialValue the initial double value; defaults to `0.0`
+ * @param dispatchToFxThread when `true` (default), RegistryBase may dispatch notifications to the
+ *   JavaFX Application Thread; when `false`, dispatches on
+ *   [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @see FxScalarPropertyDelegate
+ * @see fxDouble
+ */
+class LirpDoubleProperty(initialValue: Double = 0.0, val dispatchToFxThread: Boolean = true) :
+    SimpleDoubleProperty(initialValue),
+    LirpDelegate,
+    FxScalarPropertyDelegate {
+
+    private val mutationCallback = AtomicReference<((() -> Unit) -> Unit)?>(null)
+
+    override fun bindMutationCallback(callback: (() -> Unit) -> Unit) {
+        check(mutationCallback.compareAndSet(null, callback)) {
+            "Mutation callback already bound. FxScalarPropertyDelegate supports a single binding."
+        }
+    }
+
+    override fun set(value: Double) {
+        if (isBound) {
+            super.set(value)
+            return
+        }
+        if (get() == value) return
+        val callback = mutationCallback.get()
+        if (callback != null) {
+            callback { super.set(value) }
+        } else {
+            super.set(value)
+        }
+    }
+
+    /** Returns this instance for use as a Kotlin property delegate via `by`. */
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): LirpDoubleProperty = this
+}

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpFloatProperty.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpFloatProperty.kt
@@ -1,0 +1,69 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
+import net.transgressoft.lirp.persistence.LirpDelegate
+import javafx.beans.property.SimpleFloatProperty
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.reflect.KProperty
+
+/**
+ * JavaFX [SimpleFloatProperty] delegate that participates in lirp's reactive mutation event system.
+ *
+ * When registered in a [net.transgressoft.lirp.entity.ReactiveEntityBase] subclass and wired by
+ * RegistryBase, each call to [set] emits a [net.transgressoft.lirp.event.ReactiveMutationEvent]
+ * using the clone-before-mutation pattern. Use [fxFloat] to create instances as property delegates.
+ *
+ * @param initialValue the initial float value; defaults to `0.0f`
+ * @param dispatchToFxThread when `true` (default), RegistryBase may dispatch notifications to the
+ *   JavaFX Application Thread; when `false`, dispatches on
+ *   [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @see FxScalarPropertyDelegate
+ * @see fxFloat
+ */
+class LirpFloatProperty(initialValue: Float = 0.0f, val dispatchToFxThread: Boolean = true) :
+    SimpleFloatProperty(initialValue),
+    LirpDelegate,
+    FxScalarPropertyDelegate {
+
+    private val mutationCallback = AtomicReference<((() -> Unit) -> Unit)?>(null)
+
+    override fun bindMutationCallback(callback: (() -> Unit) -> Unit) {
+        check(mutationCallback.compareAndSet(null, callback)) {
+            "Mutation callback already bound. FxScalarPropertyDelegate supports a single binding."
+        }
+    }
+
+    override fun set(value: Float) {
+        if (isBound) {
+            super.set(value)
+            return
+        }
+        if (get() == value) return
+        val callback = mutationCallback.get()
+        if (callback != null) {
+            callback { super.set(value) }
+        } else {
+            super.set(value)
+        }
+    }
+
+    /** Returns this instance for use as a Kotlin property delegate via `by`. */
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): LirpFloatProperty = this
+}

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpIntegerProperty.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpIntegerProperty.kt
@@ -1,0 +1,69 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
+import net.transgressoft.lirp.persistence.LirpDelegate
+import javafx.beans.property.SimpleIntegerProperty
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.reflect.KProperty
+
+/**
+ * JavaFX [SimpleIntegerProperty] delegate that participates in lirp's reactive mutation event system.
+ *
+ * When registered in a [net.transgressoft.lirp.entity.ReactiveEntityBase] subclass and wired by
+ * RegistryBase, each call to [set] emits a [net.transgressoft.lirp.event.ReactiveMutationEvent]
+ * using the clone-before-mutation pattern. Use [fxInteger] to create instances as property delegates.
+ *
+ * @param initialValue the initial integer value; defaults to `0`
+ * @param dispatchToFxThread when `true` (default), RegistryBase may dispatch notifications to the
+ *   JavaFX Application Thread; when `false`, dispatches on
+ *   [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @see FxScalarPropertyDelegate
+ * @see fxInteger
+ */
+class LirpIntegerProperty(initialValue: Int = 0, val dispatchToFxThread: Boolean = true) :
+    SimpleIntegerProperty(initialValue),
+    LirpDelegate,
+    FxScalarPropertyDelegate {
+
+    private val mutationCallback = AtomicReference<((() -> Unit) -> Unit)?>(null)
+
+    override fun bindMutationCallback(callback: (() -> Unit) -> Unit) {
+        check(mutationCallback.compareAndSet(null, callback)) {
+            "Mutation callback already bound. FxScalarPropertyDelegate supports a single binding."
+        }
+    }
+
+    override fun set(value: Int) {
+        if (isBound) {
+            super.set(value)
+            return
+        }
+        if (get() == value) return
+        val callback = mutationCallback.get()
+        if (callback != null) {
+            callback { super.set(value) }
+        } else {
+            super.set(value)
+        }
+    }
+
+    /** Returns this instance for use as a Kotlin property delegate via `by`. */
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): LirpIntegerProperty = this
+}

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpLongProperty.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpLongProperty.kt
@@ -1,0 +1,69 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
+import net.transgressoft.lirp.persistence.LirpDelegate
+import javafx.beans.property.SimpleLongProperty
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.reflect.KProperty
+
+/**
+ * JavaFX [SimpleLongProperty] delegate that participates in lirp's reactive mutation event system.
+ *
+ * When registered in a [net.transgressoft.lirp.entity.ReactiveEntityBase] subclass and wired by
+ * RegistryBase, each call to [set] emits a [net.transgressoft.lirp.event.ReactiveMutationEvent]
+ * using the clone-before-mutation pattern. Use [fxLong] to create instances as property delegates.
+ *
+ * @param initialValue the initial long value; defaults to `0L`
+ * @param dispatchToFxThread when `true` (default), RegistryBase may dispatch notifications to the
+ *   JavaFX Application Thread; when `false`, dispatches on
+ *   [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @see FxScalarPropertyDelegate
+ * @see fxLong
+ */
+class LirpLongProperty(initialValue: Long = 0L, val dispatchToFxThread: Boolean = true) :
+    SimpleLongProperty(initialValue),
+    LirpDelegate,
+    FxScalarPropertyDelegate {
+
+    private val mutationCallback = AtomicReference<((() -> Unit) -> Unit)?>(null)
+
+    override fun bindMutationCallback(callback: (() -> Unit) -> Unit) {
+        check(mutationCallback.compareAndSet(null, callback)) {
+            "Mutation callback already bound. FxScalarPropertyDelegate supports a single binding."
+        }
+    }
+
+    override fun set(value: Long) {
+        if (isBound) {
+            super.set(value)
+            return
+        }
+        if (get() == value) return
+        val callback = mutationCallback.get()
+        if (callback != null) {
+            callback { super.set(value) }
+        } else {
+            super.set(value)
+        }
+    }
+
+    /** Returns this instance for use as a Kotlin property delegate via `by`. */
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): LirpLongProperty = this
+}

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpObjectProperty.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpObjectProperty.kt
@@ -1,0 +1,71 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
+import net.transgressoft.lirp.persistence.LirpDelegate
+import javafx.beans.property.SimpleObjectProperty
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.reflect.KProperty
+
+/**
+ * JavaFX [SimpleObjectProperty] delegate that participates in lirp's reactive mutation event system.
+ *
+ * Supports nullable type parameters, making it suitable for optional object-typed properties.
+ * When registered in a [net.transgressoft.lirp.entity.ReactiveEntityBase] subclass and wired by
+ * RegistryBase, each call to [set] emits a [net.transgressoft.lirp.event.ReactiveMutationEvent]
+ * using the clone-before-mutation pattern. Use [fxObject] to create instances as property delegates.
+ *
+ * @param T the type of the wrapped object; nullable (`T?`) is supported
+ * @param initialValue the initial value; defaults to `null`
+ * @param dispatchToFxThread when `true` (default), RegistryBase may dispatch notifications to the
+ *   JavaFX Application Thread; when `false`, dispatches on
+ *   [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @see FxScalarPropertyDelegate
+ * @see fxObject
+ */
+class LirpObjectProperty<T>(initialValue: T? = null, val dispatchToFxThread: Boolean = true) :
+    SimpleObjectProperty<T?>(initialValue),
+    LirpDelegate,
+    FxScalarPropertyDelegate {
+
+    private val mutationCallback = AtomicReference<((() -> Unit) -> Unit)?>(null)
+
+    override fun bindMutationCallback(callback: (() -> Unit) -> Unit) {
+        check(mutationCallback.compareAndSet(null, callback)) {
+            "Mutation callback already bound. FxScalarPropertyDelegate supports a single binding."
+        }
+    }
+
+    override fun set(newValue: T?) {
+        if (isBound) {
+            super.set(newValue)
+            return
+        }
+        if (get() === newValue) return
+        val callback = mutationCallback.get()
+        if (callback != null) {
+            callback { super.set(newValue) }
+        } else {
+            super.set(newValue)
+        }
+    }
+
+    /** Returns this instance for use as a Kotlin property delegate via `by`. */
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): LirpObjectProperty<T> = this
+}

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpStringProperty.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/LirpStringProperty.kt
@@ -1,0 +1,71 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
+import net.transgressoft.lirp.persistence.LirpDelegate
+import javafx.beans.property.SimpleStringProperty
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.reflect.KProperty
+
+/**
+ * JavaFX [SimpleStringProperty] delegate that participates in lirp's reactive mutation event system.
+ *
+ * When registered in a [net.transgressoft.lirp.entity.ReactiveEntityBase] subclass and wired by
+ * [net.transgressoft.lirp.persistence.RegistryBase], each call to [set] emits a
+ * [net.transgressoft.lirp.event.ReactiveMutationEvent]
+ * using the clone-before-mutation pattern — the entity is cloned before `super.set()` executes.
+ * Use [fxString] to create instances as property delegates.
+ *
+ * @param initialValue the initial string value; defaults to an empty string
+ * @param dispatchToFxThread when `true` (default), RegistryBase may dispatch notifications to the
+ *   JavaFX Application Thread; when `false`, dispatches on
+ *   [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @see FxScalarPropertyDelegate
+ * @see fxString
+ */
+class LirpStringProperty(initialValue: String = "", val dispatchToFxThread: Boolean = true) :
+    SimpleStringProperty(initialValue),
+    LirpDelegate,
+    FxScalarPropertyDelegate {
+
+    private val mutationCallback = AtomicReference<((() -> Unit) -> Unit)?>(null)
+
+    override fun bindMutationCallback(callback: (() -> Unit) -> Unit) {
+        check(mutationCallback.compareAndSet(null, callback)) {
+            "Mutation callback already bound. FxScalarPropertyDelegate supports a single binding."
+        }
+    }
+
+    override fun set(newValue: String?) {
+        if (isBound) {
+            super.set(newValue)
+            return
+        }
+        if (get() == newValue) return
+        val callback = mutationCallback.get()
+        if (callback != null) {
+            callback { super.set(newValue) }
+        } else {
+            super.set(newValue)
+        }
+    }
+
+    /** Returns this instance for use as a Kotlin property delegate via `by`. */
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): LirpStringProperty = this
+}

--- a/lirp-fx/src/test/java/net/transgressoft/lirp/persistence/fx/FxScalarJavaInteropTest.java
+++ b/lirp-fx/src/test/java/net/transgressoft/lirp/persistence/fx/FxScalarJavaInteropTest.java
@@ -1,0 +1,102 @@
+package net.transgressoft.lirp.persistence.fx;
+
+import net.transgressoft.lirp.persistence.AudioItem;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Java interoperability tests verifying that {@link FxProperties} @JvmStatic factory methods
+ * are accessible from Java and return correctly initialized lirp-fx property instances.
+ */
+@DisplayName("FxScalarJavaInteropTest")
+class FxScalarJavaInteropTest {
+
+    @BeforeAll
+    static void initToolkit() {
+        FxToolkitInit.INSTANCE.ensureInitialized();
+    }
+
+    @Nested
+    @DisplayName("Scalar factory access")
+    class ScalarFactoryTests {
+
+        @Test
+        @DisplayName("FxProperties.fxString() creates LirpStringProperty")
+        void stringFactory() {
+            LirpStringProperty prop = FxProperties.fxString("hello", true);
+            assertEquals("hello", prop.get());
+        }
+
+        @Test
+        @DisplayName("FxProperties.fxInteger() creates LirpIntegerProperty")
+        void integerFactory() {
+            LirpIntegerProperty prop = FxProperties.fxInteger(42, true);
+            assertEquals(42, prop.get());
+        }
+
+        @Test
+        @DisplayName("FxProperties.fxDouble() creates LirpDoubleProperty")
+        void doubleFactory() {
+            LirpDoubleProperty prop = FxProperties.fxDouble(3.14, true);
+            assertEquals(3.14, prop.get(), 0.001);
+        }
+
+        @Test
+        @DisplayName("FxProperties.fxFloat() creates LirpFloatProperty")
+        void floatFactory() {
+            LirpFloatProperty prop = FxProperties.fxFloat(1.5f, true);
+            assertEquals(1.5f, prop.get(), 0.001f);
+        }
+
+        @Test
+        @DisplayName("FxProperties.fxLong() creates LirpLongProperty")
+        void longFactory() {
+            LirpLongProperty prop = FxProperties.fxLong(100L, true);
+            assertEquals(100L, prop.get());
+        }
+
+        @Test
+        @DisplayName("FxProperties.fxBoolean() creates LirpBooleanProperty")
+        void booleanFactory() {
+            LirpBooleanProperty prop = FxProperties.fxBoolean(true, true);
+            assertTrue(prop.get());
+        }
+
+        @Test
+        @DisplayName("FxProperties.fxObject() supports nullable types")
+        void objectFactory() {
+            LirpObjectProperty<String> prop = FxProperties.fxObject(null, true);
+            assertNull(prop.get());
+            prop.set("value");
+            assertEquals("value", prop.get());
+        }
+    }
+
+    @Nested
+    @DisplayName("Collection factory access")
+    class CollectionFactoryTests {
+
+        @Test
+        @DisplayName("FxProperties.fxAggregateList() creates FxAggregateListProxy")
+        void aggregateListFactory() {
+            var list = FxProperties.<Integer, AudioItem>fxAggregateList(List.of(), true);
+            assertNotNull(list);
+            assertTrue(list instanceof javafx.collections.ObservableList);
+        }
+
+        @Test
+        @DisplayName("FxProperties.fxAggregateSet() creates FxAggregateSetProxy")
+        void aggregateSetFactory() {
+            var set = FxProperties.<Integer, AudioItem>fxAggregateSet(Set.of(), true);
+            assertNotNull(set);
+            assertTrue(set instanceof javafx.collections.ObservableSet);
+        }
+    }
+}

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxJsonSerializationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxJsonSerializationTest.kt
@@ -33,9 +33,11 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.serialization.json.Json
 
 /**
- * Tests verifying JSON serialization round-trips for entities using [fxAggregateList]
- * and [fxAggregateSet] delegates. Fx proxies wrap mutable aggregate delegates whose
- * backing IDs must serialize/deserialize identically to non-fx aggregates.
+ * Tests verifying JSON serialization round-trips for entities using [fxAggregateList],
+ * [fxAggregateSet], and fx scalar delegates. Fx proxies wrap mutable aggregate delegates whose
+ * backing IDs must serialize/deserialize identically to non-fx aggregates. Fx scalar delegates
+ * are included in serialization — their values are carried by constructor parameters and
+ * serialized/deserialized as part of the entity's JSON representation.
  */
 @DisplayName("FxJsonSerializationTest")
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -58,7 +60,7 @@ class FxJsonSerializationTest : StringSpec({
     }
 
     "serializes entity with fxAggregateList as ID list only" {
-        val entity = FxAudioPlaylistEntity(1, "My Playlist", listOf(10, 20))
+        val entity = FxAudioPlaylistEntity(1, "My Playlist", initialAudioItemIds = listOf(10, 20))
 
         val encoded = json.encodeToString(serializer, entity)
 
@@ -94,7 +96,7 @@ class FxJsonSerializationTest : StringSpec({
     }
 
     "deserializes entity preserving fxAggregateList IDs and collection facade" {
-        val original = FxAudioPlaylistEntity(5, "Round Trip", listOf(10, 20, 30))
+        val original = FxAudioPlaylistEntity(5, "Round Trip", initialAudioItemIds = listOf(10, 20, 30))
 
         val encoded = json.encodeToString(serializer, original)
         val decoded = json.decodeFromString(serializer, encoded)
@@ -120,7 +122,7 @@ class FxJsonSerializationTest : StringSpec({
     }
 
     "round-trip preserves list order" {
-        val original = FxAudioPlaylistEntity(1, "Ordered", listOf(30, 10, 20))
+        val original = FxAudioPlaylistEntity(1, "Ordered", initialAudioItemIds = listOf(30, 10, 20))
 
         val encoded = json.encodeToString(serializer, original)
         val decoded = json.decodeFromString(serializer, encoded)
@@ -129,7 +131,7 @@ class FxJsonSerializationTest : StringSpec({
     }
 
     "round-trip after mutation preserves updated state" {
-        val entity = FxAudioPlaylistEntity(1, "Mutable", listOf(10))
+        val entity = FxAudioPlaylistEntity(1, "Mutable", initialAudioItemIds = listOf(10))
         entity.name = "Updated Name"
 
         val encoded = json.encodeToString(serializer, entity)
@@ -140,7 +142,7 @@ class FxJsonSerializationTest : StringSpec({
     }
 
     "round-trip with both collections populated and facade intact" {
-        val original = FxAudioPlaylistEntity(1, "Full", listOf(10, 20), setOf(2, 3))
+        val original = FxAudioPlaylistEntity(1, "Full", initialAudioItemIds = listOf(10, 20), initialPlaylistIds = setOf(2, 3))
 
         val encoded = json.encodeToString(serializer, original)
         val decoded = json.decodeFromString(serializer, encoded)
@@ -151,5 +153,53 @@ class FxJsonSerializationTest : StringSpec({
         decoded.audioItems.shouldBeInstanceOf<FxAggregateListProxy<*, *>>()
         decoded.playlists.referenceIds shouldBe setOf(2, 3)
         decoded.playlists.shouldBeInstanceOf<FxAggregateSetProxy<*, *>>()
+    }
+
+    "serializes fx scalar delegate values in JSON" {
+        val entity =
+            FxAudioPlaylistEntity(
+                1, "Scalars", initialYear = 2025, initialActive = true,
+                initialRating = 4.5, initialTag = "rock", initialDescription = "Best of"
+            )
+
+        val encoded = json.encodeToString(serializer, entity)
+
+        encoded shouldContain "\"tagProperty\": \"rock\""
+        encoded shouldContain "\"yearProperty\": 2025"
+        encoded shouldContain "\"activeProperty\": true"
+        encoded shouldContain "\"ratingProperty\": 4.5"
+        encoded shouldContain "\"descriptionProperty\": \"Best of\""
+        encoded shouldContain "\"name\": \"Scalars\""
+    }
+
+    "round-trip preserves fx scalar delegate values" {
+        val original =
+            FxAudioPlaylistEntity(
+                1, "Complete", initialYear = 2024, initialActive = true,
+                initialRating = 9.5, initialTag = "jazz", initialDescription = "Classic",
+                initialAudioItemIds = listOf(10, 20), initialPlaylistIds = setOf(2)
+            )
+
+        val encoded = json.encodeToString(serializer, original)
+        val decoded = json.decodeFromString(serializer, encoded)
+
+        decoded.id shouldBe 1
+        decoded.name shouldBe "Complete"
+        decoded.tagProperty.get() shouldBe "jazz"
+        decoded.yearProperty.get() shouldBe 2024
+        decoded.activeProperty.get() shouldBe true
+        decoded.ratingProperty.get() shouldBe 9.5
+        decoded.descriptionProperty.get() shouldBe "Classic"
+        decoded.audioItems.referenceIds shouldBe listOf(10, 20)
+        decoded.playlists.referenceIds shouldBe setOf(2)
+    }
+
+    "round-trip preserves null fx object property" {
+        val original = FxAudioPlaylistEntity(1, "NullDesc", initialDescription = null)
+
+        val encoded = json.encodeToString(serializer, original)
+        val decoded = json.decodeFromString(serializer, encoded)
+
+        decoded.descriptionProperty.get() shouldBe null
     }
 })

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxScalarPropertyTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxScalarPropertyTest.kt
@@ -1,0 +1,319 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
+import net.transgressoft.lirp.persistence.LirpDelegate
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import javafx.beans.value.ChangeListener
+
+/**
+ * Tests for the 7 scalar Lirp*Property delegate classes and their factory functions,
+ * verifying initial values, ChangeListener behaviour, mutation callback ordering, and
+ * interface compliance with [LirpDelegate] and [FxScalarPropertyDelegate].
+ */
+class FxScalarPropertyTest : StringSpec({
+
+    beforeSpec {
+        FxToolkitInit.ensureInitialized()
+    }
+
+    // --- LirpStringProperty ---
+
+    "LirpStringProperty stores and returns initial value" {
+        LirpStringProperty("hello").get() shouldBe "hello"
+    }
+
+    "LirpStringProperty set() updates value and fires ChangeListener" {
+        val prop = LirpStringProperty("hello")
+        var oldSeen: String? = null
+        var newSeen: String? = null
+        prop.addListener(
+            ChangeListener { _, old, new ->
+                oldSeen = old
+                newSeen = new
+            }
+        )
+
+        prop.set("world")
+
+        oldSeen shouldBe "hello"
+        newSeen shouldBe "world"
+        prop.get() shouldBe "world"
+    }
+
+    "LirpStringProperty set() with same value does not fire ChangeListener" {
+        val prop = LirpStringProperty("hello")
+        var listenerFired = false
+        prop.addListener(ChangeListener { _, _, _ -> listenerFired = true })
+
+        prop.set("hello")
+
+        listenerFired.shouldBeFalse()
+    }
+
+    "LirpStringProperty set() invokes mutation callback before storing value" {
+        val prop = LirpStringProperty("hello")
+        var valueSeenInsideCallback: String? = null
+
+        prop.bindMutationCallback { mutationBlock ->
+            // Capture old value before super.set() is called
+            valueSeenInsideCallback = prop.get()
+            mutationBlock()
+        }
+
+        prop.set("world")
+
+        // Callback ran before super.set(), so it saw the old value
+        valueSeenInsideCallback shouldBe "hello"
+        prop.get() shouldBe "world"
+    }
+
+    "LirpStringProperty set() without callback falls through to super.set()" {
+        val prop = LirpStringProperty("hello")
+        // No callback bound — set() must still update the value
+        prop.set("world")
+        prop.get() shouldBe "world"
+    }
+
+    "LirpStringProperty getValue returns this for by-delegation" {
+        // Verify by-delegation works: 'by' syntax calls getValue and returns the delegate itself
+        val prop = LirpStringProperty("hello")
+        val delegated by prop
+        delegated shouldBeSameInstanceAs prop
+    }
+
+    // --- Primitive type Lirp*Property ---
+
+    "LirpIntegerProperty stores primitive int value" {
+        LirpIntegerProperty(42).get() shouldBe 42
+    }
+
+    "LirpDoubleProperty stores primitive double value" {
+        LirpDoubleProperty(3.14).get() shouldBe 3.14
+    }
+
+    "LirpFloatProperty stores primitive float value" {
+        LirpFloatProperty(1.5f).get() shouldBe 1.5f
+    }
+
+    "LirpLongProperty stores primitive long value" {
+        LirpLongProperty(100L).get() shouldBe 100L
+    }
+
+    "LirpBooleanProperty stores primitive boolean value" {
+        LirpBooleanProperty(true).get().shouldBeTrue()
+    }
+
+    // --- LirpObjectProperty ---
+
+    "LirpObjectProperty stores and returns object reference" {
+        data class MyObj(val x: Int)
+        val obj = MyObj(42)
+        LirpObjectProperty(obj).get() shouldBeSameInstanceAs obj
+    }
+
+    "LirpObjectProperty supports null values" {
+        val prop = LirpObjectProperty<String?>(null)
+        prop.get().shouldBeNull()
+        prop.set("x")
+        prop.get() shouldBe "x"
+    }
+
+    // --- Interface compliance ---
+
+    "Lirp*Property classes implement LirpDelegate" {
+        LirpStringProperty().shouldBeInstanceOf<LirpDelegate>()
+        LirpIntegerProperty().shouldBeInstanceOf<LirpDelegate>()
+        LirpDoubleProperty().shouldBeInstanceOf<LirpDelegate>()
+        LirpFloatProperty().shouldBeInstanceOf<LirpDelegate>()
+        LirpLongProperty().shouldBeInstanceOf<LirpDelegate>()
+        LirpBooleanProperty().shouldBeInstanceOf<LirpDelegate>()
+        LirpObjectProperty<Any?>().shouldBeInstanceOf<LirpDelegate>()
+    }
+
+    "Lirp*Property classes implement FxScalarPropertyDelegate" {
+        LirpStringProperty().shouldBeInstanceOf<FxScalarPropertyDelegate>()
+        LirpIntegerProperty().shouldBeInstanceOf<FxScalarPropertyDelegate>()
+        LirpDoubleProperty().shouldBeInstanceOf<FxScalarPropertyDelegate>()
+        LirpFloatProperty().shouldBeInstanceOf<FxScalarPropertyDelegate>()
+        LirpLongProperty().shouldBeInstanceOf<FxScalarPropertyDelegate>()
+        LirpBooleanProperty().shouldBeInstanceOf<FxScalarPropertyDelegate>()
+        LirpObjectProperty<Any?>().shouldBeInstanceOf<FxScalarPropertyDelegate>()
+    }
+
+    // --- set() + ChangeListener for all numeric/boolean types ---
+
+    "LirpLongProperty set() updates value and fires ChangeListener" {
+        val prop = LirpLongProperty(10L)
+        var observedNew: Number? = null
+        prop.addListener { _, _, new -> observedNew = new }
+        prop.set(99L)
+        prop.get() shouldBe 99L
+        observedNew shouldBe 99L
+    }
+
+    "LirpLongProperty set() with same value does not fire ChangeListener" {
+        val prop = LirpLongProperty(10L)
+        var fired = false
+        prop.addListener { _, _, _ -> fired = true }
+        prop.set(10L)
+        fired shouldBe false
+    }
+
+    "LirpLongProperty set() invokes mutation callback before storing value" {
+        val prop = LirpLongProperty(1L)
+        var valueSeenInsideCallback: Long = -1L
+        prop.bindMutationCallback { mutationBlock ->
+            valueSeenInsideCallback = prop.get()
+            mutationBlock()
+        }
+        prop.set(2L)
+        valueSeenInsideCallback shouldBe 1L
+        prop.get() shouldBe 2L
+    }
+
+    "LirpFloatProperty set() updates value and fires ChangeListener" {
+        val prop = LirpFloatProperty(1.0f)
+        var observedNew: Number? = null
+        prop.addListener { _, _, new -> observedNew = new }
+        prop.set(2.5f)
+        prop.get() shouldBe 2.5f
+        observedNew shouldBe 2.5f
+    }
+
+    "LirpFloatProperty set() with same value does not fire ChangeListener" {
+        val prop = LirpFloatProperty(1.0f)
+        var fired = false
+        prop.addListener { _, _, _ -> fired = true }
+        prop.set(1.0f)
+        fired shouldBe false
+    }
+
+    "LirpFloatProperty set() invokes mutation callback before storing value" {
+        val prop = LirpFloatProperty(1.0f)
+        var valueSeenInsideCallback: Float = -1.0f
+        prop.bindMutationCallback { mutationBlock ->
+            valueSeenInsideCallback = prop.get()
+            mutationBlock()
+        }
+        prop.set(2.0f)
+        valueSeenInsideCallback shouldBe 1.0f
+        prop.get() shouldBe 2.0f
+    }
+
+    "LirpDoubleProperty set() invokes mutation callback before storing value" {
+        val prop = LirpDoubleProperty(1.0)
+        var valueSeenInsideCallback: Double = -1.0
+        prop.bindMutationCallback { mutationBlock ->
+            valueSeenInsideCallback = prop.get()
+            mutationBlock()
+        }
+        prop.set(2.0)
+        valueSeenInsideCallback shouldBe 1.0
+        prop.get() shouldBe 2.0
+    }
+
+    "LirpBooleanProperty set() updates value and fires ChangeListener" {
+        val prop = LirpBooleanProperty(false)
+        var observedNew: Boolean? = null
+        prop.addListener { _, _, new -> observedNew = new }
+        prop.set(true)
+        prop.get().shouldBeTrue()
+        observedNew shouldBe true
+    }
+
+    "LirpBooleanProperty set() invokes mutation callback before storing value" {
+        val prop = LirpBooleanProperty(false)
+        var valueSeenInsideCallback: Boolean? = null
+        prop.bindMutationCallback { mutationBlock ->
+            valueSeenInsideCallback = prop.get()
+            mutationBlock()
+        }
+        prop.set(true)
+        valueSeenInsideCallback shouldBe false
+        prop.get().shouldBeTrue()
+    }
+
+    // --- Factory functions ---
+
+    "fxString factory creates LirpStringProperty with initial value" {
+        fxString("init").get() shouldBe "init"
+    }
+
+    "fxInteger factory creates LirpIntegerProperty" {
+        fxInteger(7).get() shouldBe 7
+    }
+
+    "fxDouble factory creates LirpDoubleProperty" {
+        fxDouble(3.14).get() shouldBe 3.14
+    }
+
+    "fxFloat factory creates LirpFloatProperty" {
+        fxFloat(1.5f).get() shouldBe 1.5f
+    }
+
+    "fxLong factory creates LirpLongProperty" {
+        fxLong(100L).get() shouldBe 100L
+    }
+
+    "fxBoolean factory creates LirpBooleanProperty" {
+        fxBoolean(true).get().shouldBeTrue()
+    }
+
+    "fxObject factory supports nullable type" {
+        fxObject<String?>(null).get().shouldBeNull()
+    }
+
+    // --- FxProperties static factories ---
+
+    "FxProperties.fxString creates LirpStringProperty" {
+        FxProperties.fxString("test").get() shouldBe "test"
+    }
+
+    "FxProperties.fxInteger creates LirpIntegerProperty" {
+        FxProperties.fxInteger(42).get() shouldBe 42
+    }
+
+    "FxProperties.fxDouble creates LirpDoubleProperty" {
+        FxProperties.fxDouble(2.72).get() shouldBe 2.72
+    }
+
+    "FxProperties.fxFloat creates LirpFloatProperty" {
+        FxProperties.fxFloat(0.5f).get() shouldBe 0.5f
+    }
+
+    "FxProperties.fxLong creates LirpLongProperty" {
+        FxProperties.fxLong(999L).get() shouldBe 999L
+    }
+
+    "FxProperties.fxBoolean creates LirpBooleanProperty" {
+        FxProperties.fxBoolean(false).get() shouldBe false
+    }
+
+    "FxProperties.fxObject creates LirpObjectProperty" {
+        val prop = FxProperties.fxObject<String>("hello")
+        prop.get() shouldBe "hello"
+    }
+})

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxScalarRegistryIntegrationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxScalarRegistryIntegrationTest.kt
@@ -1,0 +1,207 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.event.MutationEvent
+import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.persistence.AudioItemVolatileRepository
+import net.transgressoft.lirp.persistence.LirpContext
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+/**
+ * Integration tests verifying that [net.transgressoft.lirp.persistence.RegistryBase] correctly
+ * wires [net.transgressoft.lirp.persistence.FxScalarPropertyDelegate] instances via
+ * [net.transgressoft.lirp.persistence.RegistryBase.bindEntityRefs], enabling dual notification:
+ * lirp [net.transgressoft.lirp.event.ReactiveMutationEvent] and JavaFX [javafx.beans.value.ChangeListener]
+ * callbacks fire for the same scalar property mutation.
+ *
+ * Uses the merged [FxAudioPlaylistEntity] which exercises all fx delegate types in a single entity.
+ */
+@DisplayName("FxScalarRegistryIntegrationTest")
+@OptIn(ExperimentalCoroutinesApi::class)
+class FxScalarRegistryIntegrationTest : StringSpec({
+
+    val testDispatcher = UnconfinedTestDispatcher()
+    val testScope = CoroutineScope(testDispatcher)
+    lateinit var previousFlowScope: CoroutineScope
+    lateinit var previousIoScope: CoroutineScope
+
+    beforeSpec {
+        FxToolkitInit.ensureInitialized()
+        previousFlowScope = ReactiveScope.flowScope
+        previousIoScope = ReactiveScope.ioScope
+        ReactiveScope.flowScope = testScope
+        ReactiveScope.ioScope = testScope
+    }
+
+    afterSpec {
+        ReactiveScope.flowScope = previousFlowScope
+        ReactiveScope.ioScope = previousIoScope
+    }
+
+    lateinit var trackRepo: AudioItemVolatileRepository
+    lateinit var fxPlaylistRepo: FxAudioPlaylistVolatileRepository
+
+    beforeEach {
+        trackRepo = AudioItemVolatileRepository()
+        fxPlaylistRepo = FxAudioPlaylistVolatileRepository()
+    }
+
+    afterEach {
+        LirpContext.default.close()
+    }
+
+    "RegistryBase binds fx string property and emits ReactiveMutationEvent on set" {
+        val entity = fxPlaylistRepo.create(1, "playlist", tag = "initial")
+
+        val receivedEvent = AtomicReference<MutationEvent<Int, FxAudioPlaylistEntity>>(null)
+        val latch = CountDownLatch(1)
+
+        entity.subscribe { event ->
+            receivedEvent.set(event)
+            latch.countDown()
+        }
+
+        entity.tagProperty.set("updated")
+
+        latch.await(2, TimeUnit.SECONDS) shouldBe true
+        val event = receivedEvent.get()
+        event shouldNotBe null
+        event.oldEntity.tagProperty.get() shouldBe "initial"
+        event.newEntity.tagProperty.get() shouldBe "updated"
+    }
+
+    "fx string property fires JavaFX ChangeListener after RegistryBase binding" {
+        val entity = fxPlaylistRepo.create(1, "playlist", tag = "old")
+
+        var observedOld: String? = null
+        var observedNew: String? = null
+        entity.tagProperty.addListener { _, old, new ->
+            observedOld = old
+            observedNew = new
+        }
+
+        entity.tagProperty.set("new")
+
+        observedOld shouldBe "old"
+        observedNew shouldBe "new"
+    }
+
+    "fx integer property emits ReactiveMutationEvent on set" {
+        val entity = fxPlaylistRepo.create(2, "playlist", year = 0)
+
+        val receivedEvent = AtomicReference<MutationEvent<Int, FxAudioPlaylistEntity>>(null)
+        val latch = CountDownLatch(1)
+
+        entity.subscribe { event ->
+            receivedEvent.set(event)
+            latch.countDown()
+        }
+
+        entity.yearProperty.set(2025)
+
+        latch.await(2, TimeUnit.SECONDS) shouldBe true
+        val event = receivedEvent.get()
+        event shouldNotBe null
+        event.oldEntity.yearProperty.get() shouldBe 0
+        event.newEntity.yearProperty.get() shouldBe 2025
+    }
+
+    "fx boolean property emits ReactiveMutationEvent on set" {
+        val entity = fxPlaylistRepo.create(3, "playlist", active = false)
+
+        val receivedEvent = AtomicReference<MutationEvent<Int, FxAudioPlaylistEntity>>(null)
+        val latch = CountDownLatch(1)
+
+        entity.subscribe { event ->
+            receivedEvent.set(event)
+            latch.countDown()
+        }
+
+        entity.activeProperty.set(true)
+
+        latch.await(2, TimeUnit.SECONDS) shouldBe true
+        val event = receivedEvent.get()
+        event shouldNotBe null
+        event.oldEntity.activeProperty.get() shouldBe false
+        event.newEntity.activeProperty.get() shouldBe true
+    }
+
+    "fx object property emits ReactiveMutationEvent on set" {
+        val entity = fxPlaylistRepo.create(4, "playlist", description = null)
+
+        val receivedEvent = AtomicReference<MutationEvent<Int, FxAudioPlaylistEntity>>(null)
+        val latch = CountDownLatch(1)
+
+        entity.subscribe { event ->
+            receivedEvent.set(event)
+            latch.countDown()
+        }
+
+        entity.descriptionProperty.set("vip")
+
+        latch.await(2, TimeUnit.SECONDS) shouldBe true
+        val event = receivedEvent.get()
+        event shouldNotBe null
+        event.oldEntity.descriptionProperty.get() shouldBe null
+        event.newEntity.descriptionProperty.get() shouldBe "vip"
+    }
+
+    "withEventsDisabled suppresses MutationEvent for fx scalar property" {
+        val entity = fxPlaylistRepo.create(5, "playlist", tag = "before")
+
+        val receivedEvent = AtomicReference<MutationEvent<Int, FxAudioPlaylistEntity>>(null)
+        val latch = CountDownLatch(1)
+
+        entity.subscribe { event ->
+            receivedEvent.set(event)
+            latch.countDown()
+        }
+
+        entity.silently { entity.tagProperty.set("silent") }
+
+        latch.await(500, TimeUnit.MILLISECONDS) shouldBe false
+        receivedEvent.get() shouldBe null
+        entity.tagProperty.get() shouldBe "silent"
+    }
+
+    "fx scalar property set before repository add does not emit event" {
+        val entity = FxAudioPlaylistEntity(6, "standalone")
+
+        val receivedEvent = AtomicReference<MutationEvent<Int, FxAudioPlaylistEntity>>(null)
+
+        entity.subscribe { event ->
+            receivedEvent.set(event)
+        }
+
+        entity.tagProperty.set("changed")
+
+        Thread.sleep(200)
+        entity.tagProperty.get() shouldBe "changed"
+        receivedEvent.get() shouldBe null
+    }
+})

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxTestFixtures.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxTestFixtures.kt
@@ -24,20 +24,37 @@ import net.transgressoft.lirp.persistence.Aggregate
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.LirpRepository
 import net.transgressoft.lirp.persistence.VolatileRepository
+import javafx.beans.property.BooleanProperty
+import javafx.beans.property.DoubleProperty
+import javafx.beans.property.IntegerProperty
+import javafx.beans.property.ObjectProperty
+import javafx.beans.property.StringProperty
 
 /**
- * Entity using [fxAggregateList] and [fxAggregateSet] delegates for integration testing
- * of the FxObservableCollectionProxy wiring through RegistryBase.
+ * Cohesive test entity exercising all lirp-fx delegate types: [reactiveProperty] for name,
+ * [fxString] / [fxInteger] / [fxBoolean] / [fxDouble] / [fxObject] scalar delegates,
+ * and [fxAggregateList] / [fxAggregateSet] collection delegates.
  */
 class FxAudioPlaylistEntity(
     override val id: Int,
     name: String,
+    initialYear: Int = 0,
+    initialActive: Boolean = false,
+    initialRating: Double = 0.0,
+    initialTag: String? = null,
+    initialDescription: String? = null,
     initialAudioItemIds: List<Int> = emptyList(),
     initialPlaylistIds: Set<Int> = emptySet()
 ) : ReactiveEntityBase<Int, FxAudioPlaylistEntity>(), IdentifiableEntity<Int> {
     override val uniqueId: String get() = "fx-audio-playlist-$id"
 
     var name: String by reactiveProperty(name)
+
+    val tagProperty: StringProperty by fxString(initialTag ?: "", dispatchToFxThread = false)
+    val yearProperty: IntegerProperty by fxInteger(initialYear, dispatchToFxThread = false)
+    val activeProperty: BooleanProperty by fxBoolean(initialActive, dispatchToFxThread = false)
+    val ratingProperty: DoubleProperty by fxDouble(initialRating, dispatchToFxThread = false)
+    val descriptionProperty: ObjectProperty<String?> by fxObject<String?>(initialDescription, dispatchToFxThread = false)
 
     @Aggregate(onDelete = CascadeAction.DETACH)
     val audioItems by fxAggregateList<Int, AudioItem>(initialAudioItemIds, dispatchToFxThread = false)
@@ -46,13 +63,22 @@ class FxAudioPlaylistEntity(
     val playlists by fxAggregateSet<Int, FxAudioPlaylistEntity>(initialPlaylistIds, dispatchToFxThread = false)
 
     override fun clone(): FxAudioPlaylistEntity =
-        FxAudioPlaylistEntity(id, name, audioItems.referenceIds.toList(), LinkedHashSet(playlists.referenceIds))
+        FxAudioPlaylistEntity(
+            id, name, yearProperty.get(), activeProperty.get(), ratingProperty.get(),
+            tagProperty.get(), descriptionProperty.get(),
+            audioItems.referenceIds.toList(), LinkedHashSet(playlists.referenceIds)
+        )
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is FxAudioPlaylistEntity) return false
         return id == other.id &&
             name == other.name &&
+            tagProperty.get() == other.tagProperty.get() &&
+            yearProperty.get() == other.yearProperty.get() &&
+            activeProperty.get() == other.activeProperty.get() &&
+            ratingProperty.get() == other.ratingProperty.get() &&
+            descriptionProperty.get() == other.descriptionProperty.get() &&
             audioItems.referenceIds == other.audioItems.referenceIds &&
             playlists.referenceIds == other.playlists.referenceIds
     }
@@ -60,12 +86,20 @@ class FxAudioPlaylistEntity(
     override fun hashCode(): Int {
         var result = id.hashCode()
         result = 31 * result + name.hashCode()
+        result = 31 * result + (tagProperty.get()?.hashCode() ?: 0)
+        result = 31 * result + yearProperty.get()
+        result = 31 * result + activeProperty.get().hashCode()
+        result = 31 * result + ratingProperty.get().hashCode()
+        result = 31 * result + (descriptionProperty.get()?.hashCode() ?: 0)
         result = 31 * result + audioItems.referenceIds.hashCode()
         result = 31 * result + playlists.referenceIds.hashCode()
         return result
     }
 
     override fun toString(): String = "FxAudioPlaylistEntity(id=$id, name='$name')"
+
+    /** Test-only bridge: exposes the protected [withEventsDisabled] for integration test assertions. */
+    fun <T> silently(action: () -> T): T = withEventsDisabled(action)
 }
 
 /**
@@ -79,7 +113,13 @@ class FxAudioPlaylistVolatileRepository :
     fun create(
         id: Int,
         name: String,
+        year: Int = 0,
+        active: Boolean = false,
+        rating: Double = 0.0,
+        tag: String? = null,
+        description: String? = null,
         audioItemIds: List<Int> = emptyList(),
         playlistIds: Set<Int> = emptySet()
-    ): FxAudioPlaylistEntity = FxAudioPlaylistEntity(id, name, audioItemIds, playlistIds).also(::add)
+    ): FxAudioPlaylistEntity =
+        FxAudioPlaylistEntity(id, name, year, active, rating, tag, description, audioItemIds, playlistIds).also(::add)
 }

--- a/lirp-sql/build.gradle
+++ b/lirp-sql/build.gradle
@@ -22,6 +22,11 @@ configurations {
     integrationTestRuntimeOnly.extendsFrom runtimeOnly
 }
 
+def osName = System.getProperty('os.name').toLowerCase(Locale.ROOT)
+def osArch = System.getProperty('os.arch').toLowerCase(Locale.ROOT)
+def isArm64 = osArch.contains('aarch64') || osArch.contains('arm64')
+def fxPlatform = osName.contains('mac') ? (isArm64 ? 'mac-aarch64' : 'mac') : osName.contains('win') ? 'win' : 'linux'
+
 dependencies {
     api project(path: ':lirp-api')
     api project(path: ':lirp-core')
@@ -52,6 +57,17 @@ dependencies {
     integrationTestRuntimeOnly libs.mysql
     integrationTestRuntimeOnly libs.mariadb
 
+    // lirp-fx compiled classes for fx delegate SQL persistence tests.
+    // Uses file path instead of project() to avoid KSP plugin evaluation triggering
+    // Gradle configuration hierarchy mutation on apiElements.
+    testImplementation files("${rootProject.projectDir}/lirp-fx/build/classes/kotlin/main")
+    testImplementation files("${rootProject.projectDir}/lirp-fx/build/resources/main")
+
+    // JavaFX for fx delegate SQL persistence tests
+    testImplementation "org.openjfx:javafx-base:21:${fxPlatform}"
+    testImplementation "org.openjfx:javafx-graphics:21:${fxPlatform}"
+    testImplementation 'org.testfx:openjfx-monocle:21.0.2'
+
     // testFixtures infrastructure — shared entities, table defs, container support
     testFixturesImplementation project(path: ':lirp-api')
     testFixturesImplementation project(path: ':lirp-core')
@@ -70,6 +86,11 @@ dependencies {
     integrationTestImplementation testFixtures(project(':lirp-sql'))
 }
 
+// Ensure lirp-fx is compiled before lirp-sql tests
+tasks.named('compileTestKotlin').configure {
+    dependsOn ':lirp-fx:compileKotlin', ':lirp-fx:processResources'
+}
+
 tasks.register('integrationTest', Test) {
     description = 'Runs integration tests.'
     group = 'verification'
@@ -80,6 +101,41 @@ tasks.register('integrationTest', Test) {
     jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
             '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
             '--add-opens=java.base/java.io=ALL-UNNAMED'
+}
+
+// JavaFX module system args for fx delegate SQL tests (headless Monocle).
+// Uses doFirst to defer configuration resolution to execution time.
+tasks.named('test').configure {
+    jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
+            '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+            '--add-opens=java.base/java.io=ALL-UNNAMED'
+
+    doFirst {
+        def fxJars = configurations.testRuntimeClasspath.files
+                .findAll { it.name.contains('javafx') }
+                .collect { it.absolutePath }
+        def monocleJar = configurations.testRuntimeClasspath.files
+                .find { it.name.contains('monocle') }
+        if (monocleJar == null) {
+            throw new GradleException("Monocle JAR not found in testRuntimeClasspath")
+        }
+        if (fxJars.isEmpty()) {
+            throw new GradleException("JavaFX JARs not found in testRuntimeClasspath")
+        }
+        def fxModulePath = fxJars.join(File.pathSeparator)
+        jvmArgs "--module-path=${fxModulePath}",
+                '--add-modules=javafx.graphics',
+                "--patch-module=javafx.graphics=${monocleJar.absolutePath}",
+                '--add-reads=javafx.graphics=ALL-UNNAMED',
+                '--add-opens=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED',
+                '--add-opens=javafx.graphics/com.sun.glass.ui.monocle=ALL-UNNAMED',
+                '--add-opens=javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED',
+                '--add-opens=javafx.graphics/com.sun.javafx.tk.quantum=ALL-UNNAMED',
+                '--add-exports=javafx.graphics/com.sun.javafx.application=ALL-UNNAMED',
+                '--add-exports=javafx.graphics/com.sun.javafx.util=ALL-UNNAMED',
+                '--add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED',
+                '--add-exports=javafx.graphics/com.sun.glass.ui.monocle=ALL-UNNAMED'
+    }
 }
 
 check.dependsOn integrationTest

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlRepositoryTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlRepositoryTest.kt
@@ -1,0 +1,298 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.event.CrudEvent
+import net.transgressoft.lirp.persistence.RegistryBase
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+
+/**
+ * SQL persistence tests for entities combining fx scalar delegates ([fxString], [fxInteger],
+ * [fxBoolean], [fxDouble], [fxObject]) with [fxAggregateList] collection delegates.
+ * Uses H2 in-memory databases for fast isolated tests.
+ */
+@DisplayName("FxSqlRepositoryTest")
+internal class FxSqlRepositoryTest : FunSpec({
+
+    fun freshJdbcUrl() = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+
+    beforeSpec {
+        FxToolkitInit.ensureInitialized()
+    }
+
+    afterEach {
+        RegistryBase.deregisterRepository(FxSqlTestItem::class.java)
+        RegistryBase.deregisterRepository(FxSqlTestEntity::class.java)
+    }
+
+    test("adds entity with fx scalar properties and persists to database") {
+        val jdbcUrl = freshJdbcUrl()
+        val itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        val entity = FxSqlTestEntity(1, "Test", 2024, true, 8.5, "rock")
+        entityRepo.add(entity)
+
+        entityRepo.close()
+        itemRepo.close()
+
+        val itemRepo2 = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo2 = FxSqlTestEntityRepository(jdbcUrl)
+        entityRepo2.findById(1).shouldBePresent {
+            it.nameProperty.get() shouldBe "Test"
+            it.yearProperty.get() shouldBe 2024
+            it.activeProperty.get() shouldBe true
+            it.ratingProperty.get() shouldBe 8.5
+            it.tagProperty.get() shouldBe "rock"
+        }
+
+        entityRepo2.close()
+        itemRepo2.close()
+    }
+
+    test("persists fx scalar property mutation via flush") {
+        val jdbcUrl = freshJdbcUrl()
+        val itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        val entity = FxSqlTestEntity(1, "Original")
+        entityRepo.add(entity)
+        entity.nameProperty.set("Mutated")
+
+        entityRepo.close()
+        itemRepo.close()
+
+        val itemRepo2 = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo2 = FxSqlTestEntityRepository(jdbcUrl)
+        entityRepo2.findById(1).shouldBePresent {
+            it.nameProperty.get() shouldBe "Mutated"
+        }
+
+        entityRepo2.close()
+        itemRepo2.close()
+    }
+
+    test("persists all fx scalar types correctly") {
+        val jdbcUrl = freshJdbcUrl()
+        val itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        val entity = FxSqlTestEntity(1, "AllTypes", 2025, true, 9.99, "jazz")
+        entityRepo.add(entity)
+
+        entityRepo.close()
+        itemRepo.close()
+
+        val itemRepo2 = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo2 = FxSqlTestEntityRepository(jdbcUrl)
+        entityRepo2.findById(1).shouldBePresent {
+            it.nameProperty.get() shouldBe "AllTypes"
+            it.yearProperty.get() shouldBe 2025
+            it.activeProperty.get() shouldBe true
+            it.ratingProperty.get() shouldBe 9.99
+            it.tagProperty.get() shouldBe "jazz"
+        }
+
+        entityRepo2.close()
+        itemRepo2.close()
+    }
+
+    test("null tag property persists and reloads as null") {
+        val jdbcUrl = freshJdbcUrl()
+        val itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        val entity = FxSqlTestEntity(1, "NullTag", initialTag = null)
+        entityRepo.add(entity)
+
+        entityRepo.close()
+        itemRepo.close()
+
+        val itemRepo2 = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo2 = FxSqlTestEntityRepository(jdbcUrl)
+        entityRepo2.findById(1).shouldBePresent {
+            it.tagProperty.get() shouldBe null
+        }
+
+        entityRepo2.close()
+        itemRepo2.close()
+    }
+
+    test("persists fx aggregate itemIds and reloads them") {
+        val jdbcUrl = freshJdbcUrl()
+        val itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        val item1 = FxSqlTestItem(1, "Item A")
+        val item2 = FxSqlTestItem(2, "Item B")
+        itemRepo.add(item1)
+        itemRepo.add(item2)
+
+        val entity = FxSqlTestEntity(1, "WithItems")
+        entityRepo.add(entity)
+        entity.items.add(item1)
+        entity.items.add(item2)
+
+        entityRepo.close()
+        itemRepo.close()
+
+        val itemRepo2 = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo2 = FxSqlTestEntityRepository(jdbcUrl)
+        entityRepo2.findById(1).shouldBePresent {
+            it.items.referenceIds shouldBe listOf(1, 2)
+            it.items.resolveAll().size shouldBe 2
+        }
+
+        entityRepo2.close()
+        itemRepo2.close()
+    }
+
+    test("persists mutations on fx aggregate after reload") {
+        val jdbcUrl = freshJdbcUrl()
+        var itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        var entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        val item1 = FxSqlTestItem(1, "A")
+        val item2 = FxSqlTestItem(2, "B")
+        val item3 = FxSqlTestItem(3, "C")
+        itemRepo.add(item1)
+        itemRepo.add(item2)
+        itemRepo.add(item3)
+
+        val entity = FxSqlTestEntity(1, "Mutable", initialItemIds = listOf(1, 2))
+        entityRepo.add(entity)
+
+        entityRepo.close()
+        itemRepo.close()
+
+        itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        val reloaded = entityRepo.findById(1).get()
+        reloaded.items.referenceIds shouldBe listOf(1, 2)
+
+        val reloadedItem3 = itemRepo.findById(3).get()
+        reloaded.items.add(reloadedItem3)
+        val reloadedItem1 = itemRepo.findById(1).get()
+        reloaded.items.remove(reloadedItem1)
+
+        entityRepo.close()
+        itemRepo.close()
+
+        itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+        entityRepo.findById(1).shouldBePresent {
+            it.items.referenceIds shouldBe listOf(2, 3)
+        }
+
+        entityRepo.close()
+        itemRepo.close()
+    }
+
+    test("clear on fx aggregate persists empty state") {
+        val jdbcUrl = freshJdbcUrl()
+        val itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        val item1 = FxSqlTestItem(1, "X")
+        itemRepo.add(item1)
+        val entity = FxSqlTestEntity(1, "ToClear")
+        entityRepo.add(entity)
+        entity.items.add(item1)
+        entity.items.clear()
+
+        entityRepo.close()
+        itemRepo.close()
+
+        val itemRepo2 = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo2 = FxSqlTestEntityRepository(jdbcUrl)
+        entityRepo2.findById(1).shouldBePresent {
+            it.items.referenceIds shouldBe emptyList()
+        }
+
+        entityRepo2.close()
+        itemRepo2.close()
+    }
+
+    test("fx scalar property mutation emits UPDATE CrudEvent from SqlRepository") {
+        val jdbcUrl = freshJdbcUrl()
+        val itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+        val received = AtomicReference<CrudEvent.Type?>()
+
+        val entity = FxSqlTestEntity(1, "EventTest")
+        entityRepo.add(entity)
+
+        entityRepo.subscribe { event -> received.set(event.type) }
+        delay(50.milliseconds)
+
+        entity.nameProperty.set("Updated")
+
+        eventually(5.seconds) {
+            received.get() shouldBe CrudEvent.Type.UPDATE
+        }
+
+        entityRepo.close()
+        itemRepo.close()
+    }
+
+    test("entity with both scalar and collection mutations persists all changes") {
+        val jdbcUrl = freshJdbcUrl()
+        val itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        val item1 = FxSqlTestItem(1, "Combined")
+        itemRepo.add(item1)
+
+        val entity = FxSqlTestEntity(1, "Initial", 2020, false, 5.0, null)
+        entityRepo.add(entity)
+
+        entity.nameProperty.set("Updated")
+        entity.yearProperty.set(2025)
+        entity.activeProperty.set(true)
+        entity.ratingProperty.set(9.5)
+        entity.tagProperty.set("best")
+        entity.items.add(item1)
+
+        entityRepo.close()
+        itemRepo.close()
+
+        val itemRepo2 = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo2 = FxSqlTestEntityRepository(jdbcUrl)
+        entityRepo2.findById(1).shouldBePresent {
+            it.nameProperty.get() shouldBe "Updated"
+            it.yearProperty.get() shouldBe 2025
+            it.activeProperty.get() shouldBe true
+            it.ratingProperty.get() shouldBe 9.5
+            it.tagProperty.get() shouldBe "best"
+            it.items.referenceIds shouldBe listOf(1)
+        }
+
+        entityRepo2.close()
+        itemRepo2.close()
+    }
+})

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlTestFixtures.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlTestFixtures.kt
@@ -1,0 +1,229 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.IdentifiableEntity
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Aggregate
+import net.transgressoft.lirp.persistence.AggregateCollectionRef
+import net.transgressoft.lirp.persistence.CollectionRefEntry
+import net.transgressoft.lirp.persistence.ColumnDef
+import net.transgressoft.lirp.persistence.ColumnType
+import net.transgressoft.lirp.persistence.LirpRefAccessor
+import net.transgressoft.lirp.persistence.LirpRegistryInfo
+import net.transgressoft.lirp.persistence.RefEntry
+import net.transgressoft.lirp.persistence.fx.fxAggregateList
+import net.transgressoft.lirp.persistence.fx.fxBoolean
+import net.transgressoft.lirp.persistence.fx.fxDouble
+import net.transgressoft.lirp.persistence.fx.fxInteger
+import net.transgressoft.lirp.persistence.fx.fxObject
+import net.transgressoft.lirp.persistence.fx.fxString
+import javafx.beans.property.BooleanProperty
+import javafx.beans.property.DoubleProperty
+import javafx.beans.property.IntegerProperty
+import javafx.beans.property.ObjectProperty
+import javafx.beans.property.StringProperty
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+
+/**
+ * Minimal referenced entity for [FxSqlTestEntity]'s aggregate delegate.
+ */
+class FxSqlTestItem(override val id: Int, title: String) : ReactiveEntityBase<Int, FxSqlTestItem>() {
+    var title: String by reactiveProperty(title)
+    override val uniqueId: String get() = "fx-sql-item-$id"
+
+    override fun clone(): FxSqlTestItem = FxSqlTestItem(id, title)
+}
+
+/** SQL table definition for [FxSqlTestItem]. */
+object FxSqlTestItemTableDef : SqlTableDef<FxSqlTestItem> {
+    override val tableName = "fx_sql_test_items"
+    override val columns =
+        listOf(
+            ColumnDef("id", ColumnType.IntType, nullable = false, primaryKey = true),
+            ColumnDef("title", ColumnType.VarcharType(200), nullable = false, primaryKey = false)
+        )
+
+    @Suppress("UNCHECKED_CAST")
+    override fun fromRow(row: ResultRow, table: Table): FxSqlTestItem {
+        val cols = table.columns.associateBy { it.name }
+        return FxSqlTestItem(
+            row[cols["id"]!! as Column<Int>],
+            row[cols["title"]!! as Column<String>]
+        )
+    }
+
+    override fun toParams(entity: FxSqlTestItem, table: Table): Map<Column<*>, Any?> {
+        val cols = table.columns.associateBy { it.name }
+        return mapOf(
+            cols["id"]!! to entity.id,
+            cols["title"]!! to entity.title
+        )
+    }
+}
+
+/**
+ * Test entity combining fx scalar delegates ([fxString], [fxInteger], [fxBoolean], [fxDouble],
+ * [fxObject]) with an [fxAggregateList] collection delegate for SQL persistence testing.
+ */
+class FxSqlTestEntity(
+    override val id: Int,
+    initialName: String = "",
+    initialYear: Int = 0,
+    initialActive: Boolean = false,
+    initialRating: Double = 0.0,
+    initialTag: String? = null,
+    initialItemIds: List<Int> = emptyList()
+) : ReactiveEntityBase<Int, FxSqlTestEntity>(), IdentifiableEntity<Int> {
+    override val uniqueId: String get() = "fx-sql-test-$id"
+
+    val nameProperty: StringProperty by fxString(initialName, dispatchToFxThread = false)
+    val yearProperty: IntegerProperty by fxInteger(initialYear, dispatchToFxThread = false)
+    val activeProperty: BooleanProperty by fxBoolean(initialActive, dispatchToFxThread = false)
+    val ratingProperty: DoubleProperty by fxDouble(initialRating, dispatchToFxThread = false)
+    val tagProperty: ObjectProperty<String?> by fxObject<String?>(initialTag, dispatchToFxThread = false)
+
+    @Aggregate(onDelete = CascadeAction.NONE)
+    val items by fxAggregateList<Int, FxSqlTestItem>(initialItemIds, dispatchToFxThread = false)
+
+    override fun clone(): FxSqlTestEntity =
+        FxSqlTestEntity(
+            id, nameProperty.get(), yearProperty.get(), activeProperty.get(),
+            ratingProperty.get(), tagProperty.get(), items.referenceIds.toList()
+        )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FxSqlTestEntity) return false
+        return id == other.id &&
+            nameProperty.get() == other.nameProperty.get() &&
+            yearProperty.get() == other.yearProperty.get() &&
+            activeProperty.get() == other.activeProperty.get() &&
+            ratingProperty.get() == other.ratingProperty.get() &&
+            tagProperty.get() == other.tagProperty.get() &&
+            items.referenceIds == other.items.referenceIds
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + (nameProperty.get()?.hashCode() ?: 0)
+        result = 31 * result + yearProperty.get()
+        result = 31 * result + activeProperty.get().hashCode()
+        result = 31 * result + ratingProperty.get().hashCode()
+        result = 31 * result + (tagProperty.get()?.hashCode() ?: 0)
+        result = 31 * result + items.referenceIds.hashCode()
+        return result
+    }
+
+    override fun toString(): String = "FxSqlTestEntity(id=$id, name='${nameProperty.get()}')"
+}
+
+/** SQL table definition for [FxSqlTestEntity]. Scalar properties map to typed columns; item IDs are stored as CSV TEXT. */
+object FxSqlTestEntityTableDef : SqlTableDef<FxSqlTestEntity> {
+    override val tableName = "fx_sql_test_entities"
+    override val columns =
+        listOf(
+            ColumnDef("id", ColumnType.IntType, nullable = false, primaryKey = true),
+            ColumnDef("name", ColumnType.VarcharType(200), nullable = false, primaryKey = false),
+            ColumnDef("year", ColumnType.IntType, nullable = false, primaryKey = false),
+            ColumnDef("active", ColumnType.BooleanType, nullable = false, primaryKey = false),
+            ColumnDef("rating", ColumnType.DoubleType, nullable = false, primaryKey = false),
+            ColumnDef("tag", ColumnType.TextType, nullable = true, primaryKey = false),
+            ColumnDef("item_ids", ColumnType.TextType, nullable = false, primaryKey = false)
+        )
+
+    @Suppress("UNCHECKED_CAST")
+    override fun fromRow(row: ResultRow, table: Table): FxSqlTestEntity {
+        val cols = table.columns.associateBy { it.name }
+        val itemIdsText = row[cols["item_ids"]!! as Column<String>]
+        val parsedIds =
+            if (itemIdsText.isBlank()) emptyList()
+            else itemIdsText.split(",").map { it.trim().toInt() }
+
+        return FxSqlTestEntity(
+            row[cols["id"]!! as Column<Int>],
+            row[cols["name"]!! as Column<String>],
+            row[cols["year"]!! as Column<Int>],
+            row[cols["active"]!! as Column<Boolean>],
+            row[cols["rating"]!! as Column<Double>],
+            row[cols["tag"]!! as Column<String?>],
+            parsedIds
+        )
+    }
+
+    override fun toParams(entity: FxSqlTestEntity, table: Table): Map<Column<*>, Any?> {
+        val cols = table.columns.associateBy { it.name }
+        return mapOf(
+            cols["id"]!! to entity.id,
+            cols["name"]!! to entity.nameProperty.get(),
+            cols["year"]!! to entity.yearProperty.get(),
+            cols["active"]!! to entity.activeProperty.get(),
+            cols["rating"]!! to entity.ratingProperty.get(),
+            cols["tag"]!! to entity.tagProperty.get(),
+            cols["item_ids"]!! to entity.items.referenceIds.joinToString(",")
+        )
+    }
+}
+
+/** Named [SqlRepository] for [FxSqlTestItem]. */
+class FxSqlTestItemRepository(jdbcUrl: String) : SqlRepository<Int, FxSqlTestItem>(jdbcUrl, FxSqlTestItemTableDef)
+
+/** Manual [LirpRegistryInfo] for [FxSqlTestItemRepository]. */
+@Suppress("ClassName")
+class `FxSqlTestItemRepository_LirpRegistryInfo` : LirpRegistryInfo {
+    override val entityClass: Class<*> = FxSqlTestItem::class.java
+}
+
+/** Named [SqlRepository] for [FxSqlTestEntity]. */
+class FxSqlTestEntityRepository(jdbcUrl: String) : SqlRepository<Int, FxSqlTestEntity>(jdbcUrl, FxSqlTestEntityTableDef)
+
+/** Manual [LirpRegistryInfo] for [FxSqlTestEntityRepository]. */
+@Suppress("ClassName")
+class `FxSqlTestEntityRepository_LirpRegistryInfo` : LirpRegistryInfo {
+    override val entityClass: Class<*> = FxSqlTestEntity::class.java
+}
+
+/**
+ * Manual [LirpRefAccessor] for [FxSqlTestEntity]. Required because lirp-sql does not apply
+ * the KSP processor, and the entity has an @Aggregate delegate that triggers the fail-fast
+ * check in RegistryBase.discoverRefs.
+ */
+@Suppress("ktlint:standard:class-naming")
+class `FxSqlTestEntity_LirpRefAccessor` : LirpRefAccessor<FxSqlTestEntity> {
+    override val entries: List<RefEntry<*, FxSqlTestEntity>> = emptyList()
+
+    override val collectionEntries: List<CollectionRefEntry<*, FxSqlTestEntity>> =
+        listOf(
+            @Suppress("UNCHECKED_CAST")
+            CollectionRefEntry(
+                refName = "items",
+                idsGetter = { it.items.referenceIds },
+                delegateGetter = { it.items as AggregateCollectionRef<*, *> },
+                referencedClass = FxSqlTestItem::class.java,
+                cascadeAction = CascadeAction.NONE,
+                isOrdered = true
+            )
+        )
+
+    override fun cancelAllBubbleUp(entity: FxSqlTestEntity) {
+        entries.forEach { entry -> entry.delegateGetter(entity).cancelBubbleUp() }
+    }
+}

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxToolkitInit.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxToolkitInit.kt
@@ -15,15 +15,36 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
  ******************************************************************************/
 
-package net.transgressoft.lirp.persistence
+package net.transgressoft.lirp.persistence.sql
+
+import javafx.application.Platform
 
 /**
- * Marker interface for all LIRP property delegates that participate in the framework's
- * runtime delegate introspection. Implemented by reactive property delegates and all
- * aggregate collection reference delegates.
- *
- * The [ReactiveEntityBase.delegateRegistry][net.transgressoft.lirp.entity.ReactiveEntityBase]
- * discovers instances of this interface by scanning `memberProperties` via kotlin-reflect,
- * enabling framework-level serialization without KSP code generation.
+ * Headless JavaFX toolkit initializer for test environments.
+ * Uses Monocle as the glass platform to avoid requiring a display.
  */
-interface LirpDelegate
+object FxToolkitInit {
+
+    @Volatile
+    private var initialized = false
+
+    fun ensureInitialized() {
+        if (initialized)
+            return
+        synchronized(this) {
+            if (initialized)
+                return
+            System.setProperty("java.awt.headless", "true")
+            System.setProperty("glass.platform", "Monocle")
+            System.setProperty("monocle.platform", "Headless")
+            System.setProperty("prism.order", "sw")
+            try {
+                Platform.startup {}
+            } catch (_: IllegalStateException) {
+                // Toolkit already initialized
+            }
+            Platform.setImplicitExit(false)
+            initialized = true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Phase 33: lirp-fx fxProperty Scalar Delegates** ([#87](https://github.com/octaviospain/lirp/issues/87))

**Goal:** Create `fxInteger`, `fxFloat`, `fxDouble`, `fxLong`, `fxString`, `fxBoolean`, and `fxObject` delegate factories in `lirp-fx` that bridge lirp's `reactiveProperty` with JavaFX property types, providing one-declaration observable scalars with automatic mutation event emission and JavaFX binding support.

**Status:** Verified ✓ (14/14 must-haves)

Seven `Lirp*Property` classes extend JavaFX `Simple*Property` and implement `LirpDelegate` + `FxScalarPropertyDelegate`. Each overrides `set()` with an equality guard and callback-before-super.set() ordering for clone-before-mutation event emission. `RegistryBase.bindEntityRefs()` auto-injects the mutation callback when the entity is added to a repository — setting any fx scalar property fires both a lirp `ReactiveMutationEvent` and JavaFX `ChangeListener` notifications.

## Changes

### Production code (lirp-core)
- **`FxScalarPropertyDelegate`** — fun interface with `bindMutationCallback` for cross-module detection
- **`ReactiveEntityBase.emitFxScalarMutation()`** — internal method implementing clone-before-mutation pattern for fx scalar delegates
- **`LirpDelegate`** — promoted from `internal` to `public` visibility
- **`RegistryBase.bindEntityRefs()`** — detects `FxScalarPropertyDelegate` instances and injects mutation callbacks; extracted `bindCollectionRefs()`/`bindFxScalarDelegates()` to reduce cognitive complexity
- **`FxObservableCollectionProxy.syncLocalCache()`** — new method to populate local element cache after registry binding (fixes reload bug)
- **`LirpEntitySerializer`** — serializes/deserializes fx scalar delegates via `DelegateInfo.FxScalar`; resolves value serializers from JavaFX property return type

### Production code (lirp-fx)
- **7 Lirp*Property classes** — `LirpStringProperty`, `LirpIntegerProperty`, `LirpDoubleProperty`, `LirpFloatProperty`, `LirpLongProperty`, `LirpBooleanProperty`, `LirpObjectProperty<T>`
- **7 factory functions** in `FxFactories.kt` — `fxString()`, `fxInteger()`, `fxDouble()`, `fxFloat()`, `fxLong()`, `fxBoolean()`, `fxObject<T>()`
- **`FxProperties`** — `@JvmStatic` factory object for Java consumers using `fx`-prefixed method names
- **`FxAggregateListProxy`/`FxAggregateSetProxy`** — implemented `syncLocalCache()` to fix post-reload mutation tracking

### Test code
- **`FxScalarPropertyTest`** — 36 tests covering initial values, set/ChangeListener/callback for all types, interface compliance, factory functions, FxProperties static methods
- **`FxScalarRegistryIntegrationTest`** — 7 tests for RegistryBase wiring, dual notification, withEventsDisabled, standalone entity
- **`FxJsonSerializationTest`** — 11 tests including fx scalar serialization, round-trip with nullable ObjectProperty
- **`FxScalarJavaInteropTest`** — 9 Java interop tests for all FxProperties static factories
- **`FxSqlRepositoryTest`** — 9 tests for SQL persistence of fx scalar + fx aggregate delegates (H2)
- **Merged `FxScalarTestEntity` into `FxAudioPlaylistEntity`** — single cohesive test entity exercising all delegate types

### Documentation
- **README.md** — Annotations Reference section, Scalar Property Delegates subsection, clarified `@Aggregate` requirement
- **Wiki** — JavaFX-Integration.md updated with scalar delegates, Annotations Guide section

## Verification

- [x] Automated verification: 14/14 must-haves passed
- [x] All modules compile (`gradle check` green)
- [x] SonarCloud: 0 open issues on master
- [x] SonarQube: S3776 (cognitive complexity) and S6517 (functional interface) addressed
- [x] Coverage: LirpLongProperty 85%, LirpFloatProperty 85%, FxFactories 91%, LirpEntitySerializer 91%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified README: persistence annotation behavior, aggregate reference requirements, scalar property delegates, and an annotations reference table.

* **New Features**
  * Added JavaFX scalar property delegates (string/int/double/float/long/boolean/object) and Java-friendly FxProperties factories.
  * FX collection proxies can resync their local caches; scalar delegates emit lirp mutation events and JavaFX change notifications.

* **Bug Fixes**
  * More robust delegate discovery/handling; suppressed redundant/no-op sets; improved JSON and SQL scalar persistence.

* **Tests**
  * New unit and integration tests for FX scalars, JSON round-trips, SQL persistence, and Java interop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->