### PR TITLE
#172 Trust *-sources.jar and *-javadoc.jar in dependency verification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,9 @@ Why this exact command:
 
 **Current trust model:** `verify-metadata="true"`, `verify-signatures="false"`. PGP signature verification is deferred — it requires curating a `<trusted-keys>` block per signing identity. Checksum verification alone still defeats artifact tampering at the registry or proxy layer.
 
-`net.transgressoft` `*-SNAPSHOT` artifacts are listed under `<trusted-artifacts>` and bypass checksum verification. SNAPSHOTs are mutable by design, so pinning their checksums is impossible — trusting the group/version pattern lets cross-project snapshot testing (via `gradle publishToMavenLocal`) keep working.
+`net.transgressoft` `*-SNAPSHOT` artifacts are listed under `<trusted-artifacts>` and bypass checksum verification. SNAPSHOTs are mutable by design, so pinning their checksums is impossible — trusting the group/version pattern lets cross-project snapshot testing (via `./gradlew publishToMavenLocal`) keep working.
+
+`*-sources.jar` and `*-javadoc.jar` are also trusted blanket-wide. IDEs (IntelliJ, Eclipse) auto-download these for code navigation via their own resolver, not through the build's task graph — so they are never seen by `--write-verification-metadata`. They are inert documentation; a compromised sources jar cannot execute code in your build. Runtime checksum pinning still applies to every executable artifact.
 
 **Troubleshooting:**
 

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -4,6 +4,8 @@
       <verify-metadata>true</verify-metadata>
       <verify-signatures>false</verify-signatures>
       <trusted-artifacts>
+         <trust file=".*-javadoc\.jar" regex="true"/>
+         <trust file=".*-sources\.jar" regex="true"/>
          <trust group="net.transgressoft" version=".*-SNAPSHOT$" regex="true"/>
       </trusted-artifacts>
    </configuration>


### PR DESCRIPTION
Closes #172.

## Summary

IDEs (IntelliJ, Eclipse) auto-download source and javadoc jars for code navigation outside the Gradle task graph. These never appear during `--write-verification-metadata`, so no checksums are recorded — and any IDE-driven build fails with `Dependency verification failed` on `*-sources.jar` lookups even though `./gradlew build` from the CLI succeeds.

Adds two trust rules to `gradle/verification-metadata.xml`:

\`\`\`xml
<trust file=".*-sources\.jar" regex="true"/>
<trust file=".*-javadoc\.jar" regex="true"/>
\`\`\`

This is the Gradle-documented workaround for IDE-only artifacts. Source and javadoc jars are inert documentation — a compromised sources jar cannot execute code in your build. Runtime checksum pinning still applies to every executable artifact.

CONTRIBUTING.md updated to document the rationale alongside the existing SNAPSHOT trust.

## Test plan

- [x] \`./gradlew build -x test --no-parallel\` passes locally
- [ ] CI cross-check (\`branch-pr.yml\`) passes — verifying the dry-run regen preserves the \`<trusted-artifacts>\` block as-is
- [ ] After merge: open the project in IntelliJ, trigger a Gradle sync, confirm no verification failures