### PR TITLE
#122 KSP generates SqlTableDef for external Maven consumers

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -151,10 +151,12 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
 
     /**
      * The timestamp when this entity was last modified.
+     *
      * Automatically updated whenever a property is changed via [mutateAndPublish].
+     * Public setter enables KSP-generated `SqlTableDef.fromRow()` to restore the persisted timestamp
+     * when loading entities from a database.
      */
     override var lastDateModified: LocalDateTime = LocalDateTime.now()
-        protected set
 
     /**
      * A flow of entity change events that collectors can observe.

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/CollectionRefEntry.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/CollectionRefEntry.kt
@@ -41,7 +41,7 @@ import net.transgressoft.lirp.entity.CascadeAction
  *   entity types with different K types.
  * @property referencedClass the [Class] of the referenced entity type, used for registry lookup
  * @property cascadeAction the [CascadeAction] to execute when the owning entity is deleted;
- *   defaults to [CascadeAction.NONE] per design decision D-06
+ *   defaults to [CascadeAction.NONE]
  * @property isOrdered `true` if the reference is ordered and allows duplicates (List semantics);
  *   `false` if the reference enforces uniqueness (Set semantics)
  */

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
@@ -117,14 +117,22 @@ class TableDefProcessor(
 
         val tableName = resolveTableName(classDecl, className)
         val columns = collectColumns(classDecl)
+        // Ordered constructor parameter names — preserves declaration order for correct fromRow() generation.
         val constructorParamNames =
             classDecl.primaryConstructor?.parameters
-                ?.mapNotNull { it.name?.asString() }?.toSet() ?: emptySet()
+                ?.mapNotNull { it.name?.asString() } ?: emptyList()
+        val columnNames = columns.map { it.propertyName }.toSet()
+        val unmappedCtorParams = constructorParamNames.filter { it !in columnNames }
 
-        // Generate SqlTableDef only when all non-PK columns are mutable (settable via property setter).
-        // Entities with immutable (val) non-PK properties require a full constructor call that
-        // the id-only construction pattern cannot satisfy; fall back to descriptor-only LirpTableDef.
-        val canGenerateSqlMapping = sqlTableDefAvailable && columns.filter { !it.isPrimaryKey }.all { it.isMutable }
+        // Generate SqlTableDef only when: (1) all non-PK columns are mutable, and (2) every constructor
+        // parameter maps to a known column. Unmapped params would produce invalid constructor calls.
+        val canGenerateSqlMapping =
+            sqlTableDefAvailable &&
+                columns.filter { !it.isPrimaryKey }.all { it.isMutable } &&
+                unmappedCtorParams.isEmpty()
+        if (unmappedCtorParams.isNotEmpty() && sqlTableDefAvailable) {
+            logger.warn("$className: constructor params $unmappedCtorParams have no matching columns; falling back to LirpTableDef")
+        }
 
         val file =
             codeGenerator.createNewFile(
@@ -196,7 +204,7 @@ class TableDefProcessor(
         tableName: String,
         canGenerateSqlMapping: Boolean,
         columns: List<ColumnMeta>,
-        constructorParamNames: Set<String> = emptySet()
+        constructorParamNames: List<String> = emptyList()
     ) {
         appendLine("/** KSP-generated table descriptor for [$className]. */")
         if (canGenerateSqlMapping && columns.any { it.typeFqn == UUID_FQN }) {
@@ -226,22 +234,20 @@ class TableDefProcessor(
     private fun StringBuilder.appendFromRow(
         className: String,
         columns: List<ColumnMeta>,
-        constructorParamNames: Set<String>
+        constructorParamNames: List<String>
     ) {
-        val constructorCols = columns.filter { it.propertyName in constructorParamNames }
-        val setterCols = columns.filter { it.propertyName !in constructorParamNames }
+        val columnsByName = columns.associateBy { it.propertyName }
+        // Preserve constructor parameter declaration order for correct positional arguments
+        val orderedCtorCols = constructorParamNames.mapNotNull { columnsByName[it] }
+        val ctorParamNameSet = constructorParamNames.toSet()
+        val setterCols = columns.filter { it.propertyName !in ctorParamNameSet }
 
         appendLine("    override fun fromRow(row: ResultRow, table: Table): $className {")
-        if (constructorCols.isEmpty()) {
-            logger.error("Entity $className has no constructor parameters matching columns; cannot generate fromRow")
-            appendLine("        error(\"Entity $className missing constructor columns\")")
-        } else {
-            val ctorArgs = constructorCols.joinToString(", ") { buildRowAccess(it) }
-            appendLine("        val entity = $className($ctorArgs)")
-            for (col in setterCols) {
-                val rowAccess = buildRowAccess(col)
-                appendLine("        entity.${col.propertyName} = $rowAccess")
-            }
+        val ctorArgs = orderedCtorCols.joinToString(", ") { buildRowAccess(it) }
+        appendLine("        val entity = $className($ctorArgs)")
+        for (col in setterCols) {
+            val rowAccess = buildRowAccess(col)
+            appendLine("        entity.${col.propertyName} = $rowAccess")
         }
         appendLine("        return entity")
         appendLine("    }")

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
@@ -48,9 +48,13 @@ private const val LOCAL_DATE_TIME_FQN = "java.time.LocalDateTime"
  * properties annotated with [@PersistenceProperty][net.transgressoft.lirp.persistence.PersistenceProperty].
  *
  * The generated objects conditionally implement either [SqlTableDef][net.transgressoft.lirp.persistence.sql.SqlTableDef]
- * (when `lirp-sql` is on the KSP classpath) or [LirpTableDef][net.transgressoft.lirp.persistence.LirpTableDef]
- * (descriptor-only, when `lirp-sql` is absent). Per D-06, this check uses
- * `resolver.getClassDeclarationByName` at KSP compile time.
+ * (when `lirp-sql` is available) or [LirpTableDef][net.transgressoft.lirp.persistence.LirpTableDef]
+ * (descriptor-only, when `lirp-sql` is absent).
+ *
+ * SQL mode detection uses two mechanisms (either triggers `SqlTableDef` generation):
+ * 1. `resolver.getClassDeclarationByName` — works when `lirp-sql` is a project dependency (monorepo)
+ * 2. KSP option `lirp.sql=true` — required for external Maven consumers where the resolver cannot
+ *    see binary dependencies. Set via `ksp { arg("lirp.sql", "true") }` in `build.gradle`.
  *
  * When generating `SqlTableDef` implementations, the processor emits typed `fromRow` and `toParams`
  * methods with correct Java↔Kotlin type conversions for UUID, Date, DateTime, and Enum properties.
@@ -60,7 +64,8 @@ private const val LOCAL_DATE_TIME_FQN = "java.time.LocalDateTime"
  */
 class TableDefProcessor(
     private val codeGenerator: CodeGenerator,
-    private val logger: KSPLogger
+    private val logger: KSPLogger,
+    private val options: Map<String, String> = emptyMap()
 ) : SymbolProcessor {
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -88,11 +93,15 @@ class TableDefProcessor(
             classes.add(parent)
         }
 
-        // Per D-06: detect SqlTableDef availability at KSP compile time via resolver
+        // Detect SqlTableDef availability via resolver (monorepo) or KSP option (external consumers).
+        // The resolver approach works when lirp-sql is a project dependency. For external Maven
+        // consumers, the resolver cannot find SqlTableDef from binary JARs; the ksp { arg("lirp.sql", "true") }
+        // option acts as an explicit opt-in for SqlTableDef generation.
         val sqlTableDefAvailable =
             resolver.getClassDeclarationByName(
                 resolver.getKSNameFromString(SQL_TABLE_DEF_FQN)
-            ) != null
+            ) != null ||
+                options["lirp.sql"]?.toBoolean() == true
 
         for (classDecl in classes) {
             generateTableDef(classDecl, sqlTableDefAvailable)
@@ -108,6 +117,9 @@ class TableDefProcessor(
 
         val tableName = resolveTableName(classDecl, className)
         val columns = collectColumns(classDecl)
+        val constructorParamNames =
+            classDecl.primaryConstructor?.parameters
+                ?.mapNotNull { it.name?.asString() }?.toSet() ?: emptySet()
 
         // Generate SqlTableDef only when all non-PK columns are mutable (settable via property setter).
         // Entities with immutable (val) non-PK properties require a full constructor call that
@@ -124,7 +136,7 @@ class TableDefProcessor(
         file.write(
             buildString {
                 appendPackageAndImports(packageName, canGenerateSqlMapping, columns)
-                appendObjectBody(tableDefName, className, tableName, canGenerateSqlMapping, columns)
+                appendObjectBody(tableDefName, className, tableName, canGenerateSqlMapping, columns, constructorParamNames)
             }.toByteArray()
         )
         file.close()
@@ -158,6 +170,8 @@ class TableDefProcessor(
 
     private fun StringBuilder.appendConditionalTypeImports(columns: List<ColumnMeta>) {
         if (columns.any { it.typeFqn == UUID_FQN }) {
+            appendLine("import kotlin.uuid.ExperimentalUuidApi")
+            appendLine("import kotlin.uuid.toJavaUuid")
             appendLine("import kotlin.uuid.toKotlinUuid")
         }
         if (columns.any { it.typeFqn == LOCAL_DATE_FQN }) {
@@ -167,6 +181,9 @@ class TableDefProcessor(
         if (columns.any { it.typeFqn == LOCAL_DATE_TIME_FQN }) {
             appendLine("import kotlinx.datetime.toJavaLocalDateTime")
             appendLine("import kotlinx.datetime.toKotlinLocalDateTime")
+        }
+        if (columns.any { it.typeExpression.startsWith("ColumnType.DecimalType") }) {
+            appendLine("import java.math.BigDecimal")
         }
         columns.filter { it.isEnum }.map { it.typeFqn }.distinct().forEach { fqn ->
             appendLine("import $fqn")
@@ -178,9 +195,13 @@ class TableDefProcessor(
         className: String,
         tableName: String,
         canGenerateSqlMapping: Boolean,
-        columns: List<ColumnMeta>
+        columns: List<ColumnMeta>,
+        constructorParamNames: Set<String> = emptySet()
     ) {
         appendLine("/** KSP-generated table descriptor for [$className]. */")
+        if (canGenerateSqlMapping && columns.any { it.typeFqn == UUID_FQN }) {
+            appendLine("@OptIn(ExperimentalUuidApi::class)")
+        }
         val superType = if (canGenerateSqlMapping) "SqlTableDef<$className>" else "LirpTableDef<$className>"
         appendLine("public object $tableDefName : $superType {")
         appendLine("    override val tableName: String = \"$tableName\"")
@@ -195,28 +216,32 @@ class TableDefProcessor(
         appendLine("    )")
         if (canGenerateSqlMapping) {
             appendLine()
-            appendFromRow(className, columns)
+            appendFromRow(className, columns, constructorParamNames)
             appendLine()
             appendToParams(className, columns)
         }
         appendLine("}")
     }
 
-    private fun StringBuilder.appendFromRow(className: String, columns: List<ColumnMeta>) {
-        val pkCol = columns.firstOrNull { it.isPrimaryKey }
-        val nonPkCols = columns.filter { !it.isPrimaryKey }
+    private fun StringBuilder.appendFromRow(
+        className: String,
+        columns: List<ColumnMeta>,
+        constructorParamNames: Set<String>
+    ) {
+        val constructorCols = columns.filter { it.propertyName in constructorParamNames }
+        val setterCols = columns.filter { it.propertyName !in constructorParamNames }
 
         appendLine("    override fun fromRow(row: ResultRow, table: Table): $className {")
-        if (pkCol != null) {
-            val pkAccess = buildRowAccess(pkCol)
-            appendLine("        val entity = $className($pkAccess)")
-            for (col in nonPkCols) {
+        if (constructorCols.isEmpty()) {
+            logger.error("Entity $className has no constructor parameters matching columns; cannot generate fromRow")
+            appendLine("        error(\"Entity $className missing constructor columns\")")
+        } else {
+            val ctorArgs = constructorCols.joinToString(", ") { buildRowAccess(it) }
+            appendLine("        val entity = $className($ctorArgs)")
+            for (col in setterCols) {
                 val rowAccess = buildRowAccess(col)
                 appendLine("        entity.${col.propertyName} = $rowAccess")
             }
-        } else {
-            logger.error("Entity $className has no primary key 'id' property; cannot generate fromRow")
-            appendLine("        error(\"Entity $className missing primary key\")")
         }
         appendLine("        return entity")
         appendLine("    }")
@@ -225,9 +250,16 @@ class TableDefProcessor(
     private fun buildRowAccess(col: ColumnMeta): String {
         val rawAccess = "row[table.columns.first { it.name == \"${col.name}\" }]"
         return when {
-            col.typeFqn == UUID_FQN -> "$rawAccess as kotlin.uuid.Uuid"
+            col.typeFqn == UUID_FQN && col.nullable -> "($rawAccess as? kotlin.uuid.Uuid)?.toJavaUuid()"
+            col.typeFqn == UUID_FQN -> "($rawAccess as kotlin.uuid.Uuid).toJavaUuid()"
+            col.typeFqn == LOCAL_DATE_FQN && col.nullable -> "($rawAccess as? kotlinx.datetime.LocalDate)?.toJavaLocalDate()"
             col.typeFqn == LOCAL_DATE_FQN -> "($rawAccess as kotlinx.datetime.LocalDate).toJavaLocalDate()"
+            col.typeFqn == LOCAL_DATE_TIME_FQN && col.nullable -> "($rawAccess as? kotlinx.datetime.LocalDateTime)?.toJavaLocalDateTime()"
             col.typeFqn == LOCAL_DATE_TIME_FQN -> "($rawAccess as kotlinx.datetime.LocalDateTime).toJavaLocalDateTime()"
+            col.isEnum && col.nullable -> {
+                val enumSimpleName = col.typeFqn.substringAfterLast(".")
+                "($rawAccess as? String)?.let { enumValueOf<$enumSimpleName>(it) }"
+            }
             col.isEnum -> {
                 val enumSimpleName = col.typeFqn.substringAfterLast(".")
                 "enumValueOf<$enumSimpleName>($rawAccess as String)"
@@ -254,9 +286,13 @@ class TableDefProcessor(
     private fun buildEntityAccess(col: ColumnMeta): String {
         val prop = "entity.${col.propertyName}"
         return when {
+            col.typeFqn == UUID_FQN && col.nullable -> "$prop?.toKotlinUuid()"
             col.typeFqn == UUID_FQN -> "$prop.toKotlinUuid()"
+            col.typeFqn == LOCAL_DATE_FQN && col.nullable -> "$prop?.toKotlinLocalDate()"
             col.typeFqn == LOCAL_DATE_FQN -> "$prop.toKotlinLocalDate()"
+            col.typeFqn == LOCAL_DATE_TIME_FQN && col.nullable -> "$prop?.toKotlinLocalDateTime()"
             col.typeFqn == LOCAL_DATE_TIME_FQN -> "$prop.toKotlinLocalDateTime()"
+            col.isEnum && col.nullable -> "$prop?.name"
             col.isEnum -> "$prop.name"
             else -> prop
         }

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorProvider.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorProvider.kt
@@ -27,5 +27,5 @@ import com.google.devtools.ksp.processing.SymbolProcessorProvider
 class TableDefProcessorProvider : SymbolProcessorProvider {
 
     override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
-        TableDefProcessor(environment.codeGenerator, environment.logger)
+        TableDefProcessor(environment.codeGenerator, environment.logger, environment.options)
 }

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
@@ -21,6 +21,7 @@ import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.configureKsp
+import com.tschuchort.compiletesting.kspProcessorOptions
 import com.tschuchort.compiletesting.sourcesGeneratedBySymbolProcessor
 import com.tschuchort.compiletesting.symbolProcessorProviders
 import io.kotest.core.spec.style.FunSpec
@@ -40,13 +41,19 @@ import org.junit.jupiter.api.DisplayName
 @DisplayName("TableDefProcessor")
 internal class TableDefProcessorTest : FunSpec({
 
-    fun compileWithProcessor(vararg sources: SourceFile): JvmCompilationResult {
+    fun compileWithProcessor(
+        vararg sources: SourceFile,
+        options: Map<String, String> = emptyMap()
+    ): JvmCompilationResult {
         val compilation =
             KotlinCompilation().apply {
                 this.sources = sources.toList()
                 inheritClassPath = true
             }
         compilation.configureKsp { withCompilation = true }
+        if (options.isNotEmpty()) {
+            compilation.kspProcessorOptions.putAll(options)
+        }
         compilation.symbolProcessorProviders += TableDefProcessorProvider()
         return compilation.compile()
     }
@@ -500,5 +507,28 @@ internal class TableDefProcessorTest : FunSpec({
         content shouldContain "name = \"name\""
         content shouldNotContain "transient_field"
         content shouldNotContain "transientField"
+    }
+
+    test("generates SqlTableDef when lirp.sql option is set to true") {
+        val source =
+            SourceFile.kotlin(
+                "OptionEntity.kt",
+                """
+                package test
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                @PersistenceMapping
+                class OptionEntity(val id: Int) {
+                    var label: String = ""
+                }
+                """
+            )
+        val result = compileWithProcessor(source, options = mapOf("lirp.sql" to "true"))
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("OptionEntity_LirpTableDef.kt")
+        content shouldContain "SqlTableDef<OptionEntity>"
+        content shouldContain "override fun fromRow(row: ResultRow, table: Table): OptionEntity"
+        content shouldContain "override fun toParams(entity: OptionEntity, table: Table)"
     }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
@@ -82,7 +82,7 @@ internal class TableDefProcessorTest : FunSpec({
         content shouldContain "tableName: String = \"minimal_entity\""
         content shouldContain "ColumnType.IntType"
         content shouldContain "primaryKey = true"
-        content shouldContain "object MinimalEntity_LirpTableDef : LirpTableDef<MinimalEntity>"
+        content shouldContain "object MinimalEntity_LirpTableDef : SqlTableDef<MinimalEntity>"
     }
 
     test("generates _LirpTableDef with annotation overrides for table name and column config") {
@@ -412,6 +412,8 @@ internal class TableDefProcessorTest : FunSpec({
         content shouldContain "ColumnType.UuidType"
         content shouldContain "primaryKey = true"
         content shouldContain "tableName: String = \"uuid_key_entity\""
+        content shouldContain "SqlTableDef<UuidKeyEntity>"
+        content shouldContain "toJavaUuid()"
     }
 
     test("generates nullable columns for entity with all nullable non-PK properties") {

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
@@ -510,6 +510,9 @@ internal class TableDefProcessorTest : FunSpec({
     }
 
     test("generates SqlTableDef when lirp.sql option is set to true") {
+        // In monorepo tests, the resolver also detects SqlTableDef from the classpath.
+        // Full option-only isolation is validated by lirp-fleet-poc where lirp-sql is a
+        // binary Maven dependency and the resolver cannot detect SqlTableDef.
         val source =
             SourceFile.kotlin(
                 "OptionEntity.kt",
@@ -530,5 +533,151 @@ internal class TableDefProcessorTest : FunSpec({
         content shouldContain "SqlTableDef<OptionEntity>"
         content shouldContain "override fun fromRow(row: ResultRow, table: Table): OptionEntity"
         content shouldContain "override fun toParams(entity: OptionEntity, table: Table)"
+    }
+
+    test("generates nullable UUID, LocalDate, LocalDateTime, and enum conversions in fromRow and toParams") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "NullableTypesEntity.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+                import java.util.UUID
+                import java.time.LocalDate
+                import java.time.LocalDateTime
+
+                enum class Status { ACTIVE, INACTIVE }
+
+                @PersistenceMapping
+                class NullableTypesEntity(override val id: UUID) : ReactiveEntityBase<UUID, NullableTypesEntity>() {
+                    var parentId: UUID? by reactiveProperty(null)
+                    var startDate: LocalDate? by reactiveProperty(null)
+                    var modifiedAt: LocalDateTime? by reactiveProperty(null)
+                    var status: Status? by reactiveProperty(null)
+                    var label: String? by reactiveProperty(null)
+                    override val uniqueId: String get() = id.toString()
+                    override fun clone() = NullableTypesEntity(id)
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("NullableTypesEntity_LirpTableDef.kt")
+        content shouldContain "SqlTableDef<NullableTypesEntity>"
+        content shouldContain "@OptIn(ExperimentalUuidApi::class)"
+        // Nullable UUID conversions
+        content shouldContain "as? kotlin.uuid.Uuid)?.toJavaUuid()"
+        content shouldContain "entity.parentId?.toKotlinUuid()"
+        // Non-null UUID PK conversion
+        content shouldContain "as kotlin.uuid.Uuid).toJavaUuid()"
+        content shouldContain "entity.id.toKotlinUuid()"
+        // Nullable LocalDate conversions
+        content shouldContain "as? kotlinx.datetime.LocalDate)?.toJavaLocalDate()"
+        content shouldContain "entity.startDate?.toKotlinLocalDate()"
+        // Nullable LocalDateTime conversions
+        content shouldContain "as? kotlinx.datetime.LocalDateTime)?.toJavaLocalDateTime()"
+        content shouldContain "entity.modifiedAt?.toKotlinLocalDateTime()"
+        // Nullable enum conversions
+        content shouldContain """as? String)?.let { enumValueOf<Status>(it) }"""
+        content shouldContain "entity.status?.name"
+        // Nullable String
+        content shouldContain "as? String"
+    }
+
+    test("generates BigDecimal import and correct column type for DecimalType properties") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "DecimalEntity.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+                import net.transgressoft.lirp.persistence.PersistenceProperty
+                import java.math.BigDecimal
+
+                @PersistenceMapping
+                class DecimalEntity(val id: Int) {
+                    @PersistenceProperty(precision = 10, scale = 2)
+                    var price: BigDecimal = BigDecimal.ZERO
+
+                    @PersistenceProperty(precision = 14, scale = 4)
+                    var rate: BigDecimal? = null
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("DecimalEntity_LirpTableDef.kt")
+        content shouldContain "SqlTableDef<DecimalEntity>"
+        content shouldContain "import java.math.BigDecimal"
+        content shouldContain "ColumnType.DecimalType(10, 2)"
+        content shouldContain "ColumnType.DecimalType(14, 4)"
+        content shouldContain "as BigDecimal"
+        content shouldContain "as? BigDecimal"
+    }
+
+    test("generates correct ordered multi-param constructor call in fromRow") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "MultiParamEntity.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+                import java.util.UUID
+
+                @PersistenceMapping
+                class MultiParamEntity(
+                    override val id: UUID,
+                    tenantId: UUID
+                ) : ReactiveEntityBase<UUID, MultiParamEntity>() {
+                    var tenantId: UUID by reactiveProperty(tenantId)
+                    var name: String by reactiveProperty("")
+                    override val uniqueId: String get() = id.toString()
+                    override fun clone() = MultiParamEntity(id, tenantId)
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("MultiParamEntity_LirpTableDef.kt")
+        content shouldContain "SqlTableDef<MultiParamEntity>"
+        // Constructor args in declaration order: id first, tenantId second
+        content shouldContain "val entity = MultiParamEntity("
+        content shouldContain "entity.name ="
+        // tenantId should be in constructor, not a setter call
+        content shouldNotContain "entity.tenantId ="
+    }
+
+    test("falls back to LirpTableDef when constructor param has no matching column") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "UnmappedCtorEntity.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+                import net.transgressoft.lirp.persistence.PersistenceIgnore
+
+                @PersistenceMapping
+                class UnmappedCtorEntity(val id: Int, @PersistenceIgnore val transientParam: String) {
+                    var name: String = ""
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("UnmappedCtorEntity_LirpTableDef.kt")
+        // Should fall back to LirpTableDef since transientParam is excluded from columns
+        content shouldContain "LirpTableDef<UnmappedCtorEntity>"
+        content shouldNotContain "SqlTableDef"
+        content shouldNotContain "fromRow"
     }
 })


### PR DESCRIPTION
## Summary

- KSP `TableDefProcessor` now generates `SqlTableDef` (with `fromRow`/`toParams`) for external Maven consumers via a KSP option fallback
- Previously, `resolver.getClassDeclarationByName` could not find `SqlTableDef` from binary JARs, forcing external projects to write manual `SqlTableDef` implementations for every entity (22 files in the fleet PoC)
- With this change, external consumers add `ksp { arg("lirp.sql", "true") }` to their `build.gradle` and get fully generated `SqlTableDef` with zero boilerplate

### Changes

**TableDefProcessor.kt:**
- SQL mode detection now checks both `resolver.getClassDeclarationByName` (monorepo) and `options["lirp.sql"]` KSP option (external consumers)
- `fromRow`: UUID columns now convert `kotlin.uuid.Uuid` → `java.util.UUID` via `toJavaUuid()`, with nullable variant
- `fromRow`: multi-param constructors supported — all constructor params passed, remaining columns set via property assignment
- `fromRow`/`toParams`: nullable UUID, LocalDate, LocalDateTime, and enum columns use safe casts and null-safe conversions
- Generated objects annotated with `@OptIn(ExperimentalUuidApi::class)` when UUID columns are present
- `BigDecimal` import added when `DecimalType` columns are present

**ReactiveEntityBase.kt:**
- `lastDateModified` setter changed from `protected` to public — enables KSP-generated `fromRow` to restore persisted timestamps. The `protected set` was silently blocking `SqlTableDef` generation for ALL entities extending `ReactiveEntityBase` (both monorepo and external)

**CollectionRefEntry.kt:**
- Removed phase-specific comment from KDoc

## Test plan

- [x] All existing LIRP tests pass (`gradle build -x integrationTest`)
- [x] KSP test updated: `MinimalEntity` and `UuidKeyEntity` now correctly generate `SqlTableDef`
- [x] Validated in [lirp-fleet-poc](https://github.com/octaviospain/lirp-fleet-poc) — 22 entities across 4 aggregates, 42 tests passing with **zero manual SqlTableDef files** (all KSP-generated)

### External consumer build.gradle setup
```groovy
dependencies {
    implementation 'net.transgressoft:lirp-sql:X.Y.Z'
    ksp 'net.transgressoft:lirp-ksp:X.Y.Z'
}

ksp {
    arg("lirp.sql", "true")
}
```

Closes #122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in build-time SQL mapping mode to generate richer SQL table code (includes UUID/decimal support and required opt-ins).

* **Bug Fixes**
  * Restored persisted "last modified" timestamps when rehydrating entities from the database.
  * Improved hydration to correctly map constructor parameters vs. property assignments and handle nullable UUID/date/enum values.

* **Documentation**
  * Clarified KDoc around collection cascade defaults and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->