### PR TITLE
Cross-dialect UUID storage

### DIFF
--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ColumnType.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ColumnType.kt
@@ -40,6 +40,20 @@ sealed class ColumnType {
 
     data object FloatType : ColumnType()
 
+    /**
+     * UUID column whose physical storage is selected by the SQL dialect adapter in `lirp-sql`.
+     *
+     * | Dialect | Storage | JDBC bind/read |
+     * |---------|---------|----------------|
+     * | H2 / PostgreSQL | native `UUID` | `setObject(i, uuid)` / `getObject(c, UUID::class.java)` |
+     * | MySQL / MariaDB | `BINARY(16)` | `setBytes(i, bigEndianBytes)` / `getBytes(c)` |
+     * | SQLite | `BLOB(16)` | `setBytes(i, bigEndianBytes)` / `getBytes(c)` |
+     *
+     * Out-of-band JDBC consumers should use `bindUuid` / `readUuid` in
+     * `net.transgressoft.lirp.persistence.sql` rather than binding canonical hex
+     * strings, which do not match the byte-backed storage used by MySQL, MariaDB,
+     * and SQLite.
+     */
     data object UuidType : ColumnType()
 
     data object DateType : ColumnType()

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/UuidJdbcInteropIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/UuidJdbcInteropIntegrationTest.kt
@@ -1,0 +1,195 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withTests
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import java.sql.SQLException
+import java.sql.Types
+import java.util.UUID
+
+/**
+ * Raw-JDBC UUID interoperability tests across every SQL dialect supported by lirp-sql.
+ */
+@DisplayName("UUID JDBC Interoperability Integration")
+internal class UuidJdbcInteropIntegrationTest : FunSpec({
+
+    val uuidDatabases = DatabaseTestSupport.databases
+
+    fun idColumn(dbName: String, primaryKey: Boolean): String {
+        val columnType =
+            when (dbName) {
+                "H2", "PostgreSQL" -> "UUID"
+                "MySQL", "MariaDB" -> "BINARY(16)"
+                "SQLite" -> "BLOB"
+                else -> error("Unsupported UUID test dialect '$dbName'.")
+            }
+        return if (primaryKey) "$columnType PRIMARY KEY" else columnType
+    }
+
+    fun nullSqlType(dbName: String): Int =
+        when (dbName) {
+            "H2", "PostgreSQL" -> Types.OTHER
+            "MySQL", "MariaDB" -> Types.BINARY
+            "SQLite" -> Types.BLOB
+            else -> error("Unsupported UUID test dialect '$dbName'.")
+        }
+
+    fun createTableSql(dbName: String, includeNullableColumn: Boolean = false): String {
+        val nullableColumn =
+            if (includeNullableColumn) {
+                ", optional_uuid ${idColumn(dbName, primaryKey = false)}"
+            } else {
+                ""
+            }
+        return "CREATE TABLE uuid_interop_t (id ${idColumn(dbName, primaryKey = true)}, payload TEXT$nullableColumn)"
+    }
+
+    fun HikariDataSource.withUuidTable(dbName: String, includeNullableColumn: Boolean = false, block: (java.sql.Connection) -> Unit) {
+        try {
+            connection.use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute("DROP TABLE IF EXISTS uuid_interop_t")
+                    stmt.execute(createTableSql(dbName, includeNullableColumn))
+                }
+                block(conn)
+            }
+        } finally {
+            close()
+        }
+    }
+
+    context("bindUuid round-trips through readUuid") {
+        withTests(uuidDatabases) { db ->
+            val ds = db.buildDataSource()
+            ds.withUuidTable(db.name) { conn ->
+                val uuid = UUID.randomUUID()
+
+                conn.prepareStatement("INSERT INTO uuid_interop_t (id, payload) VALUES (?, ?)").use { ps ->
+                    ps.bindUuid(1, uuid, conn)
+                    ps.setString(2, "data")
+                    ps.executeUpdate() shouldBe 1
+                }
+
+                conn.prepareStatement("SELECT id FROM uuid_interop_t").use { ps ->
+                    ps.executeQuery().use { rs ->
+                        rs.next() shouldBe true
+                        rs.readUuid(1, conn) shouldBe uuid
+                        rs.readUuid("id", conn) shouldBe uuid
+                    }
+                }
+            }
+        }
+    }
+
+    context("bindUuid in WHERE clause matches exactly one row") {
+        withTests(uuidDatabases) { db ->
+            val ds = db.buildDataSource()
+            ds.withUuidTable(db.name) { conn ->
+                val uuid = UUID.randomUUID()
+
+                conn.prepareStatement("INSERT INTO uuid_interop_t (id, payload) VALUES (?, ?)").use { ps ->
+                    ps.bindUuid(1, uuid, conn)
+                    ps.setString(2, "data")
+                    ps.executeUpdate() shouldBe 1
+                }
+
+                conn.prepareStatement("UPDATE uuid_interop_t SET payload = ? WHERE id = ?").use { ps ->
+                    ps.setString(1, "updated")
+                    ps.bindUuid(2, uuid, conn)
+                    ps.executeUpdate() shouldBe 1
+                }
+            }
+        }
+    }
+
+    // Pinned regression from issue #161: documents byte-backed UUID columns rejecting canonical strings.
+    context("raw setString in WHERE clause asymmetry witness") {
+        withTests(uuidDatabases) { db ->
+            val ds = db.buildDataSource()
+            ds.withUuidTable(db.name) { conn ->
+                val uuid = UUID.randomUUID()
+
+                conn.prepareStatement("INSERT INTO uuid_interop_t (id, payload) VALUES (?, ?)").use { ps ->
+                    ps.bindUuid(1, uuid, conn)
+                    ps.setString(2, "data")
+                    ps.executeUpdate() shouldBe 1
+                }
+
+                when (db.name) {
+                    "MySQL", "MariaDB", "SQLite" -> {
+                        // Strict regression pin (issue #161): byte-backed UUID columns return
+                        // executeUpdate() == 0 with no exception when compared with canonical TEXT.
+                        // Any change here means the driver/storage coercion shifted; update KDoc and wiki first.
+                        conn.prepareStatement("UPDATE uuid_interop_t SET payload = ? WHERE id = ?").use { ps ->
+                            ps.setString(1, "via-string")
+                            ps.setString(2, uuid.toString())
+                            val affected = ps.executeUpdate()
+                            affected shouldBe 0
+                        }
+                    }
+                    "H2" -> {
+                        conn.prepareStatement("UPDATE uuid_interop_t SET payload = ? WHERE id = ?").use { ps ->
+                            ps.setString(1, "via-string")
+                            ps.setString(2, uuid.toString())
+                            ps.executeUpdate() shouldBe 1
+                        }
+                    }
+                    "PostgreSQL" -> {
+                        shouldThrow<SQLException> {
+                            conn.prepareStatement("UPDATE uuid_interop_t SET payload = ? WHERE id = ?").use { ps ->
+                                ps.setString(1, "via-string")
+                                ps.setString(2, uuid.toString())
+                                ps.executeUpdate()
+                            }
+                        }
+                    }
+                    else -> error("Unsupported UUID test dialect '${db.name}'.")
+                }
+            }
+        }
+    }
+
+    context("readUuid returns null for SQL NULL") {
+        withTests(uuidDatabases) { db ->
+            val ds = db.buildDataSource()
+            ds.withUuidTable(db.name, includeNullableColumn = true) { conn ->
+                val uuid = UUID.randomUUID()
+
+                conn.prepareStatement("INSERT INTO uuid_interop_t (id, payload, optional_uuid) VALUES (?, ?, ?)").use { ps ->
+                    ps.bindUuid(1, uuid, conn)
+                    ps.setString(2, "data")
+                    ps.setNull(3, nullSqlType(db.name))
+                    ps.executeUpdate() shouldBe 1
+                }
+
+                conn.prepareStatement("SELECT optional_uuid FROM uuid_interop_t").use { ps ->
+                    ps.executeQuery().use { rs ->
+                        rs.next() shouldBe true
+                        rs.readUuid("optional_uuid", conn).shouldBeNull()
+                    }
+                }
+            }
+        }
+    }
+})

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqliteRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqliteRepository.kt
@@ -31,6 +31,13 @@ import java.nio.file.Path
  * so foreign-key enforcement and WAL concurrent reads apply to every
  * pooled connection. The returned repository owns the pool and closes
  * it on [SqlRepository.close].
