### PR TITLE
#174 Trust org.apache.groovy for IntelliJ Gradle DSL parser

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,6 +240,8 @@ Why this exact command:
 
 `*-sources.jar` and `*-javadoc.jar` are also trusted blanket-wide. IDEs (IntelliJ, Eclipse) auto-download these for code navigation via their own resolver, not through the build's task graph — so they are never seen by `--write-verification-metadata`. They are inert documentation; a compromised sources jar cannot execute code in your build. Runtime checksum pinning still applies to every executable artifact.
 
+`org.apache.groovy` is trusted unconditionally for the same reason: IntelliJ's Gradle integration resolves Apache Groovy from Gradle's internal "Gradle Libs" repository to parse `build.gradle` DSL syntax, outside any task graph. Apache Groovy is published and signed by the ASF and is part of Gradle's own runtime — trusting the group avoids whack-a-mole when new IDE versions resolve different point versions.
+
 **Troubleshooting:**
 
 | Symptom | Action |

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -4,6 +4,7 @@
       <verify-metadata>true</verify-metadata>
       <verify-signatures>false</verify-signatures>
       <trusted-artifacts>
+         <trust group="org.apache.groovy"/>
          <trust file=".*-javadoc\.jar" regex="true"/>
          <trust file=".*-sources\.jar" regex="true"/>
          <trust group="net.transgressoft" version=".*-SNAPSHOT$" regex="true"/>


### PR DESCRIPTION
Closes #174. Follow-up to #172.

## Summary

After merging #172 (sources/javadoc trust), IntelliJ still failed Gradle sync because IntelliJ resolves Apache Groovy from Gradle's internal "Gradle Libs" repository to parse \`build.gradle\` DSL syntax. This resolution is invisible to \`--write-verification-metadata\` (no task triggers it), so verification rejects every IDE sync.

Adds one trust rule:

\`\`\`xml
<trust group="org.apache.groovy"/>
\`\`\`

Pinning a specific SHA would be whack-a-mole across IDE versions (each IntelliJ bundles its own Gradle, which bundles its own Groovy point version) and would break the CI cross-check (committed file diverges from dry-run, which never resolves Groovy). The group-level trust is durable and the security posture is reasonable — Apache Groovy is published and signed by the ASF and is part of Gradle's own runtime.

## Test plan

- [x] \`./gradlew build -x test --no-parallel\` passes locally
- [x] \`./gradlew --write-verification-metadata sha256 build cyclonedxBom --no-parallel --dry-run\` produces a dryrun file identical to the committed one (cross-check will pass)
- [ ] CI cross-check (\`branch-pr.yml\`) passes
- [ ] After merge: open the project in IntelliJ, trigger a Gradle sync, confirm clean resolution