### PR TITLE
Rebind aggregate refs on registerRepository for entities loaded earlier

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
@@ -497,6 +497,50 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
             check(registered || context.registryFor(entityClass) === registry) {
                 "A repository for ${entityClass.simpleName} is already registered. Only one @LirpRepository per entity type is allowed."
             }
+            if (registered) {
+                rebindReferencesTo(entityClass, context)
+            }
+        }
+
+        /**
+         * Rebinds aggregate-ref delegates that target [referencedClass] for every entity already
+         * present in any registry of [context]. Called from [registerRepository] right after a new
+         * registry is registered, so that entities whose [bindEntityRefs] ran before this point
+         * (when the [referencedClass] registry was still unregistered) get their previously-skipped
+         * delegates wired up against the freshly-registered registry.
+         *
+         * Without this pass, delegates that observed a missing registry at load time remain
+         * unbound forever and `resolveAll()` returns an empty set even after registration.
+         *
+         * For each rebound entity, [wireRefBubbleUp] is also re-run so that scalar refs declared
+         * with `bubbleUp = true` get their parent->child subscription created against the freshly
+         * resolvable referenced entity. Without this second pass, mutations on the newly registered
+         * children would never propagate to parent subscribers until a `resolve()` call lazily
+         * triggered the rewire.
+         *
+         * Only registries whose entity type declares a ref (scalar or collection) to
+         * [referencedClass] are visited; everything else is skipped via the cached
+         * [LirpRefAccessor]. Both [bindEntityRefs] and [wireRefBubbleUp] are idempotent —
+         * already-bound delegates simply have their registry/subscription reference re-set.
+         */
+        private fun rebindReferencesTo(referencedClass: Class<*>, context: LirpContext) {
+            for ((_, otherRegistry) in context.registriesSnapshot()) {
+                if (otherRegistry !is RegistryBase<*, *>) continue
+                @Suppress("UNCHECKED_CAST")
+                val typed = otherRegistry as RegistryBase<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>
+                for (entity in typed) {
+                    // Look up the accessor by the entity's concrete runtime class — refAccessorFor
+                    // resolves "${concreteClass.name}_LirpRefAccessor", and that class is generated
+                    // per concrete @Aggregate-annotated entity, not per registered interface.
+                    val accessor = refAccessorFor(entity.javaClass) ?: continue
+                    val refsThisClass =
+                        accessor.entries.any { it.referencedClass == referencedClass } ||
+                            accessor.collectionEntries.any { it.referencedClass == referencedClass }
+                    if (!refsThisClass) continue
+                    typed.bindEntityRefs(entity)
+                    typed.wireRefBubbleUp(entity)
+                }
+            }
         }
 
         /**

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegisterRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegisterRepositoryTest.kt
@@ -17,12 +17,26 @@
 
 package net.transgressoft.lirp.persistence
 
+import net.transgressoft.lirp.event.AggregateMutationEvent
+import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.persistence.json.BubbleUpOrderJsonFileRepository
+import net.transgressoft.lirp.persistence.json.JsonFileRepository
+import net.transgressoft.lirp.persistence.json.MutableAudioPlaylistJsonFileRepository
+import net.transgressoft.lirp.persistence.json.lirpSerializer
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.engine.spec.tempfile
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.mockk
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 
 /**
  * Unit tests for [RegistryBase.registerRepository], the public API for delegation-based
@@ -32,8 +46,22 @@ import io.mockk.mockk
  * duplicates throw [IllegalStateException], non-RegistryBase instances throw [IllegalArgumentException],
  * close() deregisters, and re-registration after close succeeds.
  */
