### PR TITLE
#157 KSP: recognise optionalAggregate in single-entity FK scan

### DIFF
--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
@@ -212,8 +212,9 @@ class TableDefProcessor(
             text.contains("aggregateSet")
 
     /**
-     * Extracts the backing scalar identifier referenced by the lambda passed to
-     * `aggregate { … }` (e.g. `customerId` from `aggregate<Int, Customer> { customerId }`).
+     * Extracts the backing scalar identifier referenced by the lambda passed to a
+     * single-entity aggregate factory (`aggregate { … }`, `optionalAggregate { … }`,
+     * or any future `mutableAggregate { … }` variant).
      *
      * Single-entity aggregate factories take an `idProvider: () -> K` lambda whose body is
      * conventionally a property reference, optionally with non-null assertion (`!!`) or an
@@ -222,12 +223,13 @@ class TableDefProcessor(
      * backing scalar.
      */
     private fun extractAggregateLambdaIdentifier(text: String): String? {
-        // Match `aggregate<...> { ... }` and capture the first identifier inside the braces.
-        // The first identifier is the backing scalar in conventional usage:
-        //   aggregate { customerId }      → customerId
-        //   aggregate { customerId!! }    → customerId
-        //   aggregate { customerId ?: 0 } → customerId
-        val regex = Regex("""\baggregate\b[^{]*\{\s*([A-Za-z_][A-Za-z_0-9]*)\b""")
+        // Capture the first identifier inside the lambda braces for the single-entity
+        // factory family. The first identifier is the backing scalar in conventional usage:
+        //   aggregate         { customerId }       → customerId
+        //   aggregate         { customerId!! }     → customerId
+        //   aggregate         { customerId ?: 0 }  → customerId
+        //   optionalAggregate { parentTenantId }   → parentTenantId
+        val regex = Regex("""\b(?:optional|mutable)?[Aa]ggregate\b[^{]*\{\s*([A-Za-z_][A-Za-z_0-9]*)\b""")
         return regex.find(text)?.groupValues?.getOrNull(1)
     }
 

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
@@ -1153,6 +1153,40 @@ internal class TableDefProcessorTest : FunSpec({
         content shouldContain "onDelete = CascadeAction.DETACH"
     }
 
+    test("resolves backing scalar from optionalAggregate lambda and emits SET_NULL FK") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "OptionalAggregateRef.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.entity.CascadeAction
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.Aggregate
+                import net.transgressoft.lirp.persistence.PersistenceIgnore
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+                import net.transgressoft.lirp.persistence.optionalAggregate
+                import java.util.UUID
+
+                @PersistenceMapping
+                class Tenant(override val id: UUID, parentTenantId: UUID? = null) : ReactiveEntityBase<UUID, Tenant>() {
+                    var parentTenantId: UUID? by reactiveProperty(parentTenantId)
+                    @Aggregate(onDelete = CascadeAction.DETACH)
+                    @PersistenceIgnore
+                    val parentTenant by optionalAggregate<UUID, Tenant> { parentTenantId }
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = Tenant(id, parentTenantId)
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("Tenant_LirpTableDef.kt")
+        content shouldContain "ForeignKeyDef(columnName = \"parent_tenant_id\""
+        content shouldContain "onDelete = CascadeAction.DETACH"
+    }
+
     // ---- Junction accessor wiring on _LirpTableDef (#144 / FK-04, plan 53-03a) ----
 
     test("_LirpTableDef overrides junctionTableDefs for entity with aggregateList collection ref") {


### PR DESCRIPTION
## Summary

Fixes #157.

The KSP regex used by `TableDefProcessor.extractAggregateLambdaIdentifier` only matched the bare `aggregate { … }` factory, so any property declared with `optionalAggregate { … }` — a first-class public factory in `lirp-core` — failed KSP processing with a misleading "Cannot determine backing scalar" error even when the lambda body referenced a single scalar correctly.

The collection-side scanners already handle the `mutable*` factory family (`mutableAggregateList`, `mutableAggregateSet`); the single-entity path was not given the same treatment.

## Changes

- `TableDefProcessor.kt:230` — broaden the regex from `\baggregate\b` to `\b(?:optional|mutable)?[Aa]ggregate\b` so the scanner recognises the full single-entity factory family.
- Update the KDoc on `extractAggregateLambdaIdentifier` to describe the factory family explicitly.
- Add a `TableDefProcessorTest` case that declares `optionalAggregate<UUID, Tenant> { parentTenantId }` and asserts the resulting `ForeignKeyDef(columnName = "parent_tenant_id", onDelete = CascadeAction.DETACH)` is emitted.

## Surfaced by

Dogfooding `lirp-fleet-poc` against `v2.5.0-SNAPSHOT` — first gap surfaced during the v2.3.2 → v2.5.0 bump. See issue #157 for the full reproduction.

## Test plan

- [x] `gradle :lirp-ksp:test --tests TableDefProcessorTest` — all existing tests pass, plus new `resolves backing scalar from optionalAggregate lambda and emits SET_NULL FK` case.
- [x] `gradle build` — full multi-module suite green.
- [x] Verified end-to-end against `lirp-fleet-poc` Tenant entity (`val parentTenant by optionalAggregate<UUID, Tenant> { parentTenantId }`) — KSP no longer rejects it.