### PR TITLE
Make public withEventsDisabled in ReactiveEntity

### DIFF
--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntity.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntity.kt
@@ -90,6 +90,31 @@ interface ReactiveEntity<K, R : ReactiveEntity<K, R>> :
         LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>>
 
     /**
+     * Executes [action] with event emission suppressed, restoring the previous state afterward.
+     *
+     * Equivalent to wrapping the action between disabling and re-enabling event publishing, but
+     * guarantees restoration even if the action throws. Common use cases:
+     *
+     * - Clone implementations that copy all properties without triggering mutation events
+     * - Batch property initialization from deserialized or database-loaded state
+     * - Framework-level operations that need to set multiple properties atomically
+     *
+     * ```
+     * override fun clone(): MyEntity = MyEntity(id).apply {
+     *     withEventsDisabled {
+     *         name = this@MyEntity.name
+     *         price = this@MyEntity.price
+     *     }
+     * }
+     * ```
+     *
+     * @param T The return type of the action
+     * @param action The block to execute with events disabled
+     * @return The result of the action
+     */
+    fun <T> withEventsDisabled(action: () -> T): T
+
+    /**
      * Permanently closes this entity and releases its publisher resources.
      *
      * After closing [subscribe] throw [IllegalStateException]. Idempotent: subsequent calls are safe no-ops.

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -346,32 +346,7 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
         eventsDisabled = false
     }
 
-    /**
-     * Executes [action] with event emission suppressed, restoring the previous state afterward.
-     *
-     * Equivalent to wrapping the action between [disableEvents] and [enableEvents], but
-     * guarantees restoration even if the action throws. Common use cases:
-     *
-     * - Clone implementations that copy all properties without triggering mutation events
-     * - Batch property initialization from deserialized or database-loaded state
-     * - Framework-level operations that need to set multiple properties atomically
-     *
-     * ```
-     * override fun clone(): MyEntity = MyEntity(id).apply {
-     *     withEventsDisabled {
-     *         name = this@MyEntity.name
-     *         price = this@MyEntity.price
-     *     }
-     * }
-     * ```
-     *
-     * @param T The return type of the action
-     * @param action The block to execute with events disabled
-     * @return The result of the action
-     * @see disableEvents
-     * @see enableEvents
-     */
-    inline fun <T> withEventsDisabled(action: () -> T): T {
+    override fun <T> withEventsDisabled(action: () -> T): T {
         val wasDisabled = eventsDisabled
         eventsDisabled = true
         try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `withEventsDisabled()` method to execute code blocks while temporarily suppressing event emissions. The method guarantees restoration of the prior event-publishing state even when exceptions occur, enabling efficient multi-property updates and data initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->