### PR TITLE
#166 Pre-release security & docs harness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,49 @@ spec sequential. This reduces default wall-clock time without changing spec-loca
 ordering. JavaFX specs remain serialized because `FxToolkitInit` and JavaFX toolkit state
 are process-wide. Scheduled Stress CI is not part of this setup.
 
+#### Event-asserting integration tests: SharedFlow collector warmup
+
+Tests that subscribe to a repository's `SharedFlow` event stream and then immediately fire a
+mutation are inherently racy: the collector coroutine launched by `subscribe { ... }` is not
+necessarily fully scheduled before the test's next line runs. Without a small warmup delay
+between subscribing and emitting, the very first event can be dropped and the test fails
+non-deterministically. This was the root cause of the v2.5.0 SQL event-flow flake (fixed in
+commit `ba7f2f2`).
+
+**Convention:** every integration test that subscribes to a `SharedFlow` before asserting on
+collected events MUST include a 50 ms warmup `delay` between the subscription and the first
+mutation under test.
+
+Required import:
+
+```kotlin
+import kotlin.time.Duration.Companion.milliseconds
+```
+
+Canonical snippet:
+
+```kotlin
+val received = AtomicReference<CrudEvent.Type?>()
+repo.subscribe { event -> received.set(event.type) }
+delay(50.milliseconds) // let SharedFlow collector coroutine start
+
+repo.add(TestPerson(1).apply { firstName = "Alice" })
+
+eventually(5.seconds) {
+    received.get() shouldBe CrudEvent.Type.CREATE
+}
+```
+
+Canonical call sites to mirror:
+
+- `lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEventIntegrationTest.kt`
+  — lines 53, 73, 95, 118, 143.
+- `lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryQueryDslIntegrationTest.kt`
+  — line 761.
+
+Any new integration test that asserts on `SharedFlow`-delivered events without this warmup is
+considered incomplete and will be flagged in review.
+
 ### Problem Statement Requirement
 
 When submitting a PR, always include a clear problem statement that answers:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,42 @@ class AlbumRepository(context: LirpContext) :
 
 Reads are served from the in-memory `ConcurrentHashMap`, so `findById` avoids SQL round-trips. Write behavior differs by operation type; refer to the SQL Persistence wiki for current flush/transaction details.
 
+### Credential handling
+
+JDBC URLs frequently embed secrets. Treat them like passwords, not like configuration.
+
+**Inject credentials via environment variables** rather than embedding them in the URL or committing them to source control. Use the three-argument constructor overload so the password never appears inside the URL string:
+
+```kotlin
+@LirpRepository
+class AlbumRepository(context: LirpContext) :
+    SqlRepository<Int, Album>(
+        context,
+        Album_LirpTableDef,
+        url = System.getenv("JDBC_URL") ?: error("JDBC_URL not set"),
+        username = System.getenv("DB_USER"),
+        password = System.getenv("DB_PASSWORD"),
+    )
+```
+
+**Never log a raw JDBC URL in production.** Passwords commonly appear in the userinfo segment (`user:pwd@host`), in query parameters (`?password=...`), or as H2 semicolon properties (`;PASSWORD=...`). Connection-pool metrics, HikariCP DEBUG logs, and error stack traces all routinely capture the URL.
+
+When you must include a URL in diagnostic output, route it through `ConnectionUrlSanitizer`:
+
+```kotlin
+import net.transgressoft.lirp.persistence.sql.ConnectionUrlSanitizer
+
+// masks the password with **** in userinfo, query-string, and H2 semicolon surfaces
+logger.debug { "Connecting to: ${ConnectionUrlSanitizer.sanitize(jdbcUrl)}" }
+
+// jdbc:postgresql://user:secret@host:5432/db  →  jdbc:postgresql://user:****@host:5432/db
+// jdbc:h2:mem:test;USER=sa;PASSWORD=secret    →  jdbc:h2:mem:test;USER=sa;PASSWORD=****
+```
+
+`sanitize` handles all five supported dialects (PostgreSQL, MySQL, MariaDB, SQLite, H2), is case-insensitive on the `password` key, and returns malformed input verbatim — it never throws. It is defence-in-depth for logging, not a substitute for env-var injection.
+
+See the [SQL Persistence wiki page](https://github.com/octaviospain/lirp/wiki/SQL-Persistence#credential-handling) for the long-form guidance.
+
 ## Query DSL
 
 LIRP provides a type-safe, Kotlin-native query DSL for filtering, ordering, and paginating entities directly from any `Repository`. Predicates compose with infix operators; the planner automatically routes indexed equality checks through secondary indexes and falls back to in-memory scans for range and composite predicates.

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/ConnectionUrlSanitizer.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/ConnectionUrlSanitizer.kt
@@ -1,0 +1,92 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+/**
+ * Defensive logging utility that masks password values inside JDBC connection URLs so that
+ * diagnostic output (logs, metrics labels, HikariCP DEBUG dumps, stack-trace context) does not
+ * leak credentials when the URL must be surfaced.
+ *
+ * The mask token is the literal `****`. Every surface where JDBC URLs are known to embed a
+ * password is replaced; everything else (scheme, host, port, database, non-password params,
+ * key casing, URL-encoding of non-password values, fragments) is preserved byte-for-byte so the
+ * output stays useful for diagnosis.
+ *
+ * For URL-encoded password values the entire encoded value is replaced by `****` — the
+ * sanitizer never decodes the secret, it only redacts it.
+ *
+ * Threat model: this is defence-in-depth, NOT a substitute for proper credential injection.
+ * Consumers should inject credentials via environment variables (`JDBC_URL`, `DB_USER`,
+ * `DB_PASSWORD`) and pass them to `SqlRepository.connect(url, username, password)` rather than
+ * embedding secrets in URL strings. See `README.md` and the wiki SQL-Persistence page for the
+ * canonical guidance.
+ */
+object ConnectionUrlSanitizer {
+
+    private const val MASK: String = "****"
+
+    // userinfo: matches `<scheme>://<user>:<password>@` and replaces only the password segment.
+    // Password is everything between the first `:` after `://` and the next `@`.
+    private val userinfoRegex: Regex =
+        Regex("""(://[^/:@\s?#]*:)([^@\s/?#]*)(@)""")
+
+    // Query-string `password=value` (case-insensitive on the key). Value is everything until
+    // the next `&` or `#` or end-of-string. Anchored to a leading `?` or `&` so it only matches
+    // inside the query string.
+    private val queryPasswordRegex: Regex =
+        Regex("""([?&])([Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd])=([^&#]*)""")
+
+    // Semicolon-property `PASSWORD=value` (H2 idiom; case-insensitive). Value runs until the
+    // next `;` or end-of-string. Anchored to a leading `;` so it does not collide with
+    // query-string handling.
+    private val semicolonPasswordRegex: Regex =
+        Regex(""";([Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd])=([^;]*)""")
+
+    /**
+     * Returns [jdbcUrl] with every password value masked to `****`.
+     *
+     * Three credential surfaces are handled:
+     *  1. userinfo segment (`<scheme>://user:password@host`) — only the password between the
+     *     first `:` after `://` and the next `@` is replaced.
+     *  2. query-string parameters keyed by `password` (case-insensitive), parsed from after the
+     *     first `?`. Other query parameters (including `user=`) are preserved verbatim.
+     *  3. semicolon-delimited properties keyed by `PASSWORD` (case-insensitive) — the H2 idiom,
+     *     appearing after the first `;`. Other properties (including `USER=`) are preserved.
+     *
+     * Verbatim-fallback contract: if [jdbcUrl] matches none of these surfaces, it is returned
+     * unchanged. Malformed or empty input is also returned unchanged — this utility never
+     * throws on input parsing, because it is a defensive logging aid, not a parser of any
+     * invariant-bearing state.
+     */
+    fun sanitize(jdbcUrl: String): String {
+        var result = jdbcUrl
+        result =
+            userinfoRegex.replace(result) { match ->
+                "${match.groupValues[1]}$MASK${match.groupValues[3]}"
+            }
+        result =
+            queryPasswordRegex.replace(result) { match ->
+                "${match.groupValues[1]}${match.groupValues[2]}=$MASK"
+            }
+        result =
+            semicolonPasswordRegex.replace(result) { match ->
+                ";${match.groupValues[1]}=$MASK"
+            }
+        return result
+    }
+}

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
@@ -872,7 +872,7 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
         private fun buildDataSource(jdbcUrl: String, poolSize: Int, schema: String?): HikariDataSource {
             if (jdbcUrl.startsWith("jdbc:sqlite:")) {
                 log.warn {
-                    "SQLite JDBC URL '$jdbcUrl' passed to SqlRepository(jdbcUrl, ...) without connectionInitSql; " +
+                    "SQLite JDBC URL '${ConnectionUrlSanitizer.sanitize(jdbcUrl)}' passed to SqlRepository(jdbcUrl, ...) without connectionInitSql; " +
                         "FK enforcement and WAL mode are not configured. Prefer SqliteRepository.fileBacked(...) " +
                         "or SqliteRepository.inMemory(...) for the curated PRAGMA bundle."
                 }

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/ConnectionUrlSanitizerTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/ConnectionUrlSanitizerTest.kt
@@ -1,0 +1,97 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ConnectionUrlSanitizerTest : StringSpec({
+
+    "masks userinfo password in PostgreSQL URL preserving user and host" {
+        ConnectionUrlSanitizer.sanitize("jdbc:postgresql://user:secret@host:5432/db") shouldBe
+            "jdbc:postgresql://user:****@host:5432/db"
+    }
+
+    "masks userinfo password when username is empty" {
+        ConnectionUrlSanitizer.sanitize("jdbc:postgresql://:secret@host:5432/db") shouldBe
+            "jdbc:postgresql://:****@host:5432/db"
+    }
+
+    "masks query-string password in PostgreSQL URL preserving other params" {
+        ConnectionUrlSanitizer.sanitize("jdbc:postgresql://host:5432/db?user=alice&password=secret&ssl=true") shouldBe
+            "jdbc:postgresql://host:5432/db?user=alice&password=****&ssl=true"
+    }
+
+    "masks userinfo and query password in MySQL URL together" {
+        ConnectionUrlSanitizer.sanitize("jdbc:mysql://root:hunter2@host:3306/db?useSSL=false&password=other") shouldBe
+            "jdbc:mysql://root:****@host:3306/db?useSSL=false&password=****"
+    }
+
+    "masks capitalised query password key in MariaDB URL case-insensitively" {
+        ConnectionUrlSanitizer.sanitize("jdbc:mariadb://host/db?PASSWORD=secret&user=root") shouldBe
+            "jdbc:mariadb://host/db?PASSWORD=****&user=root"
+    }
+
+    "preserves SQLite plain path URL verbatim when no credentials present" {
+        ConnectionUrlSanitizer.sanitize("jdbc:sqlite:/var/lib/app.db") shouldBe
+            "jdbc:sqlite:/var/lib/app.db"
+    }
+
+    "masks query password in SQLite URI form preserving file path" {
+        ConnectionUrlSanitizer.sanitize("jdbc:sqlite:file:/var/lib/app.db?password=secret") shouldBe
+            "jdbc:sqlite:file:/var/lib/app.db?password=****"
+    }
+
+    "masks semicolon-delimited password key in H2 URL case-insensitively" {
+        ConnectionUrlSanitizer.sanitize("jdbc:h2:mem:test;user=sa;password=secret;DB_CLOSE_DELAY=-1") shouldBe
+            "jdbc:h2:mem:test;user=sa;password=****;DB_CLOSE_DELAY=-1"
+    }
+
+    "masks semicolon-delimited PASSWORD in H2 tcp URL" {
+        ConnectionUrlSanitizer.sanitize("jdbc:h2:tcp://host:9092/~/test;PASSWORD=hunter2") shouldBe
+            "jdbc:h2:tcp://host:9092/~/test;PASSWORD=****"
+    }
+
+    "masks URL-encoded userinfo password replacing the whole encoded value" {
+        ConnectionUrlSanitizer.sanitize("jdbc:postgresql://user:s%40cret%21@host:5432/db") shouldBe
+            "jdbc:postgresql://user:****@host:5432/db"
+    }
+
+    "masks URL-encoded query password value replacing the whole encoded value" {
+        ConnectionUrlSanitizer.sanitize("jdbc:postgresql://host/db?password=s%40cret%21&ssl=true") shouldBe
+            "jdbc:postgresql://host/db?password=****&ssl=true"
+    }
+
+    "preserves URL verbatim when password is absent" {
+        ConnectionUrlSanitizer.sanitize("jdbc:postgresql://host:5432/db?user=alice") shouldBe
+            "jdbc:postgresql://host:5432/db?user=alice"
+    }
+
+    "returns malformed input verbatim without throwing" {
+        ConnectionUrlSanitizer.sanitize("not-a-url") shouldBe "not-a-url"
+    }
+
+    "returns empty input verbatim without throwing" {
+        ConnectionUrlSanitizer.sanitize("") shouldBe ""
+    }
+
+    "masks multiple query password occurrences when both present" {
+        ConnectionUrlSanitizer.sanitize("jdbc:postgresql://host/db?password=first&user=u&password=second") shouldBe
+            "jdbc:postgresql://host/db?password=****&user=u&password=****"
+    }
+})


### PR DESCRIPTION
Closes #166.

Pre-release hardening for the v2.5.0 SQL surface — adds a defensive JDBC URL sanitiser, documents credential handling for consumers, captures the SharedFlow warmup convention for contributors, and clarifies SQLite's per-connection FK semantics.

## Changes

### `ConnectionUrlSanitizer` (new utility in `lirp-sql`)

Pure-Kotlin `object` exposing `sanitize(jdbcUrl: String): String`. Masks the password value with `****` across three credential surfaces:

- **userinfo segment** — `user:password@host`, matched after `://` and before the next `@`.
- **query-string parameters** — `?password=…` / `?PASSWORD=…` (case-insensitive).
- **H2 semicolon properties** — `;PASSWORD=…` (case-insensitive).

Everything else is preserved byte-for-byte so the URL remains useful for diagnostics. URL-encoded password values are replaced wholesale. Malformed input is returned verbatim — the utility never throws. (It is a defensive logging utility, not a parser of user-controlled state; no invariant to enforce.)

Covered by Kotest `StringSpec` unit tests (13 cases) across all five supported dialects plus edge cases: absent password, case-insensitive keys, URL-encoded values, multi-occurrence pathological inputs, malformed/empty input.

### `README.md` — new `### Credential handling` subsection

Under `## SQL Persistence`. States the three operating rules: never log raw JDBC URLs in production; inject credentials via `JDBC_URL` / `DB_USER` / `DB_PASSWORD`; route any unavoidable URL logging through `ConnectionUrlSanitizer.sanitize(url)`.

### `CONTRIBUTING.md` — SharedFlow warmup convention

New `#### Event-asserting integration tests: SharedFlow collector warmup` under `### Running Tests`. Documents the `delay(50.milliseconds) // let SharedFlow collector coroutine start` pattern as project standard, with rationale (root cause of the v2.5.0 flake fixed in `ba7f2f2`), the canonical snippet, the required import, and explicit pointers to canonical call sites in `SqlRepositoryEventIntegrationTest.kt` (lines 53, 73, 95, 118, 143) and `SqlRepositoryQueryDslIntegrationTest.kt:761`.

### Wiki `SQL-Persistence` page

Applied separately in the `lirp.wiki` repo as commit [`0ccc488`](https://github.com/octaviospain/lirp/wiki/SQL-Persistence):

- **Credential handling callout** after `### JDBC URL constructor (repository-owned pool)` — long-form version of the README guidance with a worked env-var setup example.
- **SQLite per-connection FK caveat** after the Dialect Notes table — clarifies that `PRAGMA foreign_keys = ON` is set only on the LIRP-managed HikariCP pool; external SQLite connections (direct `DriverManager`, CLI tools, parallel consumers) must enable the PRAGMA themselves for consistent cascade behaviour.

## Out of scope

- No public API change to `SqlRepository` or any existing repository.
- No behaviour change to cascade / FK / write-pipeline semantics.

## Verification

- `gradle :lirp-sql:test --tests "...ConnectionUrlSanitizerTest"` → 13/13 passed.
- `gradle :lirp-sql:test` → BUILD SUCCESSFUL, no regressions.
- `gradle ktlintCheck` → clean.

## Test plan

- [x] New `ConnectionUrlSanitizerTest` covers all five dialect URL shapes + documented edge cases.
- [x] Full `:lirp-sql:test` module green (no regressions in existing SQL or event tests).
- [x] `ktlintCheck` green across the project.
- [x] README and CONTRIBUTING grep targets present (`ConnectionUrlSanitizer`, `JDBC_URL` triple, `SharedFlow collector`, `delay(50.milliseconds)`, `SqlRepositoryEventIntegrationTest`).
- [x] Wiki page renders correctly with both insertions applied.