### PR TITLE
#119 Demote no-change mutation log from WARN to DEBUG

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -414,9 +414,8 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
         val entityBeforeChange = clone()
         val result = mutationAction()
         if (entityBeforeChange == this) {
-            log.warn {
-                "Attempt to publish update event from a mutation when the entity state did not change. " +
-                    "Consider implementing equals() and hashCode() that reflects all mutable properties affected by the mutationAction."
+            log.debug {
+                "No-change mutation on ${this::class.java.simpleName}(id=$id) — event skipped"
             }
         } else {
             lastDateModified = LocalDateTime.now()


### PR DESCRIPTION
## Summary

- Demotes `log.warn` to `log.debug` in `ReactiveEntityBase.mutateAndPublish()` for no-change mutations
- Replaces misleading "implement equals/hashCode" message with entity identity: `"No-change mutation on {ClassName}(id={id}) — event skipped"`
- Reduces log noise for consumers where no-change mutations are legitimate (UI bidirectional binding, bulk initialization, idempotent operations)

Closes #119

## Test plan

- [x] `gradle clean build` passes (76 tasks)
- [x] All existing `lirp-core` tests pass
- [x] Verified `log.warn` no longer present in `mutateAndPublish()`
- [x] Verified new message includes entity class name and id
- [x] Verified no mention of `equals()` or `hashCode()` in the log message