### PR TITLE
#95 Cache reflection Method lookups in LirpEntitySerializer

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
@@ -23,6 +23,7 @@ import net.transgressoft.lirp.persistence.AggregateCollectionRef
 import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
 import net.transgressoft.lirp.persistence.MutableAggregateList
 import net.transgressoft.lirp.persistence.MutableAggregateSet
+import java.lang.reflect.Method
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
@@ -84,7 +85,8 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
         data class ReactiveProperty(
             override val name: String,
             override val serializer: KSerializer<Any?>,
-            val property: KProperty1<Any, Any?>
+            val property: KProperty1<Any, Any?>,
+            val setValueMethod: Method
         ) : DelegateInfo
 
         data class AggregateCollection(
@@ -94,12 +96,15 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
 
         data class FxScalar(
             override val name: String,
-            override val serializer: KSerializer<Any?>
+            override val serializer: KSerializer<Any?>,
+            val getMethod: Method,
+            val setMethod: Method
         ) : DelegateInfo
     }
 
     private val constructorParams: List<ConstructorParamInfo>
     private val delegateInfos: List<DelegateInfo>
+    private val delegateInfosByName: Map<String, DelegateInfo>
 
     /**
      * Constructor parameters that are also reactive delegate properties (e.g. `name` passed to
@@ -109,6 +114,14 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
     private val constructorDelegateParams: Map<String, KParameter>
 
     init {
+        fun Class<*>.requireMethod(name: String, parameterCount: Int): Method =
+            methods.singleOrNull { method ->
+                method.name == name &&
+                    method.parameterCount == parameterCount &&
+                    !method.isBridge &&
+                    !method.isSynthetic
+            } ?: error("Expected exactly one '$name' method with $parameterCount parameters on ${this.name}")
+
         val registry = sampleInstance.delegateRegistry
         val delegateNames = registry.keys.toSet()
         val memberProps = kClass.memberProperties.associateBy { it.name }
@@ -139,23 +152,31 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
                         DelegateInfo.AggregateCollection(name, ListSerializer(idSerializer) as KSerializer<Any?>)
                     }
                     delegate is FxScalarPropertyDelegate -> {
+                        val getMethod = delegate.javaClass.requireMethod("get", 0)
+                        val setMethod = delegate.javaClass.requireMethod("set", 1)
+                        getMethod.isAccessible = true
+                        setMethod.isAccessible = true
                         @Suppress("UNCHECKED_CAST")
-                        DelegateInfo.FxScalar(name, resolveFxScalarSerializer(delegate, prop) as KSerializer<Any?>)
+                        DelegateInfo.FxScalar(name, resolveFxScalarSerializer(delegate, prop) as KSerializer<Any?>, getMethod, setMethod)
                     }
                     else -> {
                         val typedProp =
                             requireNotNull(prop) {
                                 "Cannot find member property '$name' on ${kClass.simpleName}"
                             }
+                        val setValueMethod = delegate::class.java.requireMethod("setValue", 3)
+                        setValueMethod.isAccessible = true
                         @Suppress("UNCHECKED_CAST")
                         DelegateInfo.ReactiveProperty(
                             name,
                             serializer(typedProp.returnType),
-                            typedProp as KProperty1<Any, Any?>
+                            typedProp as KProperty1<Any, Any?>,
+                            setValueMethod
                         )
                     }
                 }
             }
+        delegateInfosByName = delegateInfos.associateBy { it.name }
     }
 
     @OptIn(ExperimentalSerializationApi::class)
@@ -259,7 +280,7 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
                             ?: throw IllegalStateException(
                                 "Fx scalar delegate '${info.name}' not found in registry for ${kClass.simpleName}"
                             )
-                    val fxValue = delegate.javaClass.getMethod("get").invoke(delegate)
+                    val fxValue = info.getMethod.invoke(delegate)
                     composite.encodeSerializableElement(descriptor, index++, info.serializer, fxValue)
                 }
             }
@@ -350,11 +371,9 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
     private fun restoreReactiveProperties(entity: E, reactiveValues: Map<String, Any?>) {
         val registry = entity.delegateRegistry
         for ((name, decodedValue) in reactiveValues) {
+            val info = delegateInfosByName[name] as? DelegateInfo.ReactiveProperty ?: continue
             val delegate = registry[name] ?: continue
-            val prop = kClass.memberProperties.find { it.name == name } ?: continue
-            val setMethod = delegate::class.java.methods.find { it.name == "setValue" } ?: continue
-            setMethod.isAccessible = true
-            setMethod.invoke(delegate, entity, prop, decodedValue)
+            info.setValueMethod.invoke(delegate, entity, info.property, decodedValue)
         }
     }
 
@@ -378,11 +397,10 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
     private fun restoreFxScalarProperties(entity: E, fxScalarValues: Map<String, Any?>) {
         val registry = entity.delegateRegistry
         for ((name, decodedValue) in fxScalarValues) {
+            val info = delegateInfosByName[name] as? DelegateInfo.FxScalar ?: continue
             val delegate = registry[name] ?: continue
             if (delegate !is FxScalarPropertyDelegate) continue
-            val setMethod = delegate.javaClass.methods.find { it.name == "set" } ?: continue
-            setMethod.isAccessible = true
-            setMethod.invoke(delegate, decodedValue)
+            info.setMethod.invoke(delegate, decodedValue)
         }
     }
 }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializerTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializerTest.kt
@@ -20,9 +20,12 @@ package net.transgressoft.lirp.persistence.json
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.persistence.AbstractMutableAggregateCollectionRefDelegate
 import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
+import net.transgressoft.lirp.persistence.LirpDelegate
 import net.transgressoft.lirp.persistence.MutableAggregateList
 import net.transgressoft.lirp.persistence.MutableAggregateSet
 import net.transgressoft.lirp.persistence.mutableAggregateList
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
@@ -228,7 +231,51 @@ class LirpEntitySerializerTest : StringSpec({
         decoded[1]?.name shouldBe "Alice"
         decoded[2]?.name shouldBe "Bob"
     }
+
+    "LirpEntitySerializer init fails when FxScalar delegate lacks expected get method" {
+        val entity = SimpleDelegate(1)
+        val brokenFxDelegate = BrokenFxScalarDelegate()
+        injectDelegate(entity, "broken", brokenFxDelegate)
+
+        shouldThrow<IllegalStateException> {
+            lirpSerializer(entity)
+        }.message shouldContain "Expected exactly one 'get' method with 0 parameters"
+    }
+
+    "LirpEntitySerializer init fails when reactive delegate lacks member property" {
+        val entity = SimpleDelegate(1)
+        val orphanDelegate = OrphanReactiveDelegate()
+        injectDelegate(entity, "ghost", orphanDelegate)
+
+        shouldThrow<IllegalArgumentException> {
+            lirpSerializer(entity)
+        }.message shouldContain "Cannot find member property 'ghost'"
+    }
 })
+
+/**
+ * FxScalarPropertyDelegate without get()/set() — triggers requireMethod error during serializer init.
+ */
+private class BrokenFxScalarDelegate : FxScalarPropertyDelegate, LirpDelegate {
+    override fun bindMutationCallback(callback: (() -> Unit) -> Unit) {}
+}
+
+/**
+ * A non-FxScalar, non-aggregate LirpDelegate with no matching member property — triggers requireNotNull error.
+ */
+private class OrphanReactiveDelegate : LirpDelegate
+
+/** Injects a fake delegate into an entity's delegate registry via reflection. */
+private fun injectDelegate(entity: ReactiveEntityBase<*, *>, name: String, delegate: LirpDelegate) {
+    // Force the registry to be built first
+    entity.delegateRegistry
+    // Replace the cached _delegateRegistry with a copy that includes the fake delegate
+    val field = ReactiveEntityBase::class.java.getDeclaredField("_delegateRegistry")
+    field.isAccessible = true
+    @Suppress("UNCHECKED_CAST")
+    val existing = field.get(entity) as Map<String, LirpDelegate>
+    field.set(entity, existing + (name to delegate))
+}
 
 /** Test helper to set backing IDs on a named delegate via the entity's delegateRegistry. */
 @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