+@ExperimentalCoroutinesApi
 @DisplayName("RegistryBase.registerRepository()")
 internal class RegisterRepositoryTest : StringSpec({
+
+    val testDispatcher = UnconfinedTestDispatcher()
+    val testScope = CoroutineScope(testDispatcher)
+
+    beforeSpec {
+        ReactiveScope.flowScope = testScope
+        ReactiveScope.ioScope = testScope
+    }
+
+    afterSpec {
+        ReactiveScope.resetDefaultFlowScope()
+        ReactiveScope.resetDefaultIoScope()
+    }
 
     afterEach {
         LirpContext.resetDefault()
@@ -111,5 +139,102 @@ internal class RegisterRepositoryTest : StringSpec({
         RegistryBase.registerRepository(Customer::class.java, delegate2)
 
         LirpContext.default.registryFor(Customer::class.java) shouldBe delegate2
+    }
+
+    "registerRepository() rebinds collection aggregate refs of entities loaded before registration" {
+        // Reproduces the case where a JsonFileRepository (no @LirpRepository auto-registration)
+        // loads entities whose aggregate refs target a class whose registry has not yet been
+        // registered. Without rebinding on registerRepository(), the delegates remain unbound
+        // forever and resolveAll() returns an empty set even after the registry is registered.
+        //
+        // The minimal failing scenario: a self-referential type loaded via a plain
+        // JsonFileRepository, where registerRepository() is called manually after construction
+        // (mirroring the music-commons FXPlaylistHierarchy pattern).
+        val playlistFile = tempfile("playlist-late-register", ".json").also { it.deleteOnExit() }
+
+        // Phase 1: write self-referencing playlists via the auto-registered repo so the
+        // serialized JSON encodes the parent->child relationship.
+        val authoringRepo = MutableAudioPlaylistJsonFileRepository(LirpContext.default, playlistFile, serializationDelayMs = 5L)
+        val child = authoringRepo.create(20, "Child")
+        val parent = authoringRepo.create(10, "Parent")
+        parent.playlists.add(child)
+        testDispatcher.scheduler.advanceUntilIdle()
+        authoringRepo.close()
+        LirpContext.resetDefault()
+
+        // Phase 2: load via PLAIN JsonFileRepository (no @LirpRepository annotation, so no
+        // auto-registration of the playlist registry), then manually call registerRepository()
+        // afterwards. This is exactly the pattern music-commons FXPlaylistHierarchy uses.
+        @Suppress("UNCHECKED_CAST")
+        val mapSerializer: KSerializer<Map<Int, MutableAudioPlaylist>> =
+            MapSerializer(Int.serializer(), lirpSerializer(DefaultAudioPlaylist(0, ""))) as KSerializer<Map<Int, MutableAudioPlaylist>>
+        val plainRepo = JsonFileRepository<Int, MutableAudioPlaylist>(playlistFile, mapSerializer)
+
+        // At this point, plainRepo loaded both entities. bindEntityRefs ran during load but
+        // skipped each entity's `playlists` aggregate ref because no registry was registered
+        // for MutableAudioPlaylist when it was called.
+
+        RegistryBase.registerRepository(MutableAudioPlaylist::class.java, plainRepo)
+
+        // After registerRepository(), the previously-skipped aggregate refs must now resolve.
+        val reloadedParent = plainRepo.findById(10).get() as DefaultAudioPlaylist
+        reloadedParent.playlists.referenceIds shouldBe setOf(20)
+        reloadedParent.playlists.resolveAll().map { it.id } shouldBe listOf(20)
+
+        plainRepo.close()
+    }
+
+    "registerRepository() rebinds scalar aggregate refs and rewires bubble-up" {
+        // Mirrors the collection-ref scenario for scalar refs declared with `bubbleUp = true`,
+        // verifying both that resolve() succeeds AND that the bubble-up subscription fires.
+        // Without re-running wireRefBubbleUp() inside registerRepository(), parent subscribers
+        // would not receive AggregateMutationEvent from the late-registered child.
+        val orderFile = tempfile("order-scalar-late-register", ".json").also { it.deleteOnExit() }
+
+        // Phase 1: write a customer + order via auto-registered repos so the JSON encodes
+        // the customerId scalar ref.
+        val authoringCustomers = CustomerVolatileRepo(LirpContext.default)
+        val authoringOrders = BubbleUpOrderJsonFileRepository(LirpContext.default, orderFile, 5L)
+        authoringCustomers.create(1, "Alice")
+        authoringOrders.create(10L, 1)
+        testDispatcher.scheduler.advanceUntilIdle()
+        authoringOrders.close()
+        authoringCustomers.close()
+        LirpContext.resetDefault()
+
+        // Phase 2: reload orders WITHOUT registering the Customer registry first.
+        // BubbleUpOrderJsonFileRepository auto-registers BubbleUpOrder, but Customer remains
+        // absent — each loaded order's customer scalar ref delegate is left unbound, and
+        // wireRefBubbleUp() ran with bubbleUpParent set but no resolvable child, so no
+        // bubble-up subscription was created.
+        val orderRepo = BubbleUpOrderJsonFileRepository(LirpContext.default, orderFile, 5L)
+        val loadedOrder = orderRepo.findById(10L).get()
+        loadedOrder.customer.resolve().isPresent shouldBe false
+
+        // Phase 3: late-register Customer via registerRepository(). The rebinding pass must
+        // walk all registries (including orderRepo), rebind scalar refs whose target class is
+        // now resolvable, AND re-wire bubble-up subscriptions for `bubbleUp = true` refs.
+        val lateCustomers = VolatileRepository<Int, Customer>(LirpContext.default, "CustomersLate")
+        val customer = Customer(1, "Alice").also(lateCustomers::add)
+        RegistryBase.registerRepository(Customer::class.java, lateCustomers)
+
+        // resolve() now returns the customer — confirms the scalar bind branch works.
+        loadedOrder.customer.resolve().isPresent shouldBe true
+        loadedOrder.customer.resolve().get().name shouldBe "Alice"
+
+        // Bubble-up must fire: a mutation on the customer should reach the order's subscribers
+        // as an AggregateMutationEvent. This would NOT happen if rebindReferencesTo() only
+        // re-ran bindEntityRefs() and skipped wireRefBubbleUp().
+        val bubbleUpReceived = AtomicBoolean(false)
+        loadedOrder.subscribe { event ->
+            if (event is AggregateMutationEvent<*, *>) bubbleUpReceived.set(true)
+        }
+        customer.updateName("Alice Updated")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        bubbleUpReceived.get() shouldBe true
+
+        orderRepo.close()
+        lateCustomers.close()
     }
 })


### PR DESCRIPTION
## Summary

Fix `RegistryBase.registerRepository` so it re-runs `bindEntityRefs` on entities that were loaded into other registries before the new registry was registered. Without this, those entities' aggregate-ref delegates stay unbound forever and `resolveAll()` returns an empty set.

Closes #141

## Why

The bug surfaces in delegation-style repositories that build a plain `JsonFileRepository` externally and call `RegistryBase.registerRepository` afterwards (the pattern used by `music-commons:FXPlaylistHierarchy`):

1. `JsonFileRepository.<init>` loads entities and runs `bindEntityRefs` per entity.
2. `bindEntityRefs` skips any aggregate ref whose target class has no registry yet (`context.registryFor(entry.referencedClass) ?: continue`).
3. The caller then registers the registry — but existing entities' delegates remain unbound.

A symmetric path exists for self-referential entities loaded via a plain (non-`@LirpRepository`) `JsonFileRepository`: the entity's own class registry is also unregistered at load time, so its self-references stay dangling even after manual registration.

## What changed

`RegistryBase.registerRepository(entityClass, registry)`:

- After `context.register(...)` succeeds, calls a new private `rebindReferencesTo(entityClass, context)` helper.
- The helper walks every registry in the context, iterates each entity, and re-runs `bindEntityRefs` if the entity's concrete runtime class declares a ref (scalar or collection) to the just-registered class.
- Accessor lookup uses the entity's runtime class (KSP generates `\${concreteClass.name}_LirpRefAccessor` per concrete `@Aggregate`-annotated type, not per interface).
- `bindEntityRefs` is idempotent, so already-bound delegates are unaffected.

## Test plan

- [x] New unit test in `RegisterRepositoryTest` reproduces the failing scenario directly: self-referential entity authored via an auto-registered repo, persisted, then reloaded via a plain `JsonFileRepository` plus a manual `registerRepository` call. Asserts that `resolveAll()` returns the expected child after registration.
- [x] All existing `RegisterRepositoryTest` cases pass (8/8).
- [x] Full `lirp-core` test suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where entity references weren't properly resolved when repositories were registered after entities were loaded. References now automatically bind upon repository registration, ensuring all relationships resolve correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->