### PR TITLE
#159 Query DSL: range operators accept nullable Comparable properties

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/DslOperators.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/DslOperators.kt
@@ -32,37 +32,46 @@ infix fun <T : IdentifiableEntity<*>, V> KProperty1<T, V>.eq(value: V): Predicat
 /**
  * Creates a greater-than predicate: `property > value`.
  *
- * @param value the value to compare against
+ * Accepts nullable property types — rows whose property value is `null` never match the
+ * predicate (SQL three-valued-logic style: `NULL > x` is unknown, treated as false).
+ *
+ * @param value the value to compare against (non-null)
  * @return a [Predicate.Gt] leaf node
  */
-infix fun <T : IdentifiableEntity<*>, V : Comparable<V>> KProperty1<T, V>.gt(value: V): Predicate<T> =
+infix fun <T : IdentifiableEntity<*>, V : Comparable<V>> KProperty1<T, V?>.gt(value: V): Predicate<T> =
     Predicate.Gt(this, value)
 
 /**
  * Creates a greater-than-or-equal predicate: `property >= value`.
  *
- * @param value the value to compare against
+ * Accepts nullable property types — rows whose property value is `null` never match.
+ *
+ * @param value the value to compare against (non-null)
  * @return a [Predicate.Gte] leaf node
  */
-infix fun <T : IdentifiableEntity<*>, V : Comparable<V>> KProperty1<T, V>.gte(value: V): Predicate<T> =
+infix fun <T : IdentifiableEntity<*>, V : Comparable<V>> KProperty1<T, V?>.gte(value: V): Predicate<T> =
     Predicate.Gte(this, value)
 
 /**
  * Creates a less-than predicate: `property < value`.
  *
- * @param value the value to compare against
+ * Accepts nullable property types — rows whose property value is `null` never match.
+ *
+ * @param value the value to compare against (non-null)
  * @return a [Predicate.Lt] leaf node
  */
-infix fun <T : IdentifiableEntity<*>, V : Comparable<V>> KProperty1<T, V>.lt(value: V): Predicate<T> =
+infix fun <T : IdentifiableEntity<*>, V : Comparable<V>> KProperty1<T, V?>.lt(value: V): Predicate<T> =
     Predicate.Lt(this, value)
 
 /**
  * Creates a less-than-or-equal predicate: `property <= value`.
  *
- * @param value the value to compare against
+ * Accepts nullable property types — rows whose property value is `null` never match.
+ *
+ * @param value the value to compare against (non-null)
  * @return a [Predicate.Lte] leaf node
  */
-infix fun <T : IdentifiableEntity<*>, V : Comparable<V>> KProperty1<T, V>.lte(value: V): Predicate<T> =
+infix fun <T : IdentifiableEntity<*>, V : Comparable<V>> KProperty1<T, V?>.lte(value: V): Predicate<T> =
     Predicate.Lte(this, value)
 
 /**

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/Predicate.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/Predicate.kt
@@ -54,47 +54,63 @@ sealed class Predicate<T : IdentifiableEntity<*>> {
     }
 
     /**
-     * Greater-than comparison between a comparable property and a value.
+     * Greater-than comparison between a comparable property and a value. The property type
+     * may be nullable; rows whose property value is `null` never match (SQL three-valued-logic).
      *
-     * @param prop the property reference
-     * @param value the value to compare against
+     * @param prop the property reference (may yield null)
+     * @param value the value to compare against (non-null)
      */