## Summary

**Phase 35: Cache reflection Method lookups in LirpEntitySerializer**
**Goal:** Cache `Method` references at serializer construction time so that `restoreReactiveProperties()` and `restoreFxScalarProperties()` use cached `Method.invoke()` instead of per-call `methods.find` linear scans, reducing deserialization from O(n x m) to O(n).
**Status:** Verified

Cached `java.lang.reflect.Method` references in `DelegateInfo` sealed variants at init time, replacing three O(n*m) per-call reflection hotspots with O(1) `Method.invoke()` calls via a pre-built `delegateInfosByName` map.

## Changes

### Plan 01: Cache Method references in DelegateInfo

**Key files modified:**
- `lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt`

**What changed:**
- `DelegateInfo.ReactiveProperty` gained `val setValueMethod: Method`
- `DelegateInfo.FxScalar` gained `val getMethod: Method` and `val setMethod: Method`
- New `delegateInfosByName: Map<String, DelegateInfo>` for O(1) lookup in restore methods
- Init block resolves and caches Method objects with fail-fast `error()` and `isAccessible = true`
- `restoreReactiveProperties`: uses cached `info.setValueMethod.invoke()` + `info.property`
- `restoreFxScalarProperties`: uses cached `info.setMethod.invoke()`
- `serialize()` FxScalar branch: uses cached `info.getMethod.invoke()`

## Requirements Addressed

- D-01: Extend DelegateInfo variants with cached Method fields
- D-02: Cache setValue Method and reuse existing property in restoreReactiveProperties
- D-03: Cache get/set Methods for FxScalar delegates
- D-04: Eliminate per-call getMethod("get") in serialize() FxScalar branch

## Verification

- [x] Automated verification: 6/6 must-haves passed
- [x] `gradle :lirp-core:test` — all tests pass
- [x] `gradle :lirp-fx:test` — all tests pass (including FxJsonSerializationTest)
- [x] `gradle ktlintCheck` — no violations
- [x] No per-call reflection lookups remain in hotspot methods

## Key Decisions

- Used fail-fast `error()` in init block for missing methods rather than `?: continue`
- Built `delegateInfosByName` via `associateBy` for O(1) restore-method lookups
- Left constructor-params `memberProperties.find` (line 251) and `resolveFxScalarSerializer` unchanged (init-time only, not per-deserialization)

Closes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved performance of entity serialization/deserialization by caching reflective lookups and eliminating repeated per-value reflection.
* **Tests**
  * Added tests that validate initialization fails with clear errors when entities contain malformed or incomplete delegate implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->