### PR TITLE
#140 ProjectionMap and FxProjectionMap thread-safety via ConcurrentSkipListMap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for your interest in contributing to lirp! This document provides guid
 - [Reporting Bugs](#reporting-bugs)
 - [Suggesting Enhancements](#suggesting-enhancements)
 - [Pull Requests](#pull-requests)
+- [Running Tests](#running-tests)
 - [Style Guidelines](#style-guidelines)
 
 ## Code of Conduct
@@ -64,6 +65,45 @@ All pull requests should:
 - **Be focused on a single objective** (don't mix unrelated changes)
 
 ## Development Guidelines
+
+### Running Tests
+
+The default test run executes the full deterministic suite:
+
+```bash
+./gradlew test                    # full project
+./gradlew :lirp-core:test         # single module
+```
+
+#### Opt-in stress tests (`Stress` tag)
+
+Some concurrency regression tests are tagged with `Stress` and **excluded by default**.
+They are aggressive multi-iteration tripwires that protect invariants like CME-free
+iteration of `ProjectionMap` / `FxProjectionMap`; they are too slow and noisy for the
+default loop but valuable when modifying the affected code.
+
+Include them with the `kotest.tags.include` Gradle property:
+
+```bash
+./gradlew test -Pkotest.tags.include=Stress
+./gradlew :lirp-core:test -Pkotest.tags.include=Stress
+./gradlew :lirp-fx:test -Pkotest.tags.include=Stress
+```
+
+Add a new stress-tagged test by attaching the shared tag at the test definition:
+
+```kotlin
+import net.transgressoft.lirp.testing.Stress
+
+"MyComponent stays consistent under concurrent readers and a writer"
+    .config(tags = setOf(Stress)) {
+        // ...
+    }
+```
+
+The `Stress` tag is defined once in `lirp-core/src/test/kotlin/net/transgressoft/lirp/testing/Stress.kt`
+and is visible to `lirp-fx` tests via the existing `testImplementation files(...)` wiring,
+so no per-module duplication is needed.
 
 ### Problem Statement Requirement
 

--- a/lirp-core/build.gradle
+++ b/lirp-core/build.gradle
@@ -31,3 +31,12 @@ dependencies {
     testRuntimeOnly libs.logback.classic
     testRuntimeOnly libs.junit.platform.launcher
 }
+
+tasks.withType(Test).configureEach {
+    def includeTags = project.findProperty('kotest.tags.include') as String
+    if (includeTags) {
+        systemProperty 'kotest.tags.include', includeTags
+    } else {
+        systemProperty 'kotest.tags.exclude', 'Stress'
+    }
+}

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/CoreFactories.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/CoreFactories.kt
@@ -28,7 +28,7 @@ import net.transgressoft.lirp.entity.IdentifiableEntity
  * automatically without any manual notification. For other [AggregateCollectionRef] implementations,
  * only the initial snapshot is captured.
  *
- * Keys are maintained in natural sorted order via a [java.util.TreeMap] backing. The projected
+ * Keys are maintained in natural sorted order via a [java.util.concurrent.ConcurrentSkipListMap] backing. The projected
  * map is read-only; mutations must flow through the source collection.
  *
  * Usage:

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/ProjectionMap.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/ProjectionMap.kt
@@ -135,13 +135,13 @@ class ProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEnti
     }
 
     private fun removeFromAnyBucket(element: E): Boolean {
-        val iterator = backingMap.entries.iterator()
-        while (iterator.hasNext()) {
-            val entry = iterator.next()
+        for (entry in backingMap.entries) {
             if (element in entry.value) {
                 val filtered = entry.value.filter { it != element }
-                if (filtered.isEmpty()) iterator.remove()
-                else entry.setValue(freezeBucket(filtered))
+                // ConcurrentSkipListMap entry iterators return SimpleImmutableEntry instances whose setValue throws
+                // UnsupportedOperationException — go through the map directly instead.
+                if (filtered.isEmpty()) backingMap.remove(entry.key)
+                else backingMap[entry.key] = freezeBucket(filtered)
                 return true
             }
         }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/ProjectionMap.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/ProjectionMap.kt
@@ -20,14 +20,15 @@ package net.transgressoft.lirp.persistence
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.event.CollectionChangeEvent
 import java.util.Collections
-import java.util.TreeMap
+import java.util.concurrent.ConcurrentSkipListMap
 import kotlin.reflect.KProperty
 
 /**
  * A read-only grouped view that derives a `Map<PK, List<E>>` from a source collection,
  * grouping entities by a secondary key via [keyExtractor].
  *
- * The projection uses a [TreeMap] for natural key ordering and fires an optional [onChange]
+ * The projection uses a [ConcurrentSkipListMap] for natural key ordering with CME-free iteration,
+ * and fires an optional [onChange]
  * callback when the projection state changes. It has no JavaFX dependency and works with
  * any JVM target including Android and server-side applications.
  *
@@ -39,14 +40,16 @@ import kotlin.reflect.KProperty
  *
  * The map is read-only. All mutations flow through the source collection.
  *
- * **Thread safety:** This class is not thread-safe. All mutations — whether through
- * direct source collection operations or the [onChange] callback — must be invoked
- * from a single thread or externally synchronized. The dominant use case (lirp-core
- * [MutableAggregateList]/[MutableAggregateSet] projection callbacks) satisfies this
- * contract naturally, as collection mutations are serialized by the caller.
+ * **Thread safety:** Iterating [keys], [values], [entries], or calling [size], [containsKey],
+ * and [get] is CME-free under concurrent mutation because the backing map is [ConcurrentSkipListMap].
+ * Reads are weakly-consistent: entries added concurrently may or may not be visible mid-iteration,
+ * but iteration always completes without error. Mutations via [onChange], [MutableAggregateList],
+ * or [MutableAggregateSet] still flow through a single source-collection mutation thread;
+ * the class does not provide cross-thread atomicity for compound read-modify-write of an
+ * individual bucket — that contract is unchanged.
  *
  * @param K the entity ID type, must be [Comparable]
- * @param PK the projection key type, must be [Comparable] (used as [TreeMap] key)
+ * @param PK the projection key type, must be [Comparable] (used as the backing [ConcurrentSkipListMap] key)
  * @param E the entity type
  * @param sourceRef deferred reference to the source collection (resolved on first access)
  * @param keyExtractor grouping function that extracts the projection key from an entity
@@ -55,7 +58,7 @@ class ProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEnti
     private val sourceRef: () -> AggregateCollectionRef<K, E>,
     private val keyExtractor: (E) -> PK
 ) : AbstractMap<PK, List<E>>() {
-    private val backingMap = TreeMap<PK, List<E>>()
+    private val backingMap = ConcurrentSkipListMap<PK, List<E>>()
     private val readOnlyView: Map<PK, List<E>> = Collections.unmodifiableMap(backingMap)
 
     @Volatile
@@ -64,6 +67,9 @@ class ProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEnti
     /**
      * Optional callback invoked after each projection change with the current map state.
      * Fires after every incremental update that results in at least one addition or removal.
+     *
+     * The callback fires on the same thread that performed the source mutation; subscribers
+     * requiring a specific thread must marshal themselves. No cross-thread atomicity is provided.
      */
     internal var onChange: ((Map<PK, List<E>>) -> Unit)? = null
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ProjectionMapTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ProjectionMapTest.kt
@@ -17,6 +17,8 @@
 
 package net.transgressoft.lirp.persistence
 
+import net.transgressoft.lirp.testing.Stress
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
@@ -24,6 +26,11 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 /**
  * Tests for [ProjectionMap], verifying grouping behavior, incremental auto-updates from
@@ -285,4 +292,81 @@ internal class ProjectionMapTest : StringSpec({
         lastSnapshot shouldNotBe null
         lastSnapshot!!.containsKey("Rock Playlist") shouldBe true
     }
+
+    "ProjectionMap reflects writer state in reader iteration after writer completes" {
+        val titles = listOf("Alpha", "Bravo", "Charlie", "Delta")
+        val totalItems = 200
+        val seedTracks = (1..totalItems).map { i -> trackRepo.create(i, titles[i % titles.size]) }
+        val playlist = DefaultAudioPlaylist(1, "Test", emptyList()).also(playlistRepo::add)
+
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+        // Trigger init before writer starts so the source-callback subscription is live.
+        projection.size shouldBe 0
+
+        val executor = Executors.newSingleThreadExecutor()
+        val latch = CountDownLatch(totalItems)
+
+        try {
+            for (track in seedTracks) {
+                executor.submit {
+                    playlist.audioItems.add(track)
+                    latch.countDown()
+                }
+            }
+
+            // Reader iterates concurrently; assertions run after the writer completes.
+            while (latch.count > 0L) {
+                projection.keys.toList()
+                projection.entries.forEach { it.value.size }
+            }
+
+            latch.await(10, TimeUnit.SECONDS) shouldBe true
+            projection.size shouldBe titles.size
+            projection.values.sumOf { it.size } shouldBe totalItems
+            projection.keys.toList() shouldContainExactly titles.sorted()
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    "ProjectionMap iterates without ConcurrentModificationException under multi-writer stress"
+        .config(tags = setOf(Stress)) {
+            val totalMutations = 5000
+            val readerIterations = 1000
+            val seedSize = 100
+
+            val seedTracks = (1..seedSize).map { i -> trackRepo.create(i, "Title-${i % 8}") }
+            val playlist = DefaultAudioPlaylist(1, "Stress", seedTracks.map { it.id }).also(playlistRepo::add)
+
+            val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+            // Trigger init so the source-callback subscription is live before writers start.
+            projection.size shouldBe 8
+
+            shouldNotThrowAny {
+                // Single writer coroutine: MutableAggregateList serializes mutations internally
+                // via a ReentrantLock; concurrent writes from multiple threads are not supported.
+                // The CME regression tripwire is on the reader side — a TreeMap revert causes
+                // ConcurrentModificationException when the backing map is mutated by the writer
+                // while the reader coroutine iterates projection.keys / projection.entries.
+                val writerJob =
+                    launch(Dispatchers.Default) {
+                        repeat(totalMutations) { i ->
+                            val extra = trackRepo.create(seedSize + i + 1, "Title-${i % 8}")
+                            playlist.audioItems.add(extra)
+                            playlist.audioItems.remove(extra)
+                        }
+                    }
+
+                val readerJob =
+                    launch(Dispatchers.Default) {
+                        repeat(readerIterations) {
+                            projection.keys.toList()
+                            projection.entries.forEach { it.value.size }
+                        }
+                    }
+
+                writerJob.join()
+                readerJob.join()
+            }
+        }
 })

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ProjectionMapTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ProjectionMapTest.kt
@@ -142,6 +142,28 @@ internal class ProjectionMapTest : StringSpec({
         projection.containsKey("Rock") shouldBe true
     }
 
+    "ProjectionMap keeps remaining bucket members when fallback removal leaves the bucket non-empty" {
+        val t1 = trackRepo.create(1, "Jazz")
+        val t2 = trackRepo.create(2, "Jazz")
+        val t3 = trackRepo.create(3, "Rock")
+        val playlist = DefaultAudioPlaylist(1, "Test", listOf(t1.id, t2.id, t3.id)).also(playlistRepo::add)
+
+        val projection = projectionMap<Int, String, AudioItem>({ playlist.audioItems }, { it.title })
+        projection["Jazz"]!!.size shouldBe 2
+
+        // Mutate t1's grouping key, then remove from source. handleRemoved looks under "Classical",
+        // misses, and falls back to removeFromAnyBucket which finds t1 under "Jazz" and rewrites the bucket
+        // to [t2] — exercises the filtered.isNotEmpty() branch (would throw with CSLM if entry.setValue
+        // were still in use, since the iterator entries are SimpleImmutableEntry).
+        (t1 as MutableAudioItem).title = "Classical"
+        playlist.audioItems.remove(t1)
+
+        projection.containsKey("Classical") shouldBe false
+        projection["Jazz"]!! shouldContainExactly listOf(t2)
+        projection["Rock"]!! shouldContainExactly listOf(t3)
+        projection.size shouldBe 2
+    }
+
     "ProjectionMap keys are in natural sorted order" {
         val t1 = trackRepo.create(1, "Rock")
         val t2 = trackRepo.create(2, "Classical")
@@ -306,6 +328,15 @@ internal class ProjectionMapTest : StringSpec({
         val executor = Executors.newSingleThreadExecutor()
         val latch = CountDownLatch(totalItems)
 
+        // Reader runs as a coroutine so a writer failure trips latch.await(10s) instead of looping forever.
+        val readerJob =
+            launch(Dispatchers.Default) {
+                while (latch.count > 0L) {
+                    projection.keys.toList()
+                    projection.entries.forEach { it.value.size }
+                }
+            }
+
         try {
             for (track in seedTracks) {
                 executor.submit {
@@ -314,22 +345,18 @@ internal class ProjectionMapTest : StringSpec({
                 }
             }
 
-            // Reader iterates concurrently; assertions run after the writer completes.
-            while (latch.count > 0L) {
-                projection.keys.toList()
-                projection.entries.forEach { it.value.size }
-            }
-
             latch.await(10, TimeUnit.SECONDS) shouldBe true
             projection.size shouldBe titles.size
             projection.values.sumOf { it.size } shouldBe totalItems
             projection.keys.toList() shouldContainExactly titles.sorted()
         } finally {
+            readerJob.cancel()
+            readerJob.join()
             executor.shutdownNow()
         }
     }
 
-    "ProjectionMap iterates without ConcurrentModificationException under multi-writer stress"
+    "ProjectionMap iterates without ConcurrentModificationException under concurrent reader and writer stress"
         .config(tags = setOf(Stress)) {
             val totalMutations = 5000
             val readerIterations = 1000

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/testing/Stress.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/testing/Stress.kt
@@ -1,0 +1,27 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.testing
+
+import io.kotest.core.Tag
+
+/**
+ * Marker tag for opt-in stress regression tests. Stress-tagged blocks are excluded by
+ * default and included via `-Pkotest.tags.include=Stress`. See module `build.gradle`
+ * Kotest tag wiring.
+ */
+object Stress : Tag()

--- a/lirp-fx/build.gradle
+++ b/lirp-fx/build.gradle
@@ -57,4 +57,11 @@ tasks.withType(Test).configureEach {
             '--add-exports=javafx.graphics/com.sun.javafx.util=ALL-UNNAMED',
             '--add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED',
             '--add-exports=javafx.graphics/com.sun.glass.ui.monocle=ALL-UNNAMED'
+
+    def includeTags = project.findProperty('kotest.tags.include') as String
+    if (includeTags) {
+        systemProperty 'kotest.tags.include', includeTags
+    } else {
+        systemProperty 'kotest.tags.exclude', 'Stress'
+    }
 }

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxFactories.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxFactories.kt
@@ -151,7 +151,7 @@ fun <T> fxObject(initialValue: T? = null, dispatchToFxThread: Boolean = true): L
  * from the source's current contents. Subsequent adds and removes fire incremental
  * [javafx.collections.MapChangeListener.Change] notifications per affected bucket key.
  *
- * Keys are maintained in natural sorted order via a [java.util.TreeMap] backing.
+ * Keys are maintained in natural sorted order via a [java.util.concurrent.ConcurrentSkipListMap] backing.
  * The projected map is read-only; calling `put` or `remove` on it throws [UnsupportedOperationException].
  *
  * Usage:

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxProjectionMap.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxProjectionMap.kt
@@ -28,7 +28,7 @@ import javafx.collections.MapChangeListener
 import javafx.collections.ObservableMap
 import javafx.collections.SetChangeListener
 import java.util.Collections
-import java.util.TreeMap
+import java.util.concurrent.ConcurrentSkipListMap
 import kotlin.reflect.KProperty
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
@@ -43,7 +43,8 @@ import kotlinx.coroutines.launch
  *
  * Entities from the source collection are grouped by a [keyExtractor] function into
  * buckets of type `List<E>`, keyed by projection key type `PK`. The backing map is a
- * [TreeMap], so keys are always iterated in natural sorted order.
+ * [ConcurrentSkipListMap] (wrapped by [FXCollections.observableMap]), so keys are always
+ * iterated in natural sorted order with CME-free iteration under concurrent reads.
  *
  * The projection initializes lazily: the source subscription and initial state build happen
  * on the first [getValue] call (Kotlin `by` delegation) or on the first [addListener] call,
@@ -66,8 +67,17 @@ import kotlinx.coroutines.launch
  * When `false`, notifications and mutations are serialized through a Channel-based sequential
  * processor on [ReactiveScope.flowScope], ensuring no concurrent map access.
  *
+ * **Thread safety:** Iteration of [keys], [values], [entries], plus [size], [containsKey],
+ * and [get] never throws [ConcurrentModificationException], because the underlying
+ * [ConcurrentSkipListMap] iterators are weakly-consistent — readers observe a snapshot of
+ * map state at the point of access, and entries added concurrently may or may not be visible
+ * mid-iteration. The CSLM swap is orthogonal to the dispatch model: both the [Platform.runLater]
+ * path and the [ReactiveScope.flowScope] [Channel] path continue to serialize [ListChangeListener]
+ * and [SetChangeListener] notifications exactly as documented above; the choice of backing map
+ * does not change either dispatch contract.
+ *
  * @param K the entity ID type, must be [Comparable]
- * @param PK the projection key type, must be [Comparable] (used as [TreeMap] key)
+ * @param PK the projection key type, must be [Comparable] (used as the backing [ConcurrentSkipListMap] key)
  * @param E the entity type
  * @param sourceRef deferred reference to the source [FxObservableCollection] (resolved on first [getValue] or [addListener])
  * @param keyExtractor grouping function that extracts the projection key from an entity
@@ -78,7 +88,7 @@ class FxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEn
     private val keyExtractor: (E) -> PK,
     val dispatchToFxThread: Boolean = true
 ) : ObservableMap<PK, List<E>> {
-    private val innerObservableMap: ObservableMap<PK, List<E>> = FXCollections.observableMap(TreeMap<PK, List<E>>())
+    private val innerObservableMap: ObservableMap<PK, List<E>> = FXCollections.observableMap(ConcurrentSkipListMap<PK, List<E>>())
 
     @Volatile
     private var initialized = false
@@ -190,13 +200,12 @@ class FxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEn
     }
 
     private fun removeFromAnyBucket(element: E) {
-        val iterator = innerObservableMap.entries.iterator()
-        while (iterator.hasNext()) {
-            val entry = iterator.next()
+        for (entry in innerObservableMap.entries) {
             if (element in entry.value) {
                 val filtered = entry.value.filter { it != element }
-                if (filtered.isEmpty()) iterator.remove()
-                else entry.setValue(freezeBucket(filtered))
+                // Use map put/remove rather than entry.setValue so the ObservableMap wrapper fires change listeners.
+                if (filtered.isEmpty()) innerObservableMap.remove(entry.key)
+                else innerObservableMap[entry.key] = freezeBucket(filtered)
                 return
             }
         }

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxProjectionMapTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxProjectionMapTest.kt
@@ -386,6 +386,15 @@ class FxProjectionMapTest : StringSpec({
         val executor = Executors.newSingleThreadExecutor()
         val latch = CountDownLatch(totalItems)
 
+        // Reader runs as a coroutine so a writer failure trips latch.await(10s) instead of looping forever.
+        val readerJob =
+            launch(Dispatchers.Default) {
+                while (latch.count > 0L) {
+                    projection.keys.toList()
+                    projection.entries.forEach { it.value.size }
+                }
+            }
+
         try {
             for (i in 1..totalItems) {
                 val item = FxAudioItem(i, "Track-$i", albums[i % albums.size])
@@ -395,22 +404,18 @@ class FxProjectionMapTest : StringSpec({
                 }
             }
 
-            // Reader iterates concurrently; assertions run after the writer completes.
-            while (latch.count > 0L) {
-                projection.keys.toList()
-                projection.entries.forEach { it.value.size }
-            }
-
             latch.await(10, TimeUnit.SECONDS) shouldBe true
             projection.size shouldBe albums.size
             projection.values.sumOf { it.size } shouldBe totalItems
             projection.keys.toList() shouldContainExactly albums.sorted()
         } finally {
+            readerJob.cancel()
+            readerJob.join()
             executor.shutdownNow()
         }
     }
 
-    "FxProjectionMap iterates without ConcurrentModificationException under multi-writer stress"
+    "FxProjectionMap iterates without ConcurrentModificationException under concurrent reader and writer stress"
         .config(tags = setOf(Stress)) {
             val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
             val projection = FxProjectionMap({ source }, { it.albumName }, false)

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxProjectionMapTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxProjectionMapTest.kt
@@ -19,6 +19,8 @@ package net.transgressoft.lirp.persistence.fx
 
 import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.testing.Stress
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
@@ -26,9 +28,12 @@ import io.kotest.matchers.shouldBe
 import javafx.beans.InvalidationListener
 import javafx.collections.MapChangeListener
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 /**
@@ -369,4 +374,82 @@ class FxProjectionMapTest : StringSpec({
         projection["Blues"]!!.size shouldBe 5
         projection["Pop"]!!.size shouldBe 5
     }
+
+    "FxProjectionMap reflects writer state in reader iteration after writer completes" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection = FxProjectionMap({ source }, { it.albumName }, false)
+        // Trigger init before writer starts so the source-listener subscription is live.
+        projection.size shouldBe 0
+
+        val albums = listOf("Alpha", "Bravo", "Charlie", "Delta")
+        val totalItems = 200
+        val executor = Executors.newSingleThreadExecutor()
+        val latch = CountDownLatch(totalItems)
+
+        try {
+            for (i in 1..totalItems) {
+                val item = FxAudioItem(i, "Track-$i", albums[i % albums.size])
+                executor.submit {
+                    source.add(source.size, item)
+                    latch.countDown()
+                }
+            }
+
+            // Reader iterates concurrently; assertions run after the writer completes.
+            while (latch.count > 0L) {
+                projection.keys.toList()
+                projection.entries.forEach { it.value.size }
+            }
+
+            latch.await(10, TimeUnit.SECONDS) shouldBe true
+            projection.size shouldBe albums.size
+            projection.values.sumOf { it.size } shouldBe totalItems
+            projection.keys.toList() shouldContainExactly albums.sorted()
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    "FxProjectionMap iterates without ConcurrentModificationException under multi-writer stress"
+        .config(tags = setOf(Stress)) {
+            val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+            val projection = FxProjectionMap({ source }, { it.albumName }, false)
+
+            val seedSize = 100
+            val mutationCount = 5000
+            val readerIterations = 1000
+
+            val seedItems = (1..seedSize).map { FxAudioItem(it, "Seed-$it", "Album-${it % 8}") }
+            seedItems.forEach { source.add(source.size, it) }
+            projection.size shouldBe 8
+
+            val executor = Executors.newSingleThreadExecutor()
+            val latch = CountDownLatch(mutationCount)
+
+            try {
+                shouldNotThrowAny {
+                    for (i in 1..mutationCount) {
+                        val item = FxAudioItem(seedSize + i, "Stress-$i", "Album-${i % 8}")
+                        executor.submit {
+                            source.add(source.size, item)
+                            source.remove(item)
+                            latch.countDown()
+                        }
+                    }
+
+                    val readerJob =
+                        launch(Dispatchers.Default) {
+                            repeat(readerIterations) {
+                                projection.keys.toList()
+                                projection.entries.forEach { it.value.size }
+                            }
+                        }
+
+                    latch.await(30, TimeUnit.SECONDS) shouldBe true
+                    readerJob.join()
+                }
+            } finally {
+                executor.shutdownNow()
+            }
+        }
 })


### PR DESCRIPTION
## Summary

Closes #140.

Replaces the `TreeMap` backing of both `ProjectionMap` (lirp-core) and `FxProjectionMap` (lirp-fx) with `java.util.concurrent.ConcurrentSkipListMap` so that iterating `keys` / `entries` / `values` no longer throws `ConcurrentModificationException` under concurrent FX-thread + persistence-thread mutations. Natural key ordering is preserved (CSLM is sorted), and `FxProjectionMap`'s `ObservableMap` change listeners continue to fire.

The change is validated by the spikes at `.planning/spikes/001-concurrent-skip-list-map/` (50k mutations / 250k iterations, no CME) and `.planning/spikes/002-fx-projectionmap-skip-list/` (FX side, same envelope).

## Changes

### lirp-core
- `ProjectionMap.kt` — backing map swapped to `ConcurrentSkipListMap`. Class-header `**Thread safety:**` paragraph rewritten: iteration is CME-free, reads are weakly-consistent, the single-threaded source-mutation contract is preserved (callbacks fire on the source-mutation thread).
- `CoreFactories.kt` — `projectionMap` factory KDoc references the new backing class.

### lirp-fx
- `FxProjectionMap.kt` — `FXCollections.observableMap(...)` now wraps `ConcurrentSkipListMap`. Thread-safety KDoc paragraph added covering iteration safety, weakly-consistent reads, and the FX dispatch model (orthogonal — application thread stays the listener-callback thread).
- `FxProjectionMap.removeFromAnyBucket` — switched from `entry.setValue(...)` to `innerObservableMap[key]` put/remove so `FXCollections.observableMap` change listeners fire correctly under CSLM backing. This was a latent bug in the previous implementation that the swap exposed.
- `FxFactories.kt` — `fxProjectionMap` factory KDoc updated.

### Test infrastructure (Stress Kotest tag)
- New `lirp-core/src/test/kotlin/net/transgressoft/lirp/testing/Stress.kt` — `object Stress : Tag()` defined once, reused from `lirp-fx` tests via the existing `testImplementation files(project(':lirp-core').sourceSets.test.output)` wiring.
- `lirp-core/build.gradle` and `lirp-fx/build.gradle` — Kotest tag filter wired: by default `Stress` is excluded; `-Pkotest.tags.include=Stress` opts in.

### Tests
- `ProjectionMapTest.kt` and `FxProjectionMapTest.kt` extended with two new regression tests each:
  - **Deterministic half** (always runs) — bounded-wait reader/writer functional assertion.
  - **Stress half** (`.config(tags = setOf(Stress))`) — multi-iteration reader/writer wrapped in `shouldNotThrowAny`. Acts as a CME tripwire: reverts to `TreeMap` will fail this test under load.

### Documentation
- `CONTRIBUTING.md` — new **Running Tests** section documents the default test invocation and the opt-in `-Pkotest.tags.include=Stress` form, plus the per-test idiom for adding new stress-tagged tests.
- Wiki `Projection-Maps.md` — line-15 bullet updated to reference `ConcurrentSkipListMap` and CME-free iteration; new `## Thread Safety` section added at the end of the page covering the iteration guarantee, weakly-consistent read semantics, and a cross-link to `JavaFX-Integration#fx-thread-dispatch`. Ships in the wiki repo as a separate commit (already pushed).

## Requirements addressed

- **THREAD-01** — ProjectionMap iteration must not throw CME under concurrent source mutations. Verified by both deterministic and Stress-tagged regression tests in lirp-core and lirp-fx; full verification report at `.planning/phases/49-projectionmap-thread-safety-140/49-VERIFICATION.md` (15/15 must-haves passed).

## Key decisions

- **CSLM over `Collections.synchronizedSortedMap` or copy-on-iterate snapshots** — CSLM is the JDK's standard concurrent navigable map; it preserves natural ordering, provides O(log n) operations identical to TreeMap, and exposes a weakly-consistent iterator that simply will not throw CME. No locking required at the call site.
- **Iteration semantics: weakly-consistent reads** — entries added concurrently may or may not appear mid-iteration. Documented explicitly in KDoc and in the wiki page; the existing single-threaded source-mutation contract makes this a non-issue for the dominant `MutableAggregateList` / `MutableAggregateSet` use cases.
- **Stress tests opt-in via tag filter** — kept out of the default loop to avoid CI flakiness on noisy multi-coroutine workloads while remaining trivially runnable when modifying the affected code.

## Verification

- [x] `gradle :lirp-core:test` passes (default — Stress excluded).
- [x] `gradle :lirp-core:test -Pkotest.tags.include=Stress` passes.
- [x] `gradle :lirp-fx:test` passes.
- [x] `gradle :lirp-fx:test -Pkotest.tags.include=Stress` passes.
- [x] `gradle test` (full project, regression gate) passes.
- [x] All 19 existing `ProjectionMapTest` cases and 19 existing `FxProjectionMapTest` cases continue to pass.
- [x] `gradle :lirp-core:ktlintCheck` and `:lirp-fx:ktlintCheck` clean.
- [x] Manual revert tripwire: temporarily restoring `TreeMap` makes the Stress test fail with CME, then reverting passes again.

## Test plan

- [ ] Reviewer runs `gradle test -Pkotest.tags.include=Stress` locally and confirms all tests pass.
- [ ] Reviewer skims the new `**Thread safety:**` KDoc paragraph in `ProjectionMap.kt` and `FxProjectionMap.kt` for clarity.
- [ ] Reviewer pulls the wiki repo (`git -C ../lirp.wiki pull`) and reviews the new `## Thread Safety` section in `Projection-Maps.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)