### PR TITLE
#123 Make Exposed core and datetime transitive API dependencies

### DIFF
--- a/lirp-sql/build.gradle
+++ b/lirp-sql/build.gradle
@@ -32,8 +32,10 @@ dependencies {
     api project(path: ':lirp-api')
     api project(path: ':lirp-core')
 
-    implementation platform(libs.exposed.bom)
-    implementation libs.bundles.exposed
+    api platform(libs.exposed.bom)
+    api libs.exposed.core
+    api libs.exposed.kotlin.datetime
+    implementation libs.exposed.jdbc
     implementation libs.hikari
     runtimeOnly libs.postgresql
     runtimeOnly libs.mysql


### PR DESCRIPTION
## Summary

- Changed `exposed-core` and `exposed-kotlin-datetime` from `implementation` to `api` scope in `lirp-sql/build.gradle`
- `exposed-jdbc` and HikariCP remain `implementation` — they are internal to `SqlRepository`
- External consumers no longer need explicit Exposed dependencies in their build

### Why

KSP-generated `SqlTableDef` code (from #122) imports `Table`, `Column`, `ResultRow` from `exposed-core` and `kotlinx.datetime` conversion extensions from `exposed-kotlin-datetime`. These must be on the consumer's compile classpath. With `implementation` scope, they weren't transitive and consumers had to add them manually.

### Before (consumer build.gradle)
```groovy
implementation 'net.transgressoft:lirp-sql:X.Y.Z'
implementation platform('org.jetbrains.exposed:exposed-bom:1.2.0')
implementation 'org.jetbrains.exposed:exposed-core'
implementation 'org.jetbrains.exposed:exposed-kotlin-datetime'
```

### After (consumer build.gradle)
```groovy
implementation 'net.transgressoft:lirp-sql:X.Y.Z'
```

## Test plan

- [x] All LIRP tests pass (`gradle build -x integrationTest`)
- [x] lirp-fleet-poc (22 entities, 42 tests) compiles and passes with zero explicit Exposed deps

Closes #123