### PR TITLE
#138 FxAggregateSet change objects return null on absent side

### DIFF
--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSet.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSet.kt
@@ -223,6 +223,11 @@ class FxAggregateSet<K : Comparable<K>, E : IdentifiableEntity<K>>(
     }
 
     private fun fireAdded(element: E) {
+        // Returns null (not throws) from getElementRemoved on a pure addition. JavaFX's
+        // SetExpressionHelper$SimpleChange copy constructor unconditionally reads both
+        // sides when forwarding a change to listeners attached to a SimpleSetProperty
+        // wrapping this set; throwing here crashed the FX thread with
+        // `UnsupportedOperationException: No element removed`.
         val change =
             object : SetChangeListener.Change<E>(this) {
                 override fun wasAdded() = true
@@ -231,19 +236,21 @@ class FxAggregateSet<K : Comparable<K>, E : IdentifiableEntity<K>>(
 
                 override fun getElementAdded() = element
 
-                override fun getElementRemoved(): E = throw UnsupportedOperationException("No element removed")
+                override fun getElementRemoved(): E? = null
             }
         fireChange(change)
     }
 
     private fun fireRemoved(element: E) {
+        // Mirror of fireAdded — returns null from getElementAdded on a pure removal so
+        // SetExpressionHelper$SimpleChange can copy the change without throwing.
         val change =
             object : SetChangeListener.Change<E>(this) {
                 override fun wasAdded() = false
 
                 override fun wasRemoved() = true
 
-                override fun getElementAdded(): E = throw UnsupportedOperationException("No element added")
+                override fun getElementAdded(): E? = null
 
                 override fun getElementRemoved() = element
             }

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSetTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSetTest.kt
@@ -22,9 +22,11 @@ import net.transgressoft.lirp.persistence.AggregateCollectionRef
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import javafx.application.Platform
+import javafx.beans.property.SimpleSetProperty
 import javafx.collections.ObservableSet
 import javafx.collections.SetChangeListener
 import java.util.concurrent.CountDownLatch
@@ -284,5 +286,84 @@ class FxAggregateSetTest : StringSpec({
         proxy.clear()
 
         changes.size shouldBe 0
+    }
+
+    /*
+     * The four tests below pin the [SetChangeListener.Change] semantics that JavaFX standard
+     * containers — most notably the [SimpleSetProperty] used to expose observable aggregates —
+     * rely on when they copy an incoming change via `SetExpressionHelper$SimpleChange`.
+     * That copy unconditionally calls both [SetChangeListener.Change.getElementAdded] and
+     * [SetChangeListener.Change.getElementRemoved], so if either side throws
+     * [UnsupportedOperationException], any downstream listener attached to the property
+     * crashes the FX thread instead of receiving the change.
+     */
+
+    "FxAggregateSet fireAdded change returns null from getElementRemoved" {
+        val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
+        val captured = mutableListOf<SetChangeListener.Change<out AudioItem>>()
+        proxy.addListener(SetChangeListener(captured::add))
+
+        val item = MutableAudioItem(1, "A")
+        proxy.add(item)
+
+        captured.size shouldBe 1
+        captured[0].wasAdded() shouldBe true
+        captured[0].elementAdded shouldBe item
+        // contract: getElementRemoved returns null on a pure addition (matches JavaFX defaults
+        // and lets SetExpressionHelper$SimpleChange copy the change without throwing)
+        captured[0].elementRemoved.shouldBeNull()
+    }
+
+    "FxAggregateSet fireRemoved change returns null from getElementAdded" {
+        val item = MutableAudioItem(1, "A")
+        val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
+        proxy.add(item)
+        val captured = mutableListOf<SetChangeListener.Change<out AudioItem>>()
+        proxy.addListener(SetChangeListener(captured::add))
+
+        proxy.remove(item)
+
+        captured.size shouldBe 1
+        captured[0].wasRemoved() shouldBe true
+        captured[0].elementRemoved shouldBe item
+        // contract: getElementAdded returns null on a pure removal (matches JavaFX defaults
+        // and lets SetExpressionHelper$SimpleChange copy the change without throwing)
+        captured[0].elementAdded.shouldBeNull()
+    }
+
+    "SimpleSetProperty wrapping FxAggregateSet propagates add changes to its listeners" {
+        val backing = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
+        val property = SimpleSetProperty<AudioItem>(backing)
+
+        val captured = mutableListOf<SetChangeListener.Change<out AudioItem>>()
+        property.addListener(SetChangeListener<AudioItem> { captured.add(it) })
+
+        val item = MutableAudioItem(1, "A")
+        // SetExpressionHelper$SimpleChange copies the change for the property listener — this
+        // call previously crashed with `UnsupportedOperationException: No element removed`
+        // because the lirp-side change object threw on getElementRemoved.
+        backing.add(item)
+
+        captured.size shouldBe 1
+        captured[0].wasAdded() shouldBe true
+        captured[0].elementAdded shouldBe item
+        captured[0].elementRemoved.shouldBeNull()
+    }
+
+    "SimpleSetProperty wrapping FxAggregateSet propagates remove changes to its listeners" {
+        val backing = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
+        val item = MutableAudioItem(1, "A")
+        backing.add(item)
+        val property = SimpleSetProperty<AudioItem>(backing)
+
+        val captured = mutableListOf<SetChangeListener.Change<out AudioItem>>()
+        property.addListener(SetChangeListener<AudioItem> { captured.add(it) })
+
+        backing.remove(item)
+
+        captured.size shouldBe 1
+        captured[0].wasRemoved() shouldBe true
+        captured[0].elementRemoved shouldBe item
+        captured[0].elementAdded.shouldBeNull()
     }
 })


### PR DESCRIPTION
## Summary

- `FxAggregateSet.fireAdded` and `fireRemoved` now return `null` from the unused accessor (`getElementRemoved` / `getElementAdded` respectively) instead of throwing `UnsupportedOperationException`. This matches the convention used by JavaFX's standard `ObservableSetWrapper` / `MapAdapterChange` change objects and lets `SetExpressionHelper$SimpleChange` copy the change without throwing.
- Four regression tests pin the new contract — two on the change objects directly, two on a `SimpleSetProperty` wrapping the aggregate so the JavaFX-property propagation path is exercised end-to-end.

Closes #138.

## Test plan

- [x] `gradle :lirp-fx:test --tests "*FxAggregateSetTest*"` — 25/25 passing.
- [x] `gradle test` — full lirp suite green (lirp-api / -core / -fx / -ksp / -sql).
- [x] Verified the new tests fail on `master` (without the fix) and pass on this branch.
- [x] Verified the fix unblocks the downstream Musicott use case (`PlaylistTreeView` attaching a `SetChangeListener` to a `SimpleSetProperty` wrapping the aggregate; iTunes import no longer crashes the FX thread on a top-level playlist add).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes on the JavaFX thread that occurred when processing certain set change notifications.

* **Tests**
  * Added tests verifying correct handling of set change events in observable collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->