-    class Gt<T : IdentifiableEntity<*>, V : Comparable<V>>(val prop: KProperty1<T, V>, val value: V) : Predicate<T>() {
-        /** Returns `true` if [prop] of [t] is strictly greater than [value]. */
-        override fun matches(t: T): Boolean = prop.get(t) > value
+    class Gt<T : IdentifiableEntity<*>, V : Comparable<V>>(val prop: KProperty1<T, V?>, val value: V) : Predicate<T>() {
+        /** Returns `true` if [prop] of [t] is non-null and strictly greater than [value]. */
+        override fun matches(t: T): Boolean {
+            val v = prop.get(t) ?: return false
+            return v > value
+        }
     }
 
     /**
-     * Greater-than-or-equal comparison between a comparable property and a value.
+     * Greater-than-or-equal comparison between a comparable property and a value. The property
+     * type may be nullable; rows whose property value is `null` never match.
      *
-     * @param prop the property reference
-     * @param value the value to compare against
+     * @param prop the property reference (may yield null)
+     * @param value the value to compare against (non-null)
      */
-    class Gte<T : IdentifiableEntity<*>, V : Comparable<V>>(val prop: KProperty1<T, V>, val value: V) : Predicate<T>() {
-        /** Returns `true` if [prop] of [t] is greater than or equal to [value]. */
-        override fun matches(t: T): Boolean = prop.get(t) >= value
+    class Gte<T : IdentifiableEntity<*>, V : Comparable<V>>(val prop: KProperty1<T, V?>, val value: V) : Predicate<T>() {
+        /** Returns `true` if [prop] of [t] is non-null and greater than or equal to [value]. */
+        override fun matches(t: T): Boolean {
+            val v = prop.get(t) ?: return false
+            return v >= value
+        }
     }
 
     /**
-     * Less-than comparison between a comparable property and a value.
+     * Less-than comparison between a comparable property and a value. The property type may be
+     * nullable; rows whose property value is `null` never match.
      *
-     * @param prop the property reference
-     * @param value the value to compare against
+     * @param prop the property reference (may yield null)
+     * @param value the value to compare against (non-null)
      */
-    class Lt<T : IdentifiableEntity<*>, V : Comparable<V>>(val prop: KProperty1<T, V>, val value: V) : Predicate<T>() {
-        /** Returns `true` if [prop] of [t] is strictly less than [value]. */
-        override fun matches(t: T): Boolean = prop.get(t) < value
+    class Lt<T : IdentifiableEntity<*>, V : Comparable<V>>(val prop: KProperty1<T, V?>, val value: V) : Predicate<T>() {
+        /** Returns `true` if [prop] of [t] is non-null and strictly less than [value]. */
+        override fun matches(t: T): Boolean {
+            val v = prop.get(t) ?: return false
+            return v < value
+        }
     }
 
     /**
-     * Less-than-or-equal comparison between a comparable property and a value.
+     * Less-than-or-equal comparison between a comparable property and a value. The property type
+     * may be nullable; rows whose property value is `null` never match.
      *
-     * @param prop the property reference
-     * @param value the value to compare against
+     * @param prop the property reference (may yield null)
+     * @param value the value to compare against (non-null)
      */
-    class Lte<T : IdentifiableEntity<*>, V : Comparable<V>>(val prop: KProperty1<T, V>, val value: V) : Predicate<T>() {
-        /** Returns `true` if [prop] of [t] is less than or equal to [value]. */
-        override fun matches(t: T): Boolean = prop.get(t) <= value
+    class Lte<T : IdentifiableEntity<*>, V : Comparable<V>>(val prop: KProperty1<T, V?>, val value: V) : Predicate<T>() {
+        /** Returns `true` if [prop] of [t] is non-null and less than or equal to [value]. */
+        override fun matches(t: T): Boolean {
+            val v = prop.get(t) ?: return false
+            return v <= value
+        }
     }
 
     /**

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/DslNullableRangeTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/DslNullableRangeTest.kt
@@ -1,0 +1,84 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.query
+
+import net.transgressoft.lirp.entity.IdentifiableEntity
+import net.transgressoft.lirp.persistence.LirpContext
+import net.transgressoft.lirp.persistence.VolatileRepository
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import java.math.BigDecimal
+
+/**
+ * Verifies the range operators (`gt` / `gte` / `lt` / `lte`) accept nullable `Comparable`
+ * properties and treat null property values as non-matching (SQL three-valued-logic style).
+ */
+@DisplayName("Query DSL — nullable range operators")
+internal class DslNullableRangeTest : StringSpec({
+
+    val items =
+        listOf(
+            OptionalPriceItem(1, "cheap", BigDecimal("9.99")),
+            OptionalPriceItem(2, "mid", BigDecimal("29.99")),
+            OptionalPriceItem(3, "premium", BigDecimal("99.99")),
+            OptionalPriceItem(4, "unknown", null)
+        )
+
+    "gte accepts nullable property and excludes rows whose value is null" {
+        val repo = OptionalPriceVolatileRepo()
+        items.forEach { repo.add(it) }
+
+        repo.query<Int, OptionalPriceItem> {
+            where { OptionalPriceItem::price gte BigDecimal("25.00") }
+        }.map { it.label }.toList() shouldContainExactlyInAnyOrder listOf("mid", "premium")
+    }
+
+    "lt accepts nullable property and excludes rows whose value is null" {
+        val repo = OptionalPriceVolatileRepo()
+        items.forEach { repo.add(it) }
+
+        repo.query<Int, OptionalPriceItem> {
+            where { OptionalPriceItem::price lt BigDecimal("30.00") }
+        }.map { it.label }.toList() shouldContainExactlyInAnyOrder listOf("cheap", "mid")
+    }
+
+    "compound range gte and lt brackets a window and drops nulls" {
+        val repo = OptionalPriceVolatileRepo()
+        items.forEach { repo.add(it) }
+
+        repo.query<Int, OptionalPriceItem> {
+            where {
+                (OptionalPriceItem::price gte BigDecimal("10.00")) and
+                    (OptionalPriceItem::price lt BigDecimal("50.00"))
+            }
+        }.map { it.label }.toList() shouldContainExactlyInAnyOrder listOf("mid")
+    }
+})
+
+private data class OptionalPriceItem(
+    override val id: Int,
+    val label: String,
+    val price: BigDecimal?,
+    override val uniqueId: String = "item-$id"
+) : IdentifiableEntity<Int> {
+    override fun clone() = copy()
+}
+
+private class OptionalPriceVolatileRepo(context: LirpContext = LirpContext.default) :
+    VolatileRepository<Int, OptionalPriceItem>(context, "OptionalPriceItems")


### PR DESCRIPTION
## Summary

Closes #159.

The four range operators in `DslOperators.kt` (`gt` / `gte` / `lt` / `lte`) were bound to `KProperty1<T, V>` where `V : Comparable<V>`, which Kotlin's type system rejects for nullable receivers. `eq` does not share that constraint and works on nullables out of the box. The asymmetry made any range filter over a nullable `Comparable` column (`BigDecimal? price`, `LocalDate? validUntil`, etc.) a compile error.

## Changes

- `DslOperators.kt` — relax the receiver type on `gt` / `gte` / `lt` / `lte` from `KProperty1<T, V>` to `KProperty1<T, V?>`. The value argument stays `V` (non-null) for clarity at call sites; `eq` already accepts nullable receivers, so this aligns the range family with the equality contract.
- `Predicate.kt` — relax the `prop` field on `Predicate.Gt` / `Gte` / `Lt` / `Lte` to `KProperty1<T, V?>`. `matches()` short-circuits to `false` when the property value is `null` (SQL three-valued-logic semantic: `NULL > x` is unknown, treated as not-matching, matching how `WHERE col > ?` excludes null rows on every SQL backend).
- Updated KDoc on every touched type to call out the null-as-no-match behaviour.
- New `DslNullableRangeTest` (3 cases) covering `gte`, `lt`, and a compound bracket against a `BigDecimal?` column, asserting rows with `null` are excluded.

`QueryPlanner` already accessed `Predicate.Gt`-family `prop` via a `Comparable<Any>?` cast (`QueryPlanner.kt:533`), so the planner side requires no change.

## Surfaced by

Dogfooding `lirp-fleet-poc` Stage 3 — tried `Vehicle::listenpreis gte BigDecimal("20000")` on a `BigDecimal?` column and got a "receiver type mismatch" compile error. The fleet domain has many nullable comparable columns (prices, dates, deductibles) and the workaround of switching to a non-nullable property is unworkable in general.

## Test plan

- [x] `gradle :lirp-core:test --tests DslNullableRangeTest` — 3 new tests pass.
- [x] `gradle :lirp-core:test` — full core suite green (no regressions in `QueryPlannerTest`, etc.).
- [x] `gradle :lirp-sql:test` — sql suite green.
- [x] `gradle build` — full multi-module suite green.
- [x] End-to-end validation in `lirp-fleet-poc` — the `Vehicle::listenpreis` range test now compiles and passes.