### PR TITLE
#69 Performance benchmarks: throughput, latency, memory vs JDBC and JPA/Hibernate

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,62 @@ lirp's in-memory-first architecture has trade-offs that influence where it fits 
 
 **Not suited for:** analytics workloads, high-cardinality datasets, or services requiring cross-instance consistency.
 
-Performance benchmarks comparing lirp's throughput and latency against direct JDBC and other persistence frameworks are planned — see [#69](https://github.com/octaviospain/lirp/issues/69).
+## Performance
+
+Benchmarks were run with JMH 1.37 on OpenJDK 21.0.10, 13th Gen Intel Core i7-13700, 62 GB RAM. All repository benchmarks use H2 in-memory databases with per-trial isolation. See the [Performance Benchmarks wiki page](https://github.com/octaviospain/lirp/wiki/Performance-Benchmarks) for full results, environment specs, and comparative analysis.
+
+### Key Numbers (at 10,000 entities)
+
+| Repository | Operation | Result |
+|-----------|-----------|--------|
+| `VolatileRepository` | add() throughput | 271,877 ops/s |
+| `VolatileRepository` | findById() p50 | 27 ns |
+| `SqlRepository` | add() throughput | 92,151 ops/s |
+| `SqlRepository` | findById() p50 | 27 ns |
+| `SqlRepository` | mutation-flush p50 | 63,767 µs (full batch write) |
+| `JsonFileRepository` | add() throughput | 97,720 ops/s |
+| `JsonFileRepository` | mutation-flush p50 | 66,978 µs (full file write) |
+
+### Why add() is Fast
+
+`add()` on `SqlRepository` and `JsonFileRepository` enqueues the entity in-memory immediately and returns — the SQL INSERT or JSON file write happens asynchronously via the debounced write pipeline (100 ms window, 1 s max delay). This is why add() throughput is comparable to `VolatileRepository`: all three repositories share the same O(1) in-memory write path.
+
+### SqlRepository vs Direct JDBC vs JPA/Hibernate
+
+lirp `SqlRepository` measured against raw `java.sql.PreparedStatement` (zero-overhead baseline) and JPA/Hibernate, all using H2 in-memory databases.
+
+**findById() p50 — read latency:**
+
+| Operation | lirp SqlRepository | Direct JDBC | JPA/Hibernate |
+|-----------|-------------------|-------------|---------------|
+| findById() p50 | **27 ns** | 960 ns | 1,000 ns |
+| findById() ratio | baseline | 35x slower | 37x slower |
+
+lirp's in-memory `ConcurrentHashMap` lookup eliminates the SQL round-trip entirely — 35x faster than raw JDBC and 37x faster than JPA/Hibernate at all entity counts.
+
+**add() throughput — write throughput:**
+
+| Operation | lirp SqlRepository | Direct JDBC | JPA/Hibernate |
+|-----------|-------------------|-------------|---------------|
+| add() at 10K entities | 93,776 ops/s | 517,435 ops/s | 915 ops/s |
+| vs JDBC | 5.5x lower (deferred) | baseline | 565x lower |
+| vs JPA | ~100x faster | ~565x faster | baseline |
+
+lirp's `add()` is deferred — no SQL I/O per call. JDBC's single-row autoCommit is faster per individual insert, but lirp writes all inserts as a single batch transaction, dramatically reducing I/O pressure at scale. JPA's per-call `persist()` + `flush()` is 565x slower than JDBC.
+
+### SqlRepository vs JPA/Hibernate (add, 10K entities)
+
+`SqlRepository` achieves ~85,921 ops/s vs Hibernate JPA ~915 ops/s — a ~94x throughput advantage — because lirp batches SQL writes while JPA commits a transaction per call.
+
+### Initialization Time
+
+| Entity Count | VolatileRepository | SqlRepository | JsonFileRepository |
+|-------------|-------------------|---------------|-------------------|
+| 1,000       | 12 ms             | 33 ms         | 24 ms             |
+| 10,000      | 41 ms             | 81 ms         | 108 ms            |
+| 50,000      | 212 ms            | 397 ms        | 408 ms            |
+
+See the full head-to-head results in [Section 5 of the Performance Benchmarks wiki](https://github.com/octaviospain/lirp/wiki/Performance-Benchmarks#section-5--lirp-sqlrepository-vs-direct-jdbc-zero-overhead-baseline).
 
 ## Documentation
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,11 @@ kctfork = "0.12.1"
 postgresql = "42.7.10"
 mysql = "9.6.0"
 mariadb = "3.5.8"
+jmh = "1.37"
+jol = "0.17"
+springDataJpa = "3.4.7"
+hibernate = "6.6.17.Final"
+jakartaPersistence = "3.2.0"
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
@@ -56,6 +61,13 @@ kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version = "7.0
 junit-bom = { module = "org.junit:junit-bom", version = "6.0.3" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+
+jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
+jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }
+jol-core = { module = "org.openjdk.jol:jol-core", version.ref = "jol" }
+spring-data-jpa = { module = "org.springframework.data:spring-data-jpa", version.ref = "springDataJpa" }
+hibernate-core = { module = "org.hibernate.orm:hibernate-core", version.ref = "hibernate" }
+jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-api", version.ref = "jakartaPersistence" }
 
 [bundles]
 kotest = ["kotest-runner-junit6", "kotest-assertions-core", "kotest-assertions-json", "kotest-property"]

--- a/lirp-benchmark/build.gradle
+++ b/lirp-benchmark/build.gradle
@@ -1,0 +1,55 @@
+plugins {
+    id 'kotlin'
+    id 'me.champeau.jmh' version '0.7.3'
+}
+
+description = 'LIRP Benchmark - JMH microbenchmarks and comparative analysis (not published)'
+
+dependencies {
+    jmh project(':lirp-core')
+    jmh project(':lirp-sql')
+    jmh libs.jmh.core
+    jmh libs.jmh.generator.annprocess
+    jmh libs.jol.core
+    jmh libs.h2
+    jmh libs.spring.data.jpa
+    jmh libs.hibernate.core
+    jmh libs.jakarta.persistence.api
+    jmh libs.serialization.json
+    jmh platform(libs.exposed.bom)
+    jmh libs.bundles.exposed
+    jmh libs.hikari
+    jmh libs.logback.core
+    jmh libs.logback.classic
+}
+
+jmh {
+    warmupIterations = project.hasProperty('jmh.warmupIterations') ? project.property('jmh.warmupIterations').toInteger() : 5
+    iterations = project.hasProperty('jmh.iterations') ? project.property('jmh.iterations').toInteger() : 10
+    fork = project.hasProperty('jmh.fork') ? project.property('jmh.fork').toInteger() : 1
+    if (project.hasProperty('jmh.includes')) {
+        includes = [project.property('jmh.includes')]
+    }
+    resultFormat = 'JSON'
+    resultsFile = project.file('build/reports/jmh/results.json')
+    jvmArgs = [
+        '--add-opens=java.base/java.lang=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',
+        '--add-opens=java.base/java.util=ALL-UNNAMED',
+        '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+        '--add-opens=java.base/java.io=ALL-UNNAMED'
+    ]
+}
+
+// Benchmark module is never published to Maven Central
+tasks.withType(PublishToMavenRepository).configureEach { enabled = false }
+tasks.withType(PublishToMavenLocal).configureEach { enabled = false }
+
+// No API docs for benchmark code
+tasks.matching { it.name.startsWith('dokka') }.configureEach { enabled = false }
+
+// Exclude from SonarCloud analysis
+sonar { skipProject = true }
+
+// JaCoCo test report not applicable for JMH benchmarks
+tasks.matching { it.name == 'jacocoTestReport' }.configureEach { enabled = false }

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/BenchmarkEntity.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/BenchmarkEntity.kt
@@ -17,5 +17,5 @@ open class BenchmarkEntity(
     override val uniqueId: String get() = "bench-$id"
     var name: String by reactiveProperty(label)
 
-    override fun clone(): BenchmarkEntity = BenchmarkEntity(id, label)
+    override fun clone(): BenchmarkEntity = BenchmarkEntity(id, label).also { it.name = name }
 }

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/BenchmarkEntity.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/BenchmarkEntity.kt
@@ -1,0 +1,21 @@
+package net.transgressoft.lirp.benchmark
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+
+/**
+ * Minimal reactive entity for benchmarks.
+ *
+ * Declared `open` because JMH generates subclasses of `@State` classes,
+ * and benchmark state holders may embed this entity directly. Does not
+ * depend on KSP, JavaFX, or kotlinx.serialization to keep the benchmark
+ * module lightweight.
+ */
+open class BenchmarkEntity(
+    override val id: Int,
+    val label: String
+) : ReactiveEntityBase<Int, BenchmarkEntity>() {
+    override val uniqueId: String get() = "bench-$id"
+    var name: String by reactiveProperty(label)
+
+    override fun clone(): BenchmarkEntity = BenchmarkEntity(id, label)
+}

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/BenchmarkEntityTableDef.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/BenchmarkEntityTableDef.kt
@@ -1,0 +1,43 @@
+package net.transgressoft.lirp.benchmark
+
+import net.transgressoft.lirp.persistence.ColumnDef
+import net.transgressoft.lirp.persistence.ColumnType
+import net.transgressoft.lirp.persistence.sql.SqlTableDef
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+
+/**
+ * Manual [SqlTableDef] for [BenchmarkEntity] mapping three columns: id (PK), label, and name.
+ *
+ * Provided without KSP generation since the benchmark module does not run the LIRP KSP processor.
+ * Mirrors the pattern used by [net.transgressoft.lirp.persistence.sql.TestPersonTableDef].
+ */
+object BenchmarkEntityTableDef : SqlTableDef<BenchmarkEntity> {
+    override val tableName = "benchmark_entities"
+    override val columns =
+        listOf(
+            ColumnDef("id", ColumnType.IntType, nullable = false, primaryKey = true),
+            ColumnDef("label", ColumnType.VarcharType(255), nullable = false, primaryKey = false),
+            ColumnDef("name", ColumnType.VarcharType(255), nullable = false, primaryKey = false)
+        )
+
+    @Suppress("UNCHECKED_CAST")
+    override fun fromRow(row: ResultRow, table: Table): BenchmarkEntity {
+        val cols = table.columns.associateBy { it.name }
+        val id = row[cols["id"]!! as Column<Int>]
+        val label = row[cols["label"]!! as Column<String>]
+        val entity = BenchmarkEntity(id, label)
+        entity.name = row[cols["name"]!! as Column<String>]
+        return entity
+    }
+
+    override fun toParams(entity: BenchmarkEntity, table: Table): Map<Column<*>, Any?> {
+        val cols = table.columns.associateBy { it.name }
+        return mapOf(
+            cols["id"]!! to entity.id,
+            cols["label"]!! to entity.label,
+            cols["name"]!! to entity.name
+        )
+    }
+}

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/CollapseBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/CollapseBenchmark.kt
@@ -1,0 +1,81 @@
+package net.transgressoft.lirp.benchmark
+
+import net.transgressoft.lirp.persistence.PendingDelete
+import net.transgressoft.lirp.persistence.PendingInsert
+import net.transgressoft.lirp.persistence.PendingOp
+import net.transgressoft.lirp.persistence.PendingUpdate
+import net.transgressoft.lirp.persistence.collapse
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import java.util.concurrent.TimeUnit
+
+/**
+ * JMH throughput benchmark for the [collapse] algorithm.
+ *
+ * Measures how many collapse operations per second the algorithm can perform on a pre-built
+ * list of [opCount] pending operations. The operation list uses a realistic 1:1:1 mix of
+ * inserts, updates, and deletes on overlapping entity IDs to exercise the full deduplication
+ * logic including insert+update merge, update+delete merge, and insert+delete cancellation.
+ *
+ * Each benchmark is parameterized by [opCount] at 100, 1000, 10000, and 50000 operations.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+open class CollapseBenchmark {
+
+    @Param("100", "1000", "10000", "50000")
+    var opCount: Int = 0
+
+    lateinit var ops: List<PendingOp<Int, BenchmarkEntity>>
+
+    @Setup(Level.Trial)
+    fun setup() {
+        // Build a realistic mix: one-third inserts, one-third updates on overlapping IDs,
+        // one-third deletes on overlapping IDs. Overlapping IDs exercise the collapse merging
+        // rules: insert+update -> insert, update+delete -> delete, insert+delete -> no-op.
+        val entityRange = opCount / 3
+        val built = ArrayList<PendingOp<Int, BenchmarkEntity>>(opCount)
+
+        // Insert phase: ids 0..<entityRange
+        repeat(entityRange) { i ->
+            built.add(PendingInsert(BenchmarkEntity(i, "entity-$i")))
+        }
+        // Update phase: ids 0..<entityRange (overlaps inserts -> insert absorbs update)
+        repeat(entityRange) { i ->
+            built.add(PendingUpdate(BenchmarkEntity(i, "entity-$i-updated")))
+        }
+        // Delete phase: ids entityRange/2..<entityRange + entityRange/2 (partial overlap)
+        val deleteStart = entityRange / 2
+        repeat(opCount - 2 * entityRange) { i ->
+            built.add(PendingDelete(deleteStart + i))
+        }
+
+        ops = built
+    }
+
+    /**
+     * Measures [collapse] throughput on a pre-built pending operation list.
+     *
+     * The operation list is immutable and reused across invocations. [Blackhole] consumes the
+     * collapsed result to prevent JIT dead-code elimination.
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    fun collapseOps(bh: Blackhole) {
+        bh.consume(collapse(ops))
+    }
+}

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/ComparativeExposedBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/ComparativeExposedBenchmark.kt
@@ -26,6 +26,7 @@ import org.openjdk.jmh.annotations.Warmup
 import org.openjdk.jmh.infra.Blackhole
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Compares [SqlRepository] against direct JetBrains Exposed [transaction] blocks for equivalent
@@ -55,6 +56,7 @@ open class ComparativeExposedBenchmark {
 
     // Unique DB names per trial to avoid H2 schema accumulation between parameter sets
     val trialCounter = AtomicInteger(0)
+    val addIdGen = AtomicLong(0L)
 
     @Setup(Level.Trial)
     fun setup() {
@@ -93,6 +95,7 @@ open class ComparativeExposedBenchmark {
                 }
             }
         }
+        addIdGen.set(entityCount.toLong())
     }
 
     @TearDown(Level.Trial)
@@ -106,14 +109,14 @@ open class ComparativeExposedBenchmark {
     /** Adds a new entity via SqlRepository. Paired with [directExposedAdd]. */
     @Benchmark
     fun sqlRepoAdd(bh: Blackhole) {
-        val id = entityCount + System.nanoTime().toInt()
+        val id = addIdGen.getAndIncrement().toInt()
         bh.consume(sqlRepo.add(BenchmarkEntity(id, "new-$id")))
     }
 
     /** Adds a new row via direct Exposed transaction. Paired with [sqlRepoAdd]. */
     @Benchmark
     fun directExposedAdd(bh: Blackhole) {
-        val id = entityCount + System.nanoTime().toInt()
+        val id = addIdGen.getAndIncrement().toInt()
         bh.consume(
             transaction(db = exposedDb) {
                 exposedTable.insert {

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/ComparativeExposedBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/ComparativeExposedBenchmark.kt
@@ -1,0 +1,158 @@
+package net.transgressoft.lirp.benchmark
+
+import net.transgressoft.lirp.persistence.sql.SqlRepository
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Compares [SqlRepository] against direct JetBrains Exposed [transaction] blocks for equivalent
+ * CRUD operations. Both sides use the same H2 in-memory database engine with separate databases
+ * for isolation, enabling direct overhead measurement of the SqlRepository abstraction layer.
+ *
+ * The key comparison metric is the overhead percentage added by SqlRepository relative to direct
+ * Exposed transactions for the same logical operation.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+open class ComparativeExposedBenchmark {
+
+    @Param("100", "1000", "10000", "50000")
+    var entityCount: Int = 0
+
+    lateinit var sqlRepo: SqlRepository<Int, BenchmarkEntity>
+    lateinit var repoDataSource: HikariDataSource
+
+    lateinit var exposedDataSource: HikariDataSource
+    lateinit var exposedDb: Database
+    lateinit var exposedTable: BenchmarkExposedTable
+
+    // Unique DB names per trial to avoid H2 schema accumulation between parameter sets
+    val trialCounter = AtomicInteger(0)
+
+    @Setup(Level.Trial)
+    fun setup() {
+        val trial = trialCounter.incrementAndGet()
+
+        // SqlRepository side: dedicated H2 in-memory database
+        val repoDbUrl = "jdbc:h2:mem:bench_repo_$trial;DB_CLOSE_DELAY=-1"
+        repoDataSource =
+            HikariDataSource(
+                HikariConfig().apply {
+                    jdbcUrl = repoDbUrl
+                    maximumPoolSize = 5
+                }
+            )
+        sqlRepo = SqlRepository(repoDataSource, BenchmarkEntityTableDef)
+        repeat(entityCount) { i -> sqlRepo.add(BenchmarkEntity(i, "entity-$i")) }
+
+        // Direct Exposed side: separate H2 in-memory database
+        val exposedDbUrl = "jdbc:h2:mem:bench_exposed_$trial;DB_CLOSE_DELAY=-1"
+        exposedDataSource =
+            HikariDataSource(
+                HikariConfig().apply {
+                    jdbcUrl = exposedDbUrl
+                    maximumPoolSize = 5
+                }
+            )
+        exposedDb = Database.connect(exposedDataSource)
+        exposedTable = BenchmarkExposedTable()
+        transaction(db = exposedDb) {
+            SchemaUtils.create(exposedTable)
+            repeat(entityCount) { i ->
+                exposedTable.insert {
+                    it[exposedTable.id] = i
+                    it[exposedTable.label] = "entity-$i"
+                    it[exposedTable.name] = "entity-$i"
+                }
+            }
+        }
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        sqlRepo.close()
+        repoDataSource.close()
+        transaction(db = exposedDb) { SchemaUtils.drop(exposedTable) }
+        exposedDataSource.close()
+    }
+
+    /** Adds a new entity via SqlRepository. Paired with [directExposedAdd]. */
+    @Benchmark
+    fun sqlRepoAdd(bh: Blackhole) {
+        val id = entityCount + System.nanoTime().toInt()
+        bh.consume(sqlRepo.add(BenchmarkEntity(id, "new-$id")))
+    }
+
+    /** Adds a new row via direct Exposed transaction. Paired with [sqlRepoAdd]. */
+    @Benchmark
+    fun directExposedAdd(bh: Blackhole) {
+        val id = entityCount + System.nanoTime().toInt()
+        bh.consume(
+            transaction(db = exposedDb) {
+                exposedTable.insert {
+                    it[exposedTable.id] = id
+                    it[exposedTable.label] = "new-$id"
+                    it[exposedTable.name] = "new-$id"
+                }
+            }
+        )
+    }
+
+    /** Looks up an entity by ID via SqlRepository. Paired with [directExposedFindById]. */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun sqlRepoFindById(bh: Blackhole) {
+        bh.consume(sqlRepo.findById(entityCount / 2))
+    }
+
+    /** Looks up a row by ID via direct Exposed query. Paired with [sqlRepoFindById]. */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun directExposedFindById(bh: Blackhole) {
+        val targetId = entityCount / 2
+        bh.consume(
+            transaction(db = exposedDb) {
+                exposedTable.selectAll()
+                    .where { exposedTable.id eq targetId }
+                    .singleOrNull()
+            }
+        )
+    }
+}
+
+/** Exposed table definition for [BenchmarkEntity] used in the direct Exposed comparison path. */
+class BenchmarkExposedTable : Table("benchmark_entities") {
+    val id = integer("id")
+    val label = varchar("label", 255)
+    val name = varchar("name", 255)
+    override val primaryKey = PrimaryKey(id)
+}

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/ComparativeJpaBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/ComparativeJpaBenchmark.kt
@@ -25,6 +25,7 @@ import org.openjdk.jmh.annotations.Warmup
 import org.openjdk.jmh.infra.Blackhole
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Compares [SqlRepository] against plain Hibernate [EntityManager] for equivalent CRUD operations,
@@ -51,6 +52,7 @@ open class ComparativeJpaBenchmark {
     lateinit var em: EntityManager
 
     val trialCounter = AtomicInteger(0)
+    val addIdGen = AtomicLong(0L)
 
     @Setup(Level.Trial)
     fun setup() {
@@ -87,6 +89,7 @@ open class ComparativeJpaBenchmark {
             )
         }
         em.transaction.commit()
+        addIdGen.set(entityCount.toLong())
     }
 
     @TearDown(Level.Trial)
@@ -102,7 +105,7 @@ open class ComparativeJpaBenchmark {
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.SECONDS)
     fun sqlRepoAdd(bh: Blackhole) {
-        val id = entityCount + System.nanoTime().toInt()
+        val id = addIdGen.getAndIncrement().toInt()
         bh.consume(sqlRepo.add(BenchmarkEntity(id, "new-$id")))
     }
 
@@ -111,7 +114,7 @@ open class ComparativeJpaBenchmark {
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.SECONDS)
     fun jpaAdd(bh: Blackhole) {
-        val id = entityCount + System.nanoTime().toInt()
+        val id = addIdGen.getAndIncrement().toInt()
         em.transaction.begin()
         val entity =
             JpaBenchmarkEntity().apply {
@@ -132,11 +135,19 @@ open class ComparativeJpaBenchmark {
         bh.consume(sqlRepo.findById(entityCount / 2))
     }
 
-    /** Finds an entity by ID via JPA [EntityManager.find]. Paired with [sqlRepoFindById]. */
+    /**
+     * Finds an entity by ID via JPA [EntityManager.find]. Paired with [sqlRepoFindById].
+     *
+     * [em.clear] is called before each lookup to evict the L1 persistence context cache,
+     * ensuring the measurement reflects a true database round-trip rather than an in-memory
+     * cache hit. This makes the comparison with SqlRepository's in-memory lookup symmetrical
+     * in intent: both are measured against their respective optimised read paths.
+     */
     @Benchmark
     @BenchmarkMode(Mode.SampleTime)
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     fun jpaFindById(bh: Blackhole) {
+        em.clear()
         bh.consume(em.find(JpaBenchmarkEntity::class.java, entityCount / 2))
     }
 }

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/ComparativeJpaBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/ComparativeJpaBenchmark.kt
@@ -1,0 +1,157 @@
+package net.transgressoft.lirp.benchmark
+
+import net.transgressoft.lirp.persistence.sql.SqlRepository
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityManager
+import jakarta.persistence.EntityManagerFactory
+import jakarta.persistence.Id
+import jakarta.persistence.Persistence
+import jakarta.persistence.Table
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Compares [SqlRepository] against plain Hibernate [EntityManager] for equivalent CRUD operations,
+ * both backed by an H2 in-memory database. Demonstrates the overhead or advantage of SqlRepository's
+ * in-memory-first, debounced-write design relative to direct JPA persistence semantics.
+ *
+ * Uses plain Hibernate [EntityManagerFactory] via `persistence.xml` rather than the full Spring
+ * Data JPA wrapper, following the research fallback (assumption A1): same comparison value,
+ * simpler setup without requiring a Spring application context inside the JMH harness.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+open class ComparativeJpaBenchmark {
+
+    @Param("100", "1000", "10000", "50000")
+    var entityCount: Int = 0
+
+    lateinit var sqlRepo: SqlRepository<Int, BenchmarkEntity>
+    lateinit var repoDataSource: HikariDataSource
+
+    lateinit var emf: EntityManagerFactory
+    lateinit var em: EntityManager
+
+    val trialCounter = AtomicInteger(0)
+
+    @Setup(Level.Trial)
+    fun setup() {
+        val trial = trialCounter.incrementAndGet()
+
+        // SqlRepository side: dedicated H2 in-memory database
+        val repoDbUrl = "jdbc:h2:mem:bench_jpa_repo_$trial;DB_CLOSE_DELAY=-1"
+        repoDataSource =
+            HikariDataSource(
+                HikariConfig().apply {
+                    jdbcUrl = repoDbUrl
+                    maximumPoolSize = 5
+                }
+            )
+        sqlRepo = SqlRepository(repoDataSource, BenchmarkEntityTableDef)
+        repeat(entityCount) { i -> sqlRepo.add(BenchmarkEntity(i, "entity-$i")) }
+
+        // JPA side: Hibernate EntityManagerFactory with overridden JDBC URL for unique trial isolation
+        val jpaDbUrl = "jdbc:h2:mem:bench_jpa_$trial;DB_CLOSE_DELAY=-1"
+        emf =
+            Persistence.createEntityManagerFactory(
+                "benchmark-pu",
+                mapOf("jakarta.persistence.jdbc.url" to jpaDbUrl)
+            )
+        em = emf.createEntityManager()
+        em.transaction.begin()
+        repeat(entityCount) { i ->
+            em.persist(
+                JpaBenchmarkEntity().apply {
+                    id = i
+                    label = "entity-$i"
+                    name = "entity-$i"
+                }
+            )
+        }
+        em.transaction.commit()
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        sqlRepo.close()
+        repoDataSource.close()
+        em.close()
+        emf.close()
+    }
+
+    /** Adds a new entity via [SqlRepository]. Paired with [jpaAdd]. */
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    fun sqlRepoAdd(bh: Blackhole) {
+        val id = entityCount + System.nanoTime().toInt()
+        bh.consume(sqlRepo.add(BenchmarkEntity(id, "new-$id")))
+    }
+
+    /** Persists a new entity via JPA [EntityManager]. Paired with [sqlRepoAdd]. */
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    fun jpaAdd(bh: Blackhole) {
+        val id = entityCount + System.nanoTime().toInt()
+        em.transaction.begin()
+        val entity =
+            JpaBenchmarkEntity().apply {
+                this.id = id
+                label = "new-$id"
+                name = "new-$id"
+            }
+        em.persist(entity)
+        em.transaction.commit()
+        bh.consume(entity)
+    }
+
+    /** Finds an entity by ID via [SqlRepository]. Paired with [jpaFindById]. */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun sqlRepoFindById(bh: Blackhole) {
+        bh.consume(sqlRepo.findById(entityCount / 2))
+    }
+
+    /** Finds an entity by ID via JPA [EntityManager.find]. Paired with [sqlRepoFindById]. */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun jpaFindById(bh: Blackhole) {
+        bh.consume(em.find(JpaBenchmarkEntity::class.java, entityCount / 2))
+    }
+}
+
+/**
+ * JPA entity for the Hibernate comparison path in [ComparativeJpaBenchmark].
+ *
+ * Declared `open` because Hibernate generates CGLIB proxies for JPA entities.
+ * Uses Jakarta EE 10 annotations (jakarta.persistence.*).
+ */
+@Entity
+@Table(name = "jpa_benchmark_entities")
+open class JpaBenchmarkEntity {
+    @Id
+    var id: Int = 0
+    var label: String = ""
+    var name: String = ""
+}

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/ComparativeJsonSerializationBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/ComparativeJsonSerializationBenchmark.kt
@@ -48,7 +48,8 @@ open class ComparativeJsonSerializationBenchmark {
     lateinit var repoJsonFile: File
     lateinit var tempDir: File
 
-    lateinit var rawEntities: Map<Int, SerializableBenchmarkEntity>
+    // Kept as a mutable map to avoid allocating a full copy per rawSerializationMutationWrite invocation
+    lateinit var rawEntities: MutableMap<Int, SerializableBenchmarkEntity>
     lateinit var rawJsonFile: File
 
     val trialCounter = AtomicInteger(0)
@@ -71,9 +72,9 @@ open class ComparativeJsonSerializationBenchmark {
         jsonRepo = JsonFileRepository(repoJsonFile, BenchmarkEntityMapSerializer.instance)
         repeat(entityCount) { i -> jsonRepo.add(BenchmarkEntity(i, "entity-$i")) }
 
-        // Raw serialization side: pre-built entity map
+        // Raw serialization side: pre-built mutable entity map
         rawEntities =
-            (0 until entityCount).associateWith { i ->
+            (0 until entityCount).associateWithTo(LinkedHashMap()) { i ->
                 SerializableBenchmarkEntity(i, "entity-$i", "entity-$i")
             }
         rawJsonFile = File(tempDir, "raw-$trial.json").also { it.createNewFile() }
@@ -85,11 +86,16 @@ open class ComparativeJsonSerializationBenchmark {
         tempDir.deleteRecursively()
     }
 
-    /** Adds a new entity to [JsonFileRepository]. Paired with [rawSerializationWrite]. */
+    /**
+     * Adds a new entity to [JsonFileRepository] and immediately removes it to keep the
+     * repository size stable across invocations. Paired with [rawSerializationWrite].
+     */
     @Benchmark
     fun jsonRepoAdd(bh: Blackhole) {
-        val id = entityCount + System.nanoTime().toInt()
-        bh.consume(jsonRepo.add(BenchmarkEntity(id, "new-$id")))
+        val entity = BenchmarkEntity(entityCount + System.nanoTime().toInt(), "new")
+        val result = jsonRepo.add(entity)
+        jsonRepo.remove(entity)
+        bh.consume(result)
     }
 
     /**
@@ -103,25 +109,32 @@ open class ComparativeJsonSerializationBenchmark {
         bh.consume(jsonString.length)
     }
 
-    /** Mutates an entity in [JsonFileRepository] and closes to force flush. Paired with [rawSerializationMutationWrite]. */
+    /**
+     * Mutates an entity in [JsonFileRepository] and closes the repository to force a
+     * synchronous flush of the debounce pipeline. The repository is reopened afterwards
+     * so subsequent invocations within the same trial remain valid.
+     * Paired with [rawSerializationMutationWrite].
+     */
     @Benchmark
     fun jsonRepoMutationFlush(bh: Blackhole) {
         val optional = jsonRepo.findById(entityCount / 2)
         if (optional.isPresent) optional.get().name = "mutated-${System.nanoTime()}"
-        // Close forces the debounce pipeline to flush synchronously
+        // Force synchronous flush — measures full mutation-to-disk round-trip
+        jsonRepo.close()
         bh.consume(optional)
+        // Re-open for subsequent invocations within the same trial
+        jsonRepo = JsonFileRepository(repoJsonFile, BenchmarkEntityMapSerializer.instance)
     }
 
     /**
-     * Mutates the raw entity map and serializes the full state to a file.
+     * Mutates an entry in the shared mutable map and serializes the full state to a file.
      * Paired with [jsonRepoMutationFlush].
      */
     @Benchmark
     fun rawSerializationMutationWrite(bh: Blackhole) {
         val id = entityCount / 2
-        val updated = rawEntities.toMutableMap()
-        updated[id] = SerializableBenchmarkEntity(id, "entity-$id", "mutated-${System.nanoTime()}")
-        val jsonString = json.encodeToString(rawSerializer, updated)
+        rawEntities[id] = SerializableBenchmarkEntity(id, "entity-$id", "mutated-${System.nanoTime()}")
+        val jsonString = json.encodeToString(rawSerializer, rawEntities)
         rawJsonFile.writeText(jsonString)
         bh.consume(jsonString.length)
     }

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/ComparativeJsonSerializationBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/ComparativeJsonSerializationBenchmark.kt
@@ -1,0 +1,165 @@
+package net.transgressoft.lirp.benchmark
+
+import net.transgressoft.lirp.persistence.json.JsonFileRepository
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+/**
+ * Compares [JsonFileRepository] against raw [Json.encodeToString] + file write for equivalent
+ * serialization operations. Measures the overhead that JsonFileRepository's debounce pipeline,
+ * in-memory state management, and repository lifecycle add over direct kotlinx.serialization.
+ *
+ * The raw serialization path uses [SerializableBenchmarkEntity], a data class equivalent of
+ * [BenchmarkEntity] annotated with [@Serializable][Serializable] for direct kotlinx.serialization use.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+open class ComparativeJsonSerializationBenchmark {
+
+    @Param("100", "1000", "10000", "50000")
+    var entityCount: Int = 0
+
+    lateinit var jsonRepo: JsonFileRepository<Int, BenchmarkEntity>
+    lateinit var repoJsonFile: File
+    lateinit var tempDir: File
+
+    lateinit var rawEntities: Map<Int, SerializableBenchmarkEntity>
+    lateinit var rawJsonFile: File
+
+    val trialCounter = AtomicInteger(0)
+    val json =
+        Json {
+            prettyPrint = true
+            explicitNulls = true
+            allowStructuredMapKeys = true
+        }
+    val rawSerializer: KSerializer<Map<Int, SerializableBenchmarkEntity>> =
+        MapSerializer(Int.serializer(), SerializableBenchmarkEntity.serializer())
+
+    @Setup(Level.Trial)
+    fun setup() {
+        val trial = trialCounter.incrementAndGet()
+        tempDir = Files.createTempDirectory("lirp-json-bench-$trial").toFile()
+
+        // JsonFileRepository side
+        repoJsonFile = File(tempDir, "repo-$trial.json").also { it.createNewFile() }
+        jsonRepo = JsonFileRepository(repoJsonFile, BenchmarkEntityMapSerializer.instance)
+        repeat(entityCount) { i -> jsonRepo.add(BenchmarkEntity(i, "entity-$i")) }
+
+        // Raw serialization side: pre-built entity map
+        rawEntities =
+            (0 until entityCount).associateWith { i ->
+                SerializableBenchmarkEntity(i, "entity-$i", "entity-$i")
+            }
+        rawJsonFile = File(tempDir, "raw-$trial.json").also { it.createNewFile() }
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        jsonRepo.close()
+        tempDir.deleteRecursively()
+    }
+
+    /** Adds a new entity to [JsonFileRepository]. Paired with [rawSerializationWrite]. */
+    @Benchmark
+    fun jsonRepoAdd(bh: Blackhole) {
+        val id = entityCount + System.nanoTime().toInt()
+        bh.consume(jsonRepo.add(BenchmarkEntity(id, "new-$id")))
+    }
+
+    /**
+     * Serializes the full entity map to a JSON string and writes it to a file.
+     * Paired with [jsonRepoAdd] to measure raw serialization overhead.
+     */
+    @Benchmark
+    fun rawSerializationWrite(bh: Blackhole) {
+        val jsonString = json.encodeToString(rawSerializer, rawEntities)
+        rawJsonFile.writeText(jsonString)
+        bh.consume(jsonString.length)
+    }
+
+    /** Mutates an entity in [JsonFileRepository] and closes to force flush. Paired with [rawSerializationMutationWrite]. */
+    @Benchmark
+    fun jsonRepoMutationFlush(bh: Blackhole) {
+        val optional = jsonRepo.findById(entityCount / 2)
+        if (optional.isPresent) optional.get().name = "mutated-${System.nanoTime()}"
+        // Close forces the debounce pipeline to flush synchronously
+        bh.consume(optional)
+    }
+
+    /**
+     * Mutates the raw entity map and serializes the full state to a file.
+     * Paired with [jsonRepoMutationFlush].
+     */
+    @Benchmark
+    fun rawSerializationMutationWrite(bh: Blackhole) {
+        val id = entityCount / 2
+        val updated = rawEntities.toMutableMap()
+        updated[id] = SerializableBenchmarkEntity(id, "entity-$id", "mutated-${System.nanoTime()}")
+        val jsonString = json.encodeToString(rawSerializer, updated)
+        rawJsonFile.writeText(jsonString)
+        bh.consume(jsonString.length)
+    }
+}
+
+/**
+ * Serializable counterpart of [BenchmarkEntity] for the raw kotlinx.serialization comparison path.
+ *
+ * [BenchmarkEntity] extends [ReactiveEntityBase][net.transgressoft.lirp.entity.ReactiveEntityBase]
+ * which is not [@Serializable][Serializable]. This data class carries the same logical fields
+ * (id, label, name) for a fair comparison without the reactive overhead.
+ */
+@Serializable
+data class SerializableBenchmarkEntity(val id: Int, val label: String, val name: String)
+
+/**
+ * Manual [KSerializer] for [Map] of [Int] to [BenchmarkEntity] used by [JsonFileRepository]
+ * in the benchmark. Wraps the standard [MapSerializer] with a custom entity serializer.
+ */
+object BenchmarkEntityMapSerializer {
+    val instance: KSerializer<Map<Int, BenchmarkEntity>> =
+        MapSerializer(Int.serializer(), BenchmarkEntityKSerializer)
+}
+
+/**
+ * Minimal [KSerializer] for [BenchmarkEntity] that encodes only the fields relevant
+ * to the benchmark comparison: [BenchmarkEntity.id], [BenchmarkEntity.label], and [BenchmarkEntity.name].
+ */
+object BenchmarkEntityKSerializer : KSerializer<BenchmarkEntity> {
+    private val delegate = SerializableBenchmarkEntity.serializer()
+    override val descriptor = delegate.descriptor
+
+    override fun serialize(encoder: kotlinx.serialization.encoding.Encoder, value: BenchmarkEntity) {
+        delegate.serialize(encoder, SerializableBenchmarkEntity(value.id, value.label, value.name))
+    }
+
+    override fun deserialize(decoder: kotlinx.serialization.encoding.Decoder): BenchmarkEntity {
+        val data = delegate.deserialize(decoder)
+        return BenchmarkEntity(data.id, data.label).also { it.name = data.name }
+    }
+}

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/DirectJdbcBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/DirectJdbcBenchmark.kt
@@ -1,0 +1,250 @@
+package net.transgressoft.lirp.benchmark
+
+import net.transgressoft.lirp.persistence.sql.SqlRepository
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Head-to-head comparison of [SqlRepository] against raw JDBC [java.sql.PreparedStatement]
+ * operations using H2 in-memory database, establishing the zero-overhead baseline for SQL
+ * persistence cost.
+ *
+ * Both sides use dedicated, separate H2 in-memory databases per trial to avoid cross-side
+ * interference. The JDBC side pre-creates a schema identical to the one lirp uses and seeds
+ * the same number of rows.
+ *
+ * **What is measured:**
+ * - `add` — INSERT throughput: SqlRepository in-memory enqueue vs immediate JDBC insert + commit
+ * - `findById` — SELECT by primary key latency: SqlRepository ConcurrentHashMap lookup vs JDBC
+ *   `SELECT WHERE id = ?` round-trip
+ * - `update` — Full round-trip write latency: SqlRepository mutation flush via `close()` vs JDBC
+ *   `UPDATE ... WHERE id = ?` + commit
+ *
+ * **Database isolation:** Each trial creates unique H2 URLs (`jdbc:h2:mem:lirp_<UUID>` and
+ * `jdbc:h2:mem:jdbc_<UUID>`) to prevent row accumulation between parameter sets.
+ *
+ * **JDBC connection strategy:** The JDBC side acquires a fresh connection from a dedicated pool
+ * per benchmark invocation for `add` (to avoid unique-key violations from accumulated inserts)
+ * and reuses a stable connection with `autoCommit=true` for `findById` and `update`.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+open class DirectJdbcBenchmark {
+
+    @Param("100", "1000", "10000", "50000")
+    var entityCount: Int = 0
+
+    // lirp side
+    lateinit var lirpDataSource: HikariDataSource
+    lateinit var lirpRepo: SqlRepository<Int, BenchmarkEntity>
+
+    // Raw JDBC side — separate dedicated data source with autoCommit=true for simplicity
+    lateinit var jdbcDataSource: HikariDataSource
+
+    // Monotonic counter for generating unique IDs in add benchmarks (avoids PK collisions)
+    val addIdGen = AtomicLong(0L)
+
+    @Setup(Level.Trial)
+    fun setup() {
+        val trialId = UUID.randomUUID()
+
+        // lirp side: dedicated H2 database
+        lirpDataSource =
+            HikariDataSource(
+                HikariConfig().apply {
+                    jdbcUrl = "jdbc:h2:mem:lirp_$trialId;DB_CLOSE_DELAY=-1"
+                    maximumPoolSize = 8
+                    isAutoCommit = false
+                    transactionIsolation = "TRANSACTION_REPEATABLE_READ"
+                }
+            )
+        lirpRepo = SqlRepository(lirpDataSource, BenchmarkEntityTableDef)
+        repeat(entityCount) { i -> lirpRepo.add(BenchmarkEntity(i, "entity-$i")) }
+        lirpRepo.close()
+        lirpRepo = SqlRepository(lirpDataSource, BenchmarkEntityTableDef)
+
+        // JDBC side: separate H2 database, autoCommit=true
+        jdbcDataSource =
+            HikariDataSource(
+                HikariConfig().apply {
+                    jdbcUrl = "jdbc:h2:mem:jdbc_$trialId;DB_CLOSE_DELAY=-1"
+                    maximumPoolSize = 8
+                    isAutoCommit = true
+                }
+            )
+        // Create schema and seed identical rows using JDBC directly
+        jdbcDataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute(
+                    """CREATE TABLE IF NOT EXISTS benchmark_entities (
+                        id INT PRIMARY KEY,
+                        label VARCHAR(255) NOT NULL,
+                        "name" VARCHAR(255) NOT NULL
+                    )"""
+                )
+            }
+            val ps =
+                conn.prepareStatement(
+                    "INSERT INTO benchmark_entities (id, label, \"name\") VALUES (?, ?, ?)"
+                )
+            ps.use {
+                repeat(entityCount) { i ->
+                    it.setInt(1, i)
+                    it.setString(2, "entity-$i")
+                    it.setString(3, "entity-$i")
+                    it.addBatch()
+                }
+                it.executeBatch()
+            }
+        }
+
+        addIdGen.set(entityCount.toLong())
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        try {
+            lirpRepo.close()
+        } catch (_: Exception) {
+        }
+        lirpDataSource.close()
+        jdbcDataSource.close()
+    }
+
+    /**
+     * Measures add throughput via [SqlRepository].
+     *
+     * Enqueues the entity in the in-memory store; the SQL write is deferred by the debounce
+     * pipeline. Paired with [directJdbcAdd].
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    fun lirpAdd(bh: Blackhole) {
+        val id = addIdGen.getAndIncrement().toInt()
+        bh.consume(lirpRepo.add(BenchmarkEntity(id, "entity-$id")))
+    }
+
+    /**
+     * Measures add throughput via raw JDBC with a single autoCommit=true INSERT.
+     *
+     * Each call acquires a connection from the pool, executes one INSERT, and releases
+     * the connection. This is the zero-overhead baseline for a committed insert.
+     * Paired with [lirpAdd].
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    fun directJdbcAdd(bh: Blackhole) {
+        val id = addIdGen.getAndIncrement().toInt()
+        jdbcDataSource.connection.use { conn ->
+            conn.prepareStatement(
+                "INSERT INTO benchmark_entities (id, label, \"name\") VALUES (?, ?, ?)"
+            ).use { ps ->
+                ps.setInt(1, id)
+                ps.setString(2, "entity-$id")
+                ps.setString(3, "entity-$id")
+                bh.consume(ps.executeUpdate())
+            }
+        }
+    }
+
+    /**
+     * Measures findById latency via [SqlRepository] (in-memory ConcurrentHashMap lookup).
+     *
+     * Paired with [directJdbcFindById].
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun lirpFindById(bh: Blackhole) {
+        bh.consume(lirpRepo.findById(entityCount / 2))
+    }
+
+    /**
+     * Measures findById latency via raw JDBC `SELECT ... WHERE id = ?`.
+     *
+     * Acquires a connection per call to measure the full pool-checkout + query + result-read
+     * cost, which is the actual per-operation JDBC overhead. Paired with [lirpFindById].
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun directJdbcFindById(bh: Blackhole) {
+        jdbcDataSource.connection.use { conn ->
+            conn.prepareStatement(
+                "SELECT id, label, \"name\" FROM benchmark_entities WHERE id = ?"
+            ).use { ps ->
+                ps.setInt(1, entityCount / 2)
+                ps.executeQuery().use { rs ->
+                    if (rs.next()) {
+                        bh.consume(rs.getInt(1))
+                        bh.consume(rs.getString(2))
+                        bh.consume(rs.getString(3))
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Measures full mutation-to-database round-trip via [SqlRepository].
+     *
+     * Mutates one entity property and forces a synchronous flush via [SqlRepository.close].
+     * The repository is re-opened within this method for the next invocation.
+     * Paired with [directJdbcUpdate].
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    fun lirpUpdate(bh: Blackhole) {
+        val entity = lirpRepo.findById(entityCount / 2).orElse(null)
+        if (entity != null) {
+            entity.name = "mutated-${System.nanoTime()}"
+            lirpRepo.close()
+            bh.consume(entity)
+            lirpRepo = SqlRepository(lirpDataSource, BenchmarkEntityTableDef)
+        }
+    }
+
+    /**
+     * Measures full UPDATE + commit round-trip via raw JDBC.
+     *
+     * Acquires a connection from the pool, executes `UPDATE ... WHERE id = ?`, and releases.
+     * This is the zero-overhead baseline for a single-row synchronous SQL write.
+     * Paired with [lirpUpdate].
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    fun directJdbcUpdate(bh: Blackhole) {
+        jdbcDataSource.connection.use { conn ->
+            conn.prepareStatement(
+                "UPDATE benchmark_entities SET \"name\" = ? WHERE id = ?"
+            ).use { ps ->
+                ps.setString(1, "mutated-${System.nanoTime()}")
+                ps.setInt(2, entityCount / 2)
+                bh.consume(ps.executeUpdate())
+            }
+        }
+    }
+}

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/InitTimeBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/InitTimeBenchmark.kt
@@ -100,7 +100,9 @@ open class InitTimeBenchmark {
      * Measures [VolatileRepository] cold-start initialization: create repository and add [entityCount] entities.
      *
      * VolatileRepository has no persistent backing store, so initialization is a pure in-memory
-     * add loop. This serves as the baseline for the other two initialization benchmarks.
+     * add loop rather than a load-from-storage operation. This makes it an insertion baseline,
+     * not a load baseline like [initSql] and [initJson], which construct from pre-populated stores.
+     * It still serves as a useful lower bound on repository construction cost.
      */
     @Benchmark
     fun initVolatile(bh: Blackhole) {
@@ -122,9 +124,6 @@ open class InitTimeBenchmark {
         val repo = SqlRepository(sqlDataSource, BenchmarkEntityTableDef)
         bh.consume(repo.size())
         repo.close()
-
-        // Re-populate for the next invocation (SingleShotTime runs once per fork,
-        // but setup() ensures rows exist before the benchmark starts)
     }
 
     /**

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/InitTimeBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/InitTimeBenchmark.kt
@@ -1,0 +1,143 @@
+package net.transgressoft.lirp.benchmark
+
+import net.transgressoft.lirp.persistence.VolatileRepository
+import net.transgressoft.lirp.persistence.json.JsonFileRepository
+import net.transgressoft.lirp.persistence.json.lirpSerializer
+import net.transgressoft.lirp.persistence.sql.SqlRepository
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import java.io.File
+import java.nio.file.Files
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+
+/**
+ * JMH initialization-time benchmark measuring cold-start repository construction time.
+ *
+ * Covers all three repository types — [VolatileRepository], [SqlRepository], and
+ * [JsonFileRepository] — each parameterized by [entityCount] at 100, 1000, 10000, and 50000.
+ *
+ * Uses [Mode.SingleShotTime] to measure a single cold-start rather than steady-state throughput.
+ * [Fork] is set to 5 to provide statistical significance: each fork is a new JVM with a fresh
+ * repository instance, eliminating JIT warm-up bias across measurements.
+ *
+ * The key measurement in each benchmark is repository construction and row loading, not insertion.
+ * Rows are pre-inserted during [setup] before the benchmark invocation. Each benchmark creates a
+ * NEW repository instance that loads existing data from the pre-populated store.
+ */
+@State(Scope.Benchmark)
+@Fork(5)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+open class InitTimeBenchmark {
+
+    @Param("100", "1000", "10000", "50000")
+    var entityCount: Int = 0
+
+    // JSON init state
+    lateinit var jsonFile: File
+
+    val mapSerializer: KSerializer<Map<Int, BenchmarkEntity>>
+        get() = MapSerializer(Int.serializer(), lirpSerializer(BenchmarkEntity(0, "sample")))
+
+    // SQL init state
+    lateinit var sqlDataSource: HikariDataSource
+    lateinit var sqlDbUrl: String
+
+    @Setup(Level.Trial)
+    fun setup() {
+        // --- JSON pre-population ---
+        val tempDir = Files.createTempDirectory("lirp-init-bench-json").toFile()
+        jsonFile = File(tempDir, "init-benchmark.json").also { it.createNewFile() }
+        val prepRepo = JsonFileRepository(jsonFile, mapSerializer)
+        repeat(entityCount) { i -> prepRepo.add(BenchmarkEntity(i, "entity-$i")) }
+        prepRepo.close()
+
+        // --- SQL pre-population ---
+        sqlDbUrl = "jdbc:h2:mem:init_bench_${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+        val config =
+            HikariConfig().apply {
+                jdbcUrl = sqlDbUrl
+                maximumPoolSize = 4
+                isAutoCommit = false
+                transactionIsolation = "TRANSACTION_REPEATABLE_READ"
+            }
+        sqlDataSource = HikariDataSource(config)
+
+        // Pre-create schema and insert rows
+        val prepSqlRepo = SqlRepository(sqlDataSource, BenchmarkEntityTableDef)
+        repeat(entityCount) { i -> prepSqlRepo.add(BenchmarkEntity(i, "entity-$i")) }
+        // Force flush of all inserts to the database
+        prepSqlRepo.close()
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        jsonFile.parentFile?.deleteRecursively()
+        sqlDataSource.close()
+    }
+
+    /**
+     * Measures [VolatileRepository] cold-start initialization: create repository and add [entityCount] entities.
+     *
+     * VolatileRepository has no persistent backing store, so initialization is a pure in-memory
+     * add loop. This serves as the baseline for the other two initialization benchmarks.
+     */
+    @Benchmark
+    fun initVolatile(bh: Blackhole) {
+        val repo = VolatileRepository<Int, BenchmarkEntity>("init-bench")
+        repeat(entityCount) { i -> repo.add(BenchmarkEntity(i, "entity-$i")) }
+        bh.consume(repo.size())
+        repo.clear()
+    }
+
+    /**
+     * Measures [SqlRepository] cold-start initialization: construct a repository against a
+     * pre-populated H2 database and load all [entityCount] rows into memory.
+     *
+     * The database was pre-populated during [setup]. This benchmark measures only the
+     * construction + SQL SELECT + in-memory load time, not the insert cost.
+     */
+    @Benchmark
+    fun initSql(bh: Blackhole) {
+        val repo = SqlRepository(sqlDataSource, BenchmarkEntityTableDef)
+        bh.consume(repo.size())
+        repo.close()
+
+        // Re-populate for the next invocation (SingleShotTime runs once per fork,
+        // but setup() ensures rows exist before the benchmark starts)
+    }
+
+    /**
+     * Measures [JsonFileRepository] cold-start initialization: construct a repository from a
+     * pre-populated JSON file and deserialize all [entityCount] entities into memory.
+     *
+     * The JSON file was populated during [setup]. This benchmark measures only the
+     * construction + JSON deserialization + in-memory load time, not the write cost.
+     */
+    @Benchmark
+    fun initJson(bh: Blackhole) {
+        val repo = JsonFileRepository(jsonFile, mapSerializer)
+        bh.consume(repo.size())
+        repo.close()
+    }
+}

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/JsonRepoBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/JsonRepoBenchmark.kt
@@ -20,6 +20,7 @@ import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 
@@ -37,7 +38,7 @@ import kotlinx.serialization.builtins.serializer
  *
  * **Mutation flush:** [mutationFlush] forces a synchronous flush via [JsonFileRepository.close]
  * to measure the full mutation-to-disk round-trip (Pitfall 3 mitigation). The repository is
- * re-opened in the next trial setup.
+ * re-opened immediately after close so subsequent invocations within the same trial remain valid.
  */
 @State(Scope.Benchmark)
 @Fork(1)
@@ -51,19 +52,16 @@ open class JsonRepoBenchmark {
     lateinit var jsonFile: File
     lateinit var repo: JsonFileRepository<Int, BenchmarkEntity>
 
+    // Cached at field level to avoid recreating the serializer on every mutationFlush invocation
+    val mapSerializer: KSerializer<Map<Int, BenchmarkEntity>> =
+        MapSerializer(Int.serializer(), lirpSerializer(BenchmarkEntity(0, "sample")))
+
     private val nextId = AtomicInteger()
 
     @Setup(Level.Trial)
     fun setup() {
         val tempDir = Files.createTempDirectory("lirp-bench-json").toFile()
         jsonFile = File(tempDir, "benchmark.json").also { it.createNewFile() }
-
-        val mapSerializer =
-            @Suppress("UNCHECKED_CAST")
-            (
-                MapSerializer(Int.serializer(), lirpSerializer(BenchmarkEntity(0, "sample")))
-                    as kotlinx.serialization.KSerializer<Map<Int, BenchmarkEntity>>
-            )
 
         repo = JsonFileRepository(jsonFile, mapSerializer)
         repeat(entityCount) { i -> repo.add(BenchmarkEntity(i, "entity-$i")) }
@@ -104,7 +102,8 @@ open class JsonRepoBenchmark {
      *
      * Mutates the name property of the middle entity, then forces a synchronous flush by calling
      * [JsonFileRepository.close]. This bypasses the debounce timer to capture the true end-to-end
-     * write latency. The repository is re-opened via [setup] for the next trial.
+     * write latency. The repository is re-opened immediately after close so subsequent invocations
+     * within the same trial remain valid.
      *
      * Note: because close() is called here, [tearDown] guards against double-close gracefully.
      */
@@ -119,12 +118,6 @@ open class JsonRepoBenchmark {
             repo.close()
             bh.consume(entity)
             // Re-open for subsequent invocations within the same trial
-            val mapSerializer =
-                @Suppress("UNCHECKED_CAST")
-                (
-                    MapSerializer(Int.serializer(), lirpSerializer(BenchmarkEntity(0, "sample")))
-                        as kotlinx.serialization.KSerializer<Map<Int, BenchmarkEntity>>
-                )
             repo = JsonFileRepository(jsonFile, mapSerializer)
         }
     }

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/JsonRepoBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/JsonRepoBenchmark.kt
@@ -1,0 +1,131 @@
+package net.transgressoft.lirp.benchmark
+
+import net.transgressoft.lirp.persistence.json.JsonFileRepository
+import net.transgressoft.lirp.persistence.json.lirpSerializer
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+
+/**
+ * JMH microbenchmarks for [JsonFileRepository] covering add throughput and
+ * mutation-to-file-flush round-trip latency.
+ *
+ * Each benchmark is parameterized by [entityCount] at 100, 1000, 10000, and 50000 entities.
+ *
+ * **Serialization:** [BenchmarkEntity] does not carry `@Serializable`. Serialization is handled
+ * via [lirpSerializer] which introspects the entity's delegate registry at construction time,
+ * eliminating the need for KSP or `@Serializable` annotations.
+ *
+ * **File isolation:** Each trial creates a fresh temporary JSON file and deletes it in teardown.
+ *
+ * **Mutation flush:** [mutationFlush] forces a synchronous flush via [JsonFileRepository.close]
+ * to measure the full mutation-to-disk round-trip (Pitfall 3 mitigation). The repository is
+ * re-opened in the next trial setup.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+open class JsonRepoBenchmark {
+
+    @Param("100", "1000", "10000", "50000")
+    var entityCount: Int = 0
+
+    lateinit var jsonFile: File
+    lateinit var repo: JsonFileRepository<Int, BenchmarkEntity>
+
+    private val nextId = AtomicInteger()
+
+    @Setup(Level.Trial)
+    fun setup() {
+        val tempDir = Files.createTempDirectory("lirp-bench-json").toFile()
+        jsonFile = File(tempDir, "benchmark.json").also { it.createNewFile() }
+
+        val mapSerializer =
+            @Suppress("UNCHECKED_CAST")
+            (
+                MapSerializer(Int.serializer(), lirpSerializer(BenchmarkEntity(0, "sample")))
+                    as kotlinx.serialization.KSerializer<Map<Int, BenchmarkEntity>>
+            )
+
+        repo = JsonFileRepository(jsonFile, mapSerializer)
+        repeat(entityCount) { i -> repo.add(BenchmarkEntity(i, "entity-$i")) }
+        // Force initial flush so all entities are on disk before measurement starts
+        repo.close()
+
+        // Re-open so the repo is ready for benchmark invocations
+        repo = JsonFileRepository(jsonFile, mapSerializer)
+        nextId.set(entityCount)
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        try {
+            repo.close()
+        } catch (_: Exception) {
+            // Already closed in mutationFlush — safe to ignore
+        }
+        jsonFile.parentFile?.deleteRecursively()
+    }
+
+    /**
+     * Measures add throughput for [JsonFileRepository].
+     *
+     * Each invocation inserts a new entity. The actual file write is deferred by the debounce
+     * pipeline, so this measures in-memory add + enqueue latency, not disk I/O.
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    fun addEntity(bh: Blackhole) {
+        val id = nextId.getAndIncrement()
+        bh.consume(repo.add(BenchmarkEntity(id, "entity-$id")))
+    }
+
+    /**
+     * Measures full mutation-to-disk round-trip latency for [JsonFileRepository].
+     *
+     * Mutates the name property of the middle entity, then forces a synchronous flush by calling
+     * [JsonFileRepository.close]. This bypasses the debounce timer to capture the true end-to-end
+     * write latency. The repository is re-opened via [setup] for the next trial.
+     *
+     * Note: because close() is called here, [tearDown] guards against double-close gracefully.
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    fun mutationFlush(bh: Blackhole) {
+        val entity = repo.findById(entityCount / 2).orElse(null)
+        if (entity != null) {
+            entity.name = "mutated-${System.nanoTime()}"
+            // Force synchronous flush — measures full mutation-to-disk round-trip
+            repo.close()
+            bh.consume(entity)
+            // Re-open for subsequent invocations within the same trial
+            val mapSerializer =
+                @Suppress("UNCHECKED_CAST")
+                (
+                    MapSerializer(Int.serializer(), lirpSerializer(BenchmarkEntity(0, "sample")))
+                        as kotlinx.serialization.KSerializer<Map<Int, BenchmarkEntity>>
+                )
+            repo = JsonFileRepository(jsonFile, mapSerializer)
+        }
+    }
+}

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/MemoryProfilingBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/MemoryProfilingBenchmark.kt
@@ -80,8 +80,11 @@ open class MemoryProfilingBenchmark {
      * Measures the incremental heap cost of registering an entity into a [VolatileRepository]
      * that carries secondary-index metadata (per D-09).
      *
-     * Compares the object graph before and after repository registration to isolate the
-     * overhead from index structures, ref bindings, and event subscriptions.
+     * Compares the entity's standalone object graph size against the full repository graph size
+     * after registration. Note that [repoBytes] includes the repository's own baseline overhead
+     * (internal maps, event publisher, etc.) in addition to the per-entity index cost; it is
+     * the delta between consecutive calls (or against an empty-repo baseline) that isolates the
+     * true per-entity index overhead.
      */
     @Benchmark
     fun heapWithSecondaryIndex(bh: Blackhole) {

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/MemoryProfilingBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/MemoryProfilingBenchmark.kt
@@ -1,0 +1,118 @@
+package net.transgressoft.lirp.benchmark
+
+import net.transgressoft.lirp.event.MutationEvent
+import net.transgressoft.lirp.persistence.VolatileRepository
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.infra.Blackhole
+import org.openjdk.jol.info.GraphLayout
+import java.util.concurrent.TimeUnit
+
+/**
+ * JOL-based heap memory profiling for [BenchmarkEntity] under varying subscriber counts,
+ * secondary-index overhead via [VolatileRepository], and peak memory during bulk initialization.
+ *
+ * Memory values are printed to stdout within each benchmark method so the JMH console output
+ * captures them. The wiki results table extracts these values for the hardware/JVM baseline record.
+ *
+ * Uses [Mode.SingleShotTime] because memory measurements are one-shot calculations — each
+ * benchmark invocation performs a single JOL graph walk and reports the result.
+ *
+ * JOL requires `--add-opens` JVM flags already configured in the `jmh { jvmArgs }` block of
+ * `lirp-benchmark/build.gradle`.
+ */
+@State(Scope.Benchmark)
+@Fork(3)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+open class MemoryProfilingBenchmark {
+
+    @Param("0", "1", "5", "10")
+    var subscriberCount: Int = 0
+
+    @Param("100", "1000", "10000", "50000")
+    var entityCount: Int = 0
+
+    // Pre-created entity for subscriber-count measurements (D-08)
+    lateinit var subscriberEntity: BenchmarkEntity
+
+    // Repository for index-overhead measurements (D-09)
+    lateinit var indexRepo: VolatileRepository<Int, BenchmarkEntity>
+
+    @Setup(Level.Trial)
+    fun setup() {
+        subscriberEntity = BenchmarkEntity(1, "mem-probe")
+        repeat(subscriberCount) { _ ->
+            subscriberEntity.subscribe { _: MutationEvent<Int, BenchmarkEntity> -> }
+        }
+
+        indexRepo = VolatileRepository("mem-index-bench")
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        indexRepo.clear()
+    }
+
+    /**
+     * Measures the heap size of a single [BenchmarkEntity] with [subscriberCount] MUTATION subscribers.
+     *
+     * Per D-08: reports the full object graph size including the subscriber list,
+     * publisher, and all reachable state.
+     */
+    @Benchmark
+    fun heapPerEntityWithSubscribers(bh: Blackhole) {
+        val bytes = GraphLayout.parseInstance(subscriberEntity).totalSize()
+        println("heap_per_entity_${subscriberCount}_subscribers=$bytes")
+        bh.consume(bytes)
+    }
+
+    /**
+     * Measures the incremental heap cost of registering an entity into a [VolatileRepository]
+     * that carries secondary-index metadata (per D-09).
+     *
+     * Compares the object graph before and after repository registration to isolate the
+     * overhead from index structures, ref bindings, and event subscriptions.
+     */
+    @Benchmark
+    fun heapWithSecondaryIndex(bh: Blackhole) {
+        val entity = BenchmarkEntity(999_999, "index-probe")
+        val beforeBytes = GraphLayout.parseInstance(entity).totalSize()
+        indexRepo.add(entity)
+        val repoBytes = GraphLayout.parseInstance(indexRepo).totalSize()
+        println("heap_entity_before_index=$beforeBytes heap_repo_with_entity=$repoBytes")
+        bh.consume(repoBytes)
+    }
+
+    /**
+     * Measures peak heap delta during bulk initialization of a [VolatileRepository] with [entityCount] entities.
+     *
+     * Per D-10: uses [Runtime.getRuntime] before and after initialization (coarse but appropriate
+     * for bulk-load measurement where JOL graph walk over the full collection is impractical).
+     * Forces GC before the baseline measurement to reduce GC noise.
+     */
+    @Benchmark
+    fun peakMemoryDuringInit(bh: Blackhole) {
+        val rt = Runtime.getRuntime()
+        System.gc()
+        val beforeUsed = rt.totalMemory() - rt.freeMemory()
+
+        val repo = VolatileRepository<Int, BenchmarkEntity>("mem-init-bench")
+        repeat(entityCount) { i -> repo.add(BenchmarkEntity(i, "init-$i")) }
+
+        val afterUsed = rt.totalMemory() - rt.freeMemory()
+        val deltaBytes = afterUsed - beforeUsed
+        println("peak_memory_init_${entityCount}_entities_delta_bytes=$deltaBytes")
+        bh.consume(deltaBytes)
+        repo.clear()
+    }
+}

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/SmokeTestBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/SmokeTestBenchmark.kt
@@ -3,12 +3,10 @@ package net.transgressoft.lirp.benchmark
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
 import org.openjdk.jmh.annotations.Fork
-import org.openjdk.jmh.annotations.Level
 import org.openjdk.jmh.annotations.Measurement
 import org.openjdk.jmh.annotations.Mode
 import org.openjdk.jmh.annotations.OutputTimeUnit
 import org.openjdk.jmh.annotations.Scope
-import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
 import org.openjdk.jmh.infra.Blackhole
@@ -25,13 +23,6 @@ import java.util.concurrent.TimeUnit
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 open class SmokeTestBenchmark {
-
-    lateinit var entity: BenchmarkEntity
-
-    @Setup(Level.Trial)
-    fun setup() {
-        entity = BenchmarkEntity(1, "smoke-test")
-    }
 
     @Benchmark
     fun entityCreation(bh: Blackhole) {

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/SmokeTestBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/SmokeTestBenchmark.kt
@@ -1,0 +1,40 @@
+package net.transgressoft.lirp.benchmark
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import java.util.concurrent.TimeUnit
+
+/**
+ * Smoke test to verify JMH annotation processing and benchmark execution work correctly.
+ * Run with: gradle :lirp-benchmark:jmh -Pjmh.includes='SmokeTestBenchmark'
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+open class SmokeTestBenchmark {
+
+    lateinit var entity: BenchmarkEntity
+
+    @Setup(Level.Trial)
+    fun setup() {
+        entity = BenchmarkEntity(1, "smoke-test")
+    }
+
+    @Benchmark
+    fun entityCreation(bh: Blackhole) {
+        bh.consume(BenchmarkEntity(1, "test"))
+    }
+}

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/SqlRepoBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/SqlRepoBenchmark.kt
@@ -47,7 +47,8 @@ import java.util.concurrent.atomic.AtomicInteger
  *
  * **Mutation flush:** [mutationFlush] forces a synchronous flush via [SqlRepository.close] to
  * measure the full mutation-to-database round-trip time without relying on the debounce timer.
- * The repository is re-created in the next trial setup.
+ * The repository re-open happens in a [Level.Invocation] setup hook ([reopenIfNeeded]) so the
+ * SQL SELECT load cost is excluded from the JMH measurement window.
  */
 @State(Scope.Benchmark)
 @Fork(1)
@@ -62,6 +63,9 @@ open class SqlRepoBenchmark {
     lateinit var repo: SqlRepository<Int, BenchmarkEntity>
     lateinit var exposedTable: Table
     lateinit var db: Database
+
+    // Cached once in setup to avoid per-invocation column resolution in findByLabel
+    lateinit var labelCol: Column<String>
 
     private val nextId = AtomicInteger()
 
@@ -82,6 +86,10 @@ open class SqlRepoBenchmark {
         // Expose the internal table for the findByLabel benchmark
         val interpreted = ExposedTableInterpreter().interpret(BenchmarkEntityTableDef)
         exposedTable = interpreted.table
+
+        // Cache the label column reference once to avoid per-invocation column resolution
+        @Suppress("UNCHECKED_CAST")
+        labelCol = exposedTable.columns.first { it.name == "label" } as Column<String>
 
         // Ensure schema exists before SqlRepository (which also creates it, but we need the table ref)
         transaction(db) { SchemaUtils.create(exposedTable) }
@@ -110,15 +118,18 @@ open class SqlRepoBenchmark {
     /**
      * Measures add throughput for [SqlRepository].
      *
-     * Each invocation inserts a new entity with a unique ID. The actual SQL write is deferred
-     * by the debounce pipeline, so this measures in-memory add + enqueue latency, not SQL I/O.
+     * Each invocation inserts a new entity with a unique ID and then removes it to keep the
+     * repository size stable. The actual SQL write is deferred by the debounce pipeline,
+     * so this measures in-memory add + enqueue latency, not SQL I/O.
      */
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.SECONDS)
     fun addEntity(bh: Blackhole) {
-        val id = nextId.getAndIncrement()
-        bh.consume(repo.add(BenchmarkEntity(id, "entity-$id")))
+        val entity = BenchmarkEntity(nextId.getAndIncrement(), "entity")
+        val result = repo.add(entity)
+        repo.remove(entity)
+        bh.consume(result)
     }
 
     /**
@@ -138,18 +149,15 @@ open class SqlRepoBenchmark {
     /**
      * Measures direct SQL WHERE lookup latency using Exposed `transaction {}`.
      *
-     * This benchmarks the cost of a raw SQL `SELECT ... WHERE name = ?` query, bypassing the
+     * This benchmarks the cost of a raw SQL `SELECT ... WHERE label = ?` query, bypassing the
      * in-memory cache to reflect the actual SQL-level column lookup cost. The target value
-     * is the name of the middle entity so the query always matches exactly one row.
+     * is the label of the middle entity so the query always matches exactly one row.
      */
     @Benchmark
     @BenchmarkMode(Mode.SampleTime)
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     fun findByLabel(bh: Blackhole) {
         val targetLabel = "entity-${entityCount / 2}"
-
-        @Suppress("UNCHECKED_CAST")
-        val labelCol = exposedTable.columns.first { it.name == "label" } as Column<String>
         val results =
             transaction(db) {
                 exposedTable
@@ -160,14 +168,42 @@ open class SqlRepoBenchmark {
         bh.consume(results)
     }
 
+    @Volatile
+    private var needsReopen = false
+
     /**
-     * Measures full mutation-to-database round-trip latency for [SqlRepository].
+     * Re-opens the repository after [mutationFlush] closed it.
+     *
+     * Runs at [Level.Invocation] so the re-open cost (full SQL SELECT load) is excluded from the
+     * JMH sample timer. Only triggers when [needsReopen] is set by [mutationFlush].
+     *
+     * Note: [Level.Invocation] setup/teardown is acceptable here because `mutationFlush` operates
+     * at microsecond granularity (100s of µs), well above the ~1 µs overhead of the invocation hook.
+     */
+    @Setup(Level.Invocation)
+    fun reopenIfNeeded() {
+        if (needsReopen) {
+            repo = SqlRepository(dataSource, BenchmarkEntityTableDef)
+            needsReopen = false
+        }
+    }
+
+    /**
+     * Measures mutation-to-database flush latency for [SqlRepository].
      *
      * Mutates the name property of the middle entity, then forces a synchronous flush by calling
-     * [SqlRepository.close]. This bypasses the debounce timer to capture the true end-to-end
-     * write latency (Pitfall 3 mitigation). The repository is re-opened in [setup] for the next trial.
+     * [SqlRepository.close]. `close()` is a deterministic flush barrier: it cancels debounce jobs,
+     * acquires the `flushLock` (blocking if a debounce flush is in-flight), then calls `flush()`
+     * which drains and writes all pending ops synchronously under the lock.
      *
-     * Note: because close() is called here, [tearDown] guards against double-close gracefully.
+     * The repository re-open happens in [reopenIfNeeded] at [Level.Invocation], so the SQL SELECT
+     * load time on re-open is excluded from the JMH measurement window.
+     *
+     * **Async gap caveat:** The mutation via `entity.name = ...` triggers `mutateAndPublish()` →
+     * `SharedFlow` → subscriber → `enqueue(PendingUpdate)`. In production, the subscriber
+     * dispatch is effectively immediate (same coroutine context), so by the time `close()` runs
+     * the `PendingUpdate` is in the queue. If this assumption breaks under contention, the
+     * measured flush time will be artificially low (close drains an empty queue).
      */
     @Benchmark
     @BenchmarkMode(Mode.SampleTime)
@@ -176,11 +212,9 @@ open class SqlRepoBenchmark {
         val entity = repo.findById(entityCount / 2).orElse(null)
         if (entity != null) {
             entity.name = "mutated-${System.nanoTime()}"
-            // Force synchronous flush to measure full mutation-to-DB round-trip
             repo.close()
             bh.consume(entity)
-            // Re-open for subsequent invocations within the same trial
-            repo = SqlRepository(dataSource, BenchmarkEntityTableDef)
         }
+        needsReopen = true
     }
 }

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/SqlRepoBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/SqlRepoBenchmark.kt
@@ -1,0 +1,186 @@
+package net.transgressoft.lirp.benchmark
+
+import net.transgressoft.lirp.persistence.sql.ExposedTableInterpreter
+import net.transgressoft.lirp.persistence.sql.SqlRepository
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * JMH microbenchmarks for [SqlRepository] covering add throughput, findById latency,
+ * SQL WHERE lookup latency, and mutation-to-flush round-trip latency.
+ *
+ * Each benchmark is parameterized by [entityCount] at 100, 1000, 10000, and 50000 entities.
+ *
+ * **Database isolation:** Each trial creates a fresh H2 in-memory database with a unique URL
+ * to prevent row accumulation between parameter sets (Pitfall 4 in JMH research). The URL
+ * follows the pattern `jdbc:h2:mem:bench_<UUID>;DB_CLOSE_DELAY=-1`.
+ *
+ * **findByIndex note:** [SqlRepository] uses the same in-memory secondary index mechanism as
+ * [net.transgressoft.lirp.persistence.VolatileRepository], which requires KSP-generated
+ * [net.transgressoft.lirp.persistence.IndexEntry] accessors. Since the benchmark module does
+ * not run KSP, the [findByLabel] benchmark uses a direct Exposed SQL WHERE query instead,
+ * which accurately reflects the SQL-level column lookup cost.
+ *
+ * **Mutation flush:** [mutationFlush] forces a synchronous flush via [SqlRepository.close] to
+ * measure the full mutation-to-database round-trip time without relying on the debounce timer.
+ * The repository is re-created in the next trial setup.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+open class SqlRepoBenchmark {
+
+    @Param("100", "1000", "10000", "50000")
+    var entityCount: Int = 0
+
+    lateinit var dataSource: HikariDataSource
+    lateinit var repo: SqlRepository<Int, BenchmarkEntity>
+    lateinit var exposedTable: Table
+    lateinit var db: Database
+
+    private val nextId = AtomicInteger()
+
+    @Setup(Level.Trial)
+    fun setup() {
+        // Unique URL per trial prevents row accumulation across parameter sets
+        val dbUrl = "jdbc:h2:mem:bench_${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+        val config =
+            HikariConfig().apply {
+                jdbcUrl = dbUrl
+                maximumPoolSize = 4
+                isAutoCommit = false
+                transactionIsolation = "TRANSACTION_REPEATABLE_READ"
+            }
+        dataSource = HikariDataSource(config)
+        db = Database.connect(dataSource)
+
+        // Expose the internal table for the findByLabel benchmark
+        val interpreted = ExposedTableInterpreter().interpret(BenchmarkEntityTableDef)
+        exposedTable = interpreted.table
+
+        // Ensure schema exists before SqlRepository (which also creates it, but we need the table ref)
+        transaction(db) { SchemaUtils.create(exposedTable) }
+
+        // SqlRepository creates the schema (no-op since already created above) and loads on init
+        repo = SqlRepository(dataSource, BenchmarkEntityTableDef)
+        repeat(entityCount) { i -> repo.add(BenchmarkEntity(i, "entity-$i")) }
+        // Force initial flush so setup rows are in the database before measurements begin
+        repo.close()
+
+        // Re-open for the benchmark
+        repo = SqlRepository(dataSource, BenchmarkEntityTableDef)
+        nextId.set(entityCount)
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        try {
+            repo.close()
+        } catch (_: Exception) {
+            // Already closed in mutationFlush — safe to ignore
+        }
+        dataSource.close()
+    }
+
+    /**
+     * Measures add throughput for [SqlRepository].
+     *
+     * Each invocation inserts a new entity with a unique ID. The actual SQL write is deferred
+     * by the debounce pipeline, so this measures in-memory add + enqueue latency, not SQL I/O.
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    fun addEntity(bh: Blackhole) {
+        val id = nextId.getAndIncrement()
+        bh.consume(repo.add(BenchmarkEntity(id, "entity-$id")))
+    }
+
+    /**
+     * Measures findById latency for [SqlRepository] (in-memory lookup, no SQL I/O).
+     *
+     * [SqlRepository] caches all rows in memory on init, so `findById` is an O(1) [ConcurrentHashMap]
+     * lookup. This matches the optimistic-read design of the repository.
+     * SampleTime produces p50, p95, and p99 latency percentiles in the JMH JSON output.
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun findById(bh: Blackhole) {
+        bh.consume(repo.findById(entityCount / 2))
+    }
+
+    /**
+     * Measures direct SQL WHERE lookup latency using Exposed `transaction {}`.
+     *
+     * This benchmarks the cost of a raw SQL `SELECT ... WHERE name = ?` query, bypassing the
+     * in-memory cache to reflect the actual SQL-level column lookup cost. The target value
+     * is the name of the middle entity so the query always matches exactly one row.
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun findByLabel(bh: Blackhole) {
+        val targetLabel = "entity-${entityCount / 2}"
+
+        @Suppress("UNCHECKED_CAST")
+        val labelCol = exposedTable.columns.first { it.name == "label" } as Column<String>
+        val results =
+            transaction(db) {
+                exposedTable
+                    .selectAll()
+                    .where { labelCol eq targetLabel }
+                    .map { BenchmarkEntityTableDef.fromRow(it, exposedTable) }
+            }
+        bh.consume(results)
+    }
+
+    /**
+     * Measures full mutation-to-database round-trip latency for [SqlRepository].
+     *
+     * Mutates the name property of the middle entity, then forces a synchronous flush by calling
+     * [SqlRepository.close]. This bypasses the debounce timer to capture the true end-to-end
+     * write latency (Pitfall 3 mitigation). The repository is re-opened in [setup] for the next trial.
+     *
+     * Note: because close() is called here, [tearDown] guards against double-close gracefully.
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    fun mutationFlush(bh: Blackhole) {
+        val entity = repo.findById(entityCount / 2).orElse(null)
+        if (entity != null) {
+            entity.name = "mutated-${System.nanoTime()}"
+            // Force synchronous flush to measure full mutation-to-DB round-trip
+            repo.close()
+            bh.consume(entity)
+            // Re-open for subsequent invocations within the same trial
+            repo = SqlRepository(dataSource, BenchmarkEntityTableDef)
+        }
+    }
+}

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/VolatileRepoBenchmark.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/VolatileRepoBenchmark.kt
@@ -1,0 +1,83 @@
+package net.transgressoft.lirp.benchmark
+
+import net.transgressoft.lirp.persistence.VolatileRepository
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * JMH microbenchmarks for [VolatileRepository] covering add throughput and findById latency.
+ *
+ * Each benchmark is parameterized by [entityCount] at 100, 1000, 10000, and 50000 entities.
+ * All methods use [Blackhole] to prevent JIT dead-code elimination of the result values.
+ *
+ * Note: `findByIndex` is not benchmarked for [VolatileRepository] because secondary indexes
+ * require KSP-generated [net.transgressoft.lirp.persistence.IndexEntry] accessors.
+ * Since the benchmark module does not run KSP, index registration is unavailable without it,
+ * making a meaningful `findByIndex` benchmark not applicable here.
+ * The `findByIndex` operation is covered in [SqlRepoBenchmark] via native SQL WHERE clauses.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+open class VolatileRepoBenchmark {
+
+    @Param("100", "1000", "10000", "50000")
+    var entityCount: Int = 0
+
+    lateinit var repo: VolatileRepository<Int, BenchmarkEntity>
+
+    private val nextId = AtomicInteger()
+
+    @Setup(Level.Trial)
+    fun setup() {
+        repo = VolatileRepository("volatile-bench")
+        repeat(entityCount) { i -> repo.add(BenchmarkEntity(i, "entity-$i")) }
+        nextId.set(entityCount)
+    }
+
+    @TearDown(Level.Trial)
+    fun tearDown() {
+        repo.clear()
+    }
+
+    /**
+     * Measures add throughput for [VolatileRepository].
+     *
+     * Each invocation inserts a new entity with a unique ID above [entityCount].
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    fun addEntity(bh: Blackhole) {
+        val id = nextId.getAndIncrement()
+        bh.consume(repo.add(BenchmarkEntity(id, "entity-$id")))
+    }
+
+    /**
+     * Measures findById latency for [VolatileRepository] using [Mode.SampleTime].
+     *
+     * SampleTime produces p50, p95, and p99 latency percentiles in the JMH JSON output.
+     * The lookup key is always the middle entity to avoid any ordering bias.
+     */
+    @Benchmark
+    @BenchmarkMode(Mode.SampleTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun findById(bh: Blackhole) {
+        bh.consume(repo.findById(entityCount / 2))
+    }
+}

--- a/lirp-benchmark/src/jmh/resources/META-INF/persistence.xml
+++ b/lirp-benchmark/src/jmh/resources/META-INF/persistence.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+             https://jakarta.ee/xml/ns/persistence/persistence_3_1.xsd"
+             version="3.1">
+    <persistence-unit name="benchmark-pu" transaction-type="RESOURCE_LOCAL">
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <class>net.transgressoft.lirp.benchmark.JpaBenchmarkEntity</class>
+        <properties>
+            <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <!-- JDBC URL is overridden per trial in ComparativeJpaBenchmark.setup() for isolation -->
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:jpa_bench_default;DB_CLOSE_DELAY=-1"/>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.show_sql" value="false"/>
+            <property name="hibernate.format_sql" value="false"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'lirp'
-include 'lirp-api', 'lirp-core', 'lirp-ksp', 'lirp-sql', 'lirp-fx'
+include 'lirp-api', 'lirp-core', 'lirp-ksp', 'lirp-sql', 'lirp-fx', 'lirp-benchmark'


### PR DESCRIPTION
## Summary

**Phase 45: Performance Benchmarks**
**Goal:** Empirical performance data for lirp repositories — JMH microbenchmarks, comparative analysis against direct JDBC and other frameworks, and memory profiling per entity.
**Status:** Verified ✓

New `lirp-benchmark` module with 13 JMH benchmark classes covering throughput/latency at 100-50K entity counts across all three repository types, head-to-head comparisons against raw JDBC, Exposed, and JPA/Hibernate, and JOL-based memory profiling.

## Changes

### Plan 45-01: Module setup
- `lirp-benchmark/build.gradle` — JMH plugin (`me.champeau.jmh` 0.7.3), dependencies (JMH 1.37, JOL 0.17, Spring Data JPA, Hibernate, H2), excluded from publishing/coverage/Sonar
- `BenchmarkEntity.kt` — Shared reactive entity for benchmarks
- `SmokeTestBenchmark.kt` — Compile/run validation

### Plan 45-02: JMH microbenchmarks
- `VolatileRepoBenchmark.kt` — add() throughput, findById() latency
- `SqlRepoBenchmark.kt` — add/findById/findByLabel/mutationFlush with H2
- `JsonRepoBenchmark.kt` — add/mutationFlush with lirpSerializer
- `CollapseBenchmark.kt` — collapse() throughput with realistic operation mix
- `InitTimeBenchmark.kt` — Cold-start SingleShotTime for all three repos

### Plan 45-03: Comparative + memory profiling
- `ComparativeExposedBenchmark.kt` — SqlRepository vs direct Exposed transactions
- `ComparativeJpaBenchmark.kt` — SqlRepository vs Hibernate JPA
- `ComparativeJsonSerializationBenchmark.kt` — JsonFileRepository vs raw kotlinx.serialization
- `MemoryProfilingBenchmark.kt` — JOL heap per entity (0/1/N subscribers), index overhead, peak init memory

### Plan 45-04 + gap fix: Direct JDBC baseline
- `DirectJdbcBenchmark.kt` — Raw JDBC PreparedStatement as zero-overhead baseline
- Wiki `Performance-Benchmarks.md` — Full results with environment specs
- `README.md` — Performance summary section

## Key Results

| Metric | lirp SqlRepository | Direct JDBC | Takeaway |
|--------|-------------------|-------------|----------|
| **findById latency** | **27 ns** | 907-996 ns | lirp **34x faster** (in-memory ConcurrentHashMap) |
| **add throughput** | ~95K ops/s | ~520K ops/s | JDBC 5.5x higher (lirp defers SQL I/O) |
| **flush per-entity** | ~7.2 µs | 2.2 µs/row | lirp batches all rows in one transaction |

## Requirements Addressed

- #69 — Performance benchmarks: throughput and latency vs direct JDBC and other frameworks

## Verification

- [x] Automated verification: 5/5 must-haves passed
- [x] `gradle clean build` passes (82 tasks)
- [x] `gradle :lirp-benchmark:jmhClasses` compiles
- [x] All 27 benchmark methods produce results
- [x] Wiki page published with full results
- [x] README performance section added

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Performance section with benchmark environment specifications, throughput and latency measurements, initialization time analysis, memory profiling results, and detailed performance comparisons across different persistence approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->