### PR TITLE
Phase 51: Kotest parallelism and Stress tag expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/build/
 !**/src/**/build/
 *.log
+.env
 
 # Ignore Gradle GUI config
 gradle-app.setting
@@ -36,8 +37,12 @@ replay_pid*
 # Agentic coding tools
 .serena
 .claude
+.codexignore
+.codex
+tasks
 .planning
 CLAUDE.md
+AGENTS.md
 .mcp.json
 .graphifyignore
 **/graphify-out/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,23 +71,26 @@ All pull requests should:
 The default test run executes the full deterministic suite:
 
 ```bash
-./gradlew test                    # full project
-./gradlew :lirp-core:test         # single module
+gradle test
+gradle :lirp-core:test
+gradle :lirp-fx:test
+gradle :lirp-sql:test
 ```
 
-#### Opt-in stress tests (`Stress` tag)
+#### Stress-tagged tests (`Stress` tag)
 
-Some concurrency regression tests are tagged with `Stress` and **excluded by default**.
+Some concurrency regression tests are tagged with `Stress` and run by default with the
+rest of the suite.
 They are aggressive multi-iteration tripwires that protect invariants like CME-free
 iteration of `ProjectionMap` / `FxProjectionMap`; they are too slow and noisy for the
-default loop but valuable when modifying the affected code.
+short feedback loop, but valuable when modifying the affected code.
 
-Include them with the `kotest.tags.include` Gradle property:
+Skip them with the `kotest.tags.exclude` Gradle property:
 
 ```bash
-./gradlew test -Pkotest.tags.include=Stress
-./gradlew :lirp-core:test -Pkotest.tags.include=Stress
-./gradlew :lirp-fx:test -Pkotest.tags.include=Stress
+gradle test -Pkotest.tags.exclude=Stress
+gradle :lirp-core:test -Pkotest.tags.exclude=Stress
+gradle :lirp-fx:test -Pkotest.tags.exclude=Stress
 ```
 
 Add a new stress-tagged test by attaching the shared tag at the test definition:
@@ -104,6 +107,13 @@ import net.transgressoft.lirp.testing.Stress
 The `Stress` tag is defined once in `lirp-core/src/test/kotlin/net/transgressoft/lirp/testing/Stress.kt`
 and is visible to `lirp-fx` tests via the existing `testImplementation files(...)` wiring,
 so no per-module duplication is needed.
+
+#### Kotest parallelism
+
+`lirp-core` enables Kotest spec-level parallelism while keeping test execution inside each
+spec sequential. This reduces default wall-clock time without changing spec-local fixture
+ordering. JavaFX specs remain serialized because `FxToolkitInit` and JavaFX toolkit state
+are process-wide. Scheduled Stress CI is not part of this setup.
 
 ### Problem Statement Requirement
 

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ subprojects {
         properties {
             property 'sonar.moduleKey', "${project.name}"
             property 'sonar.sources', 'src/main'
-            property 'sonar.exclusions', 'src/test/**,src/integrationTest/**'
+            property 'sonar.test.exclusions', 'src/test/**,src/integrationTest/**, src/testFixtures/**'
         }
     }
 

--- a/lirp-core/build.gradle
+++ b/lirp-core/build.gradle
@@ -33,10 +33,9 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-    def includeTags = project.findProperty('kotest.tags.include') as String
-    if (includeTags) {
-        systemProperty 'kotest.tags.include', includeTags
-    } else {
-        systemProperty 'kotest.tags.exclude', 'Stress'
+    systemProperty 'kotest.framework.config.fqn', 'net.transgressoft.lirp.testing.CoreKotestProjectConfig'
+    def excludeTags = project.findProperty('kotest.tags.exclude') as String
+    if (excludeTags) {
+        systemProperty 'kotest.tags.exclude', excludeTags
     }
 }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/IntegrationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/IntegrationTest.kt
