### PR TITLE
#158 Install single-entity @Aggregate foreign-key constraints

### DIFF
--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
@@ -261,6 +261,82 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
     }
 
     /**
+     * Installs the single-entity foreign-key constraints declared on this entity's scalar
+     * `@Aggregate` references.
+     *
+     * The entity table is created without these constraints during [init] for the same reason
+     * junction tables are: the referenced target table may belong to a different [SqlRepository]
+     * that has not yet been constructed. Once every repository in the application has
+     * materialised, call this method on each repository (or once via the application bootstrapper)
+     * to install the constraints declared in [SqlTableDef.foreignKeys].
+     *
+     * The `ON DELETE` clause is taken from each [ForeignKeyDef.onDelete] descriptor and translated
+     * via [cascadeToReferenceOption]; entries whose action is [CascadeAction.NONE] are skipped
+     * upstream by the KSP processor and never appear in `tableDef.foreignKeys()`.
+     *
+     * **SQLite caveat:** SQLite does not support `ALTER TABLE ADD CONSTRAINT`, so this method
+     * logs a warning and returns without installing any constraints. Consumers needing FK
+     * enforcement on SQLite must declare the constraints inline at `CREATE TABLE` time (a future
+     * follow-up may emit them through the table builder for the SQLite dialect).
+     *
+     * Safe to call multiple times — duplicate-constraint errors raised by the database are
+     * swallowed so the operation is effectively idempotent.
+     */
+    fun installEntityForeignKeys() {
+        val foreignKeys = tableDef.foreignKeys()
+        if (foreignKeys.isEmpty()) return
+
+        if (isSqliteDialect()) {
+            log.warn {
+                "installEntityForeignKeys: skipping ${foreignKeys.size} single-entity FK(s) on table " +
+                    "'${tableDef.tableName}' — SQLite does not support ALTER TABLE ADD CONSTRAINT. " +
+                    "FK constraints must be declared inline at CREATE TABLE time on this dialect."
+            }
+            return
+        }
+
+        val columnTypesByName = tableDef.columns.associate { it.name to it.type }
+
+        // Each FK is installed in its own transaction. Postgres (and some other dialects) abort the
+        // entire transaction on a DDL error — even a swallowed duplicate-constraint error poisons the
+        // connection for subsequent statements. Independent transactions keep each idempotent install
+        // isolated.
+        for (fk in foreignKeys) {
+            val refOption = cascadeToReferenceOption(fk.onDelete) ?: continue
+
+            val columnType =
+                columnTypesByName[fk.columnName]
+                    ?: error(
+                        "SqlTableDef '${tableDef::class.qualifiedName}' declares ForeignKeyDef on column " +
+                            "'${fk.columnName}' but no such column exists in tableDef.columns. This is a KSP " +
+                            "or hand-written SqlTableDef contract violation."
+                    )
+
+            @Suppress("UNCHECKED_CAST")
+            val fromCol = exposedTable.columnsByName.getValue(fk.columnName) as Column<Any>
+
+            transaction(db = db) {
+                installFk(
+                    fromCol = fromCol,
+                    targetTableName = fk.referencedTable,
+                    targetColType = columnType,
+                    onDelete = refOption
+                )
+            }
+        }
+    }
+
+    /**
+     * Detects SQLite by inspecting the underlying JDBC connection's `DatabaseMetaData`.
+     * Used by [installEntityForeignKeys] to short-circuit before attempting an unsupported
+     * `ALTER TABLE ADD CONSTRAINT` DDL statement.
+     */
+    private fun isSqliteDialect(): Boolean =
+        dataSource.connection.use { conn ->
+            conn.metaData.databaseProductName.orEmpty().lowercase().contains("sqlite")
+        }
+
+    /**
      * Builds an Exposed [ForeignKeyConstraint] anchored at a shadow target table whose only
      * column is `id` with the descriptor-declared type, and executes the resulting DDL inside the
      * current transaction. Duplicate-constraint failures are caught and logged at DEBUG so

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
@@ -241,6 +241,7 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
                 installFk(
                     fromCol = junction.parentIdCol,
                     targetTableName = descriptor.parentTableName,
+                    targetColumnName = "id",
                     targetColType = parentIdJunctionType(descriptor),
                     onDelete = ReferenceOption.CASCADE
                 )
@@ -252,6 +253,7 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
                     installFk(
                         fromCol = junction.itemIdCol,
                         targetTableName = descriptor.itemTableName,
+                        targetColumnName = "id",
                         targetColType = itemIdJunctionType(descriptor),
                         onDelete = itemRefOption
                     )
@@ -319,6 +321,7 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
                 installFk(
                     fromCol = fromCol,
                     targetTableName = fk.referencedTable,
+                    targetColumnName = fk.referencedColumn,
                     targetColType = columnType,
                     onDelete = refOption
                 )
@@ -338,17 +341,18 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
 
     /**
      * Builds an Exposed [ForeignKeyConstraint] anchored at a shadow target table whose only
-     * column is `id` with the descriptor-declared type, and executes the resulting DDL inside the
-     * current transaction. Duplicate-constraint failures are caught and logged at DEBUG so
-     * repeated calls are no-ops.
+     * column is [targetColumnName] with the descriptor-declared type, and executes the resulting
+     * DDL inside the current transaction. Duplicate-constraint failures are caught and logged
+     * at DEBUG so repeated calls are no-ops.
      */
     private fun JdbcTransaction.installFk(
         fromCol: Column<Any>,
         targetTableName: String,
+        targetColumnName: String,
         targetColType: net.transgressoft.lirp.persistence.ColumnType,
         onDelete: ReferenceOption
     ) {
-        val shadowTarget = ShadowEntityIdTable(targetTableName, targetColType)
+        val shadowTarget = ShadowEntityIdTable(targetTableName, targetColumnName, targetColType)
 
         @Suppress("UNCHECKED_CAST")
         val targetCol = shadowTarget.idColumn as Column<Any>
@@ -904,23 +908,24 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
 
 /**
  * Shadow Exposed [Table] used solely as a target for [ForeignKeyConstraint] DDL emission during
- * deferred junction-FK installation. The shadow table has a single `id` column whose type matches
- * the descriptor's `parent_id` / `item_id` declaration; Exposed reads only the table name and
- * column name when rendering the `REFERENCES <tbl>(<col>)` clause, so the shadow table never needs
- * to be created in the database.
+ * deferred FK installation. The shadow table has a single column named [columnName] whose type
+ * matches the descriptor's declaration; Exposed reads only the table name and column name when
+ * rendering the `REFERENCES <tbl>(<col>)` clause, so the shadow table never needs to be created
+ * in the database.
  */
 @OptIn(ExperimentalUuidApi::class)
 private class ShadowEntityIdTable(
     tableName: String,
+    columnName: String,
     idType: net.transgressoft.lirp.persistence.ColumnType
 ) : Table(tableName) {
     val idColumn: Column<*> =
         when (idType) {
-            is net.transgressoft.lirp.persistence.ColumnType.IntType -> integer("id")
-            is net.transgressoft.lirp.persistence.ColumnType.LongType -> long("id")
-            is net.transgressoft.lirp.persistence.ColumnType.UuidType -> uuid("id")
-            is net.transgressoft.lirp.persistence.ColumnType.VarcharType -> varchar("id", idType.length)
-            is net.transgressoft.lirp.persistence.ColumnType.TextType -> text("id")
-            else -> error("Unsupported junction id type for shadow target table: $idType")
+            is net.transgressoft.lirp.persistence.ColumnType.IntType -> integer(columnName)
+            is net.transgressoft.lirp.persistence.ColumnType.LongType -> long(columnName)
+            is net.transgressoft.lirp.persistence.ColumnType.UuidType -> uuid(columnName)
+            is net.transgressoft.lirp.persistence.ColumnType.VarcharType -> varchar(columnName, idType.length)
+            is net.transgressoft.lirp.persistence.ColumnType.TextType -> text(columnName)
+            else -> error("Unsupported id type for shadow target table: $idType")
         }
 }

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEntityForeignKeyInstallTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEntityForeignKeyInstallTest.kt
@@ -23,10 +23,10 @@ import net.transgressoft.lirp.persistence.ColumnDef
 import net.transgressoft.lirp.persistence.ColumnType
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
 import org.jetbrains.exposed.v1.core.Column
@@ -34,7 +34,7 @@ import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.Table
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
-import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Verifies that [SqlRepository.installEntityForeignKeys] actually applies the constraints
@@ -46,6 +46,9 @@ import kotlinx.coroutines.delay
  * [SqlRepository.installEntityForeignKeys], and asserts the resulting database-level behaviour
  * via direct JDBC. `Int` keys avoid `java.util.UUID` vs `kotlin.uuid.Uuid` plumbing noise that
  * is orthogonal to the FK install contract under test.
+ *
+ * Persistence waits use kotest's [eventually] to poll the DB rather than fixed `delay(...)` sleeps,
+ * keeping the suite deterministic under CI jitter.
  */
 class SqlRepositoryEntityForeignKeyInstallTest : StringSpec({
 
@@ -55,147 +58,143 @@ class SqlRepositoryEntityForeignKeyInstallTest : StringSpec({
         val ds = freshDataSource()
         val childRepo = SqlRepository(ds, ScalarFkChildTableDef)
         val parentRepo = SqlRepository(ds, ScalarFkParentTableDef(CascadeAction.RESTRICT))
+        try {
+            parentRepo.installEntityForeignKeys()
 
-        parentRepo.installEntityForeignKeys()
+            val childId = nextId.incrementAndGet()
+            childRepo.add(ScalarFkChild(childId).apply { name = "linked" })
+            awaitRowPresent(ds, "fk_scalar_children", childId)
 
-        val childId = nextId.incrementAndGet()
-        childRepo.add(ScalarFkChild(childId).apply { name = "linked" })
-        delay(150)
+            val parentId = nextId.incrementAndGet()
+            parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
+            awaitRowPresent(ds, "fk_scalar_parents", parentId)
 
-        val parentId = nextId.incrementAndGet()
-        parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
-        delay(150)
-
-        shouldThrow<java.sql.SQLException> {
-            ds.connection.use { conn ->
-                conn.createStatement().use { stmt ->
-                    stmt.executeUpdate("DELETE FROM fk_scalar_children WHERE id = $childId")
+            shouldThrow<java.sql.SQLException> {
+                ds.connection.use { conn ->
+                    conn.createStatement().use { stmt ->
+                        stmt.executeUpdate("DELETE FROM fk_scalar_children WHERE id = $childId")
+                    }
                 }
             }
+
+            childRepo.findById(childId).shouldBePresent { it.name shouldBe "linked" }
+        } finally {
+            closeQuietly(parentRepo, childRepo, ds)
         }
-
-        childRepo.findById(childId).shouldBePresent { it.name shouldBe "linked" }
-
-        parentRepo.close()
-        childRepo.close()
-        ds.close()
     }
 
     "installEntityForeignKeys with CASCADE deletes the parent row when its child is deleted" {
         val ds = freshDataSource()
         val childRepo = SqlRepository(ds, ScalarFkChildTableDef)
         val parentRepo = SqlRepository(ds, ScalarFkParentTableDef(CascadeAction.CASCADE))
+        try {
+            parentRepo.installEntityForeignKeys()
 
-        parentRepo.installEntityForeignKeys()
+            val childId = nextId.incrementAndGet()
+            childRepo.add(ScalarFkChild(childId).apply { name = "doomed" })
+            awaitRowPresent(ds, "fk_scalar_children", childId)
 
-        val childId = nextId.incrementAndGet()
-        childRepo.add(ScalarFkChild(childId).apply { name = "doomed" })
-        delay(150)
+            val parentId = nextId.incrementAndGet()
+            parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
+            awaitRowPresent(ds, "fk_scalar_parents", parentId)
 
-        val parentId = nextId.incrementAndGet()
-        parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
-        delay(150)
-
-        ds.connection.use { conn ->
-            conn.createStatement().use { stmt ->
-                stmt.executeUpdate("DELETE FROM fk_scalar_children WHERE id = $childId")
+            ds.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.executeUpdate("DELETE FROM fk_scalar_children WHERE id = $childId")
+                }
             }
-        }
 
-        ds.connection.use { conn ->
-            conn.createStatement().use { stmt ->
-                val rs = stmt.executeQuery("SELECT COUNT(*) FROM fk_scalar_parents WHERE id = $parentId")
-                rs.next()
-                rs.getInt(1) shouldBe 0
+            ds.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    val rs = stmt.executeQuery("SELECT COUNT(*) FROM fk_scalar_parents WHERE id = $parentId")
+                    rs.next()
+                    rs.getInt(1) shouldBe 0
+                }
             }
+        } finally {
+            closeQuietly(parentRepo, childRepo, ds)
         }
-
-        parentRepo.close()
-        childRepo.close()
-        ds.close()
     }
 
     "installEntityForeignKeys with DETACH nulls the FK column when the child is deleted" {
         val ds = freshDataSource()
         val childRepo = SqlRepository(ds, ScalarFkChildTableDef)
         val parentRepo = SqlRepository(ds, ScalarFkParentTableDef(CascadeAction.DETACH))
+        try {
+            parentRepo.installEntityForeignKeys()
 
-        parentRepo.installEntityForeignKeys()
+            val childId = nextId.incrementAndGet()
+            childRepo.add(ScalarFkChild(childId).apply { name = "to-be-orphaned" })
+            awaitRowPresent(ds, "fk_scalar_children", childId)
 
-        val childId = nextId.incrementAndGet()
-        childRepo.add(ScalarFkChild(childId).apply { name = "to-be-orphaned" })
-        delay(150)
+            val parentId = nextId.incrementAndGet()
+            parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
+            awaitRowPresent(ds, "fk_scalar_parents", parentId)
 
-        val parentId = nextId.incrementAndGet()
-        parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
-        delay(150)
-
-        ds.connection.use { conn ->
-            conn.createStatement().use { stmt ->
-                stmt.executeUpdate("DELETE FROM fk_scalar_children WHERE id = $childId")
+            ds.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.executeUpdate("DELETE FROM fk_scalar_children WHERE id = $childId")
+                }
             }
-        }
 
-        ds.connection.use { conn ->
-            conn.createStatement().use { stmt ->
-                val rs =
-                    stmt.executeQuery(
-                        "SELECT single_child_id FROM fk_scalar_parents WHERE id = $parentId"
-                    )
-                rs.next() shouldBe true
-                rs.getObject(1).shouldBeNull()
+            ds.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    val rs =
+                        stmt.executeQuery(
+                            "SELECT single_child_id FROM fk_scalar_parents WHERE id = $parentId"
+                        )
+                    rs.next() shouldBe true
+                    rs.getObject(1).shouldBeNull()
+                }
             }
+        } finally {
+            closeQuietly(parentRepo, childRepo, ds)
         }
-
-        parentRepo.close()
-        childRepo.close()
-        ds.close()
     }
 
     "installEntityForeignKeys is idempotent across repeated calls" {
         val ds = freshDataSource()
         val childRepo = SqlRepository(ds, ScalarFkChildTableDef)
         val parentRepo = SqlRepository(ds, ScalarFkParentTableDef(CascadeAction.RESTRICT))
+        try {
+            parentRepo.installEntityForeignKeys()
+            parentRepo.installEntityForeignKeys()
+            parentRepo.installEntityForeignKeys()
 
-        parentRepo.installEntityForeignKeys()
-        parentRepo.installEntityForeignKeys()
-        parentRepo.installEntityForeignKeys()
+            val childId = nextId.incrementAndGet()
+            childRepo.add(ScalarFkChild(childId).apply { name = "still-linked" })
+            awaitRowPresent(ds, "fk_scalar_children", childId)
 
-        val childId = nextId.incrementAndGet()
-        childRepo.add(ScalarFkChild(childId).apply { name = "still-linked" })
-        delay(150)
+            val parentId = nextId.incrementAndGet()
+            parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
+            awaitRowPresent(ds, "fk_scalar_parents", parentId)
 
-        val parentId = nextId.incrementAndGet()
-        parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
-        delay(150)
-
-        shouldThrow<java.sql.SQLException> {
-            ds.connection.use { conn ->
-                conn.createStatement().use { stmt ->
-                    stmt.executeUpdate("DELETE FROM fk_scalar_children WHERE id = $childId")
+            shouldThrow<java.sql.SQLException> {
+                ds.connection.use { conn ->
+                    conn.createStatement().use { stmt ->
+                        stmt.executeUpdate("DELETE FROM fk_scalar_children WHERE id = $childId")
+                    }
                 }
             }
+        } finally {
+            closeQuietly(parentRepo, childRepo, ds)
         }
-
-        parentRepo.close()
-        childRepo.close()
-        ds.close()
     }
 
     "installEntityForeignKeys is a no-op when the entity declares no foreign keys" {
         val ds = freshDataSource()
         val childRepo = SqlRepository(ds, ScalarFkChildTableDef)
+        try {
+            childRepo.installEntityForeignKeys()
 
-        childRepo.installEntityForeignKeys()
+            val childId = nextId.incrementAndGet()
+            childRepo.add(ScalarFkChild(childId).apply { name = "standalone" })
+            awaitRowPresent(ds, "fk_scalar_children", childId)
 
-        val childId = nextId.incrementAndGet()
-        childRepo.add(ScalarFkChild(childId).apply { name = "standalone" })
-        delay(150)
-
-        childRepo.findById(childId).shouldNotBeNull()
-
-        childRepo.close()
-        ds.close()
+            childRepo.findById(childId).shouldBePresent { it.name shouldBe "standalone" }
+        } finally {
+            closeQuietly(childRepo, ds)
+        }
     }
 })
 
@@ -206,6 +205,32 @@ private fun freshDataSource(): HikariDataSource {
             maximumPoolSize = 4
         }
     return HikariDataSource(cfg)
+}
+
+// Polls the DB directly until a row with the given primary key appears, with a generous timeout.
+// Replaces fixed `delay(...)` sleeps so the suite stays deterministic under CI jitter.
+private suspend fun awaitRowPresent(ds: HikariDataSource, tableName: String, id: Int) {
+    eventually(5.seconds) {
+        ds.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("SELECT COUNT(*) FROM $tableName WHERE id = $id")
+                rs.next()
+                require(rs.getInt(1) == 1) { "row id=$id not yet visible in $tableName" }
+            }
+        }
+    }
+}
+
+// Closes resources in reverse-of-acquisition order, swallowing per-resource failures so a leak
+// during cleanup never masks a test-body failure.
+private fun closeQuietly(vararg resources: AutoCloseable) {
+    for (resource in resources) {
+        try {
+            resource.close()
+        } catch (_: Throwable) {
+            // Ignore — best-effort cleanup, the original test failure (if any) is more interesting.
+        }
+    }
 }
 
 internal class ScalarFkChild(override val id: Int) : ReactiveEntityBase<Int, ScalarFkChild>() {

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEntityForeignKeyInstallTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEntityForeignKeyInstallTest.kt
@@ -1,0 +1,298 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.ColumnDef
+import net.transgressoft.lirp.persistence.ColumnType
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.delay
+
+/**
+ * Verifies that [SqlRepository.installEntityForeignKeys] actually applies the constraints
+ * declared in [SqlTableDef.foreignKeys] at the database level — closing the gap left by the
+ * Phase 53 deferral where the metadata was emitted but never consumed.
+ *
+ * Each test stands up two H2 tables in the same in-memory database (parent + child), declares
+ * a single-entity FK descriptor with the cascade variant under test, calls
+ * [SqlRepository.installEntityForeignKeys], and asserts the resulting database-level behaviour
+ * via direct JDBC. `Int` keys avoid `java.util.UUID` vs `kotlin.uuid.Uuid` plumbing noise that
+ * is orthogonal to the FK install contract under test.
+ */
+class SqlRepositoryEntityForeignKeyInstallTest : StringSpec({
+
+    val nextId = AtomicInteger(0)
+
+    "installEntityForeignKeys with RESTRICT prevents deleting a referenced child row" {
+        val ds = freshDataSource()
+        val childRepo = SqlRepository(ds, ScalarFkChildTableDef)
+        val parentRepo = SqlRepository(ds, ScalarFkParentTableDef(CascadeAction.RESTRICT))
+
+        parentRepo.installEntityForeignKeys()
+
+        val childId = nextId.incrementAndGet()
+        childRepo.add(ScalarFkChild(childId).apply { name = "linked" })
+        delay(150)
+
+        val parentId = nextId.incrementAndGet()
+        parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
+        delay(150)
+
+        shouldThrow<java.sql.SQLException> {
+            ds.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.executeUpdate("DELETE FROM fk_scalar_children WHERE id = $childId")
+                }
+            }
+        }
+
+        childRepo.findById(childId).shouldBePresent { it.name shouldBe "linked" }
+
+        parentRepo.close()
+        childRepo.close()
+        ds.close()
+    }
+
+    "installEntityForeignKeys with CASCADE deletes the parent row when its child is deleted" {
+        val ds = freshDataSource()
+        val childRepo = SqlRepository(ds, ScalarFkChildTableDef)
+        val parentRepo = SqlRepository(ds, ScalarFkParentTableDef(CascadeAction.CASCADE))
+
+        parentRepo.installEntityForeignKeys()
+
+        val childId = nextId.incrementAndGet()
+        childRepo.add(ScalarFkChild(childId).apply { name = "doomed" })
+        delay(150)
+
+        val parentId = nextId.incrementAndGet()
+        parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
+        delay(150)
+
+        ds.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.executeUpdate("DELETE FROM fk_scalar_children WHERE id = $childId")
+            }
+        }
+
+        ds.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("SELECT COUNT(*) FROM fk_scalar_parents WHERE id = $parentId")
+                rs.next()
+                rs.getInt(1) shouldBe 0
+            }
+        }
+
+        parentRepo.close()
+        childRepo.close()
+        ds.close()
+    }
+
+    "installEntityForeignKeys with DETACH nulls the FK column when the child is deleted" {
+        val ds = freshDataSource()
+        val childRepo = SqlRepository(ds, ScalarFkChildTableDef)
+        val parentRepo = SqlRepository(ds, ScalarFkParentTableDef(CascadeAction.DETACH))
+
+        parentRepo.installEntityForeignKeys()
+
+        val childId = nextId.incrementAndGet()
+        childRepo.add(ScalarFkChild(childId).apply { name = "to-be-orphaned" })
+        delay(150)
+
+        val parentId = nextId.incrementAndGet()
+        parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
+        delay(150)
+
+        ds.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.executeUpdate("DELETE FROM fk_scalar_children WHERE id = $childId")
+            }
+        }
+
+        ds.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                val rs =
+                    stmt.executeQuery(
+                        "SELECT single_child_id FROM fk_scalar_parents WHERE id = $parentId"
+                    )
+                rs.next() shouldBe true
+                rs.getObject(1).shouldBeNull()
+            }
+        }
+
+        parentRepo.close()
+        childRepo.close()
+        ds.close()
+    }
+
+    "installEntityForeignKeys is idempotent across repeated calls" {
+        val ds = freshDataSource()
+        val childRepo = SqlRepository(ds, ScalarFkChildTableDef)
+        val parentRepo = SqlRepository(ds, ScalarFkParentTableDef(CascadeAction.RESTRICT))
+
+        parentRepo.installEntityForeignKeys()
+        parentRepo.installEntityForeignKeys()
+        parentRepo.installEntityForeignKeys()
+
+        val childId = nextId.incrementAndGet()
+        childRepo.add(ScalarFkChild(childId).apply { name = "still-linked" })
+        delay(150)
+
+        val parentId = nextId.incrementAndGet()
+        parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
+        delay(150)
+
+        shouldThrow<java.sql.SQLException> {
+            ds.connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.executeUpdate("DELETE FROM fk_scalar_children WHERE id = $childId")
+                }
+            }
+        }
+
+        parentRepo.close()
+        childRepo.close()
+        ds.close()
+    }
+
+    "installEntityForeignKeys is a no-op when the entity declares no foreign keys" {
+        val ds = freshDataSource()
+        val childRepo = SqlRepository(ds, ScalarFkChildTableDef)
+
+        childRepo.installEntityForeignKeys()
+
+        val childId = nextId.incrementAndGet()
+        childRepo.add(ScalarFkChild(childId).apply { name = "standalone" })
+        delay(150)
+
+        childRepo.findById(childId).shouldNotBeNull()
+
+        childRepo.close()
+        ds.close()
+    }
+})
+
+private fun freshDataSource(): HikariDataSource {
+    val cfg =
+        HikariConfig().apply {
+            jdbcUrl = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+            maximumPoolSize = 4
+        }
+    return HikariDataSource(cfg)
+}
+
+internal class ScalarFkChild(override val id: Int) : ReactiveEntityBase<Int, ScalarFkChild>() {
+    var name: String by reactiveProperty("")
+    override val uniqueId: String get() = "scalar-fk-child-$id"
+
+    override fun clone(): ScalarFkChild =
+        ScalarFkChild(id).also { copy -> copy.withEventsDisabled { copy.name = name } }
+}
+
+internal class ScalarFkParent(override val id: Int) : ReactiveEntityBase<Int, ScalarFkParent>() {
+    var childId: Int? by reactiveProperty(null)
+    override val uniqueId: String get() = "scalar-fk-parent-$id"
+
+    override fun clone(): ScalarFkParent =
+        ScalarFkParent(id).also { copy -> copy.withEventsDisabled { copy.childId = childId } }
+}
+
+internal object ScalarFkChildTableDef : SqlTableDef<ScalarFkChild> {
+    override val tableName = "fk_scalar_children"
+    override val columns =
+        listOf(
+            ColumnDef("id", ColumnType.IntType, nullable = false, primaryKey = true),
+            ColumnDef("name", ColumnType.VarcharType(200), nullable = false, primaryKey = false)
+        )
+
+    @Suppress("UNCHECKED_CAST")
+    override fun fromRow(row: ResultRow, table: Table): ScalarFkChild {
+        val cols = table.columns.associateBy { it.name }
+        return ScalarFkChild(row[cols["id"]!! as Column<Int>]).also { entity ->
+            entity.withEventsDisabled { entity.name = row[cols["name"]!! as Column<String>] }
+        }
+    }
+
+    override fun toParams(entity: ScalarFkChild, table: Table): Map<Column<*>, Any?> {
+        val cols = table.columns.associateBy { it.name }
+        return mapOf(cols["id"]!! to entity.id, cols["name"]!! to entity.name)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun applyRow(entity: ScalarFkChild, row: ResultRow, table: Table) {
+        val cols = table.columns.associateBy { it.name }
+        entity.withEventsDisabled { entity.name = row[cols["name"]!! as Column<String>] }
+    }
+}
+
+internal class ScalarFkParentTableDef(private val onDelete: CascadeAction) : SqlTableDef<ScalarFkParent> {
+    override val tableName = "fk_scalar_parents"
+    override val columns =
+        listOf(
+            ColumnDef("id", ColumnType.IntType, nullable = false, primaryKey = true),
+            ColumnDef("single_child_id", ColumnType.IntType, nullable = true, primaryKey = false)
+        )
+
+    override fun foreignKeys(): List<ForeignKeyDef> =
+        listOf(
+            ForeignKeyDef(
+                columnName = "single_child_id",
+                referencedTable = "fk_scalar_children",
+                referencedColumn = "id",
+                onDelete = onDelete
+            )
+        )
+
+    @Suppress("UNCHECKED_CAST")
+    override fun fromRow(row: ResultRow, table: Table): ScalarFkParent {
+        val cols = table.columns.associateBy { it.name }
+        return ScalarFkParent(row[cols["id"]!! as Column<Int>]).also { entity ->
+            entity.withEventsDisabled {
+                entity.childId = row[cols["single_child_id"]!! as Column<Int?>]
+            }
+        }
+    }
+
+    override fun toParams(entity: ScalarFkParent, table: Table): Map<Column<*>, Any?> {
+        val cols = table.columns.associateBy { it.name }
+        return mapOf(
+            cols["id"]!! to entity.id,
+            cols["single_child_id"]!! to entity.childId
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun applyRow(entity: ScalarFkParent, row: ResultRow, table: Table) {
+        val cols = table.columns.associateBy { it.name }
+        entity.withEventsDisabled {
+            entity.childId = row[cols["single_child_id"]!! as Column<Int?>]
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #158.

`SqlTableDef.foreignKeys()` is correctly emitted by the KSP processor for every single-entity `@Aggregate` declaration (RESTRICT / CASCADE / DETACH per edge), but nothing in `lirp-sql` ever consumes the list to install actual `ALTER TABLE … ADD FOREIGN KEY` DDL. The metadata was a dead drop — explicitly documented as deferred at the bottom of `.planning/phases/53-sql-foreign-keys-144/53-04-SUMMARY.md`.

This PR closes that deferral.

## Changes

- New `SqlRepository.installEntityForeignKeys()` method consuming `tableDef.foreignKeys()` and installing each constraint via the existing private `installFk()` helper.
- Mirrors the existing `installJunctionForeignKeys()` two-phase bootstrap contract — user-invoked after every referenced entity table has materialised, each FK installed in its own transaction (Postgres parity), duplicate-constraint errors swallowed via the existing `isDuplicateConstraintException` idempotency check.
- SQLite detection via `DatabaseMetaData.databaseProductName`: the method short-circuits with a warning, since SQLite does not support `ALTER TABLE ADD CONSTRAINT`. Inline `CREATE TABLE`-time FK emission for SQLite is left as a follow-up.
- New `SqlRepositoryEntityForeignKeyInstallTest` covering RESTRICT / CASCADE / DETACH (`SET NULL`) variants, idempotent repeated installation, and the no-FK no-op path. 5 tests, all green on H2.

## Surfaced by

Dogfooding `lirp-fleet-poc` against `v2.5.0-SNAPSHOT` Stage 2 — wanted to validate the v2.5.0 SQL FK story against a 25-entity, 34-edge domain and discovered the metadata wasn't being consumed. The PoC's `EntityForeignKeyInstallTest` covers the multi-edge `CompanyInsuranceAgreement → Company` case (1 CASCADE + 3 DETACH against the same target) end-to-end.

## Test plan

- [x] `gradle :lirp-sql:test --tests SqlRepositoryEntityForeignKeyInstallTest` — all 5 tests pass.
- [x] `gradle :lirp-sql:test` — full lirp-sql suite green (no regressions).
- [x] `gradle build` — full multi-module suite green.
- [x] End-to-end validation against `lirp-fleet-poc` (3 fleet FK tests including the 4-edge `CompanyInsuranceAgreement → Company` case).
- [ ] Postgres / MySQL / MariaDB integration testing — covered by the existing `lirp-sql` integrationTest sourceset; left for CI / reviewer's environment.

## Follow-ups

- SQLite: inline FK emission at `CREATE TABLE` time (separate issue / PR).
- Bootstrap ergonomics: a cluster-level `LirpContext.installAllForeignKeys()` would prevent the "referenced table not found" footgun when consumers forget to materialise every referenced entity (observation from the PoC Stage 2 work).