### PR TITLE
#153 Fix flaky `query returns lazy Sequence` test

### DIFF
--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryQueryDslIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryQueryDslIntegrationTest.kt
@@ -40,7 +40,9 @@ import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.DisplayName as JunitDisplayName
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
 
 /**
  * Integration tests for the Query DSL against [SqlRepository] on PostgreSQL, MySQL, MariaDB, and SQLite.
@@ -756,6 +758,7 @@ internal class SqlRepositoryQueryDslIntegrationTest : FunSpec({
                     repo.activateEvents(CrudEvent.Type.READ)
                     val readCount = AtomicInteger(0)
                     repo.subscribe(CrudEvent.Type.READ) { readCount.incrementAndGet() }
+                    delay(50.milliseconds) // let SharedFlow collector coroutine start
 
                     val sequence = repo.query { where { TestPerson::firstName eq "A" } }
 
@@ -768,7 +771,7 @@ internal class SqlRepositoryQueryDslIntegrationTest : FunSpec({
                     rows.first().firstName shouldBe "A"
 
                     // emitAsync is asynchronous; poll until the event is processed
-                    eventually(2.seconds) {
+                    eventually(5.seconds) {
                         readCount.get() shouldBeExactly 1
                     }
                 } finally {


### PR DESCRIPTION
## Summary

Closes #153.

The `query returns lazy Sequence` test in `SqlRepositoryQueryDslIntegrationTest` was racing the SharedFlow collector startup against the async `emitAsync(Read(snapshot))` call, and using a 2-second `eventually` budget that's far below the 5+ seconds every other event integration test in `lirp-sql` uses. The flake fired on the PostgreSQL Testcontainers run after PR #152 merged.

## Changes

- Added `delay(50.milliseconds)` between `repo.subscribe(CrudEvent.Type.READ) { … }` and the terminal `sequence.toList()` — mirrors the warmup pattern already used in `SqlRepositoryEventIntegrationTest`.
- Raised `eventually(2.seconds)` to `eventually(5.seconds)` to match the rest of the suite.
- Added imports: `kotlinx.coroutines.delay`, `kotlin.time.Duration.Companion.milliseconds`.

One file, +4 / -1.

## Test plan

- [x] `gradle :lirp-sql:compileIntegrationTestKotlin` compiles cleanly
- [x] `gradle ktlintCheck` passes
- [x] `gradle :lirp-sql:integrationTest --tests "*SqlRepositoryQueryDslIntegrationTest*"` — 84 tests, 0 failures across PostgreSQL, MySQL, MariaDB, and SQLite Testcontainers
- [ ] CI exercises the same matrix