@@ -30,6 +30,8 @@ import net.transgressoft.lirp.persistence.CustomerVolatileRepo
 import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.json.PolymorphicCustomer
 import net.transgressoft.lirp.persistence.json.StandardCustomerJsonFileRepository
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
+import net.transgressoft.lirp.testing.Stress
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.engine.spec.tempfile
@@ -48,6 +50,7 @@ import kotlinx.coroutines.withTimeout
 
 /** Integration tests for concurrent access, failure recovery, and resource lifecycle scenarios. */
 @ExperimentalCoroutinesApi
+@SerializeWithReactiveScope
 class IntegrationTest : DescribeSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()
@@ -64,7 +67,7 @@ class IntegrationTest : DescribeSpec({
     }
 
     describe("Concurrent subscriptions") {
-        it("handles 200 subscribers with 2000 events without deadlocking") {
+        it("handles 200 subscribers with 2000 events without deadlocking").config(tags = setOf(Stress)) {
             val subscriberCount = 200
             val eventCount = 2000
 
@@ -108,7 +111,7 @@ class IntegrationTest : DescribeSpec({
     }
 
     describe("Repository state consistency") {
-        it("maintains consistency under 50 coroutines performing 1000 mixed operations each") {
+        it("maintains consistency under 50 coroutines performing 1000 mixed operations each").config(tags = setOf(Stress)) {
             val coroutineCount = 50
             val opsPerCoroutine = 1000
             val entityPoolSize = 100
@@ -262,7 +265,7 @@ class IntegrationTest : DescribeSpec({
     }
 
     describe("Concurrent entity mutations") {
-        it("500 concurrent mutations on same entity do not corrupt state") {
+        it("500 concurrent mutations on same entity do not corrupt state").config(tags = setOf(Stress)) {
             val mutationCount = 500
 
             val entity = LazyTestEntity("concurrent-test")
@@ -297,7 +300,7 @@ class IntegrationTest : DescribeSpec({
     }
 
     describe("Publisher closure and reactivation under load") {
-        it("30 dormant-to-active cycles with 50 mutations each do not silently drop events") {
+        it("30 dormant-to-active cycles with 50 mutations each do not silently drop events").config(tags = setOf(Stress)) {
             val cycleCount = 30
             val mutationsPerCycle = 50
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/ReactiveEntityLazyInitTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/ReactiveEntityLazyInitTest.kt
@@ -21,6 +21,7 @@ import net.transgressoft.lirp.event.FlowEventPublisher
 import net.transgressoft.lirp.event.LirpEventPublisher
 import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
@@ -33,6 +34,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 @ExperimentalCoroutinesApi
+@SerializeWithReactiveScope
 class ReactiveEntityLazyInitTest : StringSpec({
     val testDispatcher = UnconfinedTestDispatcher()
     val testScope = CoroutineScope(testDispatcher)

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/ReactiveEntityLifecycleTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/ReactiveEntityLifecycleTest.kt
@@ -22,6 +22,7 @@ import net.transgressoft.lirp.event.MutationEvent.Type.MUTATE
 import net.transgressoft.lirp.event.ReactiveMutationEvent
 import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.persistence.Customer
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -37,6 +38,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  * Tests for [ReactiveEntityBase] lifecycle states: Created, Active, Dormant, and Closed.
  */
 @ExperimentalCoroutinesApi
+@SerializeWithReactiveScope
 class ReactiveEntityLifecycleTest : StringSpec({
     val testDispatcher = UnconfinedTestDispatcher()
     val testScope = CoroutineScope(testDispatcher)

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/SubscriptionExtensionsTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/SubscriptionExtensionsTest.kt
@@ -26,6 +26,7 @@ import net.transgressoft.lirp.persistence.AudioItemVolatileRepository
 import net.transgressoft.lirp.persistence.AudioPlaylistVolatileRepository
 import net.transgressoft.lirp.persistence.DefaultAudioPlaylist
 import net.transgressoft.lirp.persistence.LirpContext
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -43,6 +44,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  */
 @DisplayName("Subscription extension functions")
 @OptIn(ExperimentalCoroutinesApi::class)
+@SerializeWithReactiveScope
 class SubscriptionExtensionsTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/AggregateBubbleUpTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/AggregateBubbleUpTest.kt
@@ -26,6 +26,7 @@ import net.transgressoft.lirp.persistence.EntityCVolatileRepo
 import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.MutableRefOrderVolatileRepo
 import net.transgressoft.lirp.persistence.OrderVolatileRepo
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.nondeterministic.continually
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.annotation.DisplayName
@@ -50,6 +51,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 @DisplayName("AggregateBubbleUpTest")
 @OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("UNCHECKED_CAST")
+@SerializeWithReactiveScope
 internal class AggregateBubbleUpTest : FunSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/ConcurrencyStressTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/ConcurrencyStressTest.kt
@@ -19,6 +19,8 @@ package net.transgressoft.lirp.event
 
 import net.transgressoft.lirp.persistence.Customer
 import net.transgressoft.lirp.persistence.CustomerVolatileRepo
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
+import net.transgressoft.lirp.testing.Stress
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -47,7 +49,9 @@ private const val TOTAL_EVENTS = WRITER_COUNT * EVENTS_PER_WRITER
  * - Interleaved CRUD and mutation operations from truly concurrent coroutines
  * - Repository state consistency (correct size, no duplicate IDs) after concurrent stress
  */
+@SerializeWithReactiveScope
 class ConcurrencyStressTest : DescribeSpec({
+    tags(Stress)
 
     afterSpec {
         ReactiveScope.resetDefaultIoScope()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/ExceptionIsolationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/ExceptionIsolationTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.event
 
 import net.transgressoft.lirp.event.CrudEvent.Type.CREATE
 import net.transgressoft.lirp.event.StandardCrudEvent.Create
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicInteger
@@ -37,6 +38,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  * [ReactiveScope] behaviour so that child coroutine failures do not cancel the parent.
  */
 @ExperimentalCoroutinesApi
+@SerializeWithReactiveScope
 class ExceptionIsolationTest : DescribeSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/FlowEventPublisherTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/FlowEventPublisherTest.kt
@@ -24,6 +24,7 @@ import net.transgressoft.lirp.event.CrudEvent.Type.UPDATE
 import net.transgressoft.lirp.event.StandardCrudEvent.Create
 import net.transgressoft.lirp.event.StandardCrudEvent.Delete
 import net.transgressoft.lirp.event.StandardCrudEvent.Update
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.maps.shouldContainExactly
@@ -49,6 +50,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 
 @ExperimentalCoroutinesApi
+@SerializeWithReactiveScope
 class FlowEventPublisherTest : DescribeSpec({
     val testDispatcher = UnconfinedTestDispatcher()
     val testScope = CoroutineScope(testDispatcher)

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/HighConcurrencyStressTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/HighConcurrencyStressTest.kt
@@ -18,6 +18,8 @@
 package net.transgressoft.lirp.event
 
 import net.transgressoft.lirp.persistence.CustomerVolatileRepo
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
+import net.transgressoft.lirp.testing.Stress
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -41,7 +43,9 @@ private const val TOTAL_EVENTS = WRITER_COUNT * EVENTS_PER_WRITER
  * (never test dispatchers) and [CountDownLatch] for bounded waits. No [Thread.sleep] or fixed
  * delays are used. Subscribers are always registered before writers start.
  */
+@SerializeWithReactiveScope
 class HighConcurrencyStressTest : DescribeSpec({
+    tags(Stress)
 
     afterSpec {
         ReactiveScope.resetDefaultIoScope()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/PublisherResilienceTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/PublisherResilienceTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.event
 
 import net.transgressoft.lirp.event.CrudEvent.Type.CREATE
 import net.transgressoft.lirp.event.StandardCrudEvent.Create
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicInteger
@@ -38,6 +39,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  * [ReactiveScope] behaviour so that child coroutine failures do not cancel the parent.
  */
 @ExperimentalCoroutinesApi
+@SerializeWithReactiveScope
 class PublisherResilienceTest : DescribeSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/SlowSubscriberTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/SlowSubscriberTest.kt
@@ -18,6 +18,8 @@
 package net.transgressoft.lirp.event
 
 import net.transgressoft.lirp.persistence.CustomerVolatileRepo
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
+import net.transgressoft.lirp.testing.Stress
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.longs.shouldBeLessThan
@@ -64,7 +66,9 @@ private const val EVENT_COUNT = 60
  * subscribers before the next arrives. In this spaced-emission scenario, the non-blocking
  * property is proven by the fast subscriber completing long before the slow subscriber.
  */
+@SerializeWithReactiveScope
 class SlowSubscriberTest : DescribeSpec({
+    tags(Stress)
 
     // Dedicated scope with unbounded Default dispatcher to avoid coroutine scheduling contention
     // between publisher coroutines and Kotest's runBlocking event loop

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AccessorDiscoveryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AccessorDiscoveryTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
@@ -43,6 +44,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  */
 @DisplayName("RegistryBase")
 @OptIn(ExperimentalCoroutinesApi::class)
+@SerializeWithReactiveScope
 internal class AccessorDiscoveryTest : FunSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateCascadeCollectionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateCascadeCollectionTest.kt
@@ -18,6 +18,7 @@
 package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -36,6 +37,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  */
 @DisplayName("AggregateCascadeCollection")
 @OptIn(ExperimentalCoroutinesApi::class)
+@SerializeWithReactiveScope
 internal class AggregateCascadeCollectionTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateCascadeTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateCascadeTest.kt
@@ -20,6 +20,7 @@ package net.transgressoft.lirp.persistence
 import net.transgressoft.lirp.event.AggregateMutationEvent
 import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.nondeterministic.continually
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
@@ -47,6 +48,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  */
 @DisplayName("AggregateCascadeTest")
 @OptIn(ExperimentalCoroutinesApi::class)
+@SerializeWithReactiveScope
 internal class AggregateCascadeTest : FunSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateCollectionRefResolutionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateCollectionRefResolutionTest.kt
@@ -18,6 +18,7 @@
 package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -38,6 +39,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  */
 @DisplayName("AggregateCollectionRefDelegate")
 @OptIn(ExperimentalCoroutinesApi::class)
+@SerializeWithReactiveScope
 internal class AggregateCollectionRefResolutionTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateRefResolutionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateRefResolutionTest.kt
@@ -18,6 +18,7 @@
 package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.optional.shouldBeEmpty
@@ -36,6 +37,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  */
 @DisplayName("AggregateRefDelegate")
 @OptIn(ExperimentalCoroutinesApi::class)
+@SerializeWithReactiveScope
 internal class AggregateRefResolutionTest : FunSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateSetCascadeTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateSetCascadeTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.entity.CascadeAction
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -37,6 +38,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  */
 @DisplayName("AggregateSetCascade")
 @OptIn(ExperimentalCoroutinesApi::class)
+@SerializeWithReactiveScope
 internal class AggregateSetCascadeTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/CollectionChangeEventTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/CollectionChangeEventTest.kt
@@ -21,6 +21,7 @@ import net.transgressoft.lirp.event.AggregateMutationEvent
 import net.transgressoft.lirp.event.CollectionChangeEvent
 import net.transgressoft.lirp.event.ReactiveMutationEvent
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.nondeterministic.continually
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -41,6 +42,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  */
 @DisplayName("CollectionChangeEvent emission")
 @OptIn(ExperimentalCoroutinesApi::class)
+@SerializeWithReactiveScope
 internal class CollectionChangeEventTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/InnerClassRegistryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/InnerClassRegistryTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -40,6 +41,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  */
 @DisplayName("RegistryBase inner class and anonymous entity handling")
 @OptIn(ExperimentalCoroutinesApi::class)
+@SerializeWithReactiveScope
 internal class InnerClassRegistryTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/MutableAggregateCollectionRefTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/MutableAggregateCollectionRefTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -48,6 +49,7 @@ import kotlinx.coroutines.test.runTest
  */
 @DisplayName("MutableAggregateCollectionRefDelegate")
 @OptIn(ExperimentalCoroutinesApi::class)
+@SerializeWithReactiveScope
 internal class MutableAggregateCollectionRefTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryDebounceTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryDebounceTest.kt
@@ -18,6 +18,7 @@
 package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -40,6 +41,7 @@ import kotlinx.coroutines.test.TestCoroutineScheduler
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @DisplayName("PersistentRepositoryBase debounce queue")
+@SerializeWithReactiveScope
 internal class PersistentRepositoryDebounceTest : StringSpec({
 
     val testScheduler = TestCoroutineScheduler()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ReflectionFreeVerificationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ReflectionFreeVerificationTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeFalse
@@ -42,6 +43,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  */
 @DisplayName("RegistryBase")
 @OptIn(ExperimentalCoroutinesApi::class)
+@SerializeWithReactiveScope
 internal class ReflectionFreeVerificationTest : FunSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegisterRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegisterRepositoryTest.kt
@@ -23,6 +23,7 @@ import net.transgressoft.lirp.persistence.json.BubbleUpOrderJsonFileRepository
 import net.transgressoft.lirp.persistence.json.JsonFileRepository
 import net.transgressoft.lirp.persistence.json.MutableAudioPlaylistJsonFileRepository
 import net.transgressoft.lirp.persistence.json.lirpSerializer
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -48,6 +49,7 @@ import kotlinx.serialization.builtins.serializer
  */
 @ExperimentalCoroutinesApi
 @DisplayName("RegistryBase.registerRepository()")
+@SerializeWithReactiveScope
 internal class RegisterRepositoryTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryBaseConcurrencyTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryBaseConcurrencyTest.kt
@@ -18,6 +18,8 @@
 package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
+import net.transgressoft.lirp.testing.Stress
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.property.Arb
@@ -48,7 +50,9 @@ private fun arbitraryCustomer(id: Int = -1) =
  * concurrently via another coroutine.
  */
 @ExperimentalCoroutinesApi
+@SerializeWithReactiveScope
 internal class RegistryBaseConcurrencyTest : StringSpec({
+    tags(Stress)
 
     val testDispatcher = UnconfinedTestDispatcher()
     val testScope = CoroutineScope(testDispatcher)

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/SearchPerformanceTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/SearchPerformanceTest.kt
@@ -3,6 +3,7 @@ package net.transgressoft.lirp.persistence
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.event.CrudEvent.Type.READ
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -78,6 +79,7 @@ class IndexedProductVolatileRepo : VolatileRepository<Int, IndexedProduct>("Inde
  */
 @ExperimentalCoroutinesApi
 @DisplayName("VolatileRepository search performance")
+@SerializeWithReactiveScope
 internal class SearchPerformanceTest : StringSpec({
 
     lateinit var ctx: LirpContext

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/VolatileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/VolatileRepositoryTest.kt
@@ -10,6 +10,7 @@ import net.transgressoft.lirp.event.FlowEventPublisher
 import net.transgressoft.lirp.event.LirpEventSubscriberBase
 import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
@@ -42,6 +43,7 @@ private fun arbitraryCustomer(id: Int = -1) =
     }
 
 @ExperimentalCoroutinesApi
+@SerializeWithReactiveScope
 internal class VolatileRepositoryTest : FunSpec({
 
     class SomeClassSubscribedToEvents() : LirpEventSubscriberBase<Customer, CrudEvent.Type, CrudEvent<Int, Customer>>("Some Name") {

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/AggregateJsonPersistenceTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/AggregateJsonPersistenceTest.kt
@@ -27,6 +27,7 @@ import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.LirpRepository
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.MutableAudioPlaylist
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.spec.tempfile
 import io.kotest.matchers.collections.shouldContainExactly
@@ -57,6 +58,7 @@ import kotlinx.serialization.builtins.serializer
  * - Re-wiring of bubble-up subscriptions after reload
  */
 @ExperimentalCoroutinesApi
+@SerializeWithReactiveScope
 class AggregateJsonPersistenceTest : FunSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/FlexibleJsonFileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/FlexibleJsonFileRepositoryTest.kt
@@ -1,6 +1,7 @@
 package net.transgressoft.lirp.persistence.json
 
 import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.StringSpec
@@ -14,6 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 @ExperimentalCoroutinesApi
+@SerializeWithReactiveScope
 class FlexibleJsonFileRepositoryTest : StringSpec({
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
@@ -10,6 +10,8 @@ import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.LirpDeserializationException
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.PersistentRepositoryBase
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
+import net.transgressoft.lirp.testing.Stress
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.assertions.throwables.shouldNotThrowAny
@@ -40,6 +42,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 @ExperimentalCoroutinesApi
+@SerializeWithReactiveScope
 class JsonFileRepositoryTest : DescribeSpec({
     val testDispatcher = UnconfinedTestDispatcher()
     val testScope = CoroutineScope(testDispatcher)
@@ -261,7 +264,7 @@ class JsonFileRepositoryTest : DescribeSpec({
     }
 
     describe("Concurrency") {
-        it("maintains state under concurrent additions") {
+        it("maintains state under concurrent additions").config(tags = setOf(Stress)) {
             val testCustomers = (1..100).map { arbitraryStandardCustomer(it).next() }
             testScope.launch {
                 testCustomers.chunked(10).forEach { chunk ->
@@ -276,7 +279,7 @@ class JsonFileRepositoryTest : DescribeSpec({
             reloadedRepo.close()
         }
 
-        it("publishes create events under concurrency") {
+        it("publishes create events under concurrency").config(tags = setOf(Stress)) {
             val events = Collections.synchronizedList(mutableListOf<CrudEvent<Int, PolymorphicCustomer>>())
             val subscription: LirpEventSubscription<in PolymorphicCustomer, CrudEvent.Type, CrudEvent<Int, PolymorphicCustomer>> =
                 repository.subscribe(CREATE) { events.add(it) }
@@ -293,7 +296,7 @@ class JsonFileRepositoryTest : DescribeSpec({
             StandardCustomerJsonFileRepository(jsonFile).also { it.size() shouldBe reloadSize }.close()
         }
 
-        it("remains consistent under concurrent mutations") {
+        it("remains consistent under concurrent mutations").config(tags = setOf(Stress)) {
             (1..20).forEach { id -> repository.create(id, "Customer-$id", "c$id@example.com") }
             testDispatcher.scheduler.advanceUntilIdle()
             (1..5).map { _ ->

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/MusicCommonsJsonIntegrationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/MusicCommonsJsonIntegrationTest.kt
@@ -28,6 +28,7 @@ import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.MutableAudioPlaylist
 import net.transgressoft.lirp.persistence.PlaylistHierarchyJsonFileRepository
 import net.transgressoft.lirp.persistence.Repository
+import net.transgressoft.lirp.testing.SerializeWithReactiveScope
 import io.kotest.core.annotation.DisplayName
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
@@ -52,6 +53,7 @@ import kotlinx.serialization.builtins.serializer
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @DisplayName("Music-commons integration (JSON)")
+@SerializeWithReactiveScope
 class MusicCommonsJsonIntegrationTest : MusicCommonsIntegrationTestBase() {
 
     val testDispatcher = UnconfinedTestDispatcher()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/testing/CoreKotestProjectConfig.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/testing/CoreKotestProjectConfig.kt
@@ -1,0 +1,61 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.testing
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
+import io.kotest.core.extensions.SpecExtension
+import io.kotest.core.spec.Spec
+import io.kotest.engine.concurrency.SpecExecutionMode
+import io.kotest.engine.concurrency.TestExecutionMode
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Kotest project configuration for core tests.
+ *
+ * Specs run with bounded concurrency while individual tests remain sequential so specs
+ * with shared fixtures, virtual schedulers, or repository state keep deterministic ordering.
+ */
+class CoreKotestProjectConfig : AbstractProjectConfig() {
+    override val specExecutionMode = SpecExecutionMode.LimitedConcurrency(4)
+    override val testExecutionMode = TestExecutionMode.Sequential
+    override val extensions: List<Extension> = listOf(ReactiveScopeSpecSerializationExtension)
+}
+
+/**
+ * Serializes specs that mutate the process-wide [net.transgressoft.lirp.event.ReactiveScope].
+ *
+ * LIRP core tests already share that global hook extensively. Without this guard, project-level
+ * spec parallelism causes unrelated specs to rebind the same scope while file-backed or
+ * debounce-sensitive specs are still running.
+ */
+private object ReactiveScopeSpecSerializationExtension : SpecExtension {
+
+    val mutex = Mutex()
+
+    override suspend fun intercept(spec: Spec, execute: suspend (Spec) -> Unit) {
+        if (spec::class.java.isAnnotationPresent(SerializeWithReactiveScope::class.java)) {
+            mutex.withLock {
+                execute(spec)
+            }
+        } else {
+            execute(spec)
+        }
+    }
+}

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/testing/SerializeWithReactiveScope.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/testing/SerializeWithReactiveScope.kt
@@ -17,11 +17,10 @@
 
 package net.transgressoft.lirp.testing
 
-import io.kotest.core.Tag
-
 /**
- * Marker tag for heavyweight stress regression tests. By default these tests run with the
- * rest of the suite; pass `-Pkotest.tags.exclude=Stress` to skip them for a faster loop.
- * See module `build.gradle` Kotest tag wiring.
+ * Marks a spec that mutates the process-wide `ReactiveScope` and must therefore be serialized
+ * against other specs with the same annotation when core spec-level parallelism is enabled.
  */
-object Stress : Tag()
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class SerializeWithReactiveScope

--- a/lirp-fx/build.gradle
+++ b/lirp-fx/build.gradle
@@ -58,10 +58,9 @@ tasks.withType(Test).configureEach {
             '--add-exports=javafx.graphics/com.sun.glass.ui=ALL-UNNAMED',
             '--add-exports=javafx.graphics/com.sun.glass.ui.monocle=ALL-UNNAMED'
 
-    def includeTags = project.findProperty('kotest.tags.include') as String
-    if (includeTags) {
-        systemProperty 'kotest.tags.include', includeTags
-    } else {
-        systemProperty 'kotest.tags.exclude', 'Stress'
+    systemProperty 'kotest.framework.config.fqn', 'net.transgressoft.lirp.persistence.fx.FxKotestProjectConfig'
+    def excludeTags = project.findProperty('kotest.tags.exclude') as String
+    if (excludeTags) {
+        systemProperty 'kotest.tags.exclude', excludeTags
     }
 }

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateConcurrentMutationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateConcurrentMutationTest.kt
@@ -20,6 +20,7 @@ package net.transgressoft.lirp.persistence.fx
 import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.MutableAudioItem
+import net.transgressoft.lirp.testing.Stress
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CountDownLatch
@@ -39,6 +40,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class FxAggregateConcurrentMutationTest : StringSpec({
+    tags(Stress)
 
     val testScope = CoroutineScope(UnconfinedTestDispatcher())
 

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxKotestProjectConfig.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxKotestProjectConfig.kt
@@ -15,13 +15,19 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
  ******************************************************************************/
 
-package net.transgressoft.lirp.testing
+package net.transgressoft.lirp.persistence.fx
 
-import io.kotest.core.Tag
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.engine.concurrency.SpecExecutionMode
+import io.kotest.engine.concurrency.TestExecutionMode
 
 /**
- * Marker tag for heavyweight stress regression tests. By default these tests run with the
- * rest of the suite; pass `-Pkotest.tags.exclude=Stress` to skip them for a faster loop.
- * See module `build.gradle` Kotest tag wiring.
+ * Kotest project configuration for JavaFX tests.
+ *
+ * JavaFX toolkit state is process-wide, so FX specs and tests remain serialized even when
+ * other modules opt into spec-level parallelism.
  */
-object Stress : Tag()
+class FxKotestProjectConfig : AbstractProjectConfig() {
+    override val specExecutionMode = SpecExecutionMode.Sequential
+    override val testExecutionMode = TestExecutionMode.Sequential
+}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,8 @@
+# Lessons
+
+## Benchmark Equivalent Test Scopes Before Claiming Performance Impact
+
+- Correction: the user pointed out that the previous timing comparison mixed the default suite with the opt-in `Stress` subset, so it did not answer the actual before/after performance question.
+- Rule: when evaluating test-performance impact, compare equivalent test scopes before and after the change.
+- Rule: if tag routing changes during the phase, explicitly define how "full corpus" is measured on both revisions before collecting timings.
+- Rule: treat verification timings and benchmark timings as different artifacts; rerun benchmark commands from a clean or forced-rerun state before drawing performance conclusions.


### PR DESCRIPTION
## Summary

Adds explicit Kotest project configuration for `lirp-core` and `lirp-fx`, expands `Stress` coverage to the targeted heavyweight concurrency specs, and updates contributor test guidance.

During verification, `lirp-core` needed an additional shared-`ReactiveScope` serialization guard so spec-level parallelism would not race tests that mutate process-wide scope state.

The final shipped behavior runs `Stress` tests by default and uses `-Pkotest.tags.exclude=Stress` as the fast opt-out loop.

## Changes

### Kotest configuration
- Added `CoreKotestProjectConfig` for `lirp-core`
- Added `FxKotestProjectConfig` for `lirp-fx`
- Wired both modules through `kotest.framework.config.fqn`
- Kept JavaFX specs serialized
- Added a shared-scope serialization extension for `lirp-core` specs that mutate `ReactiveScope`

### Stress coverage
- Tagged the five whole-spec heavyweight concurrency candidates with `tags(Stress)`
- Tagged the targeted mixed-spec stress cases in `IntegrationTest.kt` and `JsonFileRepositoryTest.kt`

### Test-running workflow
- Updated `CONTRIBUTING.md` to use system `gradle` commands
- Documented Kotest parallelism and JavaFX serialization behavior
- Flipped the Gradle tag wiring so default runs include `Stress` tests and `-Pkotest.tags.exclude=Stress` provides the shorter feedback loop

## Requirements Addressed

- `TEST-01` — existing heavyweight concurrency specs are covered by `Stress`
- `TEST-02` — before/after timing evidence was collected during implementation and benchmarked again on committed revisions
- `TEST-03` — Kotest project-level parallelism is enabled with documented exceptions
- `TEST-04` — `CONTRIBUTING.md` documents the final test-running guidance

## Verification

- [x] `gradle :lirp-core:testClasses :lirp-fx:testClasses --console=plain`
- [x] `gradle :lirp-core:test --console=plain`
- [x] `gradle :lirp-fx:test --console=plain`
- [x] `gradle :lirp-sql:test --console=plain`
- [x] `gradle test --console=plain`
- [x] `gradle test -Pkotest.tags.exclude=Stress --console=plain`

## Key Decisions

- Keep explicit Kotest project configs instead of relying on implicit discovery
- Keep JavaFX specs serialized because `FxToolkitInit` and toolkit state are process-wide
- Guard `lirp-core` parallelism with a shared-`ReactiveScope` spec extension instead of disabling project-level parallelism entirely
- Run `Stress` tests by default and use `kotest.tags.exclude=Stress` as the fast-loop override