+ *
+ * SQLite has no native UUID type, so [net.transgressoft.lirp.persistence.ColumnType.UuidType]
+ * columns materialize as 16-byte BLOB values. Raw-JDBC `setString(i, uuid.toString())`
+ * binds TEXT, and `WHERE id = ?` comparisons against those BLOB columns can return
+ * `executeUpdate() == 0` with no [java.sql.SQLException]. Out-of-band JDBC consumers
+ * should use `bindUuid` / `readUuid` in this package so the same binary representation
+ * is used for writes and reads.
  */
 object SqliteRepository {
 

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/UuidJdbcSupport.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/UuidJdbcSupport.kt
@@ -1,0 +1,96 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import java.nio.ByteBuffer
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.util.UUID
+
+/**
+ * Raw-JDBC helpers for code that needs to bind or read
+ * [net.transgressoft.lirp.persistence.ColumnType.UuidType] columns outside Exposed.
+ *
+ * | Dialect | Storage | JDBC bind/read |
+ * |---------|---------|----------------|
+ * | H2 / PostgreSQL | native `UUID` | `setObject(i, uuid)` / `getObject(c, UUID::class.java)` |
+ * | MySQL / MariaDB | `BINARY(16)` | `setBytes(i, bigEndianBytes)` / `getBytes(c)` |
+ * | SQLite | `BLOB(16)` | `setBytes(i, bigEndianBytes)` / `getBytes(c)` |
+ *
+ * Keeping this dispatch here lets migration scripts, reporting jobs, and manual JDBC tools
+ * use the same UUID representation as LIRP-managed tables without depending on Exposed internals.
+ * Canonical hex strings are intentionally avoided because byte-backed UUID columns compare
+ * against their binary representation, not their textual form.
+ */
+public fun PreparedStatement.bindUuid(index: Int, uuid: UUID, connection: Connection) {
+    val productName = connection.metaData.databaseProductName
+    when (productName) {
+        "H2", "PostgreSQL" -> setObject(index, uuid)
+        "MySQL", "MariaDB", "SQLite" -> setBytes(index, uuid.toBytesBigEndian())
+        else -> error("UUID bind not supported for dialect '$productName'. Supported: H2, PostgreSQL, MySQL, MariaDB, SQLite.")
+    }
+}
+
+/**
+ * Reads a UUID using the same dialect-specific representation as [bindUuid].
+ *
+ * Native UUID dialects require `wasNull()` after typed reads; byte-backed dialects return
+ * `null` directly from `getBytes`. The read path mirrors the write path so callers do not
+ * need to know whether the underlying column stores native UUIDs or 16-byte values.
+ */
+public fun ResultSet.readUuid(columnIndex: Int, connection: Connection): UUID? {
+    val productName = connection.metaData.databaseProductName
+    return when (productName) {
+        "H2", "PostgreSQL" -> {
+            val value = getObject(columnIndex, UUID::class.java)
+            if (wasNull()) null else value
+        }
+        "MySQL", "MariaDB", "SQLite" -> getBytes(columnIndex)?.toUuidBigEndian()
+        else -> error("UUID read not supported for dialect '$productName'. Supported: H2, PostgreSQL, MySQL, MariaDB, SQLite.")
+    }
+}
+
+/**
+ * Reads a UUID by column label using the same dialect-specific representation as [bindUuid].
+ *
+ * This overload mirrors [ResultSet]'s own index and label accessors so callers do not need to
+ * resolve column positions before reading UUID columns.
+ */
+public fun ResultSet.readUuid(columnLabel: String, connection: Connection): UUID? {
+    val productName = connection.metaData.databaseProductName
+    return when (productName) {
+        "H2", "PostgreSQL" -> {
+            val value = getObject(columnLabel, UUID::class.java)
+            if (wasNull()) null else value
+        }
+        "MySQL", "MariaDB", "SQLite" -> getBytes(columnLabel)?.toUuidBigEndian()
+        else -> error("UUID read not supported for dialect '$productName'. Supported: H2, PostgreSQL, MySQL, MariaDB, SQLite.")
+    }
+}
+
+private fun UUID.toBytesBigEndian(): ByteArray =
+    ByteBuffer.allocate(16)
+        .putLong(mostSignificantBits)
+        .putLong(leastSignificantBits)
+        .array()
+
+private fun ByteArray.toUuidBigEndian(): UUID {
+    require(size == 16) { "UUID byte array must be exactly 16 bytes, got $size" }
+    return ByteBuffer.wrap(this).let { UUID(it.long, it.long) }
+}

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/UuidJdbcSupportTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/UuidJdbcSupportTest.kt
@@ -1,0 +1,244 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withTests
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.nio.ByteBuffer
+import java.sql.Connection
+import java.sql.DatabaseMetaData
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.util.UUID
+
+/**
+ * Unit coverage for [bindUuid] and [readUuid] dialect dispatch.
+ */
+internal class UuidJdbcSupportTest : FunSpec({
+
+    context("PreparedStatement.bindUuid uses native UUID binding for native dialects") {
+        withTests("H2", "PostgreSQL") { dialect ->
+            val uuid = UUID.randomUUID()
+            val recorder = PreparedStatementRecorder()
+
+            recorder.statement.bindUuid(1, uuid, connectionFor(dialect))
+
+            recorder.objectValue shouldBe uuid
+            recorder.bytesValue.shouldBeNull()
+        }
+    }
+
+    context("PreparedStatement.bindUuid uses big-endian bytes for byte-backed dialects") {
+        withTests("MySQL", "MariaDB", "SQLite") { dialect ->
+            val uuid = UUID.randomUUID()
+            val recorder = PreparedStatementRecorder()
+
+            recorder.statement.bindUuid(1, uuid, connectionFor(dialect))
+
+            recorder.objectValue.shouldBeNull()
+            recorder.bytesValue!!.toList() shouldBe uuid.toExpectedBytes().toList()
+        }
+    }
+
+    test("PreparedStatement.bindUuid throws for unknown dialect") {
+        val ex =
+            shouldThrow<IllegalStateException> {
+                PreparedStatementRecorder().statement.bindUuid(1, UUID.randomUUID(), connectionFor("UnknownDB"))
+            }
+
+        ex.message shouldContain "UUID bind not supported for dialect 'UnknownDB'"
+    }
+
+    test("PreparedStatement.bindUuid throws for null dialect") {
+        val ex =
+            shouldThrow<IllegalStateException> {
+                PreparedStatementRecorder().statement.bindUuid(1, UUID.randomUUID(), connectionFor(null))
+            }
+
+        ex.message shouldContain "UUID bind not supported for dialect 'null'"
+    }
+
+    context("ResultSet.readUuid returns native UUID values for native dialects") {
+        withTests("H2", "PostgreSQL") { dialect ->
+            val uuid = UUID.randomUUID()
+            val resultSet = resultSetFor(objectValue = uuid, bytesValue = null, wasNull = false)
+
+            resultSet.readUuid(1, connectionFor(dialect)) shouldBe uuid
+            resultSet.readUuid("id", connectionFor(dialect)) shouldBe uuid
+        }
+    }
+
+    context("ResultSet.readUuid returns byte-backed UUID values for byte-backed dialects") {
+        withTests("MySQL", "MariaDB", "SQLite") { dialect ->
+            val uuid = UUID.randomUUID()
+            val resultSet = resultSetFor(objectValue = null, bytesValue = uuid.toExpectedBytes(), wasNull = false)
+
+            resultSet.readUuid(1, connectionFor(dialect)) shouldBe uuid
+            resultSet.readUuid("id", connectionFor(dialect)) shouldBe uuid
+        }
+    }
+
+    test("ResultSet.readUuid returns null for native SQL NULL") {
+        val resultSet = resultSetFor(objectValue = null, bytesValue = null, wasNull = true)
+
+        resultSet.readUuid(1, connectionFor("H2")).shouldBeNull()
+    }
+
+    test("ResultSet.readUuid by label returns null for native SQL NULL") {
+        val resultSet = resultSetFor(objectValue = null, bytesValue = null, wasNull = true)
+
+        resultSet.readUuid("id", connectionFor("H2")).shouldBeNull()
+    }
+
+    test("ResultSet.readUuid returns null for byte-backed SQL NULL") {
+        val resultSet = resultSetFor(objectValue = null, bytesValue = null, wasNull = true)
+
+        resultSet.readUuid(1, connectionFor("SQLite")).shouldBeNull()
+    }
+
+    test("ResultSet.readUuid by label returns null for byte-backed SQL NULL") {
+        val resultSet = resultSetFor(objectValue = null, bytesValue = null, wasNull = true)
+
+        resultSet.readUuid("id", connectionFor("SQLite")).shouldBeNull()
+    }
+
+    test("ResultSet.readUuid throws for unknown dialect") {
+        val ex =
+            shouldThrow<IllegalStateException> {
+                resultSetFor(objectValue = null, bytesValue = null, wasNull = false)
+                    .readUuid(1, connectionFor("UnknownDB"))
+            }
+
+        ex.message shouldContain "UUID read not supported for dialect 'UnknownDB'"
+    }
+
+    test("ResultSet.readUuid by label throws for unknown dialect") {
+        val ex =
+            shouldThrow<IllegalStateException> {
+                resultSetFor(objectValue = null, bytesValue = null, wasNull = false)
+                    .readUuid("id", connectionFor("UnknownDB"))
+            }
+
+        ex.message shouldContain "UUID read not supported for dialect 'UnknownDB'"
+    }
+
+    test("ResultSet.readUuid throws for null dialect") {
+        val ex =
+            shouldThrow<IllegalStateException> {
+                resultSetFor(objectValue = null, bytesValue = null, wasNull = false)
+                    .readUuid(1, connectionFor(null))
+            }
+
+        ex.message shouldContain "UUID read not supported for dialect 'null'"
+    }
+
+    test("ResultSet.readUuid rejects malformed byte arrays") {
+        val resultSet = resultSetFor(objectValue = null, bytesValue = ByteArray(15), wasNull = false)
+
+        val ex =
+            shouldThrow<IllegalArgumentException> {
+                resultSet.readUuid(1, connectionFor("SQLite"))
+            }
+
+        ex.message shouldContain "UUID byte array must be exactly 16 bytes"
+    }
+
+    test("ResultSet.readUuid by label rejects malformed byte arrays") {
+        val resultSet = resultSetFor(objectValue = null, bytesValue = ByteArray(15), wasNull = false)
+
+        val ex =
+            shouldThrow<IllegalArgumentException> {
+                resultSet.readUuid("id", connectionFor("SQLite"))
+            }
+
+        ex.message shouldContain "UUID byte array must be exactly 16 bytes"
+    }
+})
+
+data class PreparedStatementRecorder(
+    var objectValue: Any? = null,
+    var bytesValue: ByteArray? = null
+) {
+    val statement: PreparedStatement =
+        proxy(PreparedStatement::class.java) { method, args ->
+            when (method.name) {
+                "setObject" -> {
+                    objectValue = args!![1]
+                    null
+                }
+                "setBytes" -> {
+                    bytesValue = args!![1] as ByteArray
+                    null
+                }
+                else -> unsupported(method)
+            }
+        }
+}
+
+fun connectionFor(productName: String?): Connection {
+    val metadata =
+        proxy(DatabaseMetaData::class.java) { method, _ ->
+            when (method.name) {
+                "getDatabaseProductName" -> productName
+                else -> unsupported(method)
+            }
+        }
+    return proxy(Connection::class.java) { method, _ ->
+        when (method.name) {
+            "getMetaData" -> metadata
+            else -> unsupported(method)
+        }
+    }
+}
+
+fun resultSetFor(objectValue: UUID?, bytesValue: ByteArray?, wasNull: Boolean): ResultSet =
+    proxy(ResultSet::class.java) { method, _ ->
+        when (method.name) {
+            "getObject" -> objectValue
+            "getBytes" -> bytesValue
+            "wasNull" -> wasNull
+            else -> unsupported(method)
+        }
+    }
+
+fun UUID.toExpectedBytes(): ByteArray =
+    ByteBuffer.allocate(16)
+        .putLong(mostSignificantBits)
+        .putLong(leastSignificantBits)
+        .array()
+
+fun <T> proxy(type: Class<T>, handler: (Method, Array<Any?>?) -> Any?): T {
+    @Suppress("UNCHECKED_CAST")
+    return Proxy.newProxyInstance(type.classLoader, arrayOf(type)) { _, method, args ->
+        when (method.name) {
+            "toString" -> "Proxy(${type.simpleName})"
+            "hashCode" -> 0
+            "equals" -> false
+            else -> handler(method, args)
+        }
+    } as T
+}
+
+fun unsupported(method: Method): Nothing =
+    error("Unexpected JDBC call: ${method.name}")


### PR DESCRIPTION
## Summary

**Phase 54.1: Cross-dialect UUID storage**

Closes #161.

Adds raw-JDBC UUID interoperability helpers for `lirp-sql`, documents the dialect-specific storage contract at source and wiki surfaces, and pins the byte-backed canonical-string mismatch with tests.

## Changes

### Plan 01: UUID JDBC helpers

- Added `PreparedStatement.bindUuid(index, uuid, connection)`.
- Added `ResultSet.readUuid(columnIndex, connection)` and `ResultSet.readUuid(columnLabel, connection)`.
- Dispatches per call on `connection.metaData.databaseProductName` for H2, PostgreSQL, MySQL, MariaDB, and SQLite.
- Preserves `error(...)` bug-detector branches for unsupported dialects.

### Plan 02: KDoc source documentation

- Added a storage-by-dialect table to `ColumnType.UuidType` KDoc.
- Added SQLite UUID BLOB footgun guidance to `SqliteRepository` KDoc.
- Keeps `lirp-api` dependency-free by referencing helper names in prose.

### Plan 03: Verification coverage

- Added `UuidJdbcInteropIntegrationTest` with Kotest `withTests(...)` parameterization across PostgreSQL, MySQL, MariaDB, SQLite, and H2.
- Added `UuidJdbcSupportTest` for focused helper dispatch, null handling, malformed byte arrays, and unsupported dialects.
- Tests pin observed byte-backed behavior: MySQL, MariaDB, and SQLite return zero affected rows when canonical UUID strings are compared against binary UUID storage.

### Plan 04: Wiki documentation

- Applied the UUID storage section to `lirp.wiki/SQL-Persistence.md`.
- Wiki commit: `1c8feeb #161 Cross-dialect UUID storage section`.

## Key Files

- `lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/UuidJdbcSupport.kt`
- `lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/UuidJdbcSupportTest.kt`
- `lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/UuidJdbcInteropIntegrationTest.kt`
- `lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ColumnType.kt`
- `lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqliteRepository.kt`

## Verification

- [x] `gradle build` — `BUILD SUCCESSFUL in 7s` on final run.
- [x] Targeted helper/unit and UUID integration tests passed.
- [x] Wiki update committed and pushed to `octaviospain/lirp.wiki`.
- [x] Coverage compared against `origin/master`:
  - Line: `3233/3652` (88.53%) vs master `3209/3628` (88.45%)
  - Branch: `1524/2110` (72.23%) vs master `1474/2044` (72.11%)

## Notes

- Storage representation is unchanged. The helpers sit at the raw-JDBC interoperability boundary for consumers reaching around Exposed.
- PostgreSQL rejects raw canonical-string UUID matching for native UUID columns; MySQL/MariaDB/SQLite silently miss for byte-backed storage. Tests and docs reflect that observed split.
