### PR TITLE
#145 SQLite as a fourth dialect

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ kctfork = "0.12.1"
 postgresql = "42.7.10"
 mysql = "9.6.0"
 mariadb = "3.5.8"
+sqlite = "3.53.0.0"
 jmh = "1.37"
 jol = "0.17"
 springDataJpa = "3.4.7"
@@ -52,6 +53,7 @@ h2 = { module = "com.h2database:h2", version = "2.4.240" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 mysql = { module = "com.mysql:mysql-connector-j", version.ref = "mysql" }
 mariadb = { module = "org.mariadb.jdbc:mariadb-java-client", version.ref = "mariadb" }
+sqlite = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite" }
 mockk = { module = "io.mockk:mockk", version = "1.14.9" }
 logback-core = { module = "ch.qos.logback:logback-core", version = "1.5.32" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.32" }

--- a/lirp-sql/build.gradle
+++ b/lirp-sql/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     runtimeOnly libs.postgresql
     runtimeOnly libs.mysql
     runtimeOnly libs.mariadb
+    runtimeOnly libs.sqlite
 
     testImplementation platform(libs.junit.bom)
     testImplementation libs.bundles.kotest
@@ -54,6 +55,7 @@ dependencies {
     integrationTestImplementation libs.testcontainers.postgresql
     integrationTestImplementation libs.testcontainers.mysql
     integrationTestImplementation libs.testcontainers.mariadb
+    integrationTestImplementation libs.sqlite
     integrationTestImplementation libs.coroutines.test
     integrationTestImplementation libs.junit.jupiter
     integrationTestRuntimeOnly libs.junit.platform.launcher
@@ -79,6 +81,7 @@ dependencies {
     testFixturesImplementation libs.testcontainers.postgresql
     testFixturesImplementation libs.testcontainers.mysql
     testFixturesImplementation libs.testcontainers.mariadb
+    testFixturesImplementation libs.sqlite
     testFixturesImplementation libs.kotest.runner.junit6
 
     // Consume testFixtures from both test and integrationTest

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryDdlIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryDdlIntegrationTest.kt
@@ -33,7 +33,8 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 
 /**
- * Integration tests for [SqlRepository] DDL behaviour against PostgreSQL, MySQL 8.0, and MariaDB 11.
+ * Integration tests for [SqlRepository] DDL behaviour against PostgreSQL, MySQL 8.0, MariaDB 11,
+ * and SQLite.
  *
  * Verifies that tables are auto-created and all 12 [net.transgressoft.lirp.persistence.ColumnType]
  * variants round-trip correctly via CRUD operations, that re-initialization is idempotent, and that
@@ -108,7 +109,13 @@ internal class SqlRepositoryDdlIntegrationTest : FunSpec({
                 val exposedDb = Database.connect(dataSource)
                 val dialectName = transaction(exposedDb) { exposedDb.dialect.name }
 
-                val expectedDialects = mapOf("PostgreSQL" to "PostgreSQL", "MySQL" to "MySQL", "MariaDB" to "MariaDB")
+                val expectedDialects =
+                    mapOf(
+                        "PostgreSQL" to "PostgreSQL",
+                        "MySQL" to "MySQL",
+                        "MariaDB" to "MariaDB",
+                        "SQLite" to "SQLite"
+                    )
                 dialectName shouldBe expectedDialects[db.name]
             } finally {
                 dataSource.close()

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqliteForeignKeyViolationIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqliteForeignKeyViolationIntegrationTest.kt
@@ -1,0 +1,63 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.sqlite.SQLiteException
+import java.sql.SQLException
+
+internal class SqliteForeignKeyViolationIntegrationTest : StringSpec({
+
+    "orphan child insert with PRAGMA foreign_keys=ON throws SQLITE_CONSTRAINT_FOREIGNKEY" {
+        val ds = SqliteFileSupport.buildDataSource()
+        try {
+            ds.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("CREATE TABLE parent (id INTEGER PRIMARY KEY)")
+                    stmt.execute(
+                        "CREATE TABLE child (" +
+                            "id INTEGER PRIMARY KEY, " +
+                            "parent_id INTEGER NOT NULL REFERENCES parent(id) ON DELETE RESTRICT" +
+                            ")"
+                    )
+                    stmt.execute("INSERT INTO parent (id) VALUES (1)")
+                }
+
+                val ex =
+                    shouldThrow<SQLException> {
+                        conn.createStatement().use { stmt ->
+                            // parent_id=999 has no matching parent row → FK violation
+                            stmt.execute("INSERT INTO child (id, parent_id) VALUES (1, 999)")
+                        }
+                    }
+
+                // SQLState is intentionally NOT asserted — sqlite-jdbc passes null SQLState.
+                ex.shouldBeInstanceOf<SQLiteException>()
+                // SQLITE_CONSTRAINT base code; sqlite-jdbc masks the extended 787 code to 19.
+                ex.errorCode shouldBe 19
+                ex.message!! shouldContain "FOREIGN KEY constraint failed"
+            }
+        } finally {
+            ds.close()
+        }
+    }
+})

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlitePragmaAssertionIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlitePragmaAssertionIntegrationTest.kt
@@ -1,0 +1,54 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+internal class SqlitePragmaAssertionIntegrationTest : StringSpec({
+
+    "connectionInitSql enables foreign-key enforcement on every pooled connection" {
+        val ds = SqliteFileSupport.buildDataSource()
+        try {
+            ds.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    val rs = stmt.executeQuery("PRAGMA foreign_keys;")
+                    rs.next() shouldBe true
+                    rs.getInt(1) shouldBe 1
+                }
+            }
+        } finally {
+            ds.close()
+        }
+    }
+
+    "connectionInitSql sets WAL journal mode on file-backed databases" {
+        val ds = SqliteFileSupport.buildDataSource()
+        try {
+            ds.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    val rs = stmt.executeQuery("PRAGMA journal_mode;")
+                    rs.next() shouldBe true
+                    rs.getString(1) shouldBe "wal"
+                }
+            }
+        } finally {
+            ds.close()
+        }
+    }
+})

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
@@ -128,6 +128,13 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
      * The created [HikariDataSource] is owned by this repository and will be closed when [close]
      * is called.
      *
+     * For `jdbc:sqlite:` URLs, prefer [SqliteRepository.fileBacked] or
+     * [SqliteRepository.inMemory], which apply the SQLite PRAGMA bundle
+     * (`foreign_keys = ON`, `journal_mode = WAL`, `busy_timeout`,
+     * `synchronous = NORMAL`) on every pooled connection. This constructor
+     * leaves SQLite without those PRAGMAs unless the caller layers them in
+     * via a pre-built [DataSource].
+     *
      * @param jdbcUrl The JDBC connection URL (e.g. `jdbc:postgresql://host/db`).
      * @param tableDef The SQL table definition describing the entity's column mapping.
      * @param poolSize Maximum number of connections in the HikariCP pool. Defaults to 10.
@@ -486,7 +493,16 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
     }
 
     companion object {
+        private val log = KotlinLogging.logger(SqlRepository::class.java.name)
+
         private fun buildDataSource(jdbcUrl: String, poolSize: Int, schema: String?): HikariDataSource {
+            if (jdbcUrl.startsWith("jdbc:sqlite:")) {
+                log.warn {
+                    "SQLite JDBC URL '$jdbcUrl' passed to SqlRepository(jdbcUrl, ...) without connectionInitSql; " +
+                        "FK enforcement and WAL mode are not configured. Prefer SqliteRepository.fileBacked(...) " +
+                        "or SqliteRepository.inMemory(...) for the curated PRAGMA bundle."
+                }
+            }
             val config =
                 HikariConfig().apply {
                     this.jdbcUrl = jdbcUrl

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqliteRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqliteRepository.kt
@@ -1,0 +1,97 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.entity.ReactiveEntity
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import java.nio.file.Path
+
+/**
+ * Factory namespace for [SqlRepository] instances backed by SQLite.
+ *
+ * Each factory builds a HikariCP pool with the curated PRAGMA bundle
+ * (`foreign_keys = ON`, `journal_mode = WAL`, `busy_timeout = 5000`,
+ * `synchronous = NORMAL`) applied via xerial sqlite-jdbc URL parameters,
+ * so foreign-key enforcement and WAL concurrent reads apply to every
+ * pooled connection. The returned repository owns the pool and closes
+ * it on [SqlRepository.close].
+ */
+object SqliteRepository {
+
+    // PRAGMAs are passed as URL query parameters (xerial sqlite-jdbc parses them via
+    // SQLiteConnection.extractPragmasFromFilename). HikariCP's connectionInitSql cannot
+    // be used because sqlite-jdbc's Statement.execute(sql) only runs the first statement
+    // of a multi-statement string; subsequent PRAGMAs would be silently dropped.
+    private const val PRAGMA_QUERY =
+        "?foreign_keys=on&journal_mode=wal&busy_timeout=5000&synchronous=normal"
+
+    /**
+     * Creates a [SqlRepository] backed by a SQLite database file at [path].
+     *
+     * The returned repository owns the underlying HikariCP pool (closed when
+     * [SqlRepository.close] runs). The locked PRAGMA bundle is applied on every
+     * pooled connection.
+     *
+     * @param path Filesystem path of the SQLite database file. The file is
+     *   created on first connection if it does not exist.
+     * @param tableDef SQL table definition describing the entity column mapping.
+     * @param loadOnInit When `true` (default), rows are loaded immediately;
+     *   when `false`, [SqlRepository.load] must be called explicitly.
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun <K : Comparable<K>, R : ReactiveEntity<K, R>> fileBacked(
+        path: Path,
+        tableDef: SqlTableDef<R>,
+        loadOnInit: Boolean = true
+    ): SqlRepository<K, R> {
+        val ds = buildPool(jdbcUrl = "jdbc:sqlite:${path.toAbsolutePath()}$PRAGMA_QUERY", poolSize = 4)
+        return SqlRepository(ds, tableDef, ownsDataSource = true, loadOnInit)
+    }
+
+    /**
+     * Creates a [SqlRepository] backed by an in-memory SQLite database.
+     *
+     * The pool is pinned to a single connection because each `:memory:`
+     * connection in xerial's driver is an independent private database;
+     * a multi-connection pool would silently lose schema and data across
+     * acquired connections.
+     *
+     * @param tableDef SQL table definition describing the entity column mapping.
+     * @param loadOnInit When `true` (default), rows are loaded immediately;
+     *   when `false`, [SqlRepository.load] must be called explicitly.
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun <K : Comparable<K>, R : ReactiveEntity<K, R>> inMemory(
+        tableDef: SqlTableDef<R>,
+        loadOnInit: Boolean = true
+    ): SqlRepository<K, R> {
+        val ds = buildPool(jdbcUrl = "jdbc:sqlite::memory:$PRAGMA_QUERY", poolSize = 1)
+        return SqlRepository(ds, tableDef, ownsDataSource = true, loadOnInit)
+    }
+
+    private fun buildPool(jdbcUrl: String, poolSize: Int): HikariDataSource =
+        HikariDataSource(
+            HikariConfig().apply {
+                this.jdbcUrl = jdbcUrl
+                this.maximumPoolSize = poolSize
+            }
+        )
+}

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqliteRepositoryTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqliteRepositoryTest.kt
@@ -1,0 +1,50 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+internal class SqliteRepositoryTest : StringSpec({
+
+    "inMemory factory builds a JDBC URL containing :memory:" {
+        val repo = SqliteRepository.inMemory(TestPersonTableDef)
+        try {
+            val dataSourceField = SqlRepository::class.java.getDeclaredField("dataSource")
+            dataSourceField.isAccessible = true
+            val hikariDs = dataSourceField.get(repo) as HikariDataSource
+            hikariDs.jdbcUrl shouldContain ":memory:"
+        } finally {
+            repo.close()
+        }
+    }
+
+    "inMemory factory pins maximumPoolSize to 1" {
+        val repo = SqliteRepository.inMemory(TestPersonTableDef)
+        try {
+            val dataSourceField = SqlRepository::class.java.getDeclaredField("dataSource")
+            dataSourceField.isAccessible = true
+            val hikariDs = dataSourceField.get(repo) as HikariDataSource
+            hikariDs.maximumPoolSize shouldBe 1
+        } finally {
+            repo.close()
+        }
+    }
+})

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DatabaseTestSupport.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DatabaseTestSupport.kt
@@ -47,7 +47,8 @@ object DatabaseTestSupport {
         listOf(
             DbConfig("PostgreSQL") { PostgresContainerSupport.buildDataSource() },
             DbConfig("MySQL") { MysqlContainerSupport.buildDataSource() },
-            DbConfig("MariaDB") { MariaDbContainerSupport.buildDataSource() }
+            DbConfig("MariaDB") { MariaDbContainerSupport.buildDataSource() },
+            DbConfig("SQLite") { SqliteFileSupport.buildDataSource() }
         )
 
     fun dropTable(dataSource: HikariDataSource, tableDef: SqlTableDef<*>) {
@@ -59,7 +60,8 @@ object DatabaseTestSupport {
             val tableNotFound =
                 e.sqlState in listOf("42S02", "42P01") ||
                     e.message?.contains("does not exist", ignoreCase = true) == true ||
-                    e.message?.contains("Unknown table", ignoreCase = true) == true
+                    e.message?.contains("Unknown table", ignoreCase = true) == true ||
+                    e.message?.contains("no such table", ignoreCase = true) == true
             if (!tableNotFound) throw e
         }
     }

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/SqliteFileSupport.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/SqliteFileSupport.kt
@@ -1,0 +1,58 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import java.nio.file.Files
+
+/**
+ * Tempfile-backed [HikariDataSource] factory for SQLite integration tests.
+ *
+ * A fresh database file is created per [buildDataSource] call (registered for
+ * `deleteOnExit`); each `withDatabaseTest(...)` invocation therefore runs against
+ * an empty isolated database. The locked PRAGMA bundle (`foreign_keys = ON`,
+ * `journal_mode = WAL`, `busy_timeout = 5000`, `synchronous = NORMAL`) applies
+ * on every pooled connection.
+ */
+object SqliteFileSupport {
+
+    // PRAGMAs are passed as URL query parameters (xerial sqlite-jdbc parses them via
+    // SQLiteConnection.extractPragmasFromFilename). HikariCP's connectionInitSql cannot
+    // be used because sqlite-jdbc's Statement.execute(sql) only runs the first statement
+    // of a multi-statement string; subsequent PRAGMAs would be silently dropped.
+    private const val PRAGMA_QUERY =
+        "?foreign_keys=on&journal_mode=wal&busy_timeout=5000&synchronous=normal"
+
+    /**
+     * Returns a new [HikariDataSource] connected to a fresh temporary SQLite database
+     * file. The file is registered for `deleteOnExit`. The locked PRAGMA bundle is
+     * applied on every connection via xerial sqlite-jdbc URL parameters.
+     */
+    fun buildDataSource(): HikariDataSource {
+        val tempFile =
+            Files.createTempFile("lirp-sqlite-", ".db")
+                .also { it.toFile().deleteOnExit() }
+        return HikariDataSource(
+            HikariConfig().apply {
+                jdbcUrl = "jdbc:sqlite:${tempFile.toAbsolutePath()}$PRAGMA_QUERY"
+                maximumPoolSize = 4
+            }
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #145.

Add SQLite to `lirp-sql` as a peer dialect alongside PostgreSQL, MySQL 8, and MariaDB 11 — broadening LIRP's reach to desktop and embedded use cases. The driver is pinned, a curated PRAGMA bundle is applied on every Hikari-pooled connection (FK enforcement, WAL, busy timeout, synchronous mode), `object SqliteRepository` ships `fileBacked(path)` / `inMemory()` factory helpers, the test fixtures gain a fourth `DbConfig` row so every parameterized integration test now runs across four dialects, and the consumer flow is documented in `lirp.wiki`.

This lands intentionally before the FK-constraint codegen work in #144 — without `foreign_keys = ON`, the FK SQL generated by that phase would be a silent no-op on SQLite.

## Why URL parameters and not `connectionInitSql`

The original plan wired the PRAGMA bundle through Hikari's `connectionInitSql`. While building the FK-enforcement assertion test, we discovered xerial's `Statement.execute(sql)` runs only the **first** statement of a multi-statement string and silently drops the rest. `foreign_keys = ON` happened to be first, so FK enforcement worked — but `journal_mode = WAL`, `busy_timeout = 5000`, and `synchronous = NORMAL` were all silently dropped.

The canonical xerial pattern is to attach PRAGMAs as JDBC URL query parameters (`?foreign_keys=on&journal_mode=wal&...`); the driver parses them itself before connection open, so all four PRAGMAs are applied reliably on every pooled connection. `SqlitePragmaAssertionIntegrationTest` now pins this contract by asserting both `PRAGMA foreign_keys` returns `1` and `PRAGMA journal_mode` returns `wal` on a freshly handed-out pool connection.

## Changes

### `lirp-sql` (new public surface)

- `gradle/libs.versions.toml` — pins `sqlite = "3.53.0.0"` and the `org.xerial:sqlite-jdbc` library coordinate.
- `lirp-sql/build.gradle` — wires `libs.sqlite` on `runtimeOnly` (main), `integrationTestImplementation`, and `testFixturesImplementation` classpaths.
- `SqliteRepository.kt` — `object SqliteRepository` with two factories: `fileBacked(path: java.nio.file.Path, tableDef, loadOnInit = true)` and `inMemory(tableDef, loadOnInit = true)`. Both build a `HikariDataSource` carrying the locked PRAGMA bundle as URL query parameters and delegate to the existing `SqlRepository(dataSource, tableDef, ownsDataSource = true, loadOnInit)` constructor. `fileBacked` defaults to `maximumPoolSize = 4`; `inMemory` pins `maximumPoolSize = 1` to dodge SQLite's per-connection isolation trap on `:memory:`. `@JvmStatic` + `@JvmOverloads` make Java callers see static methods.
- `SqlRepository.kt` — KDoc + runtime `WARN` log on the dialect-agnostic `SqlRepository(jdbcUrl, …)` constructor when invoked with a `jdbc:sqlite:` URL: that path bypasses the PRAGMA bundle and would silently lose FK enforcement. The KDoc steers callers to the new factories.

### Test fixtures and parameterized suite

- `SqliteFileSupport.kt` (new) — parallel to the three Testcontainers fixtures. `buildDataSource()` creates a fresh tempfile per call (`Files.createTempFile("lirp-sqlite-", ".db").also { it.toFile().deleteOnExit() }`), then a Hikari pool with `maximumPoolSize = 4` and the locked PRAGMA bundle on the URL.
- `DatabaseTestSupport.kt` — adds exactly one row, `DbConfig("SQLite") { SqliteFileSupport.buildDataSource() }`, alongside the three Testcontainers configs. The `tableNotFound` matcher gains a `"no such table"` branch (case-insensitive) so `dropTable(...)` works on SQLite. After this row, **every** parameterized integration test in `lirp-sql/src/integrationTest/` runs across all four dialects automatically.
- `SqlRepositoryDdlIntegrationTest.kt` — extends the `expectedDialects` lookup with `"SQLite" to "SQLite"`. The only test-side fix the SQLite row required.

### New integration tests (FK-enforcement coverage)

- `SqlitePragmaAssertionIntegrationTest.kt` — opens a fresh connection from `SqliteFileSupport.buildDataSource()`, runs `PRAGMA foreign_keys` and `PRAGMA journal_mode`, asserts `1` and `wal`. Catches "someone removed a PRAGMA from the bundle" regressions on first run.
- `SqliteForeignKeyViolationIntegrationTest.kt` — creates a parent + child schema with `REFERENCES parent(id) ON DELETE RESTRICT`, attempts to insert a child row with an orphan parent_id, asserts `SQLiteException` with `errorCode == 19` and message containing `"FOREIGN KEY constraint failed"`. Catches "PRAGMAs applied to the wrong connection" regressions.

### Type fidelity (no `ExposedTableInterpreter` changes)

The plan budgeted for SQLite-specific column overrides if any of the four-dialect parameterized tests failed under SQLite (UUID via TEXT/BLOB, DECIMAL precision, DATE/DATETIME via ISO-8601 TEXT, BOOLEAN via INTEGER). `gradle :lirp-sql:integrationTest` ran 143/143 green across all four dialects — Exposed 1.2.0's stock SQLite mappings round-trip every column type cleanly. No `ExposedTableInterpreter` change shipped.

### Documentation

- `lirp.wiki/Desktop-Embedded-Setup.md` (separate repo, committed at `702d0d1`) — consumer guide mirroring the `Consuming-LIRP.md` style: Gradle/Maven dependency snippet, `fileBacked` vs `inMemory` factory selection table, PRAGMA bundle paragraph, Kotlin and Java examples, `:memory:` + `maximumPoolSize = 1` footgun callout, cross-link to `Consuming-LIRP`.
- `lirp.wiki/_Sidebar.md` — sidebar entry under Persistence between `SQL Persistence` and `JSON Persistence`.
- `README.md` is **not** touched; the v2.4.0 line stays the adoption surface and SQLite specifics live in the wiki.

## Requirements addressed

- **SQLITE-01** — `org.xerial:sqlite-jdbc` pinned in version catalog; wired on main, integrationTest, testFixtures classpaths.
- **SQLITE-02** — `foreign_keys = ON` and `journal_mode = WAL` applied on every pooled connection (URL parameters); verified by `SqlitePragmaAssertionIntegrationTest`.
- **SQLITE-03** — `SqliteRepository.inMemory()` pins `maximumPoolSize = 1`; verified by `SqliteRepositoryTest` config tripwire.
- **SQLITE-04** — `DbConfig("SQLite")` row in `DatabaseTestSupport.databases`; full parameterized integration suite passes across all four dialects.

Full traceability and live verification evidence in `.planning/phases/50-sqlite-as-a-fourth-dialect-145/50-VERIFICATION.md` (6/6 must-haves).

## Verification

- [x] `gradle :lirp-sql:compileKotlin` — clean.
- [x] `gradle :lirp-sql:test` — passes; includes the `SqliteRepositoryTest` `:memory:` + `maximumPoolSize = 1` tripwires.
- [x] `gradle :lirp-sql:integrationTest --rerun-tasks` — 143 tests, 0 failures, 0 errors across PostgreSQL, MySQL 8, MariaDB 11, SQLite (29 SQLite-row cases including 20-coroutine concurrency stress, optimistic locking, AllTypesEntity round-trip, MusicCommons, lifecycle, events, DDL).
- [x] `SqlitePragmaAssertionIntegrationTest` confirms `PRAGMA foreign_keys` returns `1` and `PRAGMA journal_mode` returns `wal` on a freshly pooled connection.
- [x] `SqliteForeignKeyViolationIntegrationTest` confirms orphan child insert throws `SQLiteException` with `errorCode == 19` and `"FOREIGN KEY constraint failed"`.
- [x] `gradle :lirp-sql:dependencyInsight` resolves `org.xerial:sqlite-jdbc:3.53.0.0` on `runtimeClasspath`, `integrationTestRuntimeClasspath`, and `testFixturesRuntimeClasspath`.
- [x] No regressions in `lirp-core`, `lirp-fx`, `lirp-api`, `lirp-ksp` — full `gradle test` green.

## Test plan

- [ ] Reviewer runs `gradle :lirp-sql:integrationTest` locally and confirms all 143 tests pass (Docker required for the Testcontainers rows; SQLite row needs no Docker).
- [ ] Reviewer skims `SqliteRepository.kt` factory KDoc and the PRAGMA bundle paragraph in `Desktop-Embedded-Setup.md` for clarity.
- [ ] Reviewer pulls the wiki repo (`git -C ../lirp.wiki pull`) and reviews the new `Desktop-Embedded-Setup` page + sidebar placement.
- [ ] Reviewer manually verifies the `jdbc:sqlite:` footgun WARN: pass a `jdbc:sqlite:/tmp/foo.db` URL through the `SqlRepository(jdbcUrl, ...)` constructor and confirm the WARN log fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)