### PR TITLE
Fix collectLatest event dropping and lirp-sql build path dependency

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/event/FlowEventPublisher.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/event/FlowEventPublisher.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 /**
@@ -286,7 +285,7 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
 
             val job =
                 flowScope.launch {
-                    changesFlow.collectLatest { event ->
+                    changesFlow.collect { event ->
                         subscriber.onNext(event)
                     }
                 }
@@ -320,7 +319,7 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
             @Suppress("kotlin:S6311")
             val job =
                 flowScope.launch {
-                    changesFlow.collectLatest { event ->
+                    changesFlow.collect { event ->
                         action(event)
                     }
                 }
@@ -347,7 +346,7 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
             @Suppress("kotlin:S6311")
             val job =
                 flowScope.launch {
-                    changesFlow.collectLatest { event ->
+                    changesFlow.collect { event ->
                         if (event.type in eventTypes) {
                             action(event)
                         }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/FlowEventPublisherTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/FlowEventPublisherTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Flow
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Consumer
@@ -45,6 +46,7 @@ import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 
 @ExperimentalCoroutinesApi
 class FlowEventPublisherTest : DescribeSpec({
@@ -539,6 +541,46 @@ class FlowEventPublisherTest : DescribeSpec({
             }
 
             subscription.cancel()
+        }
+
+        it("slow subscriber receives all events without dropping") {
+            val defaultScope = CoroutineScope(Dispatchers.Default)
+            val previousFlowScope = ReactiveScope.flowScope
+            ReactiveScope.flowScope = defaultScope
+            try {
+                val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("SlowPublisher")
+                publisher.activateEvents(CREATE)
+
+                val received = CopyOnWriteArrayList<CrudEvent<String, TestEntity>>()
+
+                val subscription =
+                    publisher.subscribe { event ->
+                        delay(50.milliseconds)
+                        received.add(event)
+                    }
+
+                try {
+                    repeat(5) { i ->
+                        publisher.emitAsync(Create(TestEntity("entity-$i")))
+                        delay(10.milliseconds)
+                    }
+
+                    withTimeout(5000.milliseconds) {
+                        while (received.size < 5) {
+                            delay(10.milliseconds)
+                        }
+                    }
+
+                    received.size shouldBe 5
+                    received.any { it.entities.values.first().id == "entity-0" } shouldBe true
+                    received.any { it.entities.values.first().id == "entity-4" } shouldBe true
+                } finally {
+                    subscription.cancel()
+                    publisher.close()
+                }
+            } finally {
+                ReactiveScope.flowScope = previousFlowScope
+            }
         }
 
         it("late subscriber receives no historical events (no replay)") {

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/SlowSubscriberTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/SlowSubscriberTest.kt
@@ -38,9 +38,9 @@ import kotlinx.coroutines.launch
 const val SLOW_DELAY_MS = 50L
 
 /**
- * Spacing between paced emissions. Must be significantly larger than [SLOW_DELAY_MS] to ensure
- * `collectLatest` does not cancel in-progress slow handlers on loaded CI environments where
- * coroutine scheduling adds variable overhead.
+ * Spacing between paced emissions. Must be larger than [SLOW_DELAY_MS] to ensure
+ * each event completes processing before the next arrives, avoiding backpressure
+ * on loaded CI environments where coroutine scheduling adds variable overhead.
  */
 private const val PACED_INTERVAL_MS = 120L
 
@@ -55,10 +55,9 @@ private const val EVENT_COUNT = 60
  * Each subscriber runs in its own independent coroutine: `delay()` in one subscriber only
  * suspends that coroutine, leaving other subscribers and the emitter unaffected.
  *
- * Note: [FlowEventPublisher.subscribe] uses `collectLatest` internally. With real dispatcher
- * and burst emission, `collectLatest` will restart the slow subscriber's handler for each
- * new event (since the handler delay exceeds the inter-event gap). This is expected behavior —
- * tests verify emission speed and the relative delivery advantage of the fast subscriber.
+ * Note: [FlowEventPublisher.subscribe] uses `collect` internally, processing events
+ * sequentially. Each event is fully handled before the next is delivered to that subscriber.
+ * Tests verify emission speed and the relative delivery advantage of the fast subscriber.
  *
  * To verify completeness (all events received by both subscribers), events are emitted
  * with spacing greater than [SLOW_DELAY_MS], ensuring each event fully completes in both
@@ -142,7 +141,7 @@ class SlowSubscriberTest : DescribeSpec({
                     slowLatch.countDown()
                 }
 
-            // Emit with spacing slightly above SLOW_DELAY_MS so collectLatest does not cancel any handler.
+            // Emit with spacing slightly above SLOW_DELAY_MS so each event completes before the next arrives.
             // This still proves emission is much faster than if blocking occurred.
             val pacedIntervalMs = PACED_INTERVAL_MS
             val emitter =

--- a/lirp-sql/build.gradle
+++ b/lirp-sql/build.gradle
@@ -57,11 +57,7 @@ dependencies {
     integrationTestRuntimeOnly libs.mysql
     integrationTestRuntimeOnly libs.mariadb
 
-    // lirp-fx compiled classes for fx delegate SQL persistence tests.
-    // Uses file path instead of project() to avoid KSP plugin evaluation triggering
-    // Gradle configuration hierarchy mutation on apiElements.
-    testImplementation files("${rootProject.projectDir}/lirp-fx/build/classes/kotlin/main")
-    testImplementation files("${rootProject.projectDir}/lirp-fx/build/resources/main")
+    testImplementation project(':lirp-fx')
 
     // JavaFX for fx delegate SQL persistence tests
     testImplementation "org.openjfx:javafx-base:21:${fxPlatform}"
@@ -84,11 +80,6 @@ dependencies {
     // Consume testFixtures from both test and integrationTest
     testImplementation testFixtures(project(':lirp-sql'))
     integrationTestImplementation testFixtures(project(':lirp-sql'))
-}
-
-// Ensure lirp-fx is compiled before lirp-sql tests
-tasks.named('compileTestKotlin').configure {
-    dependsOn ':lirp-fx:compileKotlin', ':lirp-fx:processResources'
 }
 
 tasks.register('integrationTest', Test) {


### PR DESCRIPTION
## Summary

**Phase 37: Core Bug Fixes**
**Goal:** FlowEventPublisher delivers every event to slow subscribers; lirp-sql uses proper Gradle project dependency.
**Status:** Verified (4/4 must-haves passed)

Two independent bug fixes addressing tech debt identified in the v2.3.0 codebase concerns audit.

## Changes

### EVT-01: Fix collectLatest event dropping (#100)

**Problem:** All three `subscribe()` overloads in `FlowEventPublisher` used `collectLatest`, which silently drops intermediate events when a subscriber's action takes longer than the emission interval. This contradicts the event publisher's delivery guarantee and could cause `PersistentRepositoryBase` to miss entity mutation updates.

**Fix:** Replaced `collectLatest` with `collect` at lines 289, 323, and 350. Removed unused `collectLatest` import. The existing `SUSPEND` buffer (capacity 5120 in `PublisherConfig.DEFAULT`) provides backpressure relief without dropping events.

**Key files:**
- `lirp-core/src/main/kotlin/net/transgressoft/lirp/event/FlowEventPublisher.kt` — 3x `collectLatest` → `collect`
- `lirp-core/src/test/kotlin/net/transgressoft/lirp/event/FlowEventPublisherTest.kt` — new regression test

**Regression test:** "slow subscriber receives all events without dropping" — uses real `Dispatchers.Default`, emits 5 events at 10ms intervals against a 50ms handler, asserts all 5 received.

### BLD-01: Replace raw file-path dependency in lirp-sql (#104)

**Problem:** `lirp-sql/build.gradle` used raw `files()` paths to reference `lirp-fx/build/classes/kotlin/main` — fragile, breaks on Gradle output directory changes, poor IDE support.

**Fix:** Replaced with `testImplementation project(':lirp-fx')`. Removed redundant `compileTestKotlin.dependsOn` block. The KSP plugin evaluation issue that originally prompted the workaround is resolved in current Gradle 9.4.1 + KSP 2.3.6.

**Key files:**
- `lirp-sql/build.gradle` — proper project dependency

## Verification

- [x] `gradle :lirp-core:test` — all tests pass including new slow-subscriber test
- [x] `gradle :lirp-sql:test` — compiles and runs without raw file path references
- [x] `gradle ktlintCheck` — clean
- [x] No `collectLatest` calls remain in FlowEventPublisher
- [x] No `files("...lirp-fx/build/classes...")` remain in lirp-sql/build.gradle

Closes #100
Closes #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured subscribers receive every published event, preventing dropped events during slower subscriber processing.

* **Tests**
  * Added tests validating complete event delivery to slow subscribers and confirming no events are lost.

* **Chores**
  * Simplified test dependency configuration for more reliable build/test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->