### PR TITLE
#124 #125 Make withEventsDisabled public and fix SqlRepository UUID conversion

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -348,7 +348,11 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
      * Executes [action] with event emission suppressed, restoring the previous state afterward.
      *
      * Equivalent to wrapping the action between [disableEvents] and [enableEvents], but
-     * guarantees restoration even if the action throws.
+     * guarantees restoration even if the action throws. Common use cases:
+     *
+     * - Clone implementations that copy all properties without triggering mutation events
+     * - Batch property initialization from deserialized or database-loaded state
+     * - Framework-level operations that need to set multiple properties atomically
      *
      * ```
      * override fun clone(): MyEntity = MyEntity(id).apply {
@@ -365,7 +369,7 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
      * @see disableEvents
      * @see enableEvents
      */
-    protected inline fun <T> withEventsDisabled(action: () -> T): T {
+    inline fun <T> withEventsDisabled(action: () -> T): T {
         val wasDisabled = eventsDisabled
         eventsDisabled = true
         try {
@@ -428,17 +432,13 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
     }
 
     /**
-     * Public bridge exposing [withEventsDisabled] for framework-level operations like
-     * [LirpEntitySerializer][net.transgressoft.lirp.persistence.json.LirpEntitySerializer]
-     * deserialization and user-written clone implementations.
-     *
-     * Provides the same event-suppression guarantee as [withEventsDisabled] while keeping that
-     * method protected for subclass use.
+     * Alias for [withEventsDisabled] retained for binary compatibility with code compiled
+     * against earlier LIRP versions where [withEventsDisabled] was protected.
      *
      * @param action the block to execute with events disabled
      * @return the result of [action]
      */
-    internal fun <T> withEventsDisabledForClone(action: () -> T): T = withEventsDisabled(action)
+    fun <T> withEventsDisabledForClone(action: () -> T): T = withEventsDisabled(action)
 
     @Volatile
     private var _delegateRegistry: Map<String, LirpDelegate>? = null

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
@@ -42,7 +42,10 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
+import java.util.UUID
 import javax.sql.DataSource
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.toKotlinUuid
 
 /**
  * SQL-backed reactive repository using JetBrains Exposed and HikariCP connection pooling.
@@ -190,7 +193,7 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
                             // Safe: pkCol is the primary key column registered by ExposedTableInterpreter. Exposed's
                             // eq() operator requires Column<Any?> due to statement-builder type erasure.
                             @Suppress("UNCHECKED_CAST")
-                            (pkCol as Column<Any?>).eq(op.entity.id)
+                            (pkCol as Column<Any?>).eq(toExposedId(op.entity.id))
                         }) { stmt ->
                             tableDef.toParams(op.entity, table).forEach { (col, value) ->
                                 // Safe: col was registered by ExposedTableInterpreter from the declared LirpTableDef column type.
@@ -204,7 +207,7 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
                             // Safe: pkCol is the primary key column registered by ExposedTableInterpreter. Exposed's
                             // eq() operator requires Column<Any?> due to statement-builder type erasure.
                             @Suppress("UNCHECKED_CAST")
-                            (pkCol as Column<Any?>).eq(op.id)
+                            (pkCol as Column<Any?>).eq(toExposedId(op.id))
                         }
                     is PendingBatchDelete -> {
                         // Use individual deleteWhere per ID within the same transaction to avoid
@@ -215,7 +218,7 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
                                 // Safe: pkCol is the primary key column registered by ExposedTableInterpreter. Exposed's
                                 // eq() operator requires Column<Any?> due to statement-builder type erasure.
                                 @Suppress("UNCHECKED_CAST")
-                                (pkCol as Column<Any?>).eq(id)
+                                (pkCol as Column<Any?>).eq(toExposedId(id))
                             }
                         }
                     }
@@ -265,5 +268,13 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
                 }
             return HikariDataSource(config)
         }
+
+        /**
+         * Converts a `java.util.UUID` to `kotlin.uuid.Uuid` for Exposed column operations.
+         * Exposed 1.x uses `kotlin.uuid.Uuid` natively; entity IDs may be `java.util.UUID`.
+         */
+        @OptIn(ExperimentalUuidApi::class)
+        private fun toExposedId(id: Any): Any =
+            if (id is UUID) id.toKotlinUuid() else id
     }
 }


### PR DESCRIPTION
Closes #124 
Closes #125

- ReactiveEntityBase.withEventsDisabled: changed from protected to public so external consumers can suppress events during entity construction, deserialization, and manual SqlTableDef.fromRow() implementations. withEventsDisabledForClone retained as public alias for binary compat.

- SqlRepository.writePending: added toExposedId() helper that converts java.util.UUID to kotlin.uuid.Uuid before Exposed eq() calls. Fixes ClassCastException when entities use java.util.UUID as their ID type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database persistence reliability with enhanced UUID identifier handling in data update and delete operations.

* **Improvements**
  * Enhanced entity event management capabilities for improved framework compatibility and seamless integration.
  * Strengthened backward compatibility while refining internal architecture and component interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->