### PR TITLE
#88 Projection Maps — derived grouped views for core and JavaFX

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,13 +255,13 @@ entity.subscribeToMutations { event ->
     println("${event.oldEntity} -> ${event.newEntity}")
 }
 
-// Collection changes only (optionally filtered by collection property name)
-entity.subscribeToCollectionChanges { event ->
+// Collection changes — type-safe with element class
+entity.subscribeToCollectionChanges(Track::class) { event ->
     println("Type: ${event.type}, Added: ${event.added}, Removed: ${event.removed}")
 }
 
 // Filter to a specific collection
-entity.subscribeToCollectionChanges("tracks") { event ->
+entity.subscribeToCollectionChanges(Track::class, "tracks") { event ->
     println("Tracks changed: +${event.added.size} -${event.removed.size}")
 }
 ```
@@ -269,14 +269,14 @@ entity.subscribeToCollectionChanges("tracks") { event ->
 **Java Consumer overloads:**
 
 ```java
-// All collections
-CollectionChangeEventExtensionsKt.subscribeToCollectionChanges(entity, null,
-    (Consumer<CollectionChangeEvent<?>>) event ->
+// All collections — type-safe with element class
+CollectionChangeEventExtensionsKt.subscribeToCollectionChanges(entity, Track.class, null,
+    (Consumer<CollectionChangeEvent<Track>>) event ->
         System.out.println("Added: " + event.getAdded()));
 
 // Specific collection
-CollectionChangeEventExtensionsKt.subscribeToCollectionChanges(entity, "tracks",
-    (Consumer<CollectionChangeEvent<?>>) event ->
+CollectionChangeEventExtensionsKt.subscribeToCollectionChanges(entity, Track.class, "tracks",
+    (Consumer<CollectionChangeEvent<Track>>) event ->
         System.out.println("Added: " + event.getAdded()));
 
 // Property mutations only
@@ -605,9 +605,74 @@ Available factories: `fxString()`, `fxInteger()`, `fxDouble()`, `fxFloat()`, `fx
 ```java
 LirpStringProperty name = FxProperties.fxString("default", true);
 LirpIntegerProperty age = FxProperties.fxInteger(0, true);
-FxAggregateListProxy<Integer, Track> tracks = FxProperties.fxAggregateList(List.of(), true);
+FxAggregateList<Integer, Track> tracks = FxProperties.fxAggregateList(List.of(), true);
 ```
 
+### Projection Maps
+
+Derive a read-only `Map<PK, List<E>>` from an existing `aggregateList` or `aggregateSet` delegate, grouping entities by a secondary key:
+
+```kotlin
+class AudioLibrary(
+    override val id: Int,
+    initialAudioItemIds: List<Int> = emptyList()
+) : ReactiveEntityBase<Int, AudioLibrary>() {
+    override val uniqueId = "audio-library-$id"
+
+    @Aggregate(onDelete = CascadeAction.DETACH)
+    val audioItems by mutableAggregateList<Int, AudioItem>(initialAudioItemIds)
+
+    val byTitle: Map<String, List<AudioItem>>
+        by projectionMap(::audioItems) { it.title }
+
+    override fun clone() = AudioLibrary(id, audioItems.referenceIds.toList())
+}
+```
+
+The projection lazily initializes on the first access and groups entities using a `TreeMap` for natural sorted key order. When the source is a `mutableAggregateList` or `mutableAggregateSet`, the projection auto-updates incrementally whenever entities are added or removed — no manual notification required:
+
+```kotlin
+val newItem = MutableAudioItem(42, "Blues")
+library.audioItems.add(newItem)
+// The projection updates automatically
+```
+
+- `onChange` — optional callback invoked after each projection change with the current map state
+
+The returned map is read-only (`Collections.unmodifiableMap`). All mutations flow through the source collection.
+
+### FX Projection Maps
+
+Derive a read-only `ObservableMap<PK, List<E>>` from an existing `fxAggregateList` or `fxAggregateSet` delegate, grouping entities by a secondary key:
+
+```kotlin
+class AudioLibrary(
+    override val id: Int,
+    initialAudioItemIds: List<Int> = emptyList()
+) : ReactiveEntityBase<Int, AudioLibrary>() {
+    override val uniqueId = "audio-library-$id"
+
+    @Aggregate(onDelete = CascadeAction.DETACH)
+    val audioItems by fxAggregateList<Int, AudioItem>(initialAudioItemIds, dispatchToFxThread = false)
+
+    val byAlbum: ObservableMap<String, List<AudioItem>>
+        by fxProjectionMap(::audioItems, AudioItem::albumName)
+
+    override fun clone() = AudioLibrary(id, audioItems.referenceIds.toList())
+}
+```
+
+The projection updates incrementally when the source collection changes, firing targeted `MapChangeListener` events per affected group key only. Keys iterate in natural sorted order via a `TreeMap` backing. The returned map is read-only — calling `put` or `remove` throws `UnsupportedOperationException`.
+
+Java callers use the static factory and access the map directly on the returned `FxProjectionMap`, which implements `ObservableMap`:
+
+```java
+FxProjectionMap<Integer, String, AudioItem> byAlbum =
+    FxProperties.fxProjectionMap(() -> audioItems, AudioItem::getAlbumName, false);
+byAlbum.addListener((MapChangeListener<String, List<AudioItem>>) change -> { ... });
+int count = byAlbum.size();
+List<AudioItem> albums = byAlbum.get("Album A");
+```
 ## Annotations Reference
 
 | Annotation | Target | Required when | Not needed for |
@@ -632,7 +697,8 @@ FxAggregateListProxy<Integer, Track> tracks = FxProperties.fxAggregateList(List.
 - **Convention-over-configuration** — KSP generates table definitions from entity classes; annotations only when you need customization
 - **JSON persistence** — debounced file writes via `JsonFileRepository`
 - **Repository-as-factory** — typed `create()` methods with automatic `@LirpRepository` registration
-- **JavaFX integration** — `fxAggregateList`/`fxAggregateSet` delegates bridging lirp collections with `ObservableList`/`ObservableSet`
+- **JavaFX integration** — `fxAggregateList`/`fxAggregateSet` delegates bridging lirp collections with `ObservableList`/`ObservableSet`; `fxProjectionMap` for read-only grouped `ObservableMap` projections
+- **Non-FX projection maps** — `projectionMap` in `lirp-core` groups entities into a standard `Map<PK, List<E>>` with no JavaFX dependency, suitable for Android, Compose Multiplatform, and server-side consumers
 - **Full Java interoperability**
 
 ## Limitations and Design Trade-offs

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/CollectionChangeEventExtensions.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/CollectionChangeEventExtensions.kt
@@ -23,6 +23,7 @@ import net.transgressoft.lirp.event.LirpEventSubscription
 import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.event.ReactiveMutationEvent
 import java.util.function.Consumer
+import kotlin.reflect.KClass
 
 // Extension functions providing a 3-tier subscription API for ReactiveEntity:
 // - subscribe — all events (property mutations, collection changes, bubble-up)
@@ -35,37 +36,60 @@ import java.util.function.Consumer
  *
  * Filters the entity's event stream to [AggregateMutationEvent] instances whose [childEvent][AggregateMutationEvent.childEvent]
  * is a [CollectionChangeEvent]. When [refName] is provided, only events for that specific collection are delivered.
+ * Only events whose elements are instances of [elementType] are delivered, providing runtime type safety.
  *
+ * ```kotlin
+ * playlist.subscribeToCollectionChanges(AudioItem::class, "audioItems") { event ->
+ *     for (added in event.added) { /* added is AudioItem — no cast needed */ }
+ * }
+ *
+ * playlist.subscribeToCollectionChanges(MutableAudioPlaylist::class, "playlists") { event ->
+ *     for (added in event.added) { /* added is MutableAudioPlaylist */ }
+ * }
+ * ```
+ *
+ * @param E the element type of the collection change event
+ * @param elementType the element class for type-safe event delivery and runtime filtering
  * @param refName optional collection property name to filter on (e.g., "audioItems"). If null, receives events from all collections.
  * @param action the suspend function invoked for each matching collection change event
  * @return a subscription handle that can be cancelled to stop receiving events
  */
-fun <K : Comparable<K>, R : ReactiveEntity<K, R>> ReactiveEntity<K, R>.subscribeToCollectionChanges(
+@Suppress("UNCHECKED_CAST")
+fun <K : Comparable<K>, R : ReactiveEntity<K, R>, E : Any> ReactiveEntity<K, R>.subscribeToCollectionChanges(
+    elementType: KClass<E>,
     refName: String? = null,
-    action: suspend (CollectionChangeEvent<*>) -> Unit
+    action: suspend (CollectionChangeEvent<E>) -> Unit
 ): LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>> =
     subscribe { event ->
         if (event is AggregateMutationEvent<*, *> &&
             event.childEvent is CollectionChangeEvent<*> &&
-            (refName == null || event.refName == refName)
+            (refName == null || event.refName == refName) &&
+            (event.childEvent as CollectionChangeEvent<*>).added.all { it == null || elementType.isInstance(it) }
         ) {
-            @Suppress("UNCHECKED_CAST")
-            action(event.childEvent as CollectionChangeEvent<*>)
+            action(event.childEvent as CollectionChangeEvent<E>)
         }
     }
 
 /**
- * Java-friendly overload of [subscribeToCollectionChanges] using a [Consumer] callback.
+ * Java-friendly overload of [subscribeToCollectionChanges] using a [Consumer] callback and [Class] instead of [KClass].
  *
+ * ```java
+ * CollectionChangeEventExtensionsKt.subscribeToCollectionChanges(playlist, AudioItem.class, "audioItems",
+ *     event -> { for (AudioItem added : event.getAdded()) { ... } });
+ * ```
+ *
+ * @param E the element type of the collection change event
+ * @param elementType the Java class for type-safe event delivery and runtime filtering
  * @param refName optional collection property name to filter on. Pass null for all collections.
  * @param action the consumer invoked for each matching collection change event
  * @return a subscription handle that can be cancelled to stop receiving events
  */
-fun <K : Comparable<K>, R : ReactiveEntity<K, R>> ReactiveEntity<K, R>.subscribeToCollectionChanges(
+fun <K : Comparable<K>, R : ReactiveEntity<K, R>, E : Any> ReactiveEntity<K, R>.subscribeToCollectionChanges(
+    elementType: Class<E>,
     refName: String?,
-    action: Consumer<CollectionChangeEvent<*>>
+    action: Consumer<CollectionChangeEvent<E>>
 ): LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>> =
-    subscribeToCollectionChanges(refName) { event -> action.accept(event) }
+    subscribeToCollectionChanges(elementType.kotlin, refName) { event -> action.accept(event) }
 
 /**
  * Subscribes to direct property mutation events on this entity, excluding aggregate/collection events.

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -27,7 +27,7 @@ import net.transgressoft.lirp.event.MutationEvent.Type.MUTATE
 import net.transgressoft.lirp.event.ReactiveMutationEvent
 import net.transgressoft.lirp.event.StandardAggregateMutationEvent
 import net.transgressoft.lirp.persistence.AggregateRefDelegate
-import net.transgressoft.lirp.persistence.FxObservableCollectionProxy
+import net.transgressoft.lirp.persistence.FxObservableCollection
 import net.transgressoft.lirp.persistence.LirpDelegate
 import net.transgressoft.lirp.persistence.LirpRefAccessor
 import mu.KotlinLogging
@@ -481,10 +481,10 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
                         }
                     if (delegate is LirpDelegate) {
                         map[prop.name] = delegate
-                    } else if (delegate is FxObservableCollectionProxy) {
+                    } else if (delegate is FxObservableCollection<*, *>) {
                         val inner = delegate.innerMutableProxy
                         require(inner is LirpDelegate) {
-                            "Fx proxy delegate '${prop.name}' must expose a LirpDelegate inner proxy, got: ${inner::class.qualifiedName}"
+                            "Fx collection delegate '${prop.name}' must expose a LirpDelegate inner proxy, got: ${inner::class.qualifiedName}"
                         }
                         map[prop.name] = inner
                     }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/AbstractMutableAggregateCollectionRefDelegate.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/AbstractMutableAggregateCollectionRefDelegate.kt
@@ -20,6 +20,7 @@ package net.transgressoft.lirp.persistence
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.event.CollectionChangeEvent
 import net.transgressoft.lirp.event.StandardCollectionChangeEvent
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -65,29 +66,59 @@ abstract class AbstractMutableAggregateCollectionRefDelegate<K : Comparable<K>, 
         collectionEmissionCallback = callback
     }
 
+    /**
+     * Secondary callbacks for projection maps that receive the full [CollectionChangeEvent] for each mutation.
+     * Supports multiple concurrent projections on the same source without overwriting each other.
+     * Invoked after [collectionEmissionCallback] via [notifyProjection].
+     */
+    private val projectionCallbacks = CopyOnWriteArrayList<(CollectionChangeEvent<*>) -> Unit>()
+
+    /**
+     * Registers [callback] as a projection listener that will receive [CollectionChangeEvent]s after each mutation.
+     */
+    internal fun addProjectionCallback(callback: (CollectionChangeEvent<*>) -> Unit) {
+        projectionCallbacks.add(callback)
+    }
+
+    /**
+     * Forwards the [CollectionChangeEvent] to all registered [projectionCallbacks].
+     * Called by [mutate] and [mutateVoid] after the main emission callback.
+     */
+    internal fun notifyProjection(event: CollectionChangeEvent<*>) {
+        projectionCallbacks.forEach { it(event) }
+    }
+
     override fun provideIds(): Collection<K> = lock.withLock { ArrayList(backingIds) }
 
     override val referenceIds: Collection<K> get() = lock.withLock { ArrayList(backingIds) }
 
     /**
      * Executes [action] on [backingIds] under the lock and returns the result.
-     * If [changed] is true and [eventBuilder] is provided, emits the [CollectionChangeEvent] after mutation.
+     * If [changed] is true and [eventBuilder] is provided, emits the [CollectionChangeEvent] after mutation
+     * and forwards the diff to [projectionCallback] if one is registered.
      */
     protected fun mutate(action: MutableCollection<K>.() -> Boolean, eventBuilder: (() -> CollectionChangeEvent<*>)? = null): Boolean {
         val changed = lock.withLock { backingIds.action() }
         if (changed && eventBuilder != null) {
-            collectionEmissionCallback?.invoke(eventBuilder())
+            val event = eventBuilder()
+            collectionEmissionCallback?.invoke(event)
+            notifyProjection(event)
         }
         return changed
     }
 
     /**
      * Executes [action] on [backingIds] under the lock without returning a result.
-     * If [eventBuilder] is provided, emits the [CollectionChangeEvent] after mutation.
+     * If [eventBuilder] is provided, emits the [CollectionChangeEvent] after mutation
+     * and forwards the diff to [projectionCallback] if one is registered.
      */
     protected fun mutateVoid(action: MutableCollection<K>.() -> Unit, eventBuilder: (() -> CollectionChangeEvent<*>)? = null) {
         lock.withLock { backingIds.action() }
-        eventBuilder?.let { collectionEmissionCallback?.invoke(it()) }
+        eventBuilder?.let {
+            val event = it()
+            collectionEmissionCallback?.invoke(event)
+            notifyProjection(event)
+        }
     }
 
     override fun clear() {
@@ -103,7 +134,9 @@ abstract class AbstractMutableAggregateCollectionRefDelegate<K : Comparable<K>, 
                 }
             backingIds.clear()
         }
-        collectionEmissionCallback?.invoke(StandardCollectionChangeEvent.clear(removedEntities))
+        val clearEvent = StandardCollectionChangeEvent.clear(removedEntities)
+        collectionEmissionCallback?.invoke(clearEvent)
+        notifyProjection(clearEvent)
     }
 
     /**
@@ -166,7 +199,9 @@ abstract class AbstractMutableAggregateCollectionRefDelegate<K : Comparable<K>, 
                 backingIds.retainAll(idsToKeep)
             }
         if (changed) {
-            collectionEmissionCallback?.invoke(StandardCollectionChangeEvent.remove(removedEntities))
+            val event = StandardCollectionChangeEvent.remove(removedEntities)
+            collectionEmissionCallback?.invoke(event)
+            notifyProjection(event)
         }
         return changed
     }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/CoreFactories.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/CoreFactories.kt
@@ -1,0 +1,49 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import net.transgressoft.lirp.entity.IdentifiableEntity
+
+/**
+ * Creates a read-only projection that groups entities from a source collection by a secondary key.
+ *
+ * The returned [ProjectionMap] lazily initializes on the first Kotlin `by`-delegation access,
+ * building its initial state from the source's current contents. When the source is a
+ * [MutableAggregateList] or [MutableAggregateSet], subsequent mutations are reflected
+ * automatically without any manual notification. For other [AggregateCollectionRef] implementations,
+ * only the initial snapshot is captured.
+ *
+ * Keys are maintained in natural sorted order via a [java.util.TreeMap] backing. The projected
+ * map is read-only; mutations must flow through the source collection.
+ *
+ * Usage:
+ * ```kotlin
+ * val audioItemsByTitle by projectionMap(::audioItems) { it.title }
+ * ```
+ *
+ * @param K the entity ID type, must be [Comparable]
+ * @param PK the projection key type, must be [Comparable]
+ * @param E the entity type
+ * @param sourceRef lambda returning the source collection (supports `::property` syntax)
+ * @param keyExtractor trailing-lambda grouping function that extracts the projection key from an entity
+ * @return a [ProjectionMap] delegate grouping entities by [keyExtractor]
+ */
+fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> projectionMap(
+    sourceRef: () -> AggregateCollectionRef<K, E>,
+    keyExtractor: (E) -> PK
+): ProjectionMap<K, PK, E> = ProjectionMap(sourceRef, keyExtractor)

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/FxObservableCollection.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/FxObservableCollection.kt
@@ -17,23 +17,28 @@
 
 package net.transgressoft.lirp.persistence
 
+import net.transgressoft.lirp.entity.IdentifiableEntity
+
 /**
- * Marker interface for JavaFX observable collection proxies that wrap a mutable aggregate
- * collection delegate. Implemented by `FxAggregateListProxy` and `FxAggregateSetProxy`
+ * Marker interface for JavaFX observable collections that wrap a mutable aggregate
+ * collection delegate. Implemented by [FxAggregateList] and [FxAggregateSet]
  * from the `lirp-fx` module.
  *
- * [RegistryBase] uses this interface to detect fx proxies in [RegistryBase.bindEntityRefs]
+ * [RegistryBase] uses this interface to detect fx collections in [RegistryBase.bindEntityRefs]
  * without creating a circular module dependency between `lirp-core` and `lirp-fx`.
- * The [innerMutableProxy] property exposes the wrapped proxy (either [MutableAggregateListProxy]
- * or [MutableAggregateSetProxy]) so that RegistryBase can reach the internal delegate for
+ * The [innerMutableProxy] property exposes the wrapped collection (either [MutableAggregateList]
+ * or [MutableAggregateSet]) so that RegistryBase can reach the internal delegate for
  * registry binding and collection emission callback injection.
+ *
+ * @param K the entity ID type, must be [Comparable]
+ * @param E the entity type
  */
-interface FxObservableCollectionProxy {
+interface FxObservableCollection<K : Comparable<K>, E : IdentifiableEntity<K>> {
     /**
-     * The wrapped mutable aggregate proxy.
+     * The wrapped mutable aggregate collection.
      *
-     * Will be either a [MutableAggregateListProxy] or [MutableAggregateSetProxy] instance.
-     * Typed as [Any] to avoid importing concrete fx proxy types in lirp-core.
+     * Will be either a [MutableAggregateList] or [MutableAggregateSet] instance.
+     * Typed as [Any] to avoid importing concrete fx collection types in lirp-core.
      */
     val innerMutableProxy: Any
 

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/MutableAggregateListRefDelegate.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/MutableAggregateListRefDelegate.kt
@@ -100,7 +100,7 @@ internal class MutableAggregateListRefDelegate<K : Comparable<K>, E : Identifiab
 }
 
 /**
- * Proxy that exposes a [MutableAggregateListRefDelegate] as a standard [MutableList].
+ * Mutable list that exposes a [MutableAggregateListRefDelegate] as a standard [MutableList].
  *
  * Holds [innerDelegate] for registry binding, ID tracking, and reactive event emission.
  * All indexed mutations ([set], [add], [removeAt]) route through the delegate's locked,
@@ -110,12 +110,12 @@ internal class MutableAggregateListRefDelegate<K : Comparable<K>, E : Identifiab
  * for free — they all funnel through the four override methods defined here.
  *
  * Implements [LirpDelegate] so that [RegistryBase] and [LirpEntitySerializer] can detect and
- * unwrap this proxy to reach the inner delegate.
+ * unwrap this collection to reach the inner delegate.
  *
  * @param K the type of the referenced entity's ID
  * @param E the referenced entity type
  */
-class MutableAggregateListProxy<K : Comparable<K>, E : IdentifiableEntity<K>>
+class MutableAggregateList<K : Comparable<K>, E : IdentifiableEntity<K>>
     internal constructor(
         internal val innerDelegate: MutableAggregateListRefDelegate<K, E>
     ) : AbstractMutableList<E>(), AggregateCollectionRef<K, E> by innerDelegate, LirpDelegate {
@@ -182,13 +182,13 @@ class MutableAggregateListProxy<K : Comparable<K>, E : IdentifiableEntity<K>>
             }
         }
 
-        operator fun getValue(thisRef: Any?, property: KProperty<*>): MutableAggregateListProxy<K, E> = this
+        operator fun getValue(thisRef: Any?, property: KProperty<*>): MutableAggregateList<K, E> = this
     }
 
 /**
  * Creates a property delegate for a mutable ordered aggregate collection reference.
  *
- * The returned object is a [MutableList] proxy that wraps an internal delegate owning the mutable
+ * The returned object is a [MutableList] that wraps an internal delegate owning the mutable
  * backing ID list, initialized from [initialIds] at property delegation time. Add, remove, and
  * indexed mutation operations update the internal list and trigger collection change event emission
  * on the owning entity after registry binding. Duplicate IDs are allowed (bag semantics).
@@ -207,4 +207,4 @@ class MutableAggregateListProxy<K : Comparable<K>, E : IdentifiableEntity<K>>
  */
 fun <K : Comparable<K>, E : IdentifiableEntity<K>> mutableAggregateList(
     initialIds: List<K> = emptyList()
-): MutableAggregateListProxy<K, E> = MutableAggregateListProxy(MutableAggregateListRefDelegate(initialIds))
+): MutableAggregateList<K, E> = MutableAggregateList(MutableAggregateListRefDelegate(initialIds))

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/MutableAggregateSetRefDelegate.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/MutableAggregateSetRefDelegate.kt
@@ -67,7 +67,9 @@ internal class MutableAggregateSetRefDelegate<K : Comparable<K>, E : Identifiabl
                 backingIds.addAll(ids)
             }
         if (changed && actuallyAdded.isNotEmpty()) {
-            collectionEmissionCallback?.invoke(StandardCollectionChangeEvent.add(actuallyAdded))
+            val event = StandardCollectionChangeEvent.add(actuallyAdded)
+            collectionEmissionCallback?.invoke(event)
+            notifyProjection(event)
         }
         return changed
     }
@@ -82,7 +84,9 @@ internal class MutableAggregateSetRefDelegate<K : Comparable<K>, E : Identifiabl
                 backingIds.removeAll(ids)
             }
         if (changed && actuallyRemoved.isNotEmpty()) {
-            collectionEmissionCallback?.invoke(StandardCollectionChangeEvent.remove(actuallyRemoved))
+            val event = StandardCollectionChangeEvent.remove(actuallyRemoved)
+            collectionEmissionCallback?.invoke(event)
+            notifyProjection(event)
         }
         return changed
     }
@@ -100,7 +104,7 @@ internal class MutableAggregateSetRefDelegate<K : Comparable<K>, E : Identifiabl
 }
 
 /**
- * Proxy that exposes a [MutableAggregateSetRefDelegate] as a standard [MutableSet].
+ * Mutable set that exposes a [MutableAggregateSetRefDelegate] as a standard [MutableSet].
  *
  * Composes the inner delegate via [AggregateCollectionRef] delegation so that [referenceIds],
  * [resolveAll], and cascade operations are forwarded. [add] and [remove] route through the
@@ -112,7 +116,7 @@ internal class MutableAggregateSetRefDelegate<K : Comparable<K>, E : Identifiabl
  * @param K the type of the referenced entity's ID
  * @param E the referenced entity type
  */
-class MutableAggregateSetProxy<K : Comparable<K>, E : IdentifiableEntity<K>>
+class MutableAggregateSet<K : Comparable<K>, E : IdentifiableEntity<K>>
     internal constructor(
         internal val innerDelegate: MutableAggregateSetRefDelegate<K, E>
     ) : AbstractMutableSet<E>(),
@@ -149,13 +153,13 @@ class MutableAggregateSetProxy<K : Comparable<K>, E : IdentifiableEntity<K>>
             }
         }
 
-        operator fun getValue(thisRef: Any?, property: KProperty<*>): MutableAggregateSetProxy<K, E> = this
+        operator fun getValue(thisRef: Any?, property: KProperty<*>): MutableAggregateSet<K, E> = this
     }
 
 /**
  * Creates a property delegate for a mutable unique-set aggregate collection reference.
  *
- * The returned object is a [MutableSet] proxy that wraps an internal delegate owning a mutable
+ * The returned object is a [MutableSet] that wraps an internal delegate owning a mutable
  * backing ID set ([LinkedHashSet]), initialized from [initialIds] at property delegation time.
  * Add and remove operations update the internal set and trigger collection change event emission
  * on the owning entity after registry binding. Uniqueness is enforced — duplicate IDs are silently ignored.
@@ -169,4 +173,4 @@ class MutableAggregateSetProxy<K : Comparable<K>, E : IdentifiableEntity<K>>
  */
 fun <K : Comparable<K>, E : IdentifiableEntity<K>> mutableAggregateSet(
     initialIds: Set<K> = emptySet()
-): MutableAggregateSetProxy<K, E> = MutableAggregateSetProxy(MutableAggregateSetRefDelegate(initialIds))
+): MutableAggregateSet<K, E> = MutableAggregateSet(MutableAggregateSetRefDelegate(initialIds))

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/ProjectionMap.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/ProjectionMap.kt
@@ -1,0 +1,186 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import net.transgressoft.lirp.entity.IdentifiableEntity
+import net.transgressoft.lirp.event.CollectionChangeEvent
+import java.util.Collections
+import java.util.TreeMap
+import kotlin.reflect.KProperty
+
+/**
+ * A read-only grouped view that derives a `Map<PK, List<E>>` from a source collection,
+ * grouping entities by a secondary key via [keyExtractor].
+ *
+ * The projection uses a [TreeMap] for natural key ordering and fires an optional [onChange]
+ * callback when the projection state changes. It has no JavaFX dependency and works with
+ * any JVM target including Android and server-side applications.
+ *
+ * The projection initializes lazily on the first [getValue] (Kotlin `by` delegation) or map
+ * access call, building its initial state from the source collection's current contents. When
+ * the source is a [MutableAggregateList] or [MutableAggregateSet], subsequent mutations are
+ * applied incrementally and automatically via the source collection's projection callback.
+ * For plain collections, the map reflects the state at initialization time only.
+ *
+ * The map is read-only. All mutations flow through the source collection.
+ *
+ * @param K the entity ID type, must be [Comparable]
+ * @param PK the projection key type, must be [Comparable] (used as [TreeMap] key)
+ * @param E the entity type
+ * @param sourceRef deferred reference to the source collection (resolved on first access)
+ * @param keyExtractor grouping function that extracts the projection key from an entity
+ */
+class ProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>>(
+    private val sourceRef: () -> AggregateCollectionRef<K, E>,
+    private val keyExtractor: (E) -> PK
+) : AbstractMap<PK, List<E>>() {
+    private val backingMap = TreeMap<PK, List<E>>()
+    private val readOnlyView: Map<PK, List<E>> = Collections.unmodifiableMap(backingMap)
+
+    @Volatile
+    private var initialized = false
+
+    /**
+     * Optional callback invoked after each projection change with the current map state.
+     * Fires after every incremental update that results in at least one addition or removal.
+     */
+    internal var onChange: ((Map<PK, List<E>>) -> Unit)? = null
+
+    private fun initialize() {
+        if (initialized) return
+        synchronized(this) {
+            if (initialized) return
+            val source = sourceRef()
+            handleAdded(source.resolveAll().toList())
+            subscribeToSource(source)
+            initialized = true
+        }
+    }
+
+    private fun freezeBucket(elements: List<E>): List<E> = java.util.Collections.unmodifiableList(ArrayList(elements))
+
+    @Suppress("UNCHECKED_CAST")
+    private fun subscribeToSource(source: AggregateCollectionRef<K, E>) {
+        val callback: (CollectionChangeEvent<*>) -> Unit = { event ->
+            if (event.type == CollectionChangeEvent.Type.CLEAR) {
+                rebuild(source)
+            } else {
+                if (event.added.isNotEmpty()) handleAdded(event.added as List<E>)
+                if (event.removed.isNotEmpty()) handleRemoved(event.removed as List<E>)
+            }
+        }
+        when (source) {
+            is MutableAggregateList<*, *> -> source.innerDelegate.addProjectionCallback(callback)
+            is MutableAggregateSet<*, *> -> source.innerDelegate.addProjectionCallback(callback)
+        }
+    }
+
+    private fun rebuild(source: AggregateCollectionRef<K, E>) {
+        backingMap.clear()
+        handleAdded(source.resolveAll().toList())
+    }
+
+    private fun handleAdded(elements: List<E>) {
+        var changed = false
+        for (element in elements) {
+            val key = keyExtractor(element)
+            backingMap[key] = freezeBucket((backingMap[key] ?: emptyList()) + element)
+            changed = true
+        }
+        if (changed) onChange?.invoke(readOnlyView)
+    }
+
+    private fun handleRemoved(elements: List<E>) {
+        var changed = false
+        for (element in elements) {
+            val key = keyExtractor(element)
+            val bucket = backingMap[key]
+            if (bucket != null && element in bucket) {
+                val filtered = bucket.filter { it != element }
+                if (filtered.isEmpty()) backingMap.remove(key)
+                else backingMap[key] = freezeBucket(filtered)
+                changed = true
+            } else {
+                changed = removeFromAnyBucket(element) || changed
+            }
+        }
+        if (changed) onChange?.invoke(readOnlyView)
+    }
+
+    private fun removeFromAnyBucket(element: E): Boolean {
+        val iterator = backingMap.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (element in entry.value) {
+                val filtered = entry.value.filter { it != element }
+                if (filtered.isEmpty()) iterator.remove()
+                else entry.setValue(freezeBucket(filtered))
+                return true
+            }
+        }
+        return false
+    }
+
+    // Map<PK, List<E>> delegation — enables direct read access (projection.size, projection["key"])
+    override val size: Int get() {
+        initialize()
+        return readOnlyView.size
+    }
+    override val entries: Set<Map.Entry<PK, List<E>>> get() {
+        initialize()
+        return readOnlyView.entries
+    }
+    override val keys: Set<PK> get() {
+        initialize()
+        return readOnlyView.keys
+    }
+    override val values: Collection<List<E>> get() {
+        initialize()
+        return readOnlyView.values
+    }
+
+    override fun containsKey(key: PK): Boolean {
+        initialize()
+        return readOnlyView.containsKey(key)
+    }
+
+    override fun containsValue(value: List<E>): Boolean {
+        initialize()
+        return readOnlyView.containsValue(value)
+    }
+
+    override fun get(key: PK): List<E>? {
+        initialize()
+        return readOnlyView[key]
+    }
+
+    override fun isEmpty(): Boolean {
+        initialize()
+        return readOnlyView.isEmpty()
+    }
+
+    /**
+     * Returns `this` projection map, initializing the source state on the first call.
+     *
+     * Implements Kotlin `by`-delegation: `val grouped by projectionMap(::items) { it.key }`.
+     */
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): ProjectionMap<K, PK, E> {
+        initialize()
+        return this
+    }
+}

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
@@ -222,7 +222,7 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
                 failFastIfDelegatePresent(entity.javaClass, AggregateRefDelegate::class.java, "LirpRefAccessor")
                 failFastIfDelegatePresent(entity.javaClass, AggregateCollectionRef::class.java, "LirpRefAccessor")
                 failFastIfDelegatePresent(entity.javaClass, MutableAggregateCollectionRef::class.java, "LirpRefAccessor")
-                failFastIfDelegatePresent(entity.javaClass, FxObservableCollectionProxy::class.java, "LirpRefAccessor")
+                failFastIfDelegatePresent(entity.javaClass, FxObservableCollection::class.java, "LirpRefAccessor")
                 collectionRefEntries = emptyList()
                 refEntries = emptyList()
             }
@@ -302,7 +302,7 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
                     entity.emitCollectionChangeEvent(entry.refName, event)
                 }
             }
-            if (delegate is FxObservableCollectionProxy) {
+            if (delegate is FxObservableCollection<*, *>) {
                 delegate.syncLocalCache()
             }
         }
@@ -321,21 +321,21 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
 
     private fun unwrapCollectionDelegate(delegate: Any?): AbstractAggregateCollectionRefDelegate<*, *>? =
         when (delegate) {
-            is MutableAggregateListProxy<*, *> -> delegate.innerDelegate
-            is MutableAggregateSetProxy<*, *> -> delegate.innerDelegate
+            is MutableAggregateList<*, *> -> delegate.innerDelegate
+            is MutableAggregateSet<*, *> -> delegate.innerDelegate
             is AggregateListProxy<*, *> -> delegate.innerDelegate
             is AggregateSetProxy<*, *> -> delegate.innerDelegate
             is AbstractAggregateCollectionRefDelegate<*, *> -> delegate
-            is FxObservableCollectionProxy -> unwrapCollectionDelegate(delegate.innerMutableProxy)
+            is FxObservableCollection<*, *> -> unwrapCollectionDelegate(delegate.innerMutableProxy)
             else -> null
         }
 
     private fun unwrapMutableDelegate(delegate: Any?): AbstractMutableAggregateCollectionRefDelegate<*, *>? =
         when (delegate) {
-            is MutableAggregateListProxy<*, *> -> delegate.innerDelegate
-            is MutableAggregateSetProxy<*, *> -> delegate.innerDelegate
+            is MutableAggregateList<*, *> -> delegate.innerDelegate
+            is MutableAggregateSet<*, *> -> delegate.innerDelegate
             is AbstractMutableAggregateCollectionRefDelegate<*, *> -> delegate
-            is FxObservableCollectionProxy -> unwrapMutableDelegate(delegate.innerMutableProxy)
+            is FxObservableCollection<*, *> -> unwrapMutableDelegate(delegate.innerMutableProxy)
             else -> null
         }
 

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
@@ -21,8 +21,8 @@ import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.persistence.AbstractMutableAggregateCollectionRefDelegate
 import net.transgressoft.lirp.persistence.AggregateCollectionRef
 import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
-import net.transgressoft.lirp.persistence.MutableAggregateListProxy
-import net.transgressoft.lirp.persistence.MutableAggregateSetProxy
+import net.transgressoft.lirp.persistence.MutableAggregateList
+import net.transgressoft.lirp.persistence.MutableAggregateSet
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
@@ -366,8 +366,8 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
             // Unwrap proxy layer to reach the backing ID delegate
             val mutableDelegate =
                 when (delegate) {
-                    is MutableAggregateListProxy<*, *> -> delegate.innerDelegate
-                    is MutableAggregateSetProxy<*, *> -> delegate.innerDelegate
+                    is MutableAggregateList<*, *> -> delegate.innerDelegate
+                    is MutableAggregateSet<*, *> -> delegate.innerDelegate
                     is AbstractMutableAggregateCollectionRefDelegate<*, *> -> delegate
                     else -> continue
                 }

--- a/lirp-core/src/test/java/net/transgressoft/lirp/JavaInteroperabilityTest.java
+++ b/lirp-core/src/test/java/net/transgressoft/lirp/JavaInteroperabilityTest.java
@@ -18,9 +18,10 @@ import net.transgressoft.lirp.persistence.BubbleUpOrderVolatileRepo;
 import net.transgressoft.lirp.persistence.Customer;
 import net.transgressoft.lirp.persistence.CustomerVolatileRepo;
 import net.transgressoft.lirp.persistence.LirpContext;
+import net.transgressoft.lirp.persistence.AudioItem;
 import net.transgressoft.lirp.persistence.AudioItemVolatileRepository;
 import net.transgressoft.lirp.persistence.MutableAudioItem;
-import net.transgressoft.lirp.persistence.MutableAudioPlaylistEntity;
+import net.transgressoft.lirp.persistence.DefaultAudioPlaylist;
 import net.transgressoft.lirp.persistence.AudioPlaylistVolatileRepository;
 import net.transgressoft.lirp.persistence.OrderVolatileRepo;
 import net.transgressoft.lirp.persistence.ReactiveEntityReference;
@@ -577,7 +578,7 @@ class JavaInteroperabilityTest {
         void javaAddsEntityToMutableAggregateListViaGetAudioItemsAdd() {
             MutableAudioItem track = new MutableAudioItem(1, "Track 1");
             trackRepo.add(track);
-            MutableAudioPlaylistEntity playlist = new MutableAudioPlaylistEntity(1, "Test Playlist", Collections.emptyList(), Collections.emptySet());
+            DefaultAudioPlaylist playlist = new DefaultAudioPlaylist(1, "Test Playlist", Collections.emptyList(), Collections.emptySet());
             playlistRepo.add(playlist);
 
             boolean added = playlist.getAudioItems().add(track);
@@ -592,7 +593,7 @@ class JavaInteroperabilityTest {
         void javaRemovesEntityFromMutableAggregateListViaGetAudioItemsRemove() {
             MutableAudioItem track = new MutableAudioItem(1, "Track 1");
             trackRepo.add(track);
-            MutableAudioPlaylistEntity playlist = new MutableAudioPlaylistEntity(1, "Test Playlist", List.of(1), Collections.emptySet());
+            DefaultAudioPlaylist playlist = new DefaultAudioPlaylist(1, "Test Playlist", List.of(1), Collections.emptySet());
             playlistRepo.add(playlist);
 
             boolean removed = playlist.getAudioItems().remove(track);
@@ -627,14 +628,14 @@ class JavaInteroperabilityTest {
         void subscribeToCollectionChanges_Java_Consumer_receives_events() throws InterruptedException {
             MutableAudioItem track = new MutableAudioItem(1, "Track 1");
             trackRepo.add(track);
-            MutableAudioPlaylistEntity playlist = new MutableAudioPlaylistEntity(1, "Test Playlist", Collections.emptyList(), Collections.emptySet());
+            DefaultAudioPlaylist playlist = new DefaultAudioPlaylist(1, "Test Playlist", Collections.emptyList(), Collections.emptySet());
             playlistRepo.add(playlist);
 
             var latch = new CountDownLatch(1);
             AtomicReference<CollectionChangeEvent<?>> receivedEvent = new AtomicReference<>(null);
 
-            CollectionChangeEventExtensionsKt.subscribeToCollectionChanges(playlist, null,
-                (Consumer<CollectionChangeEvent<?>>) event -> {
+            CollectionChangeEventExtensionsKt.subscribeToCollectionChanges(playlist, AudioItem.class, null,
+                (Consumer<CollectionChangeEvent<AudioItem>>) event -> {
                     receivedEvent.set(event);
                     latch.countDown();
                 });

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/SubscriptionExtensionsTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/SubscriptionExtensionsTest.kt
@@ -24,8 +24,8 @@ import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.AudioItemVolatileRepository
 import net.transgressoft.lirp.persistence.AudioPlaylistVolatileRepository
+import net.transgressoft.lirp.persistence.DefaultAudioPlaylist
 import net.transgressoft.lirp.persistence.LirpContext
-import net.transgressoft.lirp.persistence.MutableAudioPlaylistEntity
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -47,19 +47,15 @@ class SubscriptionExtensionsTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()
     val testScope = CoroutineScope(testDispatcher)
-    lateinit var previousFlowScope: CoroutineScope
-    lateinit var previousIoScope: CoroutineScope
 
     beforeSpec {
-        previousFlowScope = ReactiveScope.flowScope
-        previousIoScope = ReactiveScope.ioScope
         ReactiveScope.flowScope = testScope
         ReactiveScope.ioScope = testScope
     }
 
     afterSpec {
-        ReactiveScope.flowScope = previousFlowScope
-        ReactiveScope.ioScope = previousIoScope
+        ReactiveScope.resetDefaultFlowScope()
+        ReactiveScope.resetDefaultIoScope()
     }
 
     lateinit var ctx: LirpContext
@@ -78,12 +74,12 @@ class SubscriptionExtensionsTest : StringSpec({
 
     "subscribeToCollectionChanges receives ADD event from mutableAggregateList" {
         val t1 = trackRepo.create(1, "Track 1")
-        val playlist = MutableAudioPlaylistEntity(1, "Test").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
         val receivedEvent = AtomicReference<CollectionChangeEvent<*>>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribeToCollectionChanges { event ->
+        playlist.subscribeToCollectionChanges(AudioItem::class) { event ->
             receivedEvent.set(event)
             latch.countDown()
         }
@@ -94,18 +90,17 @@ class SubscriptionExtensionsTest : StringSpec({
         val collectionEvent = receivedEvent.get()
         collectionEvent.shouldBeInstanceOf<CollectionChangeEvent<*>>()
         collectionEvent.type shouldBe CollectionChangeEvent.Type.ADD
-        @Suppress("UNCHECKED_CAST")
-        (collectionEvent as CollectionChangeEvent<AudioItem>).added shouldBe listOf(t1)
+        collectionEvent.added shouldBe listOf(t1)
     }
 
     "subscribeToCollectionChanges with refName filters to named collection only" {
         val t1 = trackRepo.create(1, "Track 1")
-        val playlist = MutableAudioPlaylistEntity(1, "Test").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
         val receivedEvent = AtomicReference<CollectionChangeEvent<*>>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribeToCollectionChanges(refName = "audioItems") { event ->
+        playlist.subscribeToCollectionChanges(AudioItem::class, "audioItems") { event ->
             receivedEvent.set(event)
             latch.countDown()
         }
@@ -118,13 +113,13 @@ class SubscriptionExtensionsTest : StringSpec({
     }
 
     "subscribeToCollectionChanges with refName does not receive events from other collections" {
-        val subPlaylist = MutableAudioPlaylistEntity(2, "Sub").also(playlistRepo::add)
-        val parent = MutableAudioPlaylistEntity(1, "Parent").also(playlistRepo::add)
+        val subPlaylist = DefaultAudioPlaylist(2, "Sub").also(playlistRepo::add)
+        val parent = DefaultAudioPlaylist(1, "Parent").also(playlistRepo::add)
 
         var eventCount = 0
 
         // Subscribe only to audioItems, but mutate playlists
-        parent.subscribeToCollectionChanges(refName = "audioItems") { _ ->
+        parent.subscribeToCollectionChanges(AudioItem::class, "audioItems") { _ ->
             eventCount++
         }
 
@@ -135,8 +130,27 @@ class SubscriptionExtensionsTest : StringSpec({
         eventCount shouldBe 0
     }
 
+    "typed subscribeToCollectionChanges delivers CollectionChangeEvent with concrete element type" {
+        val t1 = trackRepo.create(1, "Track 1")
+        val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
+
+        val receivedItems = mutableListOf<AudioItem>()
+        val latch = CountDownLatch(1)
+
+        playlist.subscribeToCollectionChanges(AudioItem::class, "audioItems") { event ->
+            receivedItems.addAll(event.added)
+            latch.countDown()
+        }
+
+        playlist.audioItems.add(t1)
+
+        latch.await(2, TimeUnit.SECONDS) shouldBe true
+        receivedItems.size shouldBe 1
+        receivedItems[0].id shouldBe 1
+    }
+
     "subscribeToMutations receives ReactiveMutationEvent for property change" {
-        val playlist = MutableAudioPlaylistEntity(1, "Original Name").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Original Name").also(playlistRepo::add)
 
         val receivedEvent = AtomicReference<ReactiveMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
@@ -154,7 +168,7 @@ class SubscriptionExtensionsTest : StringSpec({
 
     "subscribeToMutations does not receive AggregateMutationEvent from collection mutation" {
         val t1 = trackRepo.create(1, "Track 1")
-        val playlist = MutableAudioPlaylistEntity(1, "Test").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
         var mutationEventCount = 0
 
@@ -172,7 +186,7 @@ class SubscriptionExtensionsTest : StringSpec({
 
     "subscribe receives both property mutations and collection change events" {
         val t1 = trackRepo.create(1, "Track 1")
-        val playlist = MutableAudioPlaylistEntity(1, "Original Name").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Original Name").also(playlistRepo::add)
 
         val receivedEvents = mutableListOf<Any>()
         val latch = CountDownLatch(2)

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateSetCascadeTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateSetCascadeTest.kt
@@ -19,7 +19,6 @@ package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.entity.CascadeAction
 import net.transgressoft.lirp.event.ReactiveScope
-import net.transgressoft.lirp.persistence.AggregateSetProxy
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -61,8 +60,8 @@ internal class AggregateSetCascadeTest : StringSpec({
     }
 
     "CASCADE on set ref removes all referenced entities from their repository" {
-        playlistRepo.add(MutableAudioPlaylistEntity(10, "Mix A"))
-        playlistRepo.add(MutableAudioPlaylistEntity(20, "Mix B"))
+        playlistRepo.add(DefaultAudioPlaylist(10, "Mix A"))
+        playlistRepo.add(DefaultAudioPlaylist(20, "Mix B"))
         playlistRepo.size() shouldBe 2
 
         val groupRepo = CascadeMusicPlaylistGroupRepo(ctx)
@@ -76,8 +75,8 @@ internal class AggregateSetCascadeTest : StringSpec({
     }
 
     "CASCADE on set ref skips already-removed entities with warning" {
-        playlistRepo.add(MutableAudioPlaylistEntity(10, "Mix A"))
-        playlistRepo.add(MutableAudioPlaylistEntity(20, "Mix B"))
+        playlistRepo.add(DefaultAudioPlaylist(10, "Mix A"))
+        playlistRepo.add(DefaultAudioPlaylist(20, "Mix B"))
 
         val groupRepo = CascadeMusicPlaylistGroupRepo(ctx)
         val group1 = groupRepo.create(id = 100, playlistIds = setOf(10, 20))
@@ -102,7 +101,7 @@ internal class AggregateSetCascadeTest : StringSpec({
     }
 
     "RESTRICT on set ref blocks parent removal when a referenced entity is still referenced" {
-        playlistRepo.add(MutableAudioPlaylistEntity(10, "Mix"))
+        playlistRepo.add(DefaultAudioPlaylist(10, "Mix"))
 
         val restrictGroupRepo = RestrictMusicPlaylistGroupRepo(ctx)
         val group1 = restrictGroupRepo.create(id = 100, playlistIds = setOf(10))
@@ -117,7 +116,7 @@ internal class AggregateSetCascadeTest : StringSpec({
     }
 
     "RESTRICT on set ref allows removal when no external references exist" {
-        playlistRepo.add(MutableAudioPlaylistEntity(10, "Mix"))
+        playlistRepo.add(DefaultAudioPlaylist(10, "Mix"))
 
         val restrictGroupRepo = RestrictMusicPlaylistGroupRepo(ctx)
         val group = restrictGroupRepo.create(id = 100, playlistIds = setOf(10))
@@ -137,7 +136,7 @@ internal class AggregateSetCascadeTest : StringSpec({
     }
 
     "DETACH on set ref is a no-op" {
-        playlistRepo.add(MutableAudioPlaylistEntity(10, "Mix"))
+        playlistRepo.add(DefaultAudioPlaylist(10, "Mix"))
 
         val detachGroupRepo = DetachMusicPlaylistGroupRepo(ctx)
         val group = detachGroupRepo.create(id = 100, playlistIds = setOf(10))
@@ -148,8 +147,8 @@ internal class AggregateSetCascadeTest : StringSpec({
     }
 
     "NONE on set ref is a no-op" {
-        playlistRepo.add(MutableAudioPlaylistEntity(10, "Mix A"))
-        playlistRepo.add(MutableAudioPlaylistEntity(20, "Mix B"))
+        playlistRepo.add(DefaultAudioPlaylist(10, "Mix A"))
+        playlistRepo.add(DefaultAudioPlaylist(20, "Mix B"))
 
         val noneGroupRepo = NoneMusicPlaylistGroupRepo(ctx)
         val group = noneGroupRepo.create(id = 100, playlistIds = setOf(10, 20))

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/CollectionChangeEventTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/CollectionChangeEventTest.kt
@@ -45,19 +45,15 @@ internal class CollectionChangeEventTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()
     val testScope = CoroutineScope(testDispatcher)
-    lateinit var previousFlowScope: CoroutineScope
-    lateinit var previousIoScope: CoroutineScope
 
     beforeSpec {
-        previousFlowScope = ReactiveScope.flowScope
-        previousIoScope = ReactiveScope.ioScope
         ReactiveScope.flowScope = testScope
         ReactiveScope.ioScope = testScope
     }
 
     afterSpec {
-        ReactiveScope.flowScope = previousFlowScope
-        ReactiveScope.ioScope = previousIoScope
+        ReactiveScope.resetDefaultFlowScope()
+        ReactiveScope.resetDefaultIoScope()
     }
 
     lateinit var ctx: LirpContext
@@ -76,7 +72,7 @@ internal class CollectionChangeEventTest : StringSpec({
 
     "add(element) on mutableAggregateList emits ADD CollectionChangeEvent with the added element" {
         val t1 = trackRepo.create(1, "Track 1")
-        val playlist = MutableAudioPlaylistEntity(1, "Test").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
@@ -103,7 +99,7 @@ internal class CollectionChangeEventTest : StringSpec({
 
     "remove(element) on mutableAggregateList emits REMOVE CollectionChangeEvent with the removed element" {
         val t1 = trackRepo.create(1, "Track 1")
-        val playlist = MutableAudioPlaylistEntity(1, "Test", listOf(1)).also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(1)).also(playlistRepo::add)
 
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
@@ -131,7 +127,7 @@ internal class CollectionChangeEventTest : StringSpec({
     "set(index, element) on mutableAggregateList emits REPLACE CollectionChangeEvent with old and new elements" {
         val t1 = trackRepo.create(1, "Track 1")
         val t2 = trackRepo.create(2, "Track 2")
-        val playlist = MutableAudioPlaylistEntity(1, "Test", listOf(1)).also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(1)).also(playlistRepo::add)
 
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
@@ -159,7 +155,7 @@ internal class CollectionChangeEventTest : StringSpec({
     "addAll(elements) emits single ADD CollectionChangeEvent with all added elements" {
         val t1 = trackRepo.create(1, "Track 1")
         val t2 = trackRepo.create(2, "Track 2")
-        val playlist = MutableAudioPlaylistEntity(1, "Test").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
         val receivedEvents = mutableListOf<AggregateMutationEvent<*, *>>()
         val latch = CountDownLatch(1)
@@ -187,7 +183,7 @@ internal class CollectionChangeEventTest : StringSpec({
     "removeAll(elements) emits single REMOVE CollectionChangeEvent with all removed elements" {
         val t1 = trackRepo.create(1, "Track 1")
         val t2 = trackRepo.create(2, "Track 2")
-        val playlist = MutableAudioPlaylistEntity(1, "Test", listOf(1, 2)).also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(1, 2)).also(playlistRepo::add)
 
         val receivedEvents = mutableListOf<AggregateMutationEvent<*, *>>()
         val latch = CountDownLatch(1)
@@ -215,7 +211,7 @@ internal class CollectionChangeEventTest : StringSpec({
     "clear() emits CLEAR CollectionChangeEvent with all removed entities" {
         val t1 = trackRepo.create(1, "Track 1")
         val t2 = trackRepo.create(2, "Track 2")
-        val playlist = MutableAudioPlaylistEntity(1, "Test", listOf(1, 2)).also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(1, 2)).also(playlistRepo::add)
 
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
@@ -241,7 +237,7 @@ internal class CollectionChangeEventTest : StringSpec({
     }
 
     "clear() on empty collection does not emit any event" {
-        val playlist = MutableAudioPlaylistEntity(1, "Test").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
         var eventCount = 0
         playlist.subscribe { event ->
@@ -259,7 +255,7 @@ internal class CollectionChangeEventTest : StringSpec({
 
     "collection mutation does not emit ReactiveMutationEvent" {
         val t1 = trackRepo.create(1, "Track 1")
-        val playlist = MutableAudioPlaylistEntity(1, "Test").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
         var reactiveMutationCount = 0
         playlist.subscribe { event ->
@@ -277,8 +273,8 @@ internal class CollectionChangeEventTest : StringSpec({
     }
 
     "add(element) on mutableAggregateSet emits ADD CollectionChangeEvent" {
-        val p1 = MutableAudioPlaylistEntity(1, "P1").also(playlistRepo::add)
-        val group = MutableAudioPlaylistEntity(100, "Group").also(playlistRepo::add)
+        val p1 = DefaultAudioPlaylist(1, "P1").also(playlistRepo::add)
+        val group = DefaultAudioPlaylist(100, "Group").also(playlistRepo::add)
 
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
@@ -305,7 +301,7 @@ internal class CollectionChangeEventTest : StringSpec({
 
     "AggregateMutationEvent.refName matches the collection property name" {
         val t1 = trackRepo.create(1, "Track 1")
-        val playlist = MutableAudioPlaylistEntity(1, "Test").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/MusicCommonsIntegrationTestBase.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/MusicCommonsIntegrationTestBase.kt
@@ -97,7 +97,7 @@ abstract class MusicCommonsIntegrationTestBase : FunSpec() {
         }
 
         test("CRUD round-trip creates AudioPlaylist with name, reads back") {
-            val playlist = MutableAudioPlaylistEntity(10, "My Playlist").also(playlistRepo::add)
+            val playlist = DefaultAudioPlaylist(10, "My Playlist").also(playlistRepo::add)
 
             playlistRepo.findById(10) shouldBePresent { it.name shouldBe "My Playlist" }
         }
@@ -112,7 +112,7 @@ abstract class MusicCommonsIntegrationTestBase : FunSpec() {
             val item3 = MutableAudioItem(3, "Track 3").also(audioItemRepo::add)
 
             val playlist =
-                MutableAudioPlaylistEntity(10, "Full Mix", listOf(1, 2, 3))
+                DefaultAudioPlaylist(10, "Full Mix", listOf(1, 2, 3))
                     .also(playlistRepo::add)
 
             val resolved = playlist.audioItems.resolveAll()
@@ -121,10 +121,10 @@ abstract class MusicCommonsIntegrationTestBase : FunSpec() {
         }
 
         test("aggregate resolution resolves nested playlists (self-referencing)") {
-            val subA = MutableAudioPlaylistEntity(20, "Sub A").also(playlistRepo::add)
-            val subB = MutableAudioPlaylistEntity(30, "Sub B").also(playlistRepo::add)
+            val subA = DefaultAudioPlaylist(20, "Sub A").also(playlistRepo::add)
+            val subB = DefaultAudioPlaylist(30, "Sub B").also(playlistRepo::add)
             val parent =
-                MutableAudioPlaylistEntity(10, "Parent", emptyList(), setOf(20, 30))
+                DefaultAudioPlaylist(10, "Parent", emptyList(), setOf(20, 30))
                     .also(playlistRepo::add)
 
             val resolved = parent.playlists.resolveAll()
@@ -133,7 +133,7 @@ abstract class MusicCommonsIntegrationTestBase : FunSpec() {
         }
 
         test("aggregate resolution returns empty for playlist with no audioItems") {
-            val playlist = MutableAudioPlaylistEntity(10, "Empty").also(playlistRepo::add)
+            val playlist = DefaultAudioPlaylist(10, "Empty").also(playlistRepo::add)
 
             playlist.audioItems.resolveAll() shouldHaveSize 0
         }
@@ -144,7 +144,7 @@ abstract class MusicCommonsIntegrationTestBase : FunSpec() {
 
         test("mutable collection adds AudioItem to playlist at runtime and backing IDs update") {
             val item = MutableAudioItem(1, "Song A").also(audioItemRepo::add)
-            val playlist = MutableAudioPlaylistEntity(10, "Runtime Add").also(playlistRepo::add)
+            val playlist = DefaultAudioPlaylist(10, "Runtime Add").also(playlistRepo::add)
 
             playlist.audioItems.add(item)
 
@@ -156,7 +156,7 @@ abstract class MusicCommonsIntegrationTestBase : FunSpec() {
             val item1 = MutableAudioItem(1, "Song A").also(audioItemRepo::add)
             val item2 = MutableAudioItem(2, "Song B").also(audioItemRepo::add)
             val playlist =
-                MutableAudioPlaylistEntity(10, "Two Items", listOf(1, 2))
+                DefaultAudioPlaylist(10, "Two Items", listOf(1, 2))
                     .also(playlistRepo::add)
 
             playlist.audioItems.remove(item1)
@@ -165,8 +165,8 @@ abstract class MusicCommonsIntegrationTestBase : FunSpec() {
         }
 
         test("mutable collection adds nested playlist at runtime (self-referencing)") {
-            val child = MutableAudioPlaylistEntity(20, "Child").also(playlistRepo::add)
-            val parent = MutableAudioPlaylistEntity(10, "Parent").also(playlistRepo::add)
+            val child = DefaultAudioPlaylist(20, "Child").also(playlistRepo::add)
+            val parent = DefaultAudioPlaylist(10, "Parent").also(playlistRepo::add)
 
             parent.playlists.add(child)
 
@@ -182,7 +182,7 @@ abstract class MusicCommonsIntegrationTestBase : FunSpec() {
             val item1 = MutableAudioItem(1, "Song A").also(audioItemRepo::add)
             val item2 = MutableAudioItem(2, "Song B").also(audioItemRepo::add)
             val playlist =
-                MutableAudioPlaylistEntity(10, "Detach Playlist", listOf(1, 2))
+                DefaultAudioPlaylist(10, "Detach Playlist", listOf(1, 2))
                     .also(playlistRepo::add)
 
             playlistRepo.remove(playlist)
@@ -192,10 +192,10 @@ abstract class MusicCommonsIntegrationTestBase : FunSpec() {
         }
 
         test("cascade DETACH on self-referencing playlist leaves sub-playlists in repo") {
-            val sub1 = MutableAudioPlaylistEntity(20, "Sub 1").also(playlistRepo::add)
-            val sub2 = MutableAudioPlaylistEntity(30, "Sub 2").also(playlistRepo::add)
+            val sub1 = DefaultAudioPlaylist(20, "Sub 1").also(playlistRepo::add)
+            val sub2 = DefaultAudioPlaylist(30, "Sub 2").also(playlistRepo::add)
             val parent =
-                MutableAudioPlaylistEntity(10, "Parent", emptyList(), setOf(20, 30))
+                DefaultAudioPlaylist(10, "Parent", emptyList(), setOf(20, 30))
                     .also(playlistRepo::add)
 
             playlistRepo.remove(parent)

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/MusicCommonsTestFixtures.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/MusicCommonsTestFixtures.kt
@@ -41,11 +41,12 @@ import kotlinx.serialization.KSerializer
 // ---------------------------------------------------------------------------
 
 /**
- * Reactive audio item with a mutable [title] property. Mirrors
+ * Reactive audio item with mutable [title] and [albumName] properties. Mirrors
  * `music-commons:ReactiveAudioItem` with its self-referencing type parameter.
  */
 interface ReactiveAudioItem<I : ReactiveAudioItem<I>> : ReactiveEntity<Int, I>, Comparable<I> {
     var title: String
+    var albumName: String
 }
 
 /**
@@ -57,29 +58,41 @@ interface AudioItem : ReactiveAudioItem<AudioItem> {
 }
 
 /**
- * Concrete mutable audio item entity backed by [reactiveProperty] for [title].
+ * Concrete mutable audio item entity backed by [reactiveProperty] for [title] and [albumName].
  *
  * Not declared `internal` so it is accessible from the lirp-sql testFixtures source set.
  */
-class MutableAudioItem(override val id: Int, title: String) : ReactiveEntityBase<Int, AudioItem>(), AudioItem {
-    override val uniqueId: String get() = "audio-item-$id"
+class MutableAudioItem
+    @JvmOverloads
+    constructor(
+        override val id: Int,
+        title: String,
+        albumName: String = ""
+    ) : ReactiveEntityBase<Int, AudioItem>(), AudioItem {
+        override val uniqueId: String get() = "audio-item-$id"
 
-    override var title: String by reactiveProperty(title)
+        override var title: String by reactiveProperty(title)
+        override var albumName: String by reactiveProperty(albumName)
 
-    override fun compareTo(other: AudioItem): Int = id.compareTo(other.id)
+        override fun compareTo(other: AudioItem): Int = id.compareTo(other.id)
 
-    override fun clone(): MutableAudioItem = MutableAudioItem(id, title)
+        override fun clone(): MutableAudioItem = MutableAudioItem(id, title, albumName)
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is MutableAudioItem) return false
-        return id == other.id && title == other.title
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is MutableAudioItem) return false
+            return id == other.id && title == other.title && albumName == other.albumName
+        }
+
+        override fun hashCode(): Int {
+            var result = id.hashCode()
+            result = 31 * result + title.hashCode()
+            result = 31 * result + albumName.hashCode()
+            return result
+        }
+
+        override fun toString(): String = "MutableAudioItem(id=$id, title='$title', albumName='$albumName')"
     }
-
-    override fun hashCode(): Int = 31 * id.hashCode() + title.hashCode()
-
-    override fun toString(): String = "MutableAudioItem(id=$id, title='$title')"
-}
 
 // ---------------------------------------------------------------------------
 // Playlist hierarchy
@@ -134,7 +147,7 @@ abstract class MutablePlaylistBase<I : ReactiveAudioItem<I>, P : ReactiveAudioPl
  *
  * Not declared `internal` so it is accessible from the lirp-sql testFixtures source set.
  */
-class MutableAudioPlaylistEntity(
+class DefaultAudioPlaylist(
     id: Int,
     name: String,
     initialAudioItemIds: List<Int> = emptyList(),
@@ -148,12 +161,12 @@ class MutableAudioPlaylistEntity(
     @Aggregate(onDelete = CascadeAction.DETACH)
     override val playlists by mutableAggregateSet<Int, MutableAudioPlaylist>(initialPlaylistIds)
 
-    override fun clone(): MutableAudioPlaylistEntity =
-        MutableAudioPlaylistEntity(id, name, audioItems.referenceIds.toList(), LinkedHashSet(playlists.referenceIds))
+    override fun clone(): DefaultAudioPlaylist =
+        DefaultAudioPlaylist(id, name, audioItems.referenceIds.toList(), LinkedHashSet(playlists.referenceIds))
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is MutableAudioPlaylistEntity) return false
+        if (other !is DefaultAudioPlaylist) return false
         return id == other.id &&
             name == other.name &&
             audioItems.referenceIds == other.audioItems.referenceIds &&
@@ -168,7 +181,7 @@ class MutableAudioPlaylistEntity(
         return result
     }
 
-    override fun toString(): String = "MutableAudioPlaylistEntity(id=$id, name='$name')"
+    override fun toString(): String = "DefaultAudioPlaylist(id=$id, name='$name')"
 }
 
 // ---------------------------------------------------------------------------
@@ -227,7 +240,7 @@ class AudioItemVolatileRepository internal constructor(context: LirpContext) :
     VolatileRepository<Int, AudioItem>(context, "AudioItems") {
         constructor() : this(LirpContext.default)
 
-        fun create(id: Int, title: String): AudioItem = MutableAudioItem(id, title).also(::add)
+        fun create(id: Int, title: String, albumName: String = ""): AudioItem = MutableAudioItem(id, title, albumName).also(::add)
     }
 
 /**
@@ -240,7 +253,7 @@ class DefaultAudioLibrary internal constructor(repository: Repository<Int, Audio
         constructor(context: LirpContext) : this(AudioItemVolatileRepository(context))
         constructor() : this(LirpContext.default)
 
-        fun create(id: Int, title: String): AudioItem = MutableAudioItem(id, title).also(::add)
+        fun create(id: Int, title: String, albumName: String = ""): AudioItem = MutableAudioItem(id, title, albumName).also(::add)
     }
 
 // ---------------------------------------------------------------------------
@@ -305,7 +318,7 @@ class DefaultPlaylistHierarchy internal constructor(repository: Repository<Int, 
             audioItemIds: List<Int> = emptyList(),
             playlistIds: Set<Int> = emptySet()
         ): MutableAudioPlaylist =
-            MutableAudioPlaylistEntity(id, name, audioItemIds, playlistIds)
+            DefaultAudioPlaylist(id, name, audioItemIds, playlistIds)
     }
 
 // ---------------------------------------------------------------------------

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/MutableAggregateCollectionRefTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/MutableAggregateCollectionRefTest.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 
 /**
- * Tests for [MutableAggregateListProxy] and [MutableAggregateSetProxy], validating
+ * Tests for [MutableAggregateList] and [MutableAggregateSet], validating
  * all proxy behaviors: lazy resolution per-access (D-01/D-02), indexed mutations (D-03),
  * replace at index (D-03), indexed removal (D-03), live sub-list and list-iterator views (D-07),
  * iterator().remove on set proxy (D-02), NoSuchElementException on unresolvable ID (D-05),
@@ -76,7 +76,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
     "mutableAggregateList resolves added entities from registry" {
         val t1 = trackRepo.create(1, "Track 1")
         val t2 = trackRepo.create(2, "Track 2")
-        val playlist = MutableAudioPlaylistEntity(1, "Test").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
         playlist.audioItems.add(t1)
         playlist.audioItems.add(t2)
@@ -86,14 +86,14 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
 
     // CORE-01 additional: resolveAll() returns empty list before registry binding
     "mutableAggregateList returns empty before registry binding" {
-        val playlist = MutableAudioPlaylistEntity(1, "Unbound")
+        val playlist = DefaultAudioPlaylist(1, "Unbound")
 
         playlist.audioItems.resolveAll() shouldBe emptyList()
     }
 
     "mutableAggregateSet enforces uniqueness" {
-        val p1 = MutableAudioPlaylistEntity(1, "P1").also(playlistRepo::add)
-        val group = MutableAudioPlaylistEntity(100, "Group").also(playlistRepo::add)
+        val p1 = DefaultAudioPlaylist(1, "P1").also(playlistRepo::add)
+        val group = DefaultAudioPlaylist(100, "Group").also(playlistRepo::add)
 
         group.playlists.add(p1) shouldBe true
         group.playlists.add(p1) shouldBe false
@@ -102,7 +102,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
 
     "add updates delegate backing ID collection" {
         val t1 = trackRepo.create(1, "T1")
-        val playlist = MutableAudioPlaylistEntity(1, "Test").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
         playlist.audioItems.add(t1)
 
@@ -112,7 +112,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
     "remove updates delegate backing ID collection" {
         val t1 = trackRepo.create(1, "T1")
         val playlist =
-            MutableAudioPlaylistEntity(1, "Test", listOf(1))
+            DefaultAudioPlaylist(1, "Test", listOf(1))
                 .also(playlistRepo::add)
 
         playlist.audioItems.remove(t1)
@@ -124,7 +124,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         trackRepo.create(1, "T1")
         trackRepo.create(2, "T2")
         val playlist =
-            MutableAudioPlaylistEntity(1, "Test", listOf(1, 2))
+            DefaultAudioPlaylist(1, "Test", listOf(1, 2))
                 .also(playlistRepo::add)
 
         playlist.audioItems.clear()
@@ -133,14 +133,14 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
     }
 
     "clone produces independent copy of mutable list field" {
-        val playlist = MutableAudioPlaylistEntity(1, "Test", listOf(1, 2))
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(1, 2))
         val cloned = playlist.clone()
 
         (cloned.audioItems.referenceIds !== playlist.audioItems.referenceIds) shouldBe true
     }
 
     "concurrent coroutine adds produce no lost updates" {
-        val playlist = MutableAudioPlaylistEntity(1, "Concurrent").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Concurrent").also(playlistRepo::add)
         (1..1000).forEach { trackRepo.create(it, "Track $it") }
 
         runTest {
@@ -162,7 +162,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
 
     "MutationEvent emitted after add on mutable list" {
         val t1 = trackRepo.create(1, "T1")
-        val playlist = MutableAudioPlaylistEntity(1, "Test").also(playlistRepo::add)
+        val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
 
         playlist.subscribe { events.add(it) }
@@ -180,21 +180,21 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         playlist.lastDateModified shouldBeGreaterThan beforeModified
     }
 
-    "MutableAggregateListProxy get(index) resolves entity from registry" {
+    "MutableAggregateList get(index) resolves entity from registry" {
         val t1 = trackRepo.create(1, "Track 1")
         trackRepo.create(2, "Track 2")
         val t3 = trackRepo.create(3, "Track 3")
         val playlist =
-            MutableAudioPlaylistEntity(1, "Test", listOf(1, 2, 3))
+            DefaultAudioPlaylist(1, "Test", listOf(1, 2, 3))
                 .also(playlistRepo::add)
 
         playlist.audioItems[0] shouldBe t1
         playlist.audioItems[2] shouldBe t3
     }
 
-    "MutableAggregateListProxy get(index) throws IndexOutOfBoundsException for invalid index" {
+    "MutableAggregateList get(index) throws IndexOutOfBoundsException for invalid index" {
         val playlist =
-            MutableAudioPlaylistEntity(1, "Test", listOf(1, 2))
+            DefaultAudioPlaylist(1, "Test", listOf(1, 2))
                 .also(playlistRepo::add)
 
         shouldThrow<IndexOutOfBoundsException> {
@@ -202,10 +202,10 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         }
     }
 
-    "MutableAggregateListProxy get(index) throws NoSuchElementException for unresolvable ID" {
+    "MutableAggregateList get(index) throws NoSuchElementException for unresolvable ID" {
         // ID 999 is not in trackRepo
         val playlist =
-            MutableAudioPlaylistEntity(1, "Test", listOf(999))
+            DefaultAudioPlaylist(1, "Test", listOf(999))
                 .also(playlistRepo::add)
 
         shouldThrow<NoSuchElementException> {
@@ -213,11 +213,11 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         }
     }
 
-    "MutableAggregateListProxy set(index, element) replaces entity and emits MutationEvent" {
+    "MutableAggregateList set(index, element) replaces entity and emits MutationEvent" {
         trackRepo.create(1, "Track 1")
         val t2 = trackRepo.create(2, "Track 2")
         val playlist =
-            MutableAudioPlaylistEntity(1, "Test", listOf(1))
+            DefaultAudioPlaylist(1, "Test", listOf(1))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
         playlist.subscribe { events.add(it) }
@@ -231,12 +231,12 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         events shouldHaveSize 1
     }
 
-    "MutableAggregateListProxy add(index, element) inserts at position and emits MutationEvent" {
+    "MutableAggregateList add(index, element) inserts at position and emits MutationEvent" {
         val t1 = trackRepo.create(1, "Track 1")
         val t2 = trackRepo.create(2, "Track 2")
         val t3 = trackRepo.create(3, "Track 3")
         val playlist =
-            MutableAudioPlaylistEntity(1, "Test", listOf(1, 3))
+            DefaultAudioPlaylist(1, "Test", listOf(1, 3))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
         playlist.subscribe { events.add(it) }
@@ -249,12 +249,12 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         events shouldHaveSize 1
     }
 
-    "MutableAggregateListProxy removeAt(index) removes by position and emits MutationEvent" {
+    "MutableAggregateList removeAt(index) removes by position and emits MutationEvent" {
         val t1 = trackRepo.create(1, "Track 1")
         val t2 = trackRepo.create(2, "Track 2")
         val t3 = trackRepo.create(3, "Track 3")
         val playlist =
-            MutableAudioPlaylistEntity(1, "Test", listOf(1, 2, 3))
+            DefaultAudioPlaylist(1, "Test", listOf(1, 2, 3))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
         playlist.subscribe { events.add(it) }
@@ -268,13 +268,13 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         events shouldHaveSize 1
     }
 
-    "MutableAggregateListProxy subList() returns live view that emits events on mutation" {
+    "MutableAggregateList subList() returns live view that emits events on mutation" {
         val t1 = trackRepo.create(1, "Track 1")
         val t2 = trackRepo.create(2, "Track 2")
         val t3 = trackRepo.create(3, "Track 3")
         val tNew = trackRepo.create(4, "Track 4")
         val playlist =
-            MutableAudioPlaylistEntity(1, "Test", listOf(1, 2, 3))
+            DefaultAudioPlaylist(1, "Test", listOf(1, 2, 3))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
         playlist.subscribe { events.add(it) }
@@ -288,12 +288,12 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         events shouldHaveSize 1
     }
 
-    "MutableAggregateListProxy listIterator() set emits MutationEvent" {
+    "MutableAggregateList listIterator() set emits MutationEvent" {
         trackRepo.create(1, "Track 1")
         trackRepo.create(2, "Track 2")
         val t3 = trackRepo.create(3, "Track 3")
         val playlist =
-            MutableAudioPlaylistEntity(1, "Test", listOf(1, 2))
+            DefaultAudioPlaylist(1, "Test", listOf(1, 2))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
         playlist.subscribe { events.add(it) }
@@ -308,11 +308,11 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         events shouldHaveSize 1
     }
 
-    "MutableAggregateSetProxy iterator().remove() removes entity and emits MutationEvent" {
-        val p1 = MutableAudioPlaylistEntity(1, "P1").also(playlistRepo::add)
-        val p2 = MutableAudioPlaylistEntity(2, "P2").also(playlistRepo::add)
+    "MutableAggregateSet iterator().remove() removes entity and emits MutationEvent" {
+        val p1 = DefaultAudioPlaylist(1, "P1").also(playlistRepo::add)
+        val p2 = DefaultAudioPlaylist(2, "P2").also(playlistRepo::add)
         val group =
-            MutableAudioPlaylistEntity(100, "Group", initialPlaylistIds = setOf(1, 2))
+            DefaultAudioPlaylist(100, "Group", initialPlaylistIds = setOf(1, 2))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
         group.subscribe { events.add(it) }
@@ -327,10 +327,10 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         events shouldHaveSize 1
     }
 
-    "MutableAggregateListProxy resolve-per-call returns updated entity after registry change" {
+    "MutableAggregateList resolve-per-call returns updated entity after registry change" {
         val track = trackRepo.create(1, "Original Title")
         val playlist =
-            MutableAudioPlaylistEntity(1, "Test", listOf(1))
+            DefaultAudioPlaylist(1, "Test", listOf(1))
                 .also(playlistRepo::add)
 
         playlist.audioItems[0].title shouldBe "Original Title"
@@ -346,7 +346,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         trackRepo.create(1, "T1")
         trackRepo.create(2, "T2")
         val playlist =
-            MutableAudioPlaylistEntity(1, "Test", listOf(1, 2))
+            DefaultAudioPlaylist(1, "Test", listOf(1, 2))
                 .also(playlistRepo::add)
 
         val ids = (playlist.audioItems as AggregateCollectionRef<*, *>).referenceIds

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ProjectionMapTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ProjectionMapTest.kt
@@ -1,0 +1,288 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for [ProjectionMap], verifying grouping behavior, incremental auto-updates from
+ * mutable aggregate sources, sorted key ordering, onChange callback, and lazy initialization semantics.
+ */
+@DisplayName("ProjectionMap")
+internal class ProjectionMapTest : StringSpec({
+
+    lateinit var ctx: LirpContext
+    lateinit var trackRepo: AudioItemVolatileRepository
+    lateinit var playlistRepo: AudioPlaylistVolatileRepository
+
+    beforeEach {
+        ctx = LirpContext()
+        trackRepo = AudioItemVolatileRepository(ctx)
+        playlistRepo = AudioPlaylistVolatileRepository(ctx)
+    }
+
+    afterEach {
+        ctx.close()
+    }
+
+    "ProjectionMap groups entities by key extractor into buckets" {
+        val t1 = trackRepo.create(1, "Jazz")
+        val t2 = trackRepo.create(2, "Jazz")
+        val t3 = trackRepo.create(3, "Rock")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id, t2.id, t3.id)).also(playlistRepo::add)
+
+        val itemsByTitle by ProjectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+
+        itemsByTitle.size shouldBe 2
+        itemsByTitle["Jazz"]!!.size shouldBe 2
+        itemsByTitle["Rock"]!!.size shouldBe 1
+    }
+
+    "ProjectionMap builds initial state from source contents on first access" {
+        val t1 = trackRepo.create(1, "Pop")
+        val t2 = trackRepo.create(2, "Jazz")
+        val t3 = trackRepo.create(3, "Pop")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id, t2.id, t3.id)).also(playlistRepo::add)
+
+        val itemsByTitle by ProjectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+
+        itemsByTitle.size shouldBe 2
+        itemsByTitle["Pop"]!!.size shouldBe 2
+        itemsByTitle["Jazz"]!!.size shouldBe 1
+    }
+
+    "ProjectionMap auto-updates bucket when entity added to source" {
+        val t1 = trackRepo.create(1, "Jazz")
+        val t2 = trackRepo.create(2, "Rock")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id, t2.id)).also(playlistRepo::add)
+
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+        projection.size shouldBe 2
+
+        val t3 = trackRepo.create(3, "Jazz")
+        playlist.audioItems.add(t3)
+
+        projection["Jazz"]!!.size shouldBe 2
+        projection["Jazz"]!! shouldContainExactlyInAnyOrder listOf(t1, t3)
+    }
+
+    "ProjectionMap auto-removes empty bucket when last entity removed from source" {
+        val t1 = trackRepo.create(1, "Jazz")
+        val t2 = trackRepo.create(2, "Rock")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id, t2.id)).also(playlistRepo::add)
+
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+        projection.containsKey("Rock") shouldBe true
+
+        playlist.audioItems.remove(t2)
+
+        projection.containsKey("Rock") shouldBe false
+        projection.size shouldBe 1
+    }
+
+    "ProjectionMap auto-updates bucket without removing on partial remove" {
+        val t1 = trackRepo.create(1, "Jazz")
+        val t2 = trackRepo.create(2, "Jazz")
+        val t3 = trackRepo.create(3, "Rock")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id, t2.id, t3.id)).also(playlistRepo::add)
+
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+
+        playlist.audioItems.remove(t1)
+
+        projection.containsKey("Jazz") shouldBe true
+        projection["Jazz"]!!.size shouldBe 1
+        projection["Jazz"]!! shouldContainExactly listOf(t2)
+    }
+
+    "ProjectionMap removes entity from original bucket when grouping key changed before removal" {
+        val t1 = trackRepo.create(1, "Jazz")
+        val t2 = trackRepo.create(2, "Rock")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id, t2.id)).also(playlistRepo::add)
+
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+        projection["Jazz"]!!.size shouldBe 1
+
+        // Mutate the grouping field BEFORE removing from source
+        (t1 as MutableAudioItem).title = "Classical"
+        playlist.audioItems.remove(t1)
+
+        // The entity should be removed from the original "Jazz" bucket via fallback search
+        projection.containsKey("Jazz") shouldBe false
+        projection.containsKey("Classical") shouldBe false
+        projection.size shouldBe 1
+        projection.containsKey("Rock") shouldBe true
+    }
+
+    "ProjectionMap keys are in natural sorted order" {
+        val t1 = trackRepo.create(1, "Rock")
+        val t2 = trackRepo.create(2, "Classical")
+        val t3 = trackRepo.create(3, "Blues")
+        val t4 = trackRepo.create(4, "Jazz")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id, t2.id, t3.id, t4.id)).also(playlistRepo::add)
+
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+
+        projection.keys.toList() shouldContainExactly listOf("Blues", "Classical", "Jazz", "Rock")
+    }
+
+    "ProjectionMap auto-clears when source collection is cleared" {
+        val t1 = trackRepo.create(1, "Jazz")
+        val t2 = trackRepo.create(2, "Rock")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id, t2.id)).also(playlistRepo::add)
+
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+        projection.size shouldBe 2
+
+        playlist.audioItems.clear()
+
+        projection.shouldBeEmpty()
+    }
+
+    "ProjectionMap fires onChange callback when projection changes on add" {
+        val t1 = trackRepo.create(1, "Jazz")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id)).also(playlistRepo::add)
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+
+        // trigger initialization before registering callback so auto-subscription is active
+        projection["Jazz"]!!.size shouldBe 1
+
+        var callbackFiredCount = 0
+        var lastMapSnapshot: Map<String, List<AudioItem>>? = null
+        projection.onChange = { currentMap ->
+            callbackFiredCount++
+            lastMapSnapshot = currentMap
+        }
+
+        val t2 = trackRepo.create(2, "Rock")
+        playlist.audioItems.add(t2)
+
+        callbackFiredCount shouldBe 1
+        lastMapSnapshot shouldNotBe null
+        lastMapSnapshot!!["Rock"]!!.size shouldBe 1
+    }
+
+    "ProjectionMap fires onChange callback when projection changes on remove" {
+        val t1 = trackRepo.create(1, "Jazz")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id)).also(playlistRepo::add)
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+
+        // trigger initialization then register callback
+        projection["Jazz"]!!.size shouldBe 1
+
+        var callbackFiredCount = 0
+        projection.onChange = { callbackFiredCount++ }
+
+        playlist.audioItems.remove(t1)
+
+        callbackFiredCount shouldBe 1
+    }
+
+    "ProjectionMap with MutableAggregateSet auto-updates on add and remove" {
+        val p1 = DefaultAudioPlaylist(1, "Jazz Playlist").also(playlistRepo::add)
+        val p2 = DefaultAudioPlaylist(2, "Rock Playlist").also(playlistRepo::add)
+        val parent = DefaultAudioPlaylist(10, "Parent", emptyList(), setOf(p1.id, p2.id)).also(playlistRepo::add)
+
+        val projection = projectionMap<Int, String, MutableAudioPlaylist>({ parent.playlists }, { it.name })
+        projection.size shouldBe 2
+
+        parent.playlists.remove(p2)
+
+        projection.size shouldBe 1
+        projection.containsKey("Rock Playlist") shouldBe false
+    }
+
+    "ProjectionMap entries contains all key-value pairs after population" {
+        val t1 = trackRepo.create(1, "Jazz")
+        val t2 = trackRepo.create(2, "Rock")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id, t2.id)).also(playlistRepo::add)
+
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+
+        val entries = projection.entries
+        entries.size shouldBe 2
+        entries.map { it.key }.toSet() shouldBe setOf("Jazz", "Rock")
+        entries.first { it.key == "Jazz" }.value shouldContainExactly listOf(t1)
+    }
+
+    "ProjectionMap values contains all bucket lists" {
+        val t1 = trackRepo.create(1, "Jazz")
+        val t2 = trackRepo.create(2, "Jazz")
+        val t3 = trackRepo.create(3, "Rock")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id, t2.id, t3.id)).also(playlistRepo::add)
+
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+
+        val values = projection.values
+        values.size shouldBe 2
+        values.any { it.size == 2 } shouldBe true
+        values.any { it.size == 1 } shouldBe true
+    }
+
+    "ProjectionMap containsValue returns true for a matching bucket" {
+        val t1 = trackRepo.create(1, "Jazz")
+        val t2 = trackRepo.create(2, "Rock")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id, t2.id)).also(playlistRepo::add)
+
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+
+        projection.containsValue(listOf(t1)) shouldBe true
+        projection.containsValue(listOf(t2)) shouldBe true
+        projection.containsValue(listOf(t1, t2)) shouldBe false
+    }
+
+    "ProjectionMap fires onChange callback on MutableAggregateSet remove" {
+        val p1 = DefaultAudioPlaylist(1, "Jazz Playlist").also(playlistRepo::add)
+        val p2 = DefaultAudioPlaylist(2, "Rock Playlist").also(playlistRepo::add)
+        val parent = DefaultAudioPlaylist(10, "Parent", emptyList(), setOf(p1.id, p2.id)).also(playlistRepo::add)
+        val projection = projectionMap<Int, String, MutableAudioPlaylist>({ parent.playlists }, { it.name })
+
+        projection.size shouldBe 2
+
+        var callbackFiredCount = 0
+        projection.onChange = { callbackFiredCount++ }
+
+        parent.playlists.remove(p1)
+
+        callbackFiredCount shouldBe 1
+        projection.containsKey("Jazz Playlist") shouldBe false
+    }
+
+    "ProjectionMap fires onChange callback on MutableAggregateSet add" {
+        val p1 = DefaultAudioPlaylist(1, "Jazz Playlist").also(playlistRepo::add)
+        val parent = DefaultAudioPlaylist(10, "Parent", emptyList(), setOf(p1.id)).also(playlistRepo::add)
+        val projection = projectionMap<Int, String, MutableAudioPlaylist>({ parent.playlists }, { it.name })
+
+        projection.size shouldBe 1
+
+        var lastSnapshot: Map<String, List<MutableAudioPlaylist>>? = null
+        projection.onChange = { lastSnapshot = it }
+
+        val p2 = DefaultAudioPlaylist(2, "Rock Playlist").also(playlistRepo::add)
+        parent.playlists.add(p2)
+
+        lastSnapshot shouldNotBe null
+        lastSnapshot!!.containsKey("Rock Playlist") shouldBe true
+    }
+})

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/VolatileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/VolatileRepositoryTest.kt
@@ -358,13 +358,13 @@ internal class VolatileRepositoryTest : FunSpec({
 
             val t1 = trackRepo.create(1, "Track A")
             val t2 = trackRepo.create(2, "Track B")
-            val playlist = MutableAudioPlaylistEntity(1, "My Playlist").also(playlistRepo::add)
+            val playlist = DefaultAudioPlaylist(1, "My Playlist").also(playlistRepo::add)
 
             playlist.audioItems.add(t1)
             playlist.audioItems.add(t2)
 
             playlistRepo.findById(1).shouldBePresent {
-                (it as MutableAudioPlaylistEntity).audioItems.referenceIds shouldContainExactly listOf(1, 2)
+                (it as DefaultAudioPlaylist).audioItems.referenceIds shouldContainExactly listOf(1, 2)
                 it.audioItems.resolveAll() shouldContainExactly listOf(t1, t2)
             }
         }
@@ -377,19 +377,19 @@ internal class VolatileRepositoryTest : FunSpec({
             val t2 = trackRepo.create(2, "T2")
             trackRepo.create(3, "T3")
             val playlist =
-                MutableAudioPlaylistEntity(1, "Playlist", listOf(1, 2, 3))
+                DefaultAudioPlaylist(1, "Playlist", listOf(1, 2, 3))
                     .also(playlistRepo::add)
 
             playlist.audioItems.remove(t2)
 
             playlistRepo.findById(1).shouldBePresent {
-                (it as MutableAudioPlaylistEntity).audioItems.referenceIds shouldContainExactly listOf(1, 3)
+                (it as DefaultAudioPlaylist).audioItems.referenceIds shouldContainExactly listOf(1, 3)
             }
 
             playlist.audioItems.clear()
 
             playlistRepo.findById(1).shouldBePresent {
-                (it as MutableAudioPlaylistEntity).audioItems.referenceIds shouldBe emptyList()
+                (it as DefaultAudioPlaylist).audioItems.referenceIds shouldBe emptyList()
             }
         }
 
@@ -400,12 +400,12 @@ internal class VolatileRepositoryTest : FunSpec({
             val t1 = trackRepo.create(1, "T1")
             val t2 = trackRepo.create(2, "T2")
             val t3 = trackRepo.create(3, "T3")
-            val playlist = MutableAudioPlaylistEntity(1, "Bulk Add").also(playlistRepo::add)
+            val playlist = DefaultAudioPlaylist(1, "Bulk Add").also(playlistRepo::add)
 
             playlist.audioItems.addAll(listOf(t1, t2, t3))
 
             playlistRepo.findById(1).shouldBePresent {
-                (it as MutableAudioPlaylistEntity).audioItems.referenceIds shouldContainExactly listOf(1, 2, 3)
+                (it as DefaultAudioPlaylist).audioItems.referenceIds shouldContainExactly listOf(1, 2, 3)
                 it.audioItems.resolveAll() shouldContainExactly listOf(t1, t2, t3)
             }
         }
@@ -418,13 +418,13 @@ internal class VolatileRepositoryTest : FunSpec({
             val t2 = trackRepo.create(2, "T2")
             val t3 = trackRepo.create(3, "T3")
             val playlist =
-                MutableAudioPlaylistEntity(1, "Bulk Remove", listOf(1, 2, 3))
+                DefaultAudioPlaylist(1, "Bulk Remove", listOf(1, 2, 3))
                     .also(playlistRepo::add)
 
             playlist.audioItems.removeAll(setOf(t1, t3))
 
             playlistRepo.findById(1).shouldBePresent {
-                (it as MutableAudioPlaylistEntity).audioItems.referenceIds shouldContainExactly listOf(2)
+                (it as DefaultAudioPlaylist).audioItems.referenceIds shouldContainExactly listOf(2)
                 it.audioItems.resolveAll() shouldContainExactly listOf(t2)
             }
         }
@@ -440,7 +440,7 @@ internal class VolatileRepositoryTest : FunSpec({
             val t1 = trackRepo.create(1, "T1")
             val t2 = trackRepo.create(2, "T2")
             val t3 = trackRepo.create(3, "T3")
-            val playlist = MutableAudioPlaylistEntity(1, "Bulk Add").also(playlistRepo::add)
+            val playlist = DefaultAudioPlaylist(1, "Bulk Add").also(playlistRepo::add)
 
             playlist.subscribe { events.add(it) }
 
@@ -462,7 +462,7 @@ internal class VolatileRepositoryTest : FunSpec({
             val t2 = trackRepo.create(2, "T2")
             val t3 = trackRepo.create(3, "T3")
             val playlist =
-                MutableAudioPlaylistEntity(1, "Bulk Remove", listOf(1, 2, 3))
+                DefaultAudioPlaylist(1, "Bulk Remove", listOf(1, 2, 3))
                     .also(playlistRepo::add)
 
             playlist.subscribe { events.add(it) }
@@ -480,7 +480,7 @@ internal class VolatileRepositoryTest : FunSpec({
                     mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>()
                 )
 
-            val playlist = MutableAudioPlaylistEntity(1, "Empty Add").also(playlistRepo::add)
+            val playlist = DefaultAudioPlaylist(1, "Empty Add").also(playlistRepo::add)
 
             playlist.subscribe { events.add(it) }
 
@@ -500,7 +500,7 @@ internal class VolatileRepositoryTest : FunSpec({
                 )
 
             val unrelated = trackRepo.create(99, "Unrelated")
-            val playlist = MutableAudioPlaylistEntity(1, "No Match Remove").also(playlistRepo::add)
+            val playlist = DefaultAudioPlaylist(1, "No Match Remove").also(playlistRepo::add)
 
             playlist.subscribe { events.add(it) }
 
@@ -518,10 +518,10 @@ internal class VolatileRepositoryTest : FunSpec({
                     mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>()
                 )
 
-            val p1 = MutableAudioPlaylistEntity(1, "P1").also(sharedRepo::add)
-            val p2 = MutableAudioPlaylistEntity(2, "P2").also(sharedRepo::add)
-            val p3 = MutableAudioPlaylistEntity(3, "P3").also(sharedRepo::add)
-            val group = MutableAudioPlaylistEntity(100, "Group").also(sharedRepo::add)
+            val p1 = DefaultAudioPlaylist(1, "P1").also(sharedRepo::add)
+            val p2 = DefaultAudioPlaylist(2, "P2").also(sharedRepo::add)
+            val p3 = DefaultAudioPlaylist(3, "P3").also(sharedRepo::add)
+            val group = DefaultAudioPlaylist(100, "Group").also(sharedRepo::add)
 
             group.subscribe { events.add(it) }
 
@@ -540,7 +540,7 @@ internal class VolatileRepositoryTest : FunSpec({
                 )
 
             val t1 = trackRepo.create(1, "Track")
-            val playlist = MutableAudioPlaylistEntity(1, "Test").also(playlistRepo::add)
+            val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
             playlist.subscribe { events.add(it) }
 
@@ -560,7 +560,7 @@ internal class VolatileRepositoryTest : FunSpec({
 
             val t1 = trackRepo.create(1, "Track")
             val playlist =
-                MutableAudioPlaylistEntity(1, "Test", listOf(1))
+                DefaultAudioPlaylist(1, "Test", listOf(1))
                     .also(playlistRepo::add)
 
             playlist.subscribe { events.add(it) }
@@ -581,7 +581,7 @@ internal class VolatileRepositoryTest : FunSpec({
 
             trackRepo.create(1, "T1")
             val playlist =
-                MutableAudioPlaylistEntity(1, "Test", listOf(1))
+                DefaultAudioPlaylist(1, "Test", listOf(1))
                     .also(playlistRepo::add)
 
             playlist.subscribe { events.add(it) }
@@ -599,29 +599,29 @@ internal class VolatileRepositoryTest : FunSpec({
             val t1 = trackRepo.create(1, "Track 1")
             val t2 = trackRepo.create(2, "Track 2")
             val t3 = trackRepo.create(3, "Track 3")
-            val pl1 = MutableAudioPlaylistEntity(1, "Playlist A").also(playlistRepo::add)
-            val pl2 = MutableAudioPlaylistEntity(2, "Playlist B").also(playlistRepo::add)
+            val pl1 = DefaultAudioPlaylist(1, "Playlist A").also(playlistRepo::add)
+            val pl2 = DefaultAudioPlaylist(2, "Playlist B").also(playlistRepo::add)
 
             pl1.audioItems.addAll(listOf(t1, t2))
             pl2.audioItems.addAll(listOf(t2, t3))
 
-            playlistRepo.findById(1).shouldBePresent { (it as MutableAudioPlaylistEntity).audioItems.referenceIds shouldContainExactly listOf(1, 2) }
-            playlistRepo.findById(2).shouldBePresent { (it as MutableAudioPlaylistEntity).audioItems.referenceIds shouldContainExactly listOf(2, 3) }
+            playlistRepo.findById(1).shouldBePresent { (it as DefaultAudioPlaylist).audioItems.referenceIds shouldContainExactly listOf(1, 2) }
+            playlistRepo.findById(2).shouldBePresent { (it as DefaultAudioPlaylist).audioItems.referenceIds shouldContainExactly listOf(2, 3) }
         }
 
         test("set-based mutable aggregate maintains uniqueness across repository operations") {
             val sharedRepo = AudioPlaylistVolatileRepository(ctx)
 
-            val p1 = MutableAudioPlaylistEntity(1, "P1").also(sharedRepo::add)
-            val p2 = MutableAudioPlaylistEntity(2, "P2").also(sharedRepo::add)
-            val group = MutableAudioPlaylistEntity(100, "Group").also(sharedRepo::add)
+            val p1 = DefaultAudioPlaylist(1, "P1").also(sharedRepo::add)
+            val p2 = DefaultAudioPlaylist(2, "P2").also(sharedRepo::add)
+            val group = DefaultAudioPlaylist(100, "Group").also(sharedRepo::add)
 
             group.playlists.add(p1)
             group.playlists.add(p2)
             group.playlists.add(p1) // duplicate
 
             sharedRepo.findById(100).shouldBePresent {
-                (it as MutableAudioPlaylistEntity).playlists.referenceIds shouldContainExactlyInAnyOrder setOf(1, 2)
+                (it as DefaultAudioPlaylist).playlists.referenceIds shouldContainExactlyInAnyOrder setOf(1, 2)
             }
         }
 
@@ -637,7 +637,7 @@ internal class VolatileRepositoryTest : FunSpec({
             val t2 = trackRepo.create(2, "T2")
             val t3 = trackRepo.create(3, "T3")
             val playlist =
-                MutableAudioPlaylistEntity(1, "Retain", listOf(1, 2, 3))
+                DefaultAudioPlaylist(1, "Retain", listOf(1, 2, 3))
                     .also(playlistRepo::add)
 
             playlist.subscribe { events.add(it) }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/AggregateJsonPersistenceTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/AggregateJsonPersistenceTest.kt
@@ -22,11 +22,11 @@ import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.persistence.AudioItemVolatileRepository
 import net.transgressoft.lirp.persistence.BubbleUpOrder
 import net.transgressoft.lirp.persistence.CustomerVolatileRepo
+import net.transgressoft.lirp.persistence.DefaultAudioPlaylist
 import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.LirpRepository
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.MutableAudioPlaylist
-import net.transgressoft.lirp.persistence.MutableAudioPlaylistEntity
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.spec.tempfile
 import io.kotest.matchers.collections.shouldContainExactly
@@ -237,7 +237,7 @@ class AggregateJsonPersistenceTest : FunSpec({
 
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val reloaded = playlistRepo2.findById(100).get() as MutableAudioPlaylistEntity
+        val reloaded = playlistRepo2.findById(100).get() as DefaultAudioPlaylist
         reloaded.audioItems.resolveAll().map { it.id } shouldContainExactly listOf(1, 2)
 
         ctx2.close()
@@ -266,7 +266,7 @@ class AggregateJsonPersistenceTest : FunSpec({
 
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val reloaded = playlistRepo2.findById(100).get() as MutableAudioPlaylistEntity
+        val reloaded = playlistRepo2.findById(100).get() as DefaultAudioPlaylist
         reloaded.audioItems.resolveAll().map { it.id } shouldContainExactly listOf(3, 1, 2)
 
         ctx2.close()
@@ -290,7 +290,7 @@ class AggregateJsonPersistenceTest : FunSpec({
 
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val reloaded = playlistRepo2.findById(100).get() as MutableAudioPlaylistEntity
+        val reloaded = playlistRepo2.findById(100).get() as DefaultAudioPlaylist
         reloaded.audioItems.resolveAll().size shouldBe 0
 
         ctx2.close()
@@ -298,7 +298,7 @@ class AggregateJsonPersistenceTest : FunSpec({
 })
 
 /**
- * JSON-backed repository for [MutableAudioPlaylistEntity] entities, used in tests that verify
+ * JSON-backed repository for [DefaultAudioPlaylist] entities, used in tests that verify
  * mutable aggregate list persistence round-trips.
  */
 @LirpRepository
@@ -311,15 +311,15 @@ class MutableAudioPlaylistJsonFileRepository internal constructor(
         context,
         file,
         @Suppress("UNCHECKED_CAST")
-        (MapSerializer(Int.serializer(), lirpSerializer(MutableAudioPlaylistEntity(0, ""))) as KSerializer<Map<Int, MutableAudioPlaylist>>),
+        (MapSerializer(Int.serializer(), lirpSerializer(DefaultAudioPlaylist(0, ""))) as KSerializer<Map<Int, MutableAudioPlaylist>>),
         serializationDelay = serializationDelayMs.milliseconds,
         loadOnInit = loadOnInit
     ) {
     constructor(file: File, serializationDelayMs: Long = 50L, loadOnInit: Boolean = true) :
         this(LirpContext.default, file, serializationDelayMs, loadOnInit)
 
-    fun create(id: Int, name: String, audioItemIds: List<Int> = emptyList()): MutableAudioPlaylistEntity =
-        MutableAudioPlaylistEntity(id, name, audioItemIds).also(::add)
+    fun create(id: Int, name: String, audioItemIds: List<Int> = emptyList()): DefaultAudioPlaylist =
+        DefaultAudioPlaylist(id, name, audioItemIds).also(::add)
 }
 
 /**

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
@@ -5,10 +5,10 @@ import net.transgressoft.lirp.event.CrudEvent.Type.CREATE
 import net.transgressoft.lirp.event.LirpEventSubscription
 import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.persistence.AudioItemVolatileRepository
+import net.transgressoft.lirp.persistence.DefaultAudioPlaylist
 import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.LirpDeserializationException
 import net.transgressoft.lirp.persistence.MutableAudioItem
-import net.transgressoft.lirp.persistence.MutableAudioPlaylistEntity
 import net.transgressoft.lirp.persistence.PersistentRepositoryBase
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.nondeterministic.eventually
@@ -695,7 +695,7 @@ class JsonFileRepositoryTest : DescribeSpec({
             val playlistRepo2 = MutableAudioPlaylistJsonFileRepository(ctx2, file, 10L)
 
             playlistRepo2.findById(1).shouldBePresent {
-                (it as MutableAudioPlaylistEntity).audioItems.referenceIds shouldContainExactly listOf(1, 2, 3)
+                (it as DefaultAudioPlaylist).audioItems.referenceIds shouldContainExactly listOf(1, 2, 3)
                 it.audioItems.resolveAll() shouldHaveSize 3
             }
 
@@ -725,7 +725,7 @@ class JsonFileRepositoryTest : DescribeSpec({
             trackRepo2.add(MutableAudioItem(3, "T3"))
             val playlistRepo2 = MutableAudioPlaylistJsonFileRepository(ctx2, file, 10L)
 
-            val reloaded = playlistRepo2.findById(1).get() as MutableAudioPlaylistEntity
+            val reloaded = playlistRepo2.findById(1).get() as DefaultAudioPlaylist
             reloaded.audioItems.referenceIds shouldContainExactly listOf(1, 2)
 
             playlistRepo2.close()
@@ -829,7 +829,7 @@ class JsonFileRepositoryTest : DescribeSpec({
             val playlistRepo2 = MutableAudioPlaylistJsonFileRepository(ctx2, file, 10L)
 
             playlistRepo2.findById(1).shouldBePresent {
-                (it as MutableAudioPlaylistEntity).audioItems.referenceIds shouldContainExactly listOf(10, 20, 30)
+                (it as DefaultAudioPlaylist).audioItems.referenceIds shouldContainExactly listOf(10, 20, 30)
             }
 
             playlistRepo2.close()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializerTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializerTest.kt
@@ -20,8 +20,8 @@ package net.transgressoft.lirp.persistence.json
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.persistence.AbstractMutableAggregateCollectionRefDelegate
 import net.transgressoft.lirp.persistence.AudioItem
-import net.transgressoft.lirp.persistence.MutableAggregateListProxy
-import net.transgressoft.lirp.persistence.MutableAggregateSetProxy
+import net.transgressoft.lirp.persistence.MutableAggregateList
+import net.transgressoft.lirp.persistence.MutableAggregateSet
 import net.transgressoft.lirp.persistence.mutableAggregateList
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
@@ -236,8 +236,8 @@ private fun <K : Comparable<K>> ReactiveEntityBase<*, *>.setDelegateIds(delegate
     val raw = delegateRegistry[delegateName]
     val delegate: AbstractMutableAggregateCollectionRefDelegate<K, *>? =
         when (raw) {
-            is MutableAggregateListProxy<*, *> -> raw.innerDelegate as AbstractMutableAggregateCollectionRefDelegate<K, *>
-            is MutableAggregateSetProxy<*, *> -> raw.innerDelegate as AbstractMutableAggregateCollectionRefDelegate<K, *>
+            is MutableAggregateList<*, *> -> raw.innerDelegate as AbstractMutableAggregateCollectionRefDelegate<K, *>
+            is MutableAggregateSet<*, *> -> raw.innerDelegate as AbstractMutableAggregateCollectionRefDelegate<K, *>
             is AbstractMutableAggregateCollectionRefDelegate<*, *> -> raw as AbstractMutableAggregateCollectionRefDelegate<K, *>
             else -> null
         }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/MusicCommonsJsonIntegrationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/MusicCommonsJsonIntegrationTest.kt
@@ -21,11 +21,11 @@ import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.AudioItemJsonFileRepository
 import net.transgressoft.lirp.persistence.AudioItemVolatileRepository
+import net.transgressoft.lirp.persistence.DefaultAudioPlaylist
 import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.MusicCommonsIntegrationTestBase
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.MutableAudioPlaylist
-import net.transgressoft.lirp.persistence.MutableAudioPlaylistEntity
 import net.transgressoft.lirp.persistence.PlaylistHierarchyJsonFileRepository
 import net.transgressoft.lirp.persistence.Repository
 import io.kotest.core.annotation.DisplayName
@@ -82,7 +82,7 @@ class MusicCommonsJsonIntegrationTest : MusicCommonsIntegrationTestBase() {
     @Suppress("UNCHECKED_CAST")
     override fun createPlaylistRepo(ctx: LirpContext): Repository<Int, MutableAudioPlaylist> {
         playlistFile = File.createTempFile("playlists", ".json").also { it.deleteOnExit() }
-        val serializer = MapSerializer(Int.serializer(), lirpSerializer(MutableAudioPlaylistEntity(0, ""))) as KSerializer<Map<Int, MutableAudioPlaylist>>
+        val serializer = MapSerializer(Int.serializer(), lirpSerializer(DefaultAudioPlaylist(0, ""))) as KSerializer<Map<Int, MutableAudioPlaylist>>
         return PlaylistHierarchyJsonFileRepository(ctx, playlistFile, serializer)
     }
 
@@ -105,8 +105,8 @@ class MusicCommonsJsonIntegrationTest : MusicCommonsIntegrationTestBase() {
                     audioItemRepo.add(it)
                 }
 
-            val child = MutableAudioPlaylistEntity(20, "Child Playlist").also(playlistRepo::add)
-            val parent = MutableAudioPlaylistEntity(10, "Parent Playlist", listOf(1, 2), setOf(20)).also(playlistRepo::add)
+            val child = DefaultAudioPlaylist(20, "Child Playlist").also(playlistRepo::add)
+            val parent = DefaultAudioPlaylist(10, "Parent Playlist", listOf(1, 2), setOf(20)).also(playlistRepo::add)
 
             flushPendingWrites()
 
@@ -137,7 +137,7 @@ class MusicCommonsJsonIntegrationTest : MusicCommonsIntegrationTestBase() {
                 MutableAudioItem(2, "Song 2").also {
                     audioItemRepo.add(it)
                 }
-            val playlist = MutableAudioPlaylistEntity(10, "Dynamic").also(playlistRepo::add)
+            val playlist = DefaultAudioPlaylist(10, "Dynamic").also(playlistRepo::add)
             flushPendingWrites()
 
             playlist.audioItems.add(item1)
@@ -154,7 +154,7 @@ class MusicCommonsJsonIntegrationTest : MusicCommonsIntegrationTestBase() {
                 MutableAudioItem(1, "Persisted Track").also {
                     audioItemRepo.add(it)
                 }
-            val playlist = MutableAudioPlaylistEntity(10, "Persisted Playlist", listOf(1)).also(playlistRepo::add)
+            val playlist = DefaultAudioPlaylist(10, "Persisted Playlist", listOf(1)).also(playlistRepo::add)
             flushPendingWrites()
             ctx.close()
 
@@ -168,7 +168,7 @@ class MusicCommonsJsonIntegrationTest : MusicCommonsIntegrationTestBase() {
 
             val playlistSerializer =
                 MapSerializer(
-                    Int.serializer(), lirpSerializer(MutableAudioPlaylistEntity(0, ""))
+                    Int.serializer(), lirpSerializer(DefaultAudioPlaylist(0, ""))
                 ) as KSerializer<Map<Int, MutableAudioPlaylist>>
             val reloadedRepo = PlaylistHierarchyJsonFileRepository(ctx2, playlistFile, playlistSerializer)
             flushPendingWrites()
@@ -184,16 +184,16 @@ class MusicCommonsJsonIntegrationTest : MusicCommonsIntegrationTestBase() {
 
         @Suppress("UNCHECKED_CAST")
         test("JSON round-trip preserves self-referencing playlist aggregates after reload") {
-            val subA = MutableAudioPlaylistEntity(20, "Sub A").also(playlistRepo::add)
-            val subB = MutableAudioPlaylistEntity(30, "Sub B").also(playlistRepo::add)
-            val parent = MutableAudioPlaylistEntity(10, "Parent", emptyList(), setOf(20, 30)).also(playlistRepo::add)
+            val subA = DefaultAudioPlaylist(20, "Sub A").also(playlistRepo::add)
+            val subB = DefaultAudioPlaylist(30, "Sub B").also(playlistRepo::add)
+            val parent = DefaultAudioPlaylist(10, "Parent", emptyList(), setOf(20, 30)).also(playlistRepo::add)
             flushPendingWrites()
             ctx.close()
 
             val ctx2 = LirpContext()
             val playlistSerializer =
                 MapSerializer(
-                    Int.serializer(), lirpSerializer(MutableAudioPlaylistEntity(0, ""))
+                    Int.serializer(), lirpSerializer(DefaultAudioPlaylist(0, ""))
                 ) as KSerializer<Map<Int, MutableAudioPlaylist>>
             // JsonFileRepository self-registers in ctx2; playlists self-reference via the same repo
             val reloadedRepo = PlaylistHierarchyJsonFileRepository(ctx2, playlistFile, playlistSerializer)

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateList.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateList.kt
@@ -20,8 +20,8 @@ package net.transgressoft.lirp.persistence.fx
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.persistence.AggregateCollectionRef
-import net.transgressoft.lirp.persistence.FxObservableCollectionProxy
-import net.transgressoft.lirp.persistence.MutableAggregateListProxy
+import net.transgressoft.lirp.persistence.FxObservableCollection
+import net.transgressoft.lirp.persistence.MutableAggregateList
 import javafx.application.Platform
 import javafx.beans.InvalidationListener
 import javafx.collections.ListChangeListener
@@ -31,7 +31,7 @@ import kotlin.reflect.KProperty
 import kotlinx.coroutines.launch
 
 /**
- * JavaFX-observable proxy that wraps a [MutableAggregateListProxy] and implements both
+ * JavaFX-observable list that wraps a [MutableAggregateList] and implements both
  * [ObservableList] and [AggregateCollectionRef].
  *
  * Mutations to this list fire [ListChangeListener.Change] notifications automatically.
@@ -46,13 +46,13 @@ import kotlinx.coroutines.launch
  *
  * @param K the entity ID type
  * @param E the entity type
- * @param innerProxy the wrapped lirp mutable aggregate list proxy
+ * @param innerProxy the wrapped lirp mutable aggregate list
  * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
  */
-class FxAggregateListProxy<K : Comparable<K>, E : IdentifiableEntity<K>>(
-    val innerProxy: MutableAggregateListProxy<K, E>,
+class FxAggregateList<K : Comparable<K>, E : IdentifiableEntity<K>>(
+    val innerProxy: MutableAggregateList<K, E>,
     val dispatchToFxThread: Boolean = true
-) : AbstractMutableList<E>(), ObservableList<E>, AggregateCollectionRef<K, E> by innerProxy, FxObservableCollectionProxy {
+) : AbstractMutableList<E>(), ObservableList<E>, AggregateCollectionRef<K, E> by innerProxy, FxObservableCollection<K, E> {
 
     override val innerMutableProxy: Any get() = innerProxy
 
@@ -209,7 +209,7 @@ class FxAggregateListProxy<K : Comparable<K>, E : IdentifiableEntity<K>>(
         invalidationListeners.remove(listener)
     }
 
-    operator fun getValue(thisRef: Any?, property: KProperty<*>): FxAggregateListProxy<K, E> = this
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): FxAggregateList<K, E> = this
 
     private fun fireChange(change: ListChangeListener.Change<E>) {
         val notify = {

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSet.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSet.kt
@@ -20,8 +20,8 @@ package net.transgressoft.lirp.persistence.fx
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.persistence.AggregateCollectionRef
-import net.transgressoft.lirp.persistence.FxObservableCollectionProxy
-import net.transgressoft.lirp.persistence.MutableAggregateSetProxy
+import net.transgressoft.lirp.persistence.FxObservableCollection
+import net.transgressoft.lirp.persistence.MutableAggregateSet
 import javafx.application.Platform
 import javafx.beans.InvalidationListener
 import javafx.collections.ObservableSet
@@ -31,7 +31,7 @@ import kotlin.reflect.KProperty
 import kotlinx.coroutines.launch
 
 /**
- * JavaFX-observable proxy that wraps a [MutableAggregateSetProxy] and implements both
+ * JavaFX-observable set that wraps a [MutableAggregateSet] and implements both
  * [ObservableSet] and [AggregateCollectionRef].
  *
  * Mutations to this set fire [SetChangeListener.Change] notifications automatically.
@@ -46,13 +46,13 @@ import kotlinx.coroutines.launch
  *
  * @param K the entity ID type
  * @param E the entity type
- * @param innerProxy the wrapped lirp mutable aggregate set proxy
+ * @param innerProxy the wrapped lirp mutable aggregate set
  * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
  */
-class FxAggregateSetProxy<K : Comparable<K>, E : IdentifiableEntity<K>>(
-    val innerProxy: MutableAggregateSetProxy<K, E>,
+class FxAggregateSet<K : Comparable<K>, E : IdentifiableEntity<K>>(
+    val innerProxy: MutableAggregateSet<K, E>,
     val dispatchToFxThread: Boolean = true
-) : AbstractMutableSet<E>(), ObservableSet<E>, AggregateCollectionRef<K, E> by innerProxy, FxObservableCollectionProxy {
+) : AbstractMutableSet<E>(), ObservableSet<E>, AggregateCollectionRef<K, E> by innerProxy, FxObservableCollection<K, E> {
 
     override val innerMutableProxy: Any get() = innerProxy
 
@@ -82,7 +82,7 @@ class FxAggregateSetProxy<K : Comparable<K>, E : IdentifiableEntity<K>>(
 
             override fun remove() {
                 val element = lastReturned ?: throw IllegalStateException("next() not yet called or already removed")
-                this@FxAggregateSetProxy.remove(element)
+                this@FxAggregateSet.remove(element)
                 lastReturned = null
             }
         }
@@ -166,7 +166,7 @@ class FxAggregateSetProxy<K : Comparable<K>, E : IdentifiableEntity<K>>(
         setChangeListeners.remove(listener)
     }
 
-    operator fun getValue(thisRef: Any?, property: KProperty<*>): FxAggregateSetProxy<K, E> = this
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): FxAggregateSet<K, E> = this
 
     private fun fireChange(change: SetChangeListener.Change<E>) {
         val notify = {

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxFactories.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxFactories.kt
@@ -18,13 +18,14 @@
 package net.transgressoft.lirp.persistence.fx
 
 import net.transgressoft.lirp.entity.IdentifiableEntity
+import net.transgressoft.lirp.persistence.FxObservableCollection
 import net.transgressoft.lirp.persistence.mutableAggregateList
 import net.transgressoft.lirp.persistence.mutableAggregateSet
 
 /**
  * Creates a property delegate for a JavaFX-observable mutable ordered aggregate collection reference.
  *
- * Returns an [FxAggregateListProxy] that implements both [javafx.collections.ObservableList] and
+ * Returns an [FxAggregateList] that implements both [javafx.collections.ObservableList] and
  * lirp's [net.transgressoft.lirp.persistence.AggregateCollectionRef]. Mutations fire
  * [javafx.collections.ListChangeListener.Change] notifications automatically.
  *
@@ -38,13 +39,13 @@ import net.transgressoft.lirp.persistence.mutableAggregateSet
 fun <K : Comparable<K>, E : IdentifiableEntity<K>> fxAggregateList(
     initialIds: List<K> = emptyList(),
     dispatchToFxThread: Boolean = true
-): FxAggregateListProxy<K, E> =
-    FxAggregateListProxy(mutableAggregateList(initialIds), dispatchToFxThread)
+): FxAggregateList<K, E> =
+    FxAggregateList(mutableAggregateList(initialIds), dispatchToFxThread)
 
 /**
  * Creates a property delegate for a JavaFX-observable mutable unique-set aggregate collection reference.
  *
- * Returns an [FxAggregateSetProxy] that implements both [javafx.collections.ObservableSet] and
+ * Returns an [FxAggregateSet] that implements both [javafx.collections.ObservableSet] and
  * lirp's [net.transgressoft.lirp.persistence.AggregateCollectionRef]. Mutations fire
  * [javafx.collections.SetChangeListener.Change] notifications automatically, with one Change
  * per element per the JavaFX [javafx.collections.SetChangeListener] contract.
@@ -59,8 +60,8 @@ fun <K : Comparable<K>, E : IdentifiableEntity<K>> fxAggregateList(
 fun <K : Comparable<K>, E : IdentifiableEntity<K>> fxAggregateSet(
     initialIds: Set<K> = emptySet(),
     dispatchToFxThread: Boolean = true
-): FxAggregateSetProxy<K, E> =
-    FxAggregateSetProxy(mutableAggregateSet(initialIds), dispatchToFxThread)
+): FxAggregateSet<K, E> =
+    FxAggregateSet(mutableAggregateSet(initialIds), dispatchToFxThread)
 
 /**
  * Creates a [LirpStringProperty] delegate with an optional initial value.
@@ -132,3 +133,36 @@ fun fxBoolean(initialValue: Boolean = false, dispatchToFxThread: Boolean = true)
  */
 fun <T> fxObject(initialValue: T? = null, dispatchToFxThread: Boolean = true): LirpObjectProperty<T> =
     LirpObjectProperty(initialValue, dispatchToFxThread)
+
+/**
+ * Creates a read-only [javafx.collections.ObservableMap] projection delegate that groups entities
+ * from an [FxObservableCollection] source by a secondary key.
+ *
+ * The returned [FxProjectionMap] lazily initializes on the first Kotlin `by`-delegation
+ * access, subscribing to the source collection's change listener and building initial state
+ * from the source's current contents. Subsequent adds and removes fire incremental
+ * [javafx.collections.MapChangeListener.Change] notifications per affected bucket key.
+ *
+ * Keys are maintained in natural sorted order via a [java.util.TreeMap] backing.
+ * The projected map is read-only; calling `put` or `remove` on it throws [UnsupportedOperationException].
+ *
+ * Usage:
+ * ```kotlin
+ * val audioItemsByAlbum by fxProjectionMap(::audioItems, AudioItem::albumName)
+ * ```
+ *
+ * @param K the entity ID type
+ * @param PK the projection key type, must be [Comparable]
+ * @param E the entity type
+ * @param sourceRef lambda returning the source [FxObservableCollection] (supports `::property` syntax)
+ * @param keyExtractor grouping function that extracts the projection key from an entity
+ * @param dispatchToFxThread when `true` (default), dispatches notifications to the FX Application Thread;
+ *   when `false`, dispatches on [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @return a read-only projection map delegate incrementally updated from the source collection
+ */
+fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> fxProjectionMap(
+    sourceRef: () -> FxObservableCollection<K, E>,
+    keyExtractor: (E) -> PK,
+    dispatchToFxThread: Boolean = true
+): FxProjectionMap<K, PK, E> =
+    FxProjectionMap(sourceRef, keyExtractor, dispatchToFxThread)

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxProjectionMap.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxProjectionMap.kt
@@ -1,0 +1,273 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.entity.IdentifiableEntity
+import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.persistence.FxObservableCollection
+import javafx.application.Platform
+import javafx.beans.InvalidationListener
+import javafx.collections.FXCollections
+import javafx.collections.ListChangeListener
+import javafx.collections.MapChangeListener
+import javafx.collections.ObservableMap
+import javafx.collections.SetChangeListener
+import java.util.Collections
+import java.util.TreeMap
+import kotlin.reflect.KProperty
+import kotlinx.coroutines.launch
+
+/**
+ * This is the JavaFX counterpart of [net.transgressoft.lirp.persistence.ProjectionMap] from `lirp-core`,
+ * extending it with a JavaFX [ObservableMap] interface and reactive listener support.
+ *
+ * A read-only [ObservableMap] that derives a grouped view from an existing
+ * [FxObservableCollection] source (either an [FxAggregateList] or [FxAggregateSet]).
+ *
+ * Entities from the source collection are grouped by a [keyExtractor] function into
+ * buckets of type `List<E>`, keyed by projection key type `PK`. The backing map is a
+ * [TreeMap], so keys are always iterated in natural sorted order.
+ *
+ * The projection initializes lazily: the source subscription and initial state build happen
+ * on the first [getValue] call (Kotlin `by` delegation) or on the first [addListener] call,
+ * not at construction time. This keeps construction cheap even if the source is not yet fully populated.
+ *
+ * Changes to the source collection are propagated incrementally via a [ListChangeListener]
+ * (for list sources) or [SetChangeListener] (for set sources). Each add or remove fires a
+ * targeted [MapChangeListener.Change] on the affected bucket key only.
+ *
+ * This class implements [ObservableMap] directly — callers can add [MapChangeListener] or
+ * [javafx.beans.InvalidationListener] and read map state (`size`, `get`, `keys`) directly on
+ * the instance. Mutation methods (`put`, `remove`, `putAll`, `clear`) throw
+ * [UnsupportedOperationException]; all mutations flow through the source collection.
+ *
+ * When [dispatchToFxThread] is `true` (the default), map change notifications are dispatched
+ * to the JavaFX Application Thread via [Platform.runLater] when fired from a background thread.
+ * When `false`, notifications fire asynchronously on [ReactiveScope.flowScope].
+ *
+ * @param K the entity ID type, must be [Comparable]
+ * @param PK the projection key type, must be [Comparable] (used as [TreeMap] key)
+ * @param E the entity type
+ * @param sourceRef deferred reference to the source [FxObservableCollection] (resolved on first [getValue] or [addListener])
+ * @param keyExtractor grouping function that extracts the projection key from an entity
+ * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
+ */
+class FxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>>(
+    private val sourceRef: () -> FxObservableCollection<K, E>,
+    private val keyExtractor: (E) -> PK,
+    val dispatchToFxThread: Boolean = true
+) : ObservableMap<PK, List<E>> {
+    private val innerObservableMap: ObservableMap<PK, List<E>> = FXCollections.observableMap(TreeMap<PK, List<E>>())
+
+    @Volatile
+    private var initialized = false
+
+    private fun initialize() {
+        if (initialized) return
+        synchronized(this) {
+            if (initialized) return
+            when (val source = sourceRef()) {
+                is FxAggregateList<*, *> -> subscribeToList(source)
+                is FxAggregateSet<*, *> -> subscribeToSet(source)
+                else ->
+                    error(
+                        "FxProjectionMap requires an FxObservableCollection source, " +
+                            "but received: ${source::class.qualifiedName}"
+                    )
+            }
+            initialized = true
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun subscribeToList(source: FxAggregateList<*, *>) {
+        val typedSource = source as FxAggregateList<K, E>
+        val initialElements = typedSource.toList().ifEmpty { typedSource.innerProxy.resolveAll().toList() }
+        populateInitialState(initialElements)
+        typedSource.addListener(
+            ListChangeListener { change ->
+                while (change.next()) {
+                    if (change.wasAdded()) handleAdded(change.addedSubList as List<E>)
+                    if (change.wasRemoved()) handleRemoved(change.removed as List<E>)
+                }
+            }
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun subscribeToSet(source: FxAggregateSet<*, *>) {
+        val typedSource = source as FxAggregateSet<K, E>
+        val initialElements = typedSource.toList().ifEmpty { typedSource.innerProxy.resolveAll().toList() }
+        populateInitialState(initialElements)
+        typedSource.addListener(
+            SetChangeListener { change ->
+                if (change.wasAdded()) handleAdded(listOf(change.elementAdded as E))
+                if (change.wasRemoved()) handleRemoved(listOf(change.elementRemoved as E))
+            }
+        )
+    }
+
+    private fun freezeBucket(elements: List<E>): List<E> = java.util.Collections.unmodifiableList(ArrayList(elements))
+
+    // Writes directly to innerObservableMap without mutateMap dispatch — called during
+    // initialize() so the initial state is available synchronously before initialized=true.
+    private fun populateInitialState(elements: List<E>) {
+        for (element in elements) {
+            val key = keyExtractor(element)
+            val updated = freezeBucket((innerObservableMap[key] ?: emptyList()) + element)
+            innerObservableMap[key] = updated
+        }
+    }
+
+    private fun handleAdded(elements: List<E>) {
+        for (element in elements) {
+            val key = keyExtractor(element)
+            mutateMap {
+                val updated = freezeBucket((innerObservableMap[key] ?: emptyList()) + element)
+                innerObservableMap[key] = updated
+            }
+        }
+    }
+
+    private fun handleRemoved(elements: List<E>) {
+        for (element in elements) {
+            val key = keyExtractor(element)
+            mutateMap {
+                val current = innerObservableMap[key]
+                if (current != null && element in current) {
+                    val filtered = current.filter { it != element }
+                    if (filtered.isEmpty()) innerObservableMap.remove(key)
+                    else innerObservableMap[key] = freezeBucket(filtered)
+                } else {
+                    removeFromAnyBucket(element)
+                }
+            }
+        }
+    }
+
+    private fun removeFromAnyBucket(element: E) {
+        val iterator = innerObservableMap.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (element in entry.value) {
+                val filtered = entry.value.filter { it != element }
+                if (filtered.isEmpty()) iterator.remove()
+                else entry.setValue(freezeBucket(filtered))
+                return
+            }
+        }
+    }
+
+    private fun mutateMap(action: () -> Unit) {
+        if (dispatchToFxThread) {
+            if (Platform.isFxApplicationThread()) {
+                action()
+            } else {
+                Platform.runLater(action)
+            }
+        } else {
+            ReactiveScope.flowScope.launch { action() }
+        }
+    }
+
+    // ObservableMap<PK, List<E>> — read operations delegate to innerObservableMap after initialization
+    override val size: Int get() {
+        initialize()
+        return innerObservableMap.size
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override val entries: MutableSet<MutableMap.MutableEntry<PK, List<E>>> get() {
+        initialize()
+        val snapshot = innerObservableMap.entries.map { java.util.AbstractMap.SimpleImmutableEntry(it.key, it.value) }.toSet()
+        return Collections.unmodifiableSet(snapshot) as MutableSet<MutableMap.MutableEntry<PK, List<E>>>
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override val keys: MutableSet<PK> get() {
+        initialize()
+        return Collections.unmodifiableSet(innerObservableMap.keys) as MutableSet<PK>
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override val values: MutableCollection<List<E>> get() {
+        initialize()
+        return Collections.unmodifiableCollection(innerObservableMap.values) as MutableCollection<List<E>>
+    }
+
+    override fun containsKey(key: PK): Boolean {
+        initialize()
+        return innerObservableMap.containsKey(key)
+    }
+
+    override fun containsValue(value: List<E>): Boolean {
+        initialize()
+        return innerObservableMap.containsValue(value)
+    }
+
+    override fun get(key: PK): List<E>? {
+        initialize()
+        return innerObservableMap[key]
+    }
+
+    override fun isEmpty(): Boolean {
+        initialize()
+        return innerObservableMap.isEmpty()
+    }
+
+    // Mutation methods — this projection is read-only; all mutations flow through the source collection
+    override fun put(key: PK, value: List<E>): List<E> = throw UnsupportedOperationException(READ_ONLY_MESSAGE)
+
+    override fun remove(key: PK): List<E>? = throw UnsupportedOperationException(READ_ONLY_MESSAGE)
+
+    override fun putAll(from: Map<out PK, List<E>>) = throw UnsupportedOperationException(READ_ONLY_MESSAGE)
+
+    override fun clear() = throw UnsupportedOperationException(READ_ONLY_MESSAGE)
+
+    companion object {
+        private const val READ_ONLY_MESSAGE = "FxProjectionMap is read-only"
+    }
+
+    // Listener methods delegate to innerObservableMap; addListener also triggers initialization
+    // so the source subscription is established before the first change fires.
+    override fun addListener(listener: MapChangeListener<in PK, in List<E>>) {
+        initialize()
+        innerObservableMap.addListener(listener)
+    }
+
+    override fun removeListener(listener: MapChangeListener<in PK, in List<E>>) =
+        innerObservableMap.removeListener(listener)
+
+    override fun addListener(listener: InvalidationListener) {
+        initialize()
+        innerObservableMap.addListener(listener)
+    }
+
+    override fun removeListener(listener: InvalidationListener) =
+        innerObservableMap.removeListener(listener)
+
+    /**
+     * Returns `this` projection map, initializing the source subscription on the first call.
+     *
+     * Implements Kotlin `by`-delegation: `val byAlbum: ObservableMap<String, List<AudioItem>> by fxProjectionMap(...)`.
+     */
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): FxProjectionMap<K, PK, E> {
+        initialize()
+        return this
+    }
+}

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxProperties.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxProperties.kt
@@ -18,6 +18,7 @@
 package net.transgressoft.lirp.persistence.fx
 
 import net.transgressoft.lirp.entity.IdentifiableEntity
+import net.transgressoft.lirp.persistence.FxObservableCollection
 import net.transgressoft.lirp.persistence.mutableAggregateList
 import net.transgressoft.lirp.persistence.mutableAggregateSet
 
@@ -74,19 +75,38 @@ object FxProperties {
     fun <T> fxObject(initialValue: T? = null, dispatchToFxThread: Boolean = true): LirpObjectProperty<T> =
         LirpObjectProperty(initialValue, dispatchToFxThread)
 
-    /** Creates an [FxAggregateListProxy] for a JavaFX-observable mutable ordered aggregate collection. */
+    /** Creates an [FxAggregateList] for a JavaFX-observable mutable ordered aggregate collection. */
     @JvmStatic
     @JvmOverloads
     fun <K : Comparable<K>, E : IdentifiableEntity<K>> fxAggregateList(
         initialIds: List<K> = emptyList(),
         dispatchToFxThread: Boolean = true
-    ): FxAggregateListProxy<K, E> = FxAggregateListProxy(mutableAggregateList(initialIds), dispatchToFxThread)
+    ): FxAggregateList<K, E> = FxAggregateList(mutableAggregateList(initialIds), dispatchToFxThread)
 
-    /** Creates an [FxAggregateSetProxy] for a JavaFX-observable mutable unique-set aggregate collection. */
+    /** Creates an [FxAggregateSet] for a JavaFX-observable mutable unique-set aggregate collection. */
     @JvmStatic
     @JvmOverloads
     fun <K : Comparable<K>, E : IdentifiableEntity<K>> fxAggregateSet(
         initialIds: Set<K> = emptySet(),
         dispatchToFxThread: Boolean = true
-    ): FxAggregateSetProxy<K, E> = FxAggregateSetProxy(mutableAggregateSet(initialIds), dispatchToFxThread)
+    ): FxAggregateSet<K, E> = FxAggregateSet(mutableAggregateSet(initialIds), dispatchToFxThread)
+
+    /**
+     * Creates an [FxProjectionMap] that groups entities from any [FxObservableCollection]
+     * source by a projection key.
+     *
+     * @param K the entity ID type
+     * @param PK the projection key type
+     * @param E the entity type
+     * @param sourceRef lambda returning the source collection
+     * @param keyExtractor function extracting the projection key from an entity
+     * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> fxProjectionMap(
+        sourceRef: () -> FxObservableCollection<K, E>,
+        keyExtractor: (E) -> PK,
+        dispatchToFxThread: Boolean = true
+    ): FxProjectionMap<K, PK, E> = FxProjectionMap(sourceRef, keyExtractor, dispatchToFxThread)
 }

--- a/lirp-fx/src/test/java/net/transgressoft/lirp/persistence/fx/FxProjectionMapJavaInteropTest.java
+++ b/lirp-fx/src/test/java/net/transgressoft/lirp/persistence/fx/FxProjectionMapJavaInteropTest.java
@@ -1,0 +1,114 @@
+package net.transgressoft.lirp.persistence.fx;
+
+import javafx.collections.MapChangeListener;
+import kotlinx.coroutines.CoroutineScopeKt;
+import kotlinx.coroutines.Dispatchers;
+import kotlinx.coroutines.SupervisorKt;
+import net.transgressoft.lirp.event.ReactiveScope;
+import net.transgressoft.lirp.persistence.AudioItem;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Java interoperability tests verifying that {@link FxProperties#fxProjectionMap} static factory
+ * method is accessible from Java and that the resulting projection correctly groups entities
+ * and fires {@link MapChangeListener} notifications for both list and set sources.
+ */
+@DisplayName("FxProjectionMap Java interop")
+class FxProjectionMapJavaInteropTest {
+
+    @BeforeAll
+    static void initToolkit() {
+        FxToolkitInit.INSTANCE.ensureInitialized();
+        ReactiveScope.INSTANCE.setFlowScope(
+            CoroutineScopeKt.CoroutineScope(
+                Dispatchers.getUnconfined().plus(SupervisorKt.SupervisorJob(null))
+            )
+        );
+    }
+
+    @AfterAll
+    static void resetScope() {
+        ReactiveScope.INSTANCE.resetDefaultFlowScope();
+    }
+
+    @Test
+    @DisplayName("FxProperties.fxProjectionMap creates projection from list source in Java")
+    void projectionMapFromListSource() {
+        FxAggregateList<Integer, AudioItem> source = FxProperties.fxAggregateList(List.of(), false);
+
+        FxProjectionMap<Integer, String, AudioItem> audioItemsByAlbum =
+            FxProperties.fxProjectionMap(() -> source, AudioItem::getAlbumName, false);
+
+        assertTrue(audioItemsByAlbum.isEmpty(), "Map is empty before any items are added");
+
+        FxAudioItem item1 = new FxAudioItem(1, "Track 1", "Album A");
+        FxAudioItem item2 = new FxAudioItem(2, "Track 2", "Album A");
+        FxAudioItem item3 = new FxAudioItem(3, "Track 3", "Album B");
+
+        source.add(item1);
+        source.add(item2);
+        source.add(item3);
+
+        assertEquals(2, audioItemsByAlbum.size(), "Map has two keys after adding items to two albums");
+        assertTrue(audioItemsByAlbum.containsKey("Album A"), "Map contains key Album A");
+        assertTrue(audioItemsByAlbum.containsKey("Album B"), "Map contains key Album B");
+        assertEquals(2, audioItemsByAlbum.get("Album A").size(), "Album A has two items");
+        assertEquals(1, audioItemsByAlbum.get("Album B").size(), "Album B has one item");
+    }
+
+    @Test
+    @DisplayName("FxProperties.fxProjectionMap fires MapChangeListener from Java")
+    @SuppressWarnings("unchecked")
+    void projectionMapFiresMapChangeListener() {
+        FxAggregateList<Integer, AudioItem> source = FxProperties.fxAggregateList(List.of(), false);
+
+        FxProjectionMap<Integer, String, AudioItem> projection =
+            FxProperties.fxProjectionMap(() -> source, AudioItem::getAlbumName, false);
+
+        AtomicBoolean listenerFired = new AtomicBoolean(false);
+        AtomicReference<String> addedKey = new AtomicReference<>();
+
+        projection.addListener((MapChangeListener<? super String, ? super List<? extends AudioItem>>) change -> {
+            if (change.wasAdded()) {
+                listenerFired.set(true);
+                addedKey.set(change.getKey());
+            }
+        });
+
+        FxAudioItem item = new FxAudioItem(10, "Song X", "New Album");
+        source.add(item);
+
+        assertTrue(listenerFired.get(), "MapChangeListener was fired after adding to source");
+        assertEquals("New Album", addedKey.get(), "MapChangeListener received the correct key");
+    }
+
+    @Test
+    @DisplayName("FxProperties.fxProjectionMap creates projection from set source in Java")
+    void projectionMapFromSetSource() {
+        FxAggregateSet<Integer, AudioItem> source = FxProperties.fxAggregateSet(Set.of(), false);
+
+        FxProjectionMap<Integer, String, AudioItem> projection =
+            FxProperties.fxProjectionMap(() -> source, AudioItem::getAlbumName, false);
+
+        assertTrue(projection.isEmpty(), "Map is empty before any items are added");
+
+        FxAudioItem item1 = new FxAudioItem(1, "Track 1", "Album A");
+        FxAudioItem item2 = new FxAudioItem(2, "Track 2", "Album B");
+
+        source.add(item1);
+        source.add(item2);
+
+        assertEquals(2, projection.size(), "Map has two keys after adding items to two albums");
+        assertTrue(projection.containsKey("Album A"), "Map contains key Album A");
+        assertTrue(projection.containsKey("Album B"), "Map contains key Album B");
+    }
+}

--- a/lirp-fx/src/test/java/net/transgressoft/lirp/persistence/fx/FxScalarJavaInteropTest.java
+++ b/lirp-fx/src/test/java/net/transgressoft/lirp/persistence/fx/FxScalarJavaInteropTest.java
@@ -84,7 +84,7 @@ class FxScalarJavaInteropTest {
     class CollectionFactoryTests {
 
         @Test
-        @DisplayName("FxProperties.fxAggregateList() creates FxAggregateListProxy")
+        @DisplayName("FxProperties.fxAggregateList() creates FxAggregateList")
         void aggregateListFactory() {
             var list = FxProperties.<Integer, AudioItem>fxAggregateList(List.of(), true);
             assertNotNull(list);
@@ -92,7 +92,7 @@ class FxScalarJavaInteropTest {
         }
 
         @Test
-        @DisplayName("FxProperties.fxAggregateSet() creates FxAggregateSetProxy")
+        @DisplayName("FxProperties.fxAggregateSet() creates FxAggregateSet")
         void aggregateSetFactory() {
             var set = FxProperties.<Integer, AudioItem>fxAggregateSet(Set.of(), true);
             assertNotNull(set);

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateListTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateListTest.kt
@@ -34,11 +34,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 /**
- * Tests for [FxAggregateListProxy] verifying JavaFX [ListChangeListener.Change] notifications,
+ * Tests for [FxAggregateList] verifying JavaFX [ListChangeListener.Change] notifications,
  * dispatch thread behavior, and type compatibility with [ObservableList] and [AggregateCollectionRef].
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class FxAggregateListProxyTest : StringSpec({
+class FxAggregateListTest : StringSpec({
 
     val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
@@ -51,13 +51,13 @@ class FxAggregateListProxyTest : StringSpec({
         ReactiveScope.resetDefaultFlowScope()
     }
 
-    "FxAggregateListProxy returns correct size after add" {
+    "FxAggregateList returns correct size after add" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         proxy.add(0, MutableAudioItem(1, "Song A"))
         proxy.size shouldBe 1
     }
 
-    "FxAggregateListProxy fires ListChangeListener on single add" {
+    "FxAggregateList fires ListChangeListener on single add" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val changes = mutableListOf<ListChangeListener.Change<out AudioItem>>()
         proxy.addListener(ListChangeListener(changes::add))
@@ -72,7 +72,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.to shouldBe 1
     }
 
-    "FxAggregateListProxy fires ListChangeListener on single remove" {
+    "FxAggregateList fires ListChangeListener on single remove" {
         val item = MutableAudioItem(1, "Song A")
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         proxy.add(0, item)
@@ -89,7 +89,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.removed.size shouldBe 1
     }
 
-    "FxAggregateListProxy fires ListChangeListener on set" {
+    "FxAggregateList fires ListChangeListener on set" {
         val item1 = MutableAudioItem(1, "Song A")
         val item2 = MutableAudioItem(2, "Song B")
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
@@ -106,7 +106,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.wasReplaced() shouldBe true
     }
 
-    "FxAggregateListProxy fires single Change on addAll" {
+    "FxAggregateList fires single Change on addAll" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val testItems = listOf(MutableAudioItem(1, "A"), MutableAudioItem(2, "B"), MutableAudioItem(3, "C"))
         val changes = mutableListOf<ListChangeListener.Change<out AudioItem>>()
@@ -122,7 +122,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.to shouldBe 3
     }
 
-    "FxAggregateListProxy fires Change on clear" {
+    "FxAggregateList fires Change on clear" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         proxy.add(0, MutableAudioItem(1, "A"))
         proxy.add(1, MutableAudioItem(2, "B"))
@@ -139,7 +139,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.removed.size shouldBe 2
     }
 
-    "FxAggregateListProxy fires listeners on flowScope when dispatchToFxThread=false" {
+    "FxAggregateList fires listeners on flowScope when dispatchToFxThread=false" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         var listenerFired = false
 
@@ -150,7 +150,7 @@ class FxAggregateListProxyTest : StringSpec({
         listenerFired shouldBe true
     }
 
-    "FxAggregateListProxy fires listeners on FX thread when dispatchToFxThread=true" {
+    "FxAggregateList fires listeners on FX thread when dispatchToFxThread=true" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = true)
         val latch = CountDownLatch(1)
         var wasFxThread = false
@@ -168,22 +168,22 @@ class FxAggregateListProxyTest : StringSpec({
         wasFxThread shouldBe true
     }
 
-    "FxAggregateListProxy implements ObservableList" {
+    "FxAggregateList implements ObservableList" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         proxy.shouldBeInstanceOf<ObservableList<AudioItem>>()
     }
 
-    "FxAggregateListProxy implements AggregateCollectionRef" {
+    "FxAggregateList implements AggregateCollectionRef" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         proxy.shouldBeInstanceOf<AggregateCollectionRef<Int, AudioItem>>()
     }
 
-    "FxAggregateListProxy supports property delegation via getValue" {
+    "FxAggregateList supports property delegation via getValue" {
         val proxy by fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
-        proxy.shouldBeInstanceOf<FxAggregateListProxy<Int, AudioItem>>()
+        proxy.shouldBeInstanceOf<FxAggregateList<Int, AudioItem>>()
     }
 
-    "FxAggregateListProxy fires MultiRemoveChange with ascending indices on removeAll" {
+    "FxAggregateList fires MultiRemoveChange with ascending indices on removeAll" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val item1 = MutableAudioItem(1, "A")
         val item2 = MutableAudioItem(2, "B")
@@ -208,7 +208,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.next() shouldBe false
     }
 
-    "FxAggregateListProxy MultiRemoveChange supports reset" {
+    "FxAggregateList MultiRemoveChange supports reset" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val items = listOf(MutableAudioItem(1, "A"), MutableAudioItem(2, "B"), MutableAudioItem(3, "C"))
         proxy.addAll(items)
@@ -227,7 +227,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.wasRemoved() shouldBe true
     }
 
-    "FxAggregateListProxy fires ReplaceAllChange on setAll" {
+    "FxAggregateList fires ReplaceAllChange on setAll" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val item1 = MutableAudioItem(1, "A")
         val item2 = MutableAudioItem(2, "B")
@@ -248,7 +248,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.next() shouldBe false
     }
 
-    "FxAggregateListProxy setAll with collection replaces all elements" {
+    "FxAggregateList setAll with collection replaces all elements" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         proxy.addAll(listOf(MutableAudioItem(1, "A"), MutableAudioItem(2, "B")))
 
@@ -263,7 +263,7 @@ class FxAggregateListProxyTest : StringSpec({
         changes.size shouldBe 1
     }
 
-    "FxAggregateListProxy setAll on empty with empty returns false" {
+    "FxAggregateList setAll on empty with empty returns false" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val changes = mutableListOf<ListChangeListener.Change<out AudioItem>>()
         proxy.addListener(ListChangeListener(changes::add))
@@ -273,7 +273,7 @@ class FxAggregateListProxyTest : StringSpec({
         changes.size shouldBe 0
     }
 
-    "FxAggregateListProxy retainAll removes non-matching elements" {
+    "FxAggregateList retainAll removes non-matching elements" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val item1 = MutableAudioItem(1, "A")
         val item2 = MutableAudioItem(2, "B")
@@ -290,7 +290,7 @@ class FxAggregateListProxyTest : StringSpec({
         changes.size shouldBe 1
     }
 
-    "FxAggregateListProxy remove(from, to) fires Change for range" {
+    "FxAggregateList remove(from, to) fires Change for range" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val items = listOf(MutableAudioItem(1, "A"), MutableAudioItem(2, "B"), MutableAudioItem(3, "C"))
         proxy.addAll(items)
@@ -308,7 +308,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.removedSize shouldBe 2
     }
 
-    "FxAggregateListProxy removeAt fires Change with correct index" {
+    "FxAggregateList removeAt fires Change with correct index" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val item1 = MutableAudioItem(1, "A")
         val item2 = MutableAudioItem(2, "B")
@@ -328,7 +328,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.removed shouldBe listOf(item1)
     }
 
-    "FxAggregateListProxy addAll at index inserts at correct position" {
+    "FxAggregateList addAll at index inserts at correct position" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         proxy.add(0, MutableAudioItem(1, "A"))
         proxy.add(1, MutableAudioItem(4, "D"))
@@ -350,7 +350,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.to shouldBe 3
     }
 
-    "FxAggregateListProxy AddChange supports reset and getPermutation" {
+    "FxAggregateList AddChange supports reset and getPermutation" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val changes = mutableListOf<ListChangeListener.Change<out AudioItem>>()
         proxy.addListener(ListChangeListener(changes::add))
@@ -366,7 +366,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.next() shouldBe true
     }
 
-    "FxAggregateListProxy SetChange supports reset and getPermutation" {
+    "FxAggregateList SetChange supports reset and getPermutation" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         proxy.add(0, MutableAudioItem(1, "A"))
 
@@ -386,7 +386,7 @@ class FxAggregateListProxyTest : StringSpec({
         change.next() shouldBe true
     }
 
-    "FxAggregateListProxy invalidation listeners fire on changes" {
+    "FxAggregateList invalidation listeners fire on changes" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         var invalidated = false
 
@@ -397,7 +397,7 @@ class FxAggregateListProxyTest : StringSpec({
         invalidated shouldBe true
     }
 
-    "FxAggregateListProxy removeListener removes listener" {
+    "FxAggregateList removeListener removes listener" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val changes = mutableListOf<ListChangeListener.Change<out AudioItem>>()
         val listener = ListChangeListener(changes::add)
@@ -409,7 +409,7 @@ class FxAggregateListProxyTest : StringSpec({
         changes.size shouldBe 0
     }
 
-    "FxAggregateListProxy removeListener removes invalidation listener" {
+    "FxAggregateList removeListener removes invalidation listener" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         var count = 0
         val listener = javafx.beans.InvalidationListener { count++ }
@@ -421,7 +421,7 @@ class FxAggregateListProxyTest : StringSpec({
         count shouldBe 0
     }
 
-    "FxAggregateListProxy clear on empty list is no-op" {
+    "FxAggregateList clear on empty list is no-op" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val changes = mutableListOf<ListChangeListener.Change<out AudioItem>>()
         proxy.addListener(ListChangeListener(changes::add))
@@ -431,18 +431,18 @@ class FxAggregateListProxyTest : StringSpec({
         changes.size shouldBe 0
     }
 
-    "FxAggregateListProxy addAll with empty collection returns false" {
+    "FxAggregateList addAll with empty collection returns false" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         proxy.addAll(emptyList()) shouldBe false
         proxy.addAll(0, emptyList()) shouldBe false
     }
 
-    "FxAggregateListProxy removeAll with empty collection returns false" {
+    "FxAggregateList removeAll with empty collection returns false" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         proxy.removeAll(emptyList()) shouldBe false
     }
 
-    "FxAggregateListProxy retainAll with all elements is no-op" {
+    "FxAggregateList retainAll with all elements is no-op" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val item = MutableAudioItem(1, "A")
         proxy.add(0, item)

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSetTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSetTest.kt
@@ -34,12 +34,12 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 /**
- * Tests for [FxAggregateSetProxy] verifying JavaFX [SetChangeListener.Change] notifications,
+ * Tests for [FxAggregateSet] verifying JavaFX [SetChangeListener.Change] notifications,
  * per-element change semantics, dispatch thread behavior, and type compatibility with
  * [ObservableSet] and [AggregateCollectionRef].
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class FxAggregateSetProxyTest : StringSpec({
+class FxAggregateSetTest : StringSpec({
 
     val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
@@ -52,13 +52,13 @@ class FxAggregateSetProxyTest : StringSpec({
         ReactiveScope.resetDefaultFlowScope()
     }
 
-    "FxAggregateSetProxy returns correct size after add" {
+    "FxAggregateSet returns correct size after add" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         proxy.add(MutableAudioItem(1, "Song A"))
         proxy.size shouldBe 1
     }
 
-    "FxAggregateSetProxy fires SetChangeListener per element on add" {
+    "FxAggregateSet fires SetChangeListener per element on add" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         val changes = mutableListOf<SetChangeListener.Change<out AudioItem>>()
         proxy.addListener(SetChangeListener(changes::add))
@@ -71,7 +71,7 @@ class FxAggregateSetProxyTest : StringSpec({
         changes[0].elementAdded shouldBe item
     }
 
-    "FxAggregateSetProxy fires SetChangeListener per element on remove" {
+    "FxAggregateSet fires SetChangeListener per element on remove" {
         val item = MutableAudioItem(1, "Song A")
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         proxy.add(item)
@@ -86,7 +86,7 @@ class FxAggregateSetProxyTest : StringSpec({
         changes[0].elementRemoved shouldBe item
     }
 
-    "FxAggregateSetProxy fires one Change per element on addAll" {
+    "FxAggregateSet fires one Change per element on addAll" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         val testItems = listOf(MutableAudioItem(1, "A"), MutableAudioItem(2, "B"), MutableAudioItem(3, "C"))
         val changes = mutableListOf<SetChangeListener.Change<out AudioItem>>()
@@ -98,7 +98,7 @@ class FxAggregateSetProxyTest : StringSpec({
         changes.all { it.wasAdded() } shouldBe true
     }
 
-    "FxAggregateSetProxy fires one Change per element on clear" {
+    "FxAggregateSet fires one Change per element on clear" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         proxy.add(MutableAudioItem(1, "A"))
         proxy.add(MutableAudioItem(2, "B"))
@@ -112,7 +112,7 @@ class FxAggregateSetProxyTest : StringSpec({
         changes.all { it.wasRemoved() } shouldBe true
     }
 
-    "FxAggregateSetProxy fires listeners on flowScope when dispatchToFxThread=false" {
+    "FxAggregateSet fires listeners on flowScope when dispatchToFxThread=false" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         var listenerFired = false
 
@@ -123,7 +123,7 @@ class FxAggregateSetProxyTest : StringSpec({
         listenerFired shouldBe true
     }
 
-    "FxAggregateSetProxy fires listeners on FX thread when dispatchToFxThread=true" {
+    "FxAggregateSet fires listeners on FX thread when dispatchToFxThread=true" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = true)
         val latch = CountDownLatch(1)
         var wasFxThread = false
@@ -141,22 +141,22 @@ class FxAggregateSetProxyTest : StringSpec({
         wasFxThread shouldBe true
     }
 
-    "FxAggregateSetProxy implements ObservableSet" {
+    "FxAggregateSet implements ObservableSet" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         proxy.shouldBeInstanceOf<ObservableSet<AudioItem>>()
     }
 
-    "FxAggregateSetProxy implements AggregateCollectionRef" {
+    "FxAggregateSet implements AggregateCollectionRef" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         proxy.shouldBeInstanceOf<AggregateCollectionRef<Int, AudioItem>>()
     }
 
-    "FxAggregateSetProxy supports property delegation via getValue" {
+    "FxAggregateSet supports property delegation via getValue" {
         val proxy by fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
-        proxy.shouldBeInstanceOf<FxAggregateSetProxy<Int, AudioItem>>()
+        proxy.shouldBeInstanceOf<FxAggregateSet<Int, AudioItem>>()
     }
 
-    "FxAggregateSetProxy iterator remove fires Change" {
+    "FxAggregateSet iterator remove fires Change" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         val item1 = MutableAudioItem(1, "A")
         val item2 = MutableAudioItem(2, "B")
@@ -174,7 +174,7 @@ class FxAggregateSetProxyTest : StringSpec({
         proxy.size shouldBe 1
     }
 
-    "FxAggregateSetProxy iterator throws on remove before next" {
+    "FxAggregateSet iterator throws on remove before next" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         proxy.add(MutableAudioItem(1, "A"))
 
@@ -183,7 +183,7 @@ class FxAggregateSetProxyTest : StringSpec({
         exception.shouldBeInstanceOf<IllegalStateException>()
     }
 
-    "FxAggregateSetProxy removeAll fires one Change per removed element" {
+    "FxAggregateSet removeAll fires one Change per removed element" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         val item1 = MutableAudioItem(1, "A")
         val item2 = MutableAudioItem(2, "B")
@@ -200,7 +200,7 @@ class FxAggregateSetProxyTest : StringSpec({
         proxy.size shouldBe 1
     }
 
-    "FxAggregateSetProxy retainAll removes non-matching elements" {
+    "FxAggregateSet retainAll removes non-matching elements" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         val item1 = MutableAudioItem(1, "A")
         val item2 = MutableAudioItem(2, "B")
@@ -218,7 +218,7 @@ class FxAggregateSetProxyTest : StringSpec({
         changes.all { it.wasRemoved() } shouldBe true
     }
 
-    "FxAggregateSetProxy contains returns correct result" {
+    "FxAggregateSet contains returns correct result" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         val item = MutableAudioItem(1, "A")
 
@@ -227,7 +227,7 @@ class FxAggregateSetProxyTest : StringSpec({
         proxy.contains(item) shouldBe true
     }
 
-    "FxAggregateSetProxy invalidation listeners fire on changes" {
+    "FxAggregateSet invalidation listeners fire on changes" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         var invalidated = false
 
@@ -238,7 +238,7 @@ class FxAggregateSetProxyTest : StringSpec({
         invalidated shouldBe true
     }
 
-    "FxAggregateSetProxy removeListener removes set change listener" {
+    "FxAggregateSet removeListener removes set change listener" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         val changes = mutableListOf<SetChangeListener.Change<out AudioItem>>()
         val listener = SetChangeListener(changes::add)
@@ -250,7 +250,7 @@ class FxAggregateSetProxyTest : StringSpec({
         changes.size shouldBe 0
     }
 
-    "FxAggregateSetProxy removeListener removes invalidation listener" {
+    "FxAggregateSet removeListener removes invalidation listener" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         var count = 0
         val listener = javafx.beans.InvalidationListener { count++ }
@@ -262,7 +262,7 @@ class FxAggregateSetProxyTest : StringSpec({
         count shouldBe 0
     }
 
-    "FxAggregateSetProxy add duplicate returns false" {
+    "FxAggregateSet add duplicate returns false" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         val item = MutableAudioItem(1, "A")
 
@@ -271,12 +271,12 @@ class FxAggregateSetProxyTest : StringSpec({
         proxy.size shouldBe 1
     }
 
-    "FxAggregateSetProxy remove non-existing returns false" {
+    "FxAggregateSet remove non-existing returns false" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         proxy.remove(MutableAudioItem(1, "A")) shouldBe false
     }
 
-    "FxAggregateSetProxy clear on empty set is no-op" {
+    "FxAggregateSet clear on empty set is no-op" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         val changes = mutableListOf<SetChangeListener.Change<out AudioItem>>()
         proxy.addListener(SetChangeListener(changes::add))

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxJsonSerializationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxJsonSerializationTest.kt
@@ -105,7 +105,7 @@ class FxJsonSerializationTest : StringSpec({
         decoded.name shouldBe "Round Trip"
         decoded.audioItems.referenceIds shouldBe listOf(10, 20, 30)
         decoded.audioItems.shouldBeInstanceOf<ObservableList<*>>()
-        decoded.audioItems.shouldBeInstanceOf<FxAggregateListProxy<*, *>>()
+        decoded.audioItems.shouldBeInstanceOf<FxAggregateList<*, *>>()
     }
 
     "deserializes entity preserving fxAggregateSet IDs and collection facade" {
@@ -118,7 +118,7 @@ class FxJsonSerializationTest : StringSpec({
         decoded.name shouldBe "With Sets"
         decoded.playlists.referenceIds shouldBe setOf(2, 3)
         decoded.playlists.shouldBeInstanceOf<ObservableSet<*>>()
-        decoded.playlists.shouldBeInstanceOf<FxAggregateSetProxy<*, *>>()
+        decoded.playlists.shouldBeInstanceOf<FxAggregateSet<*, *>>()
     }
 
     "round-trip preserves list order" {
@@ -150,9 +150,9 @@ class FxJsonSerializationTest : StringSpec({
         decoded.id shouldBe 1
         decoded.name shouldBe "Full"
         decoded.audioItems.referenceIds shouldBe listOf(10, 20)
-        decoded.audioItems.shouldBeInstanceOf<FxAggregateListProxy<*, *>>()
+        decoded.audioItems.shouldBeInstanceOf<FxAggregateList<*, *>>()
         decoded.playlists.referenceIds shouldBe setOf(2, 3)
-        decoded.playlists.shouldBeInstanceOf<FxAggregateSetProxy<*, *>>()
+        decoded.playlists.shouldBeInstanceOf<FxAggregateSet<*, *>>()
     }
 
     "serializes fx scalar delegate values in JSON" {

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxProjectionMapIntegrationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxProjectionMapIntegrationTest.kt
@@ -1,0 +1,158 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.LirpContext
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+/**
+ * Integration tests verifying that [fxProjectionMap] correctly groups and updates entities
+ * sourced from [FxAggregateList] collections backed by VolatileRepository-stored entities.
+ *
+ * Covers initial grouping, add propagation, and remove propagation.
+ */
+@DisplayName("FxProjectionMapIntegrationTest")
+@OptIn(ExperimentalCoroutinesApi::class)
+class FxProjectionMapIntegrationTest : StringSpec({
+
+    val testDispatcher = UnconfinedTestDispatcher()
+    val testScope = CoroutineScope(testDispatcher)
+
+    beforeSpec {
+        FxToolkitInit.ensureInitialized()
+        ReactiveScope.flowScope = testScope
+        ReactiveScope.ioScope = testScope
+    }
+
+    afterSpec {
+        ReactiveScope.resetDefaultFlowScope()
+        ReactiveScope.resetDefaultIoScope()
+    }
+
+    afterEach {
+        LirpContext.default.close()
+    }
+
+    "fxProjectionMap groups entities added through VolatileRepository by albumName" {
+        val trackRepo = FxAudioItemVolatileRepository()
+        val track1 = trackRepo.create(1, "Song A", "Jazz")
+        val track2 = trackRepo.create(2, "Song B", "Jazz")
+        val track3 = trackRepo.create(3, "Song C", "Rock")
+
+        val playlistRepo = FxAudioPlaylistVolatileRepository()
+        val playlist = playlistRepo.create(1, "My Playlist")
+
+        playlist.audioItems.add(track1)
+        playlist.audioItems.add(track2)
+        playlist.audioItems.add(track3)
+
+        val map by fxProjectionMap(playlist::audioItems, AudioItem::albumName, false)
+
+        map.size shouldBe 2
+        map["Jazz"]!!.size shouldBe 2
+        map["Rock"]!!.size shouldBe 1
+    }
+
+    "fxProjectionMap updates when entity is added to VolatileRepository aggregate list" {
+        val trackRepo = FxAudioItemVolatileRepository()
+        val track1 = trackRepo.create(1, "Song A", "Jazz")
+
+        val playlistRepo = FxAudioPlaylistVolatileRepository()
+        val playlist = playlistRepo.create(1, "Playlist")
+
+        playlist.audioItems.add(track1)
+
+        val map by fxProjectionMap(playlist::audioItems, AudioItem::albumName, false)
+
+        map["Jazz"]!!.size shouldBe 1
+
+        val track2 = trackRepo.create(2, "Song B", "Jazz")
+        playlist.audioItems.add(track2)
+
+        map["Jazz"]!!.size shouldBe 2
+    }
+
+    "fxProjectionMap updates when entity is removed from VolatileRepository aggregate list" {
+        val trackRepo = FxAudioItemVolatileRepository()
+        val track1 = trackRepo.create(1, "Song A", "Jazz")
+        val track2 = trackRepo.create(2, "Song B", "Jazz")
+
+        val playlistRepo = FxAudioPlaylistVolatileRepository()
+        val playlist = playlistRepo.create(1, "Playlist")
+
+        playlist.audioItems.add(track1)
+        playlist.audioItems.add(track2)
+
+        val map by fxProjectionMap(playlist::audioItems, AudioItem::albumName, false)
+
+        map["Jazz"]!!.size shouldBe 2
+
+        playlist.audioItems.remove(track1)
+
+        map["Jazz"]!!.size shouldBe 1
+    }
+
+    "fxProjectionMap removes bucket when last entity for a key is removed" {
+        val trackRepo = FxAudioItemVolatileRepository()
+        val track1 = trackRepo.create(1, "Song A", "Jazz")
+        val track2 = trackRepo.create(2, "Song B", "Rock")
+
+        val playlistRepo = FxAudioPlaylistVolatileRepository()
+        val playlist = playlistRepo.create(1, "Playlist")
+
+        playlist.audioItems.add(track1)
+        playlist.audioItems.add(track2)
+
+        val map by fxProjectionMap(playlist::audioItems, AudioItem::albumName, false)
+
+        map.size shouldBe 2
+
+        playlist.audioItems.remove(track1)
+
+        map.containsKey("Jazz") shouldBe false
+        map.size shouldBe 1
+    }
+
+    "fxProjectionMap groups entities across multiple albums from VolatileRepository" {
+        val trackRepo = FxAudioItemVolatileRepository()
+        val track1 = trackRepo.create(1, "Song A", "Jazz")
+        val track2 = trackRepo.create(2, "Song B", "Rock")
+        val track3 = trackRepo.create(3, "Song C", "Jazz")
+        val track4 = trackRepo.create(4, "Song D", "Classical")
+
+        val playlistRepo = FxAudioPlaylistVolatileRepository()
+        val playlist = playlistRepo.create(1, "Playlist")
+
+        playlist.audioItems.addAll(listOf(track1, track2, track3, track4))
+
+        val map by fxProjectionMap(playlist::audioItems, AudioItem::albumName, false)
+
+        map.size shouldBe 3
+        map["Jazz"]!!.size shouldBe 2
+        map["Rock"]!!.size shouldBe 1
+        map["Classical"]!!.size shouldBe 1
+        map.keys.toList() shouldBe listOf("Classical", "Jazz", "Rock")
+    }
+})

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxProjectionMapTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxProjectionMapTest.kt
@@ -1,0 +1,316 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.persistence.AudioItem
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import javafx.beans.InvalidationListener
+import javafx.collections.MapChangeListener
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+/**
+ * Tests for [FxProjectionMap] verifying grouped projection from list and set sources,
+ * [MapChangeListener.Change] notifications, key ordering, and unmodifiability.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FxProjectionMapTest : StringSpec({
+
+    val testScope = CoroutineScope(UnconfinedTestDispatcher())
+
+    beforeSpec {
+        FxToolkitInit.ensureInitialized()
+        ReactiveScope.flowScope = testScope
+    }
+
+    afterSpec {
+        ReactiveScope.resetDefaultFlowScope()
+    }
+
+    "FxProjectionMap groups entities by key extractor on add" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        source.add(0, FxAudioItem(1, "Track A", "Jazz"))
+
+        projection.containsKey("Jazz") shouldBe true
+        projection["Jazz"]!!.size shouldBe 1
+        projection["Jazz"]!![0].id shouldBe 1
+    }
+
+    "FxProjectionMap fires MapChangeListener wasAdded when new group key appears" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        val changes = mutableListOf<MapChangeListener.Change<out String, out List<AudioItem>>>()
+        projection.addListener(MapChangeListener(changes::add))
+
+        source.add(0, FxAudioItem(1, "Track A", "Jazz"))
+
+        changes.size shouldBe 1
+        changes[0].wasAdded() shouldBe true
+        changes[0].key shouldBe "Jazz"
+    }
+
+    "FxProjectionMap fires MapChangeListener when entity added to existing group" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        source.add(0, FxAudioItem(1, "Track A", "Jazz"))
+
+        val changes = mutableListOf<MapChangeListener.Change<out String, out List<AudioItem>>>()
+        projection.addListener(MapChangeListener(changes::add))
+
+        source.add(1, FxAudioItem(2, "Track B", "Jazz"))
+
+        changes.size shouldBe 1
+        changes[0].key shouldBe "Jazz"
+        projection["Jazz"]!!.size shouldBe 2
+    }
+
+    "FxProjectionMap removes bucket when last entity removed" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        val item = FxAudioItem(1, "Track A", "Jazz")
+        source.add(0, item)
+        source.removeAt(0)
+
+        projection.containsKey("Jazz") shouldBe false
+    }
+
+    "FxProjectionMap fires MapChangeListener wasRemoved when bucket removed" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        val item = FxAudioItem(1, "Track A", "Jazz")
+        source.add(0, item)
+
+        val changes = mutableListOf<MapChangeListener.Change<out String, out List<AudioItem>>>()
+        projection.addListener(MapChangeListener(changes::add))
+
+        source.removeAt(0)
+
+        changes.any { it.wasRemoved() } shouldBe true
+    }
+
+    "FxProjectionMap updates bucket without removing on partial remove" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        val item1 = FxAudioItem(1, "Track A", "Jazz")
+        val item2 = FxAudioItem(2, "Track B", "Jazz")
+        source.addAll(listOf(item1, item2))
+
+        source.removeAt(0)
+
+        projection.containsKey("Jazz") shouldBe true
+        projection["Jazz"]!!.size shouldBe 1
+    }
+
+    "FxProjectionMap keys are in natural sorted order" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        source.addAll(
+            listOf(
+                FxAudioItem(1, "T1", "Zebra"),
+                FxAudioItem(2, "T2", "Alpha"),
+                FxAudioItem(3, "T3", "Middle")
+            )
+        )
+
+        projection.keys.toList() shouldContainExactly listOf("Alpha", "Middle", "Zebra")
+    }
+
+    "FxProjectionMap handles clear on source" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        source.addAll(
+            listOf(
+                FxAudioItem(1, "T1", "Jazz"),
+                FxAudioItem(2, "T2", "Rock")
+            )
+        )
+        source.clear()
+
+        projection.isEmpty() shouldBe true
+    }
+
+    "FxProjectionMap builds initial state from source on first getValue" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        source.addAll(
+            listOf(
+                FxAudioItem(1, "T1", "Jazz"),
+                FxAudioItem(2, "T2", "Jazz"),
+                FxAudioItem(3, "T3", "Rock")
+            )
+        )
+
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        projection["Jazz"]!!.size shouldBe 2
+        projection["Rock"]!!.size shouldBe 1
+    }
+
+    "FxProjectionMap with set source groups entities correctly" {
+        val source = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        source.add(FxAudioItem(1, "Track A", "Jazz"))
+        source.add(FxAudioItem(2, "Track B", "Rock"))
+
+        projection["Jazz"]!!.size shouldBe 1
+        projection["Rock"]!!.size shouldBe 1
+    }
+
+    "FxProjectionMap is unmodifiable" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        shouldThrow<UnsupportedOperationException> {
+            projection.put("Jazz", listOf(FxAudioItem(1, "T1", "Jazz")))
+        }
+        shouldThrow<UnsupportedOperationException> {
+            projection.remove("Jazz")
+        }
+    }
+
+    "FxProjectionMap with dispatchToFxThread=false fires on flowScope" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        var listenerFired = false
+        projection.addListener(MapChangeListener { listenerFired = true })
+
+        source.add(0, FxAudioItem(1, "Track A", "Jazz"))
+
+        listenerFired shouldBe true
+    }
+
+    "FxProjectionMap entries contains all key-value pairs after population" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        source.addAll(listOf(FxAudioItem(1, "T1", "Jazz"), FxAudioItem(2, "T2", "Rock")))
+
+        val entries = projection.entries
+        entries.size shouldBe 2
+        entries.map { it.key }.toSet() shouldBe setOf("Jazz", "Rock")
+    }
+
+    "FxProjectionMap values contains all bucket lists" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        source.addAll(
+            listOf(
+                FxAudioItem(1, "T1", "Jazz"),
+                FxAudioItem(2, "T2", "Jazz"),
+                FxAudioItem(3, "T3", "Rock")
+            )
+        )
+
+        val values = projection.values
+        values.size shouldBe 2
+        values.any { it.size == 2 } shouldBe true
+        values.any { it.size == 1 } shouldBe true
+    }
+
+    "FxProjectionMap containsValue returns true for a matching bucket" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        val item1 = FxAudioItem(1, "T1", "Jazz")
+        val item2 = FxAudioItem(2, "T2", "Rock")
+        source.addAll(listOf(item1, item2))
+
+        projection.containsValue(listOf(item1)) shouldBe true
+        projection.containsValue(listOf(item2)) shouldBe true
+        projection.containsValue(listOf(item1, item2)) shouldBe false
+    }
+
+    "FxProjectionMap putAll throws UnsupportedOperationException" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        shouldThrow<UnsupportedOperationException> {
+            projection.putAll(mapOf("Jazz" to listOf(FxAudioItem(1, "T1", "Jazz"))))
+        }
+    }
+
+    "FxProjectionMap clear throws UnsupportedOperationException" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        shouldThrow<UnsupportedOperationException> {
+            projection.clear()
+        }
+    }
+
+    "FxProjectionMap removeListener stops MapChangeListener from receiving changes" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        var changeCount = 0
+        val listener = MapChangeListener<String, List<AudioItem>> { changeCount++ }
+        projection.addListener(listener)
+
+        source.add(0, FxAudioItem(1, "T1", "Jazz"))
+        changeCount shouldBe 1
+
+        projection.removeListener(listener)
+        source.add(1, FxAudioItem(2, "T2", "Rock"))
+        changeCount shouldBe 1
+    }
+
+    "FxProjectionMap addListener InvalidationListener fires on change" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        var invalidationCount = 0
+        val listener = InvalidationListener { invalidationCount++ }
+        projection.addListener(listener)
+
+        source.add(0, FxAudioItem(1, "T1", "Jazz"))
+
+        invalidationCount shouldBe 1
+    }
+
+    "FxProjectionMap removeListener InvalidationListener stops invalidation notifications" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+        var invalidationCount = 0
+        val listener = InvalidationListener { invalidationCount++ }
+        projection.addListener(listener)
+
+        source.add(0, FxAudioItem(1, "T1", "Jazz"))
+        invalidationCount shouldBe 1
+
+        projection.removeListener(listener)
+        source.add(1, FxAudioItem(2, "T2", "Rock"))
+        invalidationCount shouldBe 1
+    }
+})

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxRegistryIntegrationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxRegistryIntegrationTest.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 /**
  * Integration tests verifying that RegistryBase correctly unwraps fx proxies via
- * [FxObservableCollectionProxy][net.transgressoft.lirp.persistence.FxObservableCollectionProxy],
+ * [FxObservableCollection][net.transgressoft.lirp.persistence.FxObservableCollection],
  * enabling dual notification: lirp [CollectionChangeEvent] and JavaFX listener callbacks
  * fire for the same mutation.
  */
@@ -48,20 +48,16 @@ class FxRegistryIntegrationTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()
     val testScope = CoroutineScope(testDispatcher)
-    lateinit var previousFlowScope: CoroutineScope
-    lateinit var previousIoScope: CoroutineScope
 
     beforeSpec {
         FxToolkitInit.ensureInitialized()
-        previousFlowScope = ReactiveScope.flowScope
-        previousIoScope = ReactiveScope.ioScope
         ReactiveScope.flowScope = testScope
         ReactiveScope.ioScope = testScope
     }
 
     afterSpec {
-        ReactiveScope.flowScope = previousFlowScope
-        ReactiveScope.ioScope = previousIoScope
+        ReactiveScope.resetDefaultFlowScope()
+        ReactiveScope.resetDefaultIoScope()
     }
 
     lateinit var trackRepo: AudioItemVolatileRepository
@@ -83,7 +79,7 @@ class FxRegistryIntegrationTest : StringSpec({
         val lirpEvent = AtomicReference<CollectionChangeEvent<*>>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribeToCollectionChanges {
+        playlist.subscribeToCollectionChanges(AudioItem::class) {
             lirpEvent.set(it)
             latch.countDown()
         }
@@ -103,7 +99,7 @@ class FxRegistryIntegrationTest : StringSpec({
         val lirpEvent = AtomicReference<CollectionChangeEvent<*>>(null)
         val latch = CountDownLatch(1)
 
-        playlist1.subscribeToCollectionChanges {
+        playlist1.subscribeToCollectionChanges(FxAudioPlaylistEntity::class) {
             lirpEvent.set(it)
             latch.countDown()
         }
@@ -126,7 +122,7 @@ class FxRegistryIntegrationTest : StringSpec({
         val lirpEvent = AtomicReference<CollectionChangeEvent<*>>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribeToCollectionChanges {
+        playlist.subscribeToCollectionChanges(AudioItem::class) {
             lirpEvent.set(it)
             latch.countDown()
         }
@@ -155,7 +151,7 @@ class FxRegistryIntegrationTest : StringSpec({
         val lirpEvent = AtomicReference<CollectionChangeEvent<*>>(null)
         val latch = CountDownLatch(1)
 
-        playlist1.subscribeToCollectionChanges {
+        playlist1.subscribeToCollectionChanges(FxAudioPlaylistEntity::class) {
             lirpEvent.set(it)
             latch.countDown()
         }

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxScalarRegistryIntegrationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxScalarRegistryIntegrationTest.kt
@@ -47,20 +47,16 @@ class FxScalarRegistryIntegrationTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()
     val testScope = CoroutineScope(testDispatcher)
-    lateinit var previousFlowScope: CoroutineScope
-    lateinit var previousIoScope: CoroutineScope
 
     beforeSpec {
         FxToolkitInit.ensureInitialized()
-        previousFlowScope = ReactiveScope.flowScope
-        previousIoScope = ReactiveScope.ioScope
         ReactiveScope.flowScope = testScope
         ReactiveScope.ioScope = testScope
     }
 
     afterSpec {
-        ReactiveScope.flowScope = previousFlowScope
-        ReactiveScope.ioScope = previousIoScope
+        ReactiveScope.resetDefaultFlowScope()
+        ReactiveScope.resetDefaultIoScope()
     }
 
     lateinit var trackRepo: AudioItemVolatileRepository

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxTestFixtures.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxTestFixtures.kt
@@ -103,6 +103,63 @@ class FxAudioPlaylistEntity(
 }
 
 /**
+ * Fx-aware audio item entity extending the core [AudioItem] interface with JavaFX property
+ * delegates for [title] and [albumName]. Used for projection map and fx integration tests.
+ */
+class FxAudioItem(
+    override val id: Int,
+    title: String,
+    albumName: String = ""
+) : ReactiveEntityBase<Int, AudioItem>(), AudioItem {
+    override val uniqueId: String get() = "fx-audio-item-$id"
+
+    val titleProperty: StringProperty by fxString(title, dispatchToFxThread = false)
+    val albumNameProperty: StringProperty by fxString(albumName, dispatchToFxThread = false)
+
+    override var title: String
+        get() = titleProperty.get()
+        set(value) {
+            titleProperty.set(value)
+        }
+
+    override var albumName: String
+        get() = albumNameProperty.get()
+        set(value) {
+            albumNameProperty.set(value)
+        }
+
+    override fun compareTo(other: AudioItem): Int = id.compareTo(other.id)
+
+    override fun clone(): FxAudioItem = FxAudioItem(id, title, albumName)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FxAudioItem) return false
+        return id == other.id && title == other.title && albumName == other.albumName
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + title.hashCode()
+        result = 31 * result + albumName.hashCode()
+        return result
+    }
+
+    override fun toString(): String = "FxAudioItem(id=$id, title='$title', albumName='$albumName')"
+}
+
+/**
+ * In-memory repository for [FxAudioItem] entities used in projection map integration tests.
+ */
+@LirpRepository
+class FxAudioItemVolatileRepository :
+    VolatileRepository<Int, AudioItem>("FxAudioItems") {
+
+    fun create(id: Int, title: String, albumName: String = ""): FxAudioItem =
+        FxAudioItem(id, title, albumName).also(::add)
+}
+
+/**
  * Repository for [FxAudioPlaylistEntity] entities. Uses [LirpContext.default] and the
  * public [VolatileRepository] constructor. KSP generates the accessor for delegate discovery.
  */

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/MusicCommonsSqlIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/MusicCommonsSqlIntegrationTest.kt
@@ -18,11 +18,11 @@
 package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.DefaultAudioPlaylist
 import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.MusicCommonsIntegrationTestBase
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.MutableAudioPlaylist
-import net.transgressoft.lirp.persistence.MutableAudioPlaylistEntity
 import net.transgressoft.lirp.persistence.Registry
 import net.transgressoft.lirp.persistence.Repository
 import com.zaxxer.hikari.HikariDataSource
@@ -124,7 +124,7 @@ class MusicCommonsSqlIntegrationTest : MusicCommonsIntegrationTestBase() {
         test("SQL persistence survives close and reopen for playlists with referenced items") {
             MutableAudioItem(1, "Track 1").also(audioItemRepo::add)
             MutableAudioItem(2, "Track 2").also(audioItemRepo::add)
-            MutableAudioPlaylistEntity(10, "My Playlist", listOf(1, 2)).also(playlistRepo::add)
+            DefaultAudioPlaylist(10, "My Playlist", listOf(1, 2)).also(playlistRepo::add)
             flushPendingWrites()
 
             ctx.close()
@@ -147,9 +147,9 @@ class MusicCommonsSqlIntegrationTest : MusicCommonsIntegrationTestBase() {
         }
 
         test("SQL persistence preserves self-referencing playlist aggregates after reload") {
-            val subA = MutableAudioPlaylistEntity(20, "Sub A").also(playlistRepo::add)
-            val subB = MutableAudioPlaylistEntity(30, "Sub B").also(playlistRepo::add)
-            MutableAudioPlaylistEntity(10, "Parent", emptyList(), setOf(20, 30)).also(playlistRepo::add)
+            val subA = DefaultAudioPlaylist(20, "Sub A").also(playlistRepo::add)
+            val subB = DefaultAudioPlaylist(30, "Sub B").also(playlistRepo::add)
+            DefaultAudioPlaylist(10, "Parent", emptyList(), setOf(20, 30)).also(playlistRepo::add)
             flushPendingWrites()
 
             ctx.close()
@@ -171,7 +171,7 @@ class MusicCommonsSqlIntegrationTest : MusicCommonsIntegrationTestBase() {
 
         test("SQL persistence reflects runtime mutations after close and reload") {
             val item = MutableAudioItem(1, "Original").also(audioItemRepo::add)
-            val playlist = MutableAudioPlaylistEntity(10, "Empty").also(playlistRepo::add)
+            val playlist = DefaultAudioPlaylist(10, "Empty").also(playlistRepo::add)
 
             // Mutate at runtime: add item (auto-persists via mutation event subscription)
             playlist.audioItems.add(item)

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlProjectionMapTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlProjectionMapTest.kt
@@ -1,0 +1,151 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.fx.fxAggregateList
+import net.transgressoft.lirp.persistence.fx.fxProjectionMap
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Integration tests verifying that [fxProjectionMap] correctly groups entities from
+ * an [net.transgressoft.lirp.persistence.fx.FxAggregateList] holding references to
+ * entities loaded from a [SqlRepository].
+ *
+ * The projection operates on the in-memory aggregate list — the SQL layer provides persistence
+ * and round-trip fidelity, while the projection map groups entities by [FxSqlTestEntity.groupProperty].
+ */
+@DisplayName("FxSqlProjectionMapTest")
+internal class FxSqlProjectionMapTest : FunSpec({
+
+    fun freshJdbcUrl() = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+
+    beforeSpec {
+        FxToolkitInit.ensureInitialized()
+        ReactiveScope.flowScope = CoroutineScope(Dispatchers.Unconfined)
+    }
+
+    afterSpec {
+        ReactiveScope.resetDefaultFlowScope()
+    }
+
+    afterEach {
+        RegistryBase.deregisterRepository(FxSqlTestItem::class.java)
+        RegistryBase.deregisterRepository(FxSqlTestEntity::class.java)
+    }
+
+    test("fxProjectionMap groups SQL-persisted entities by groupProperty") {
+        val jdbcUrl = freshJdbcUrl()
+        val itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        val entity1 = FxSqlTestEntity(1, "Entity A", initialGroup = "Alpha")
+        val entity2 = FxSqlTestEntity(2, "Entity B", initialGroup = "Alpha")
+        val entity3 = FxSqlTestEntity(3, "Entity C", initialGroup = "Beta")
+        entityRepo.add(entity1)
+        entityRepo.add(entity2)
+        entityRepo.add(entity3)
+
+        val list = fxAggregateList<Int, FxSqlTestEntity>(dispatchToFxThread = false)
+        list.addAll(listOf(entity1, entity2, entity3))
+
+        val projection =
+            fxProjectionMap<Int, String, FxSqlTestEntity>(
+                { list },
+                { it.groupProperty.get() },
+                false
+            )
+
+        projection.size shouldBe 2
+        projection["Alpha"]!!.size shouldBe 2
+        projection["Beta"]!!.size shouldBe 1
+
+        entityRepo.close()
+        itemRepo.close()
+    }
+
+    test("fxProjectionMap updates when entity is added after SQL persistence") {
+        val jdbcUrl = freshJdbcUrl()
+        val itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        val entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        val entity1 = FxSqlTestEntity(1, "E1", initialGroup = "GroupA")
+        entityRepo.add(entity1)
+
+        val list = fxAggregateList<Int, FxSqlTestEntity>(dispatchToFxThread = false)
+        list.add(entity1)
+
+        val projection =
+            fxProjectionMap<Int, String, FxSqlTestEntity>(
+                { list },
+                { it.groupProperty.get() },
+                false
+            )
+
+        projection["GroupA"]!!.size shouldBe 1
+
+        val entity2 = FxSqlTestEntity(2, "E2", initialGroup = "GroupA")
+        entityRepo.add(entity2)
+        list.add(entity2)
+
+        projection["GroupA"]!!.size shouldBe 2
+
+        entityRepo.close()
+        itemRepo.close()
+    }
+
+    test("fxProjectionMap reloads and groups entities from SQL round-trip") {
+        val jdbcUrl = freshJdbcUrl()
+        var itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        var entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        entityRepo.add(FxSqlTestEntity(1, "E1", initialGroup = "Alpha"))
+        entityRepo.add(FxSqlTestEntity(2, "E2", initialGroup = "Beta"))
+        entityRepo.add(FxSqlTestEntity(3, "E3", initialGroup = "Alpha"))
+
+        entityRepo.close()
+        itemRepo.close()
+
+        itemRepo = FxSqlTestItemRepository(jdbcUrl)
+        entityRepo = FxSqlTestEntityRepository(jdbcUrl)
+
+        val reloaded = entityRepo.search { true }
+        val list = fxAggregateList<Int, FxSqlTestEntity>(dispatchToFxThread = false)
+        list.addAll(reloaded)
+
+        val projection =
+            fxProjectionMap<Int, String, FxSqlTestEntity>(
+                { list },
+                { it.groupProperty.get() },
+                false
+            )
+
+        projection.size shouldBe 2
+        projection["Alpha"]!!.size shouldBe 2
+        projection["Beta"]!!.size shouldBe 1
+
+        entityRepo.close()
+        itemRepo.close()
+    }
+})

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlTestFixtures.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlTestFixtures.kt
@@ -83,6 +83,7 @@ object FxSqlTestItemTableDef : SqlTableDef<FxSqlTestItem> {
 /**
  * Test entity combining fx scalar delegates ([fxString], [fxInteger], [fxBoolean], [fxDouble],
  * [fxObject]) with an [fxAggregateList] collection delegate for SQL persistence testing.
+ * The [groupProperty] field is used in projection map tests as the grouping key.
  */
 class FxSqlTestEntity(
     override val id: Int,
@@ -91,7 +92,8 @@ class FxSqlTestEntity(
     initialActive: Boolean = false,
     initialRating: Double = 0.0,
     initialTag: String? = null,
-    initialItemIds: List<Int> = emptyList()
+    initialItemIds: List<Int> = emptyList(),
+    initialGroup: String = ""
 ) : ReactiveEntityBase<Int, FxSqlTestEntity>(), IdentifiableEntity<Int> {
     override val uniqueId: String get() = "fx-sql-test-$id"
 
@@ -100,6 +102,7 @@ class FxSqlTestEntity(
     val activeProperty: BooleanProperty by fxBoolean(initialActive, dispatchToFxThread = false)
     val ratingProperty: DoubleProperty by fxDouble(initialRating, dispatchToFxThread = false)
     val tagProperty: ObjectProperty<String?> by fxObject<String?>(initialTag, dispatchToFxThread = false)
+    val groupProperty: StringProperty by fxString(initialGroup, dispatchToFxThread = false)
 
     @Aggregate(onDelete = CascadeAction.NONE)
     val items by fxAggregateList<Int, FxSqlTestItem>(initialItemIds, dispatchToFxThread = false)
@@ -107,7 +110,8 @@ class FxSqlTestEntity(
     override fun clone(): FxSqlTestEntity =
         FxSqlTestEntity(
             id, nameProperty.get(), yearProperty.get(), activeProperty.get(),
-            ratingProperty.get(), tagProperty.get(), items.referenceIds.toList()
+            ratingProperty.get(), tagProperty.get(), items.referenceIds.toList(),
+            groupProperty.get()
         )
 
     override fun equals(other: Any?): Boolean {
@@ -119,6 +123,7 @@ class FxSqlTestEntity(
             activeProperty.get() == other.activeProperty.get() &&
             ratingProperty.get() == other.ratingProperty.get() &&
             tagProperty.get() == other.tagProperty.get() &&
+            groupProperty.get() == other.groupProperty.get() &&
             items.referenceIds == other.items.referenceIds
     }
 
@@ -129,6 +134,7 @@ class FxSqlTestEntity(
         result = 31 * result + activeProperty.get().hashCode()
         result = 31 * result + ratingProperty.get().hashCode()
         result = 31 * result + (tagProperty.get()?.hashCode() ?: 0)
+        result = 31 * result + groupProperty.get().hashCode()
         result = 31 * result + items.referenceIds.hashCode()
         return result
     }
@@ -147,7 +153,8 @@ object FxSqlTestEntityTableDef : SqlTableDef<FxSqlTestEntity> {
             ColumnDef("active", ColumnType.BooleanType, nullable = false, primaryKey = false),
             ColumnDef("rating", ColumnType.DoubleType, nullable = false, primaryKey = false),
             ColumnDef("tag", ColumnType.TextType, nullable = true, primaryKey = false),
-            ColumnDef("item_ids", ColumnType.TextType, nullable = false, primaryKey = false)
+            ColumnDef("item_ids", ColumnType.TextType, nullable = false, primaryKey = false),
+            ColumnDef("group_name", ColumnType.VarcharType(200), nullable = false, primaryKey = false)
         )
 
     @Suppress("UNCHECKED_CAST")
@@ -165,7 +172,8 @@ object FxSqlTestEntityTableDef : SqlTableDef<FxSqlTestEntity> {
             row[cols["active"]!! as Column<Boolean>],
             row[cols["rating"]!! as Column<Double>],
             row[cols["tag"]!! as Column<String?>],
-            parsedIds
+            parsedIds,
+            row[cols["group_name"]!! as Column<String>]
         )
     }
 
@@ -178,7 +186,8 @@ object FxSqlTestEntityTableDef : SqlTableDef<FxSqlTestEntity> {
             cols["active"]!! to entity.activeProperty.get(),
             cols["rating"]!! to entity.ratingProperty.get(),
             cols["tag"]!! to entity.tagProperty.get(),
-            cols["item_ids"]!! to entity.items.referenceIds.joinToString(",")
+            cols["item_ids"]!! to entity.items.referenceIds.joinToString(","),
+            cols["group_name"]!! to entity.groupProperty.get()
         )
     }
 }

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/AudioItemSqlFixtures.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/AudioItemSqlFixtures.kt
@@ -20,17 +20,17 @@ package net.transgressoft.lirp.persistence.sql
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.ColumnDef
 import net.transgressoft.lirp.persistence.ColumnType
+import net.transgressoft.lirp.persistence.DefaultAudioPlaylist
 import net.transgressoft.lirp.persistence.LirpRegistryInfo
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.MutableAudioPlaylist
-import net.transgressoft.lirp.persistence.MutableAudioPlaylistEntity
 import com.zaxxer.hikari.HikariDataSource
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.Table
 
 /**
- * SQL table definition for [AudioItem], mapping the [id] and [title] fields
+ * SQL table definition for [AudioItem], mapping the [id], [title], and [albumName] fields
  * to their respective SQL columns.
  */
 object AudioItemSqlTableDef : SqlTableDef<AudioItem> {
@@ -38,7 +38,8 @@ object AudioItemSqlTableDef : SqlTableDef<AudioItem> {
     override val columns =
         listOf(
             ColumnDef("id", ColumnType.IntType, nullable = false, primaryKey = true),
-            ColumnDef("title", ColumnType.VarcharType(500), nullable = false, primaryKey = false)
+            ColumnDef("title", ColumnType.VarcharType(500), nullable = false, primaryKey = false),
+            ColumnDef("album_name", ColumnType.VarcharType(255), nullable = false, primaryKey = false)
         )
 
     @Suppress("UNCHECKED_CAST")
@@ -46,7 +47,8 @@ object AudioItemSqlTableDef : SqlTableDef<AudioItem> {
         val cols = table.columns.associateBy { it.name }
         return MutableAudioItem(
             row[cols["id"]!! as Column<Int>],
-            row[cols["title"]!! as Column<String>]
+            row[cols["title"]!! as Column<String>],
+            row[cols["album_name"]!! as Column<String>]
         )
     }
 
@@ -54,7 +56,8 @@ object AudioItemSqlTableDef : SqlTableDef<AudioItem> {
         val cols = table.columns.associateBy { it.name }
         return mapOf(
             cols["id"]!! to entity.id,
-            cols["title"]!! to entity.title
+            cols["title"]!! to entity.title,
+            cols["album_name"]!! to entity.albumName
         )
     }
 }
@@ -87,13 +90,12 @@ object AudioPlaylistSqlTableDef : SqlTableDef<MutableAudioPlaylist> {
         val parsedPlaylistIds =
             if (playlistIdsText.isBlank()) emptySet()
             else playlistIdsText.split(",").mapNotNull { it.trim().toIntOrNull() }.toSet()
-        return MutableAudioPlaylistEntity(row[cols["id"]!! as Column<Int>], row[cols["name"]!! as Column<String>], parsedAudioItemIds, parsedPlaylistIds)
+        return DefaultAudioPlaylist(row[cols["id"]!! as Column<Int>], row[cols["name"]!! as Column<String>], parsedAudioItemIds, parsedPlaylistIds)
     }
 
     override fun toParams(entity: MutableAudioPlaylist, table: Table): Map<Column<*>, Any?> {
         val cols = table.columns.associateBy { it.name }
-        // Access audioItems/playlists via cast to the concrete entity which has the delegate properties
-        val concrete = entity as MutableAudioPlaylistEntity
+        val concrete = entity as DefaultAudioPlaylist
         return mapOf(
             cols["id"]!! to entity.id,
             cols["name"]!! to entity.name,


### PR DESCRIPTION
## Summary

**Phase 34: lirp-fx-fxaggregatemap**
**Goal:** Create projection map delegates that derive read-only grouped views from aggregate collections, grouping entities by a secondary key with incremental change propagation.
**Status:** Verified

Two projection map implementations cover the full lirp stack:
- **`ProjectionMap`** (lirp-core) — implements `Map<PK, List<E>>`, auto-subscribes via internal `projectionCallback`, no JavaFX dependency
- **`FxProjectionMap`** (lirp-fx) — implements `ObservableMap<PK, List<E>>`, auto-subscribes via JavaFX `ListChangeListener`/`SetChangeListener`, supports `MapChangeListener` binding

Both are lazy-initialized, read-only, TreeMap-backed for natural key ordering, and auto-update incrementally when the source collection changes.

## Changes

### Core Projection Map (lirp-core)
- `ProjectionMap<K, PK, E>` — implements `Map<PK, List<E>>` directly
- `projectionMap()` factory function in `CoreFactories.kt`
- Auto-subscription via `projectionCallback` on `AbstractMutableAggregateCollectionRefDelegate`
- 16 unit tests (95% coverage)

### FxProjectionMap (lirp-fx)
- `FxProjectionMap<K, PK, E>` — implements `ObservableMap<PK, List<E>>` directly
- Single `fxProjectionMap()` factory accepting `FxObservableCollection<K, E>` (unified, no list/set overloads)
- `FxProperties.fxProjectionMap()` for Java interop
- 20 unit + 3 Java interop + 5 Volatile integration + 3 SQL integration tests (87% coverage)

### API Improvements
- `FxObservableCollection<K, E>` — made generic (renamed from `FxObservableCollectionProxy`)
- Removed "Proxy" suffix: `FxAggregateList`, `FxAggregateSet`, `MutableAggregateList`, `MutableAggregateSet`
- Parameter order: `fxProjectionMap(sourceRef, keyExtractor, dispatchToFxThread=true)` — keyExtractor second for clean call sites
- `FxAudioItem` test entity extending `AudioItem` with fx scalar delegates

### Test Entities
- `FxAudioItem` — extends `AudioItem` with `albumName` for projection grouping + `fxString` delegates for `titleProperty`/`albumNameProperty`
- Repository integration tests covering Volatile and SQL persistence

## Key Files

**New:**
- `lirp-core/.../ProjectionMap.kt`
- `lirp-core/.../CoreFactories.kt`
- `lirp-fx/.../FxProjectionMap.kt`

**Renamed:**
- `FxObservableCollectionProxy.kt` → `FxObservableCollection.kt`
- `FxAggregateListProxy.kt` → `FxAggregateList.kt`
- `FxAggregateSetProxy.kt` → `FxAggregateSet.kt`

**Modified:**
- `MutableAggregateListRefDelegate.kt` — `projectionCallback`, renamed classes
- `MutableAggregateSetRefDelegate.kt` — `projectionCallback`, renamed classes
- `FxFactories.kt` — single `fxProjectionMap` factory
- `FxProperties.kt` — `fxProjectionMap` Java interop
- `RegistryBase.kt`, `ReactiveEntityBase.kt` — generic `FxObservableCollection<K, E>`
- `README.md` — documented both projection variants

## Verification

- [x] Automated verification: passed (16/16 must-haves)
- [x] Full test suite: 750+ tests passing across lirp-core, lirp-fx, lirp-sql
- [x] ktlintCheck: clean
- [x] SonarQube: all 4 introduced issues resolved (S3776 cognitive complexity, S1192 duplicated literal, S1128 unused import)

Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only projection views: projectionMap and JavaFX fxProjectionMap — lazy-initialized, incrementally updated, naturally ordered, and immutable; fxProjectionMap emits targeted JavaFX map-change events.
* **Documentation**
  * README updated with Kotlin/Java/JavaFX usage examples for projectionMap and fxProjectionMap.
* **Refactor**
  * Public JavaFX collection facades and mutable aggregate wrappers renamed/simplified for a clearer public API.
* **Tests**
  * New and updated tests for projection behavior, JavaFX interop, SQL integration, and updated fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->