### PR TITLE
#197 Benchmark template auto-generation and write-path performance improvements

### DIFF
--- a/lirp-benchmark/build.gradle
+++ b/lirp-benchmark/build.gradle
@@ -41,6 +41,31 @@ jmh {
     ]
 }
 
+// Post-process JMH results.json into CSV files and a rendered Performance-Benchmarks.md.
+// Wired via finalizedBy below so it runs automatically after every successful :jmh execution.
+tasks.register('renderBenchmarkReport', Exec) {
+    description = 'Render CSV files and Performance-Benchmarks.md from the JMH results.json.'
+    group = 'verification'
+    workingDir rootProject.projectDir
+    def resultsJson = layout.buildDirectory.file('reports/jmh/results.json')
+    def template = file('scripts/Performance-Benchmarks.template.md')
+    def outMd = layout.buildDirectory.file('reports/jmh/Performance-Benchmarks.md')
+    def csvDir = layout.buildDirectory.dir('reports/jmh/csv')
+    inputs.file(resultsJson).optional()
+    inputs.file(template).optional()
+    outputs.file(outMd)
+    outputs.dir(csvDir)
+    commandLine 'python3',
+        file('scripts/render_benchmark_results.py').absolutePath,
+        '--results', resultsJson.get().asFile.absolutePath,
+        '--template', template.absolutePath,
+        '--out', outMd.get().asFile.absolutePath,
+        '--csv-dir', csvDir.get().asFile.absolutePath
+    onlyIf { resultsJson.get().asFile.exists() }
+}
+
+tasks.named('jmh').configure { finalizedBy 'renderBenchmarkReport' }
+
 // Benchmark module is never published to Maven Central
 tasks.withType(PublishToMavenRepository).configureEach { enabled = false }
 tasks.withType(PublishToMavenLocal).configureEach { enabled = false }

--- a/lirp-benchmark/scripts/Performance-Benchmarks.template.md
+++ b/lirp-benchmark/scripts/Performance-Benchmarks.template.md
@@ -239,18 +239,18 @@ For applications exceeding these bounds, consider SQL-level pagination or stream
 
 ---
 
-## Section 5 — lirp SqlRepository vs Direct JDBC (Zero-Overhead Baseline)
+## Section 4 — lirp SqlRepository vs Direct JDBC (Zero-Overhead Baseline)
 
 **Date:** {{ TODAY }}
 **Configuration:** 2 warmup iterations, 3 measurement iterations, 1 fork
 
 This is the most direct comparison in the benchmark suite: lirp `SqlRepository` measured against raw `java.sql.PreparedStatement` with no ORM or framework overhead. Both sides use the same H2 in-memory engine with separate databases per trial.
 
-The key insight is that lirp's architecture inverts the naive trade-off: its `add()` and `findById()` operations are faster than raw JDBC (not slower), because they operate entirely in memory. The cost appears only in the full batch flush, which writes all accumulated changes in a single transaction.
+The key insight is that lirp's architecture inverts the naive trade-off on the read path: `findById()` is faster than raw JDBC because it serves from an in-memory `ConcurrentHashMap`. On the write path, raw JDBC `add()` is faster per call (a single autocommit INSERT is tiny), but lirp amortizes I/O across the full batch flush at `close()` — see Section 4.3.
 
 ---
 
-### 5.1 add() Throughput — lirp vs Direct JDBC (ops/s)
+### 4.1 add() Throughput — lirp vs Direct JDBC (ops/s)
 
 Direct JDBC `add()` executes one `INSERT` + autoCommit per call. lirp `add()` enqueues in memory; the SQL write is deferred and batched.
 
@@ -261,11 +261,11 @@ Direct JDBC `add()` executes one `INSERT` + autoCommit per call. lirp `add()` en
 | 10,000      | {{ score | DirectJdbcBenchmark | lirpAdd | 10000 }} | {{ score | DirectJdbcBenchmark | directJdbcAdd | 10000 }} |
 | 50,000      | {{ score | DirectJdbcBenchmark | lirpAdd | 50000 }} | {{ score | DirectJdbcBenchmark | directJdbcAdd | 50000 }} |
 
-**Interpretation:** Direct JDBC `add()` is faster here because each call is a single row insert with immediate autoCommit — tiny and constant. lirp `add()` has additional overhead from event publication, the debounce pipeline enqueue, and the in-memory map put. However, the lirp cost is also constant regardless of entity count — and critically, the SQL I/O cost is amortized across all inserts in a single batch transaction (see Section 5.3).
+**Interpretation:** Direct JDBC `add()` is faster here because each call is a single row insert with immediate autoCommit — tiny and constant. lirp `add()` has additional overhead from event publication, the debounce pipeline enqueue, and the in-memory map put. However, the lirp cost is also constant regardless of entity count — and critically, the SQL I/O cost is amortized across all inserts in a single batch transaction (see Section 4.3).
 
 ---
 
-### 5.2 findById() Latency — lirp vs Direct JDBC (ns/op, p50)
+### 4.2 findById() Latency — lirp vs Direct JDBC (ns/op, p50)
 
 Direct JDBC `findById()` executes `SELECT ... WHERE id = ?` and reads the result set. lirp reads from a `ConcurrentHashMap`.
 
@@ -280,7 +280,7 @@ Direct JDBC `findById()` executes `SELECT ... WHERE id = ?` and reads the result
 
 ---
 
-### 5.3 Full Flush/Update Latency — lirp vs Direct JDBC (µs/op, p50)
+### 4.3 Full Flush/Update Latency — lirp vs Direct JDBC (µs/op, p50)
 
 lirp `update` mutates one entity then calls `close()`, which flushes ALL entities in the repository as a batch transaction. Direct JDBC `update` executes a single `UPDATE WHERE id = ?` + autoCommit.
 
@@ -295,7 +295,7 @@ lirp `update` mutates one entity then calls `close()`, which flushes ALL entitie
 
 ---
 
-## Section 4 — How to Run
+## Section 5 — How to Run
 
 Run all benchmarks (full production configuration: 5 warmup, 10 measurement, 1 fork):
 

--- a/lirp-benchmark/scripts/Performance-Benchmarks.template.md
+++ b/lirp-benchmark/scripts/Performance-Benchmarks.template.md
@@ -1,0 +1,329 @@
+# Performance Benchmarks
+
+**Date:** {{ TODAY }}
+**Configuration:** 2 warmup iterations, 3 measurement iterations, 1 fork (per JMH recommendation for initial profiling runs)
+
+---
+
+## Environment
+
+| Attribute         | Value                                                       |
+|-------------------|-------------------------------------------------------------|
+| JVM               | {{ JVM_VERSION }}                                           |
+| OS                | {{ OS_VERSION }}                                            |
+| CPU               | {{ CPU_MODEL }}                                             |
+| RAM               | {{ RAM_GB }} GB                                             |
+| Database          | H2 (in-memory, per-trial isolated)                          |
+| JMH               | 1.37                                                        |
+| JVM args          | `--add-opens` for JOL reflection access                     |
+
+---
+
+## Section 1 — Repository Microbenchmarks
+
+### 1.1 VolatileRepository — add() Throughput
+
+`VolatileRepository` uses `ConcurrentHashMap` for in-memory storage. Add throughput is effectively constant across entity counts, showing that the hash map overhead does not grow with collection size.
+
+| Entity Count | add() ops/s |
+|-------------|-------------|
+| 100         | {{ score | VolatileRepoBenchmark | addEntity | 100 }}     |
+| 1,000       | {{ score | VolatileRepoBenchmark | addEntity | 1000 }}    |
+| 10,000      | {{ score | VolatileRepoBenchmark | addEntity | 10000 }}   |
+| 50,000      | {{ score | VolatileRepoBenchmark | addEntity | 50000 }}   |
+
+### 1.2 VolatileRepository — findById() Latency (ns/op)
+
+| Entity Count | Mean  | p50  | p95  | p99  |
+|-------------|-------|------|------|------|
+| 100         | {{ mean | VolatileRepoBenchmark | findById | 100 | bare }} ns | {{ p50 | VolatileRepoBenchmark | findById | 100 | bare }} | {{ p95 | VolatileRepoBenchmark | findById | 100 | bare }} | {{ p99 | VolatileRepoBenchmark | findById | 100 | bare }} |
+| 1,000       | {{ mean | VolatileRepoBenchmark | findById | 1000 | bare }} ns | {{ p50 | VolatileRepoBenchmark | findById | 1000 | bare }} | {{ p95 | VolatileRepoBenchmark | findById | 1000 | bare }} | {{ p99 | VolatileRepoBenchmark | findById | 1000 | bare }} |
+| 10,000      | {{ mean | VolatileRepoBenchmark | findById | 10000 | bare }} ns | {{ p50 | VolatileRepoBenchmark | findById | 10000 | bare }} | {{ p95 | VolatileRepoBenchmark | findById | 10000 | bare }} | {{ p99 | VolatileRepoBenchmark | findById | 10000 | bare }} |
+| 50,000      | {{ mean | VolatileRepoBenchmark | findById | 50000 | bare }} ns | {{ p50 | VolatileRepoBenchmark | findById | 50000 | bare }} | {{ p95 | VolatileRepoBenchmark | findById | 50000 | bare }} | {{ p99 | VolatileRepoBenchmark | findById | 50000 | bare }} |
+
+`findById` uses `ConcurrentHashMap.get` — O(1) with no performance degradation at higher entity counts.
+
+### 1.3 SqlRepository — add() Throughput
+
+`SqlRepository` stores entities in-memory immediately on `add()`. SQL writes are batched via the debounce pipeline (100 ms window). The add() throughput reflects in-memory enqueue time.
+
+| Entity Count | add() ops/s |
+|-------------|-------------|
+| 100         | {{ score | SqlRepoBenchmark | addEntity | 100 }}   |
+| 1,000       | {{ score | SqlRepoBenchmark | addEntity | 1000 }}  |
+| 10,000      | {{ score | SqlRepoBenchmark | addEntity | 10000 }} |
+| 50,000      | {{ score | SqlRepoBenchmark | addEntity | 50000 }} |
+
+### 1.4 SqlRepository — findById() Latency (ns/op)
+
+| Entity Count | Mean  | p50  | p95  | p99  |
+|-------------|-------|------|------|------|
+| 100         | {{ mean | SqlRepoBenchmark | findById | 100 | bare }} ns | {{ p50 | SqlRepoBenchmark | findById | 100 | bare }} | {{ p95 | SqlRepoBenchmark | findById | 100 | bare }} | {{ p99 | SqlRepoBenchmark | findById | 100 | bare }} |
+| 1,000       | {{ mean | SqlRepoBenchmark | findById | 1000 | bare }} ns | {{ p50 | SqlRepoBenchmark | findById | 1000 | bare }} | {{ p95 | SqlRepoBenchmark | findById | 1000 | bare }} | {{ p99 | SqlRepoBenchmark | findById | 1000 | bare }} |
+| 10,000      | {{ mean | SqlRepoBenchmark | findById | 10000 | bare }} ns | {{ p50 | SqlRepoBenchmark | findById | 10000 | bare }} | {{ p95 | SqlRepoBenchmark | findById | 10000 | bare }} | {{ p99 | SqlRepoBenchmark | findById | 10000 | bare }} |
+| 50,000      | {{ mean | SqlRepoBenchmark | findById | 50000 | bare }} ns | {{ p50 | SqlRepoBenchmark | findById | 50000 | bare }} | {{ p95 | SqlRepoBenchmark | findById | 50000 | bare }} | {{ p99 | SqlRepoBenchmark | findById | 50000 | bare }} |
+
+### 1.5 SqlRepository — findByLabel() Latency (SQL WHERE lookup, ns/op)
+
+This measures a direct SQL WHERE clause column lookup, which involves a full table scan in H2 without a secondary index. Note: lirp's `@Indexed` secondary indexes are O(1) in-memory lookups; this SQL path is used only in the benchmark because KSP-generated index accessors are unavailable in the benchmark module.
+
+| Entity Count | Mean        | p50         | p95         | p99         |
+|-------------|-------------|-------------|-------------|-------------|
+| 100         | {{ mean | SqlRepoBenchmark | findByLabel | 100 }} ns | {{ p50 | SqlRepoBenchmark | findByLabel | 100 }} | {{ p95 | SqlRepoBenchmark | findByLabel | 100 }} | {{ p99 | SqlRepoBenchmark | findByLabel | 100 }} |
+| 1,000       | {{ mean | SqlRepoBenchmark | findByLabel | 1000 }} ns | {{ p50 | SqlRepoBenchmark | findByLabel | 1000 }} | {{ p95 | SqlRepoBenchmark | findByLabel | 1000 }} | {{ p99 | SqlRepoBenchmark | findByLabel | 1000 }} |
+| 10,000      | {{ mean | SqlRepoBenchmark | findByLabel | 10000 }} ns | {{ p50 | SqlRepoBenchmark | findByLabel | 10000 }} | {{ p95 | SqlRepoBenchmark | findByLabel | 10000 }} | {{ p99 | SqlRepoBenchmark | findByLabel | 10000 }} |
+| 50,000      | {{ mean | SqlRepoBenchmark | findByLabel | 50000 }} ns | {{ p50 | SqlRepoBenchmark | findByLabel | 50000 }} | {{ p95 | SqlRepoBenchmark | findByLabel | 50000 }} | {{ p99 | SqlRepoBenchmark | findByLabel | 50000 }} |
+
+### 1.6 SqlRepository — mutationFlush Latency (µs/op)
+
+`mutationFlush` measures: mutate one entity property + call `close()` (which triggers a synchronous batch flush to H2). This includes the full SQL write cost for all entities in the repository.
+
+| Entity Count | Mean          | p50           | p95           | p99           |
+|-------------|---------------|---------------|---------------|---------------|
+| 100         | {{ mean | SqlRepoBenchmark | mutationFlush | 100 }} µs | {{ p50 | SqlRepoBenchmark | mutationFlush | 100 }} | {{ p95 | SqlRepoBenchmark | mutationFlush | 100 }} | {{ p99 | SqlRepoBenchmark | mutationFlush | 100 }} |
+| 1,000       | {{ mean | SqlRepoBenchmark | mutationFlush | 1000 }} µs | {{ p50 | SqlRepoBenchmark | mutationFlush | 1000 }} | {{ p95 | SqlRepoBenchmark | mutationFlush | 1000 }} | {{ p99 | SqlRepoBenchmark | mutationFlush | 1000 }} |
+| 10,000      | {{ mean | SqlRepoBenchmark | mutationFlush | 10000 }} µs | {{ p50 | SqlRepoBenchmark | mutationFlush | 10000 }} | {{ p95 | SqlRepoBenchmark | mutationFlush | 10000 }} | {{ p99 | SqlRepoBenchmark | mutationFlush | 10000 }} |
+| 50,000      | {{ mean | SqlRepoBenchmark | mutationFlush | 50000 }} µs | {{ p50 | SqlRepoBenchmark | mutationFlush | 50000 }} | {{ p95 | SqlRepoBenchmark | mutationFlush | 50000 }} | {{ p99 | SqlRepoBenchmark | mutationFlush | 50000 }} |
+
+### 1.7 JsonFileRepository — add() Throughput
+
+| Entity Count | add() ops/s |
+|-------------|-------------|
+| 100         | {{ score | JsonRepoBenchmark | addEntity | 100 }}   |
+| 1,000       | {{ score | JsonRepoBenchmark | addEntity | 1000 }}  |
+| 10,000      | {{ score | JsonRepoBenchmark | addEntity | 10000 }} |
+| 50,000      | {{ score | JsonRepoBenchmark | addEntity | 50000 }} |
+
+### 1.8 JsonFileRepository — mutationFlush Latency (µs/op)
+
+`mutationFlush` measures: mutate one entity property + call `close()` (synchronous JSON file write). Full serialization and file I/O cost included.
+
+| Entity Count | Mean       | p50        | p95        | p99        |
+|-------------|------------|------------|------------|------------|
+| 100         | {{ mean | JsonRepoBenchmark | mutationFlush | 100 }} µs | {{ p50 | JsonRepoBenchmark | mutationFlush | 100 }} | {{ p95 | JsonRepoBenchmark | mutationFlush | 100 }} | {{ p99 | JsonRepoBenchmark | mutationFlush | 100 }} |
+| 1,000       | {{ mean | JsonRepoBenchmark | mutationFlush | 1000 }} µs | {{ p50 | JsonRepoBenchmark | mutationFlush | 1000 }} | {{ p95 | JsonRepoBenchmark | mutationFlush | 1000 }} | {{ p99 | JsonRepoBenchmark | mutationFlush | 1000 }} |
+| 10,000      | {{ mean | JsonRepoBenchmark | mutationFlush | 10000 }} µs | {{ p50 | JsonRepoBenchmark | mutationFlush | 10000 }} | {{ p95 | JsonRepoBenchmark | mutationFlush | 10000 }} | {{ p99 | JsonRepoBenchmark | mutationFlush | 10000 }} |
+| 50,000      | {{ mean | JsonRepoBenchmark | mutationFlush | 50000 }} µs | {{ p50 | JsonRepoBenchmark | mutationFlush | 50000 }} | {{ p95 | JsonRepoBenchmark | mutationFlush | 50000 }} | {{ p99 | JsonRepoBenchmark | mutationFlush | 50000 }} |
+
+### 1.9 CollapseBenchmark — Throughput (ops/s)
+
+The collapse algorithm eliminates redundant `PendingOp` entries before SQL/JSON flush (`Insert+Update→Insert`, `Insert+Delete→no-op`, multiple `Update→single Update`).
+
+| Entity Count | collapseOps ops/s |
+|-------------|-------------------|
+| 100         | {{ score | CollapseBenchmark | collapseOps | opCount=100 }}   |
+| 1,000       | {{ score | CollapseBenchmark | collapseOps | opCount=1000 }}  |
+| 10,000      | {{ score | CollapseBenchmark | collapseOps | opCount=10000 }} |
+| 50,000      | {{ score | CollapseBenchmark | collapseOps | opCount=50000 }} |
+
+### 1.10 Initialization Time (ms, SingleShotTime)
+
+Cold-start initialization — from constructor to all entities loaded and indexed in memory.
+
+| Entity Count | VolatileRepository | SqlRepository | JsonFileRepository |
+|-------------|-------------------|---------------|-------------------|
+| 100         | {{ mean | InitTimeBenchmark | initVolatile | 100 }} ms | {{ mean | InitTimeBenchmark | initSql | 100 }} ms | {{ mean | InitTimeBenchmark | initJson | 100 }} ms |
+| 1,000       | {{ mean | InitTimeBenchmark | initVolatile | 1000 }} ms | {{ mean | InitTimeBenchmark | initSql | 1000 }} ms | {{ mean | InitTimeBenchmark | initJson | 1000 }} ms |
+| 10,000      | {{ mean | InitTimeBenchmark | initVolatile | 10000 }} ms | {{ mean | InitTimeBenchmark | initSql | 10000 }} ms | {{ mean | InitTimeBenchmark | initJson | 10000 }} ms |
+| 50,000      | {{ mean | InitTimeBenchmark | initVolatile | 50000 }} ms | {{ mean | InitTimeBenchmark | initSql | 50000 }} ms | {{ mean | InitTimeBenchmark | initJson | 50000 }} ms |
+
+---
+
+## Section 2 — Comparative Benchmarks
+
+### 2.1 SqlRepository vs Direct JetBrains Exposed
+
+Both sides use separate H2 in-memory databases. The lirp side uses the debounce pipeline; the Exposed side executes direct transactions.
+
+**add() Throughput (ops/s):**
+
+| Entity Count | SqlRepository | Direct Exposed |
+|-------------|---------------|----------------|
+| 100         | {{ score | ComparativeExposedBenchmark | sqlRepoAdd | 100 }}     | {{ score | ComparativeExposedBenchmark | directExposedAdd | 100 }}   |
+| 1,000       | {{ score | ComparativeExposedBenchmark | sqlRepoAdd | 1000 }}    | {{ score | ComparativeExposedBenchmark | directExposedAdd | 1000 }}  |
+| 10,000      | {{ score | ComparativeExposedBenchmark | sqlRepoAdd | 10000 }}   | {{ score | ComparativeExposedBenchmark | directExposedAdd | 10000 }} |
+| 50,000      | {{ score | ComparativeExposedBenchmark | sqlRepoAdd | 50000 }}   | {{ score | ComparativeExposedBenchmark | directExposedAdd | 50000 }} |
+
+**findById() Latency (ns/op, p50):**
+
+| Entity Count | SqlRepository | Direct Exposed |
+|-------------|---------------|----------------|
+| 100         | {{ p50 | ComparativeExposedBenchmark | sqlRepoFindById | 100 | bare }} ns | {{ p50 | ComparativeExposedBenchmark | directExposedFindById | 100 }} ns |
+| 1,000       | {{ p50 | ComparativeExposedBenchmark | sqlRepoFindById | 1000 | bare }} ns | {{ p50 | ComparativeExposedBenchmark | directExposedFindById | 1000 }} ns |
+| 10,000      | {{ p50 | ComparativeExposedBenchmark | sqlRepoFindById | 10000 | bare }} ns | {{ p50 | ComparativeExposedBenchmark | directExposedFindById | 10000 }} ns |
+| 50,000      | {{ p50 | ComparativeExposedBenchmark | sqlRepoFindById | 50000 | bare }} ns | {{ p50 | ComparativeExposedBenchmark | directExposedFindById | 50000 }} ns |
+
+SqlRepository `findById` reads from the in-memory `ConcurrentHashMap` (O(1)). Direct Exposed `findById` executes a SQL `SELECT WHERE id = ?` per call.
+
+### 2.2 SqlRepository vs Hibernate JPA
+
+**add() Throughput (ops/s):**
+
+| Entity Count | SqlRepository | JPA/Hibernate |
+|-------------|---------------|---------------|
+| 100         | {{ score | ComparativeJpaBenchmark | sqlRepoAdd | 100 }} | {{ score | ComparativeJpaBenchmark | jpaAdd | 100 }} |
+| 1,000       | {{ score | ComparativeJpaBenchmark | sqlRepoAdd | 1000 }} | {{ score | ComparativeJpaBenchmark | jpaAdd | 1000 }} |
+| 10,000      | {{ score | ComparativeJpaBenchmark | sqlRepoAdd | 10000 }} | {{ score | ComparativeJpaBenchmark | jpaAdd | 10000 }} |
+| 50,000      | {{ score | ComparativeJpaBenchmark | sqlRepoAdd | 50000 }} | {{ score | ComparativeJpaBenchmark | jpaAdd | 50000 }} |
+
+JPA `add()` commits a transaction per call via Hibernate `EntityManager.persist()` + `flush()`. SqlRepository enqueues in-memory and batches SQL writes — this is the fundamental architectural difference.
+
+**findById() Latency (ns/op, p50):**
+
+| Entity Count | SqlRepository | JPA/Hibernate |
+|-------------|---------------|---------------|
+| 100         | {{ p50 | ComparativeJpaBenchmark | sqlRepoFindById | 100 | bare }} ns | {{ p50 | ComparativeJpaBenchmark | jpaFindById | 100 }} ns |
+| 1,000       | {{ p50 | ComparativeJpaBenchmark | sqlRepoFindById | 1000 | bare }} ns | {{ p50 | ComparativeJpaBenchmark | jpaFindById | 1000 }} ns |
+| 10,000      | {{ p50 | ComparativeJpaBenchmark | sqlRepoFindById | 10000 | bare }} ns | {{ p50 | ComparativeJpaBenchmark | jpaFindById | 10000 }} ns |
+| 50,000      | {{ p50 | ComparativeJpaBenchmark | sqlRepoFindById | 50000 | bare }} ns | {{ p50 | ComparativeJpaBenchmark | jpaFindById | 50000 }} ns |
+
+### 2.3 JsonFileRepository vs Raw kotlinx.serialization
+
+**add() Latency (µs/op, p50):**
+
+| Entity Count | JsonFileRepository | Raw Serialization |
+|-------------|-------------------|-------------------|
+| 100         | {{ p50 | ComparativeJsonSerializationBenchmark | jsonRepoAdd | 100 }} µs | {{ p50 | ComparativeJsonSerializationBenchmark | rawSerializationWrite | 100 }} µs |
+| 1,000       | {{ p50 | ComparativeJsonSerializationBenchmark | jsonRepoAdd | 1000 }} µs | {{ p50 | ComparativeJsonSerializationBenchmark | rawSerializationWrite | 1000 }} µs |
+| 10,000      | {{ p50 | ComparativeJsonSerializationBenchmark | jsonRepoAdd | 10000 }} µs | {{ p50 | ComparativeJsonSerializationBenchmark | rawSerializationWrite | 10000 }} µs |
+| 50,000      | {{ p50 | ComparativeJsonSerializationBenchmark | jsonRepoAdd | 50000 }} µs | {{ p50 | ComparativeJsonSerializationBenchmark | rawSerializationWrite | 50000 }} µs |
+
+`jsonRepoAdd` enqueues the entity in-memory (no file I/O during add). Raw serialization re-encodes and rewrites the entire JSON file on every add call — this grows linearly with entity count.
+
+**mutationFlush Latency (µs/op, p50):**
+
+| Entity Count | JsonFileRepository | Raw Serialization |
+|-------------|-------------------|-------------------|
+| 100         | {{ p50 | ComparativeJsonSerializationBenchmark | jsonRepoMutationFlush | 100 }} µs | {{ p50 | ComparativeJsonSerializationBenchmark | rawSerializationMutationWrite | 100 }} µs |
+| 1,000       | {{ p50 | ComparativeJsonSerializationBenchmark | jsonRepoMutationFlush | 1000 }} µs | {{ p50 | ComparativeJsonSerializationBenchmark | rawSerializationMutationWrite | 1000 }} µs |
+| 10,000      | {{ p50 | ComparativeJsonSerializationBenchmark | jsonRepoMutationFlush | 10000 }} µs | {{ p50 | ComparativeJsonSerializationBenchmark | rawSerializationMutationWrite | 10000 }} µs |
+| 50,000      | {{ p50 | ComparativeJsonSerializationBenchmark | jsonRepoMutationFlush | 50000 }} µs | {{ p50 | ComparativeJsonSerializationBenchmark | rawSerializationMutationWrite | 50000 }} µs |
+
+`jsonRepoMutationFlush` mutates one entity's property and forces a synchronous flush via `close()`. Raw serialization rewrites the full file per call. At equal repository size, lirp's debounce pipeline still amortizes I/O across many mutations in normal usage — this benchmark intentionally bypasses that to measure the close-time round-trip cost.
+
+---
+
+## Section 3 — Memory Profiling
+
+### 3.1 Peak Memory During Initialization (ms, SingleShotTime)
+
+These measurements use `Runtime.getRuntime().totalMemory() - freeMemory()` delta between before and after loading all entities. The metric is the JMH iteration time (ms) which includes GC pressure; actual heap bytes allocated depend on subscriber count and entity size.
+
+| Entity Count | 0 Subscribers | 1 Subscriber | 5 Subscribers | 10 Subscribers |
+|-------------|--------------|--------------|---------------|----------------|
+| 100         | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=100,subscriberCount=0 }} ms | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=100,subscriberCount=1 }} ms | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=100,subscriberCount=5 }} ms | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=100,subscriberCount=10 }} ms |
+| 1,000       | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=1000,subscriberCount=0 }} ms | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=1000,subscriberCount=1 }} ms | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=1000,subscriberCount=5 }} ms | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=1000,subscriberCount=10 }} ms |
+| 10,000      | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=10000,subscriberCount=0 }} ms | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=10000,subscriberCount=1 }} ms | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=10000,subscriberCount=5 }} ms | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=10000,subscriberCount=10 }} ms |
+| 50,000      | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=50000,subscriberCount=0 }} ms | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=50000,subscriberCount=1 }} ms | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=50000,subscriberCount=5 }} ms | {{ mean | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=50000,subscriberCount=10 }} ms |
+
+### 3.2 Heap Per Entity (JOL)
+
+`MemoryProfilingBenchmark.heapPerEntityWithSubscribers` uses JOL `GraphLayout.parseInstance` to measure total reachable heap size of a single `BenchmarkEntity` with varying subscriber counts. The reported metric is JMH iteration time (ms); the actual heap bytes per entity are printed to stdout during the benchmark run and vary by subscriber count due to `FlowEventPublisher` and `SharedFlow` allocation.
+
+Key observations from the benchmark design:
+- With 0 subscribers, the entity publisher is never initialized (lazy init) — only the entity object itself and its backing field values are allocated
+- With 1+ subscribers, `FlowEventPublisher` and its `SharedFlow` buffer are allocated on first subscription
+- Additional subscribers add a `Job` entry per subscription but share the same `SharedFlow`
+
+### 3.3 Dataset Size Recommendations
+
+Based on the measured initialization times and throughput characteristics:
+
+| Repository Type    | Practical Sweet Spot | Upper Bound   | Notes |
+|-------------------|---------------------|---------------|-------|
+| VolatileRepository | Up to 50K entities  | ~500K entities | Pure in-memory; limited by heap only |
+| SqlRepository      | Up to 10K entities  | ~100K entities | Init time grows with row count and table scan |
+| JsonFileRepository | Up to 10K entities  | ~50K entities  | Full-file rewrite on each flush |
+
+For applications exceeding these bounds, consider SQL-level pagination or streaming — lirp is designed for bounded-context working sets that fit comfortably in heap.
+
+---
+
+## Section 5 — lirp SqlRepository vs Direct JDBC (Zero-Overhead Baseline)
+
+**Date:** {{ TODAY }}
+**Configuration:** 2 warmup iterations, 3 measurement iterations, 1 fork
+
+This is the most direct comparison in the benchmark suite: lirp `SqlRepository` measured against raw `java.sql.PreparedStatement` with no ORM or framework overhead. Both sides use the same H2 in-memory engine with separate databases per trial.
+
+The key insight is that lirp's architecture inverts the naive trade-off: its `add()` and `findById()` operations are faster than raw JDBC (not slower), because they operate entirely in memory. The cost appears only in the full batch flush, which writes all accumulated changes in a single transaction.
+
+---
+
+### 5.1 add() Throughput — lirp vs Direct JDBC (ops/s)
+
+Direct JDBC `add()` executes one `INSERT` + autoCommit per call. lirp `add()` enqueues in memory; the SQL write is deferred and batched.
+
+| Entity Count | lirp SqlRepository | Direct JDBC (baseline) |
+|-------------|-------------------|------------------------|
+| 100         | {{ score | DirectJdbcBenchmark | lirpAdd | 100 }} | {{ score | DirectJdbcBenchmark | directJdbcAdd | 100 }} |
+| 1,000       | {{ score | DirectJdbcBenchmark | lirpAdd | 1000 }} | {{ score | DirectJdbcBenchmark | directJdbcAdd | 1000 }} |
+| 10,000      | {{ score | DirectJdbcBenchmark | lirpAdd | 10000 }} | {{ score | DirectJdbcBenchmark | directJdbcAdd | 10000 }} |
+| 50,000      | {{ score | DirectJdbcBenchmark | lirpAdd | 50000 }} | {{ score | DirectJdbcBenchmark | directJdbcAdd | 50000 }} |
+
+**Interpretation:** Direct JDBC `add()` is faster here because each call is a single row insert with immediate autoCommit — tiny and constant. lirp `add()` has additional overhead from event publication, the debounce pipeline enqueue, and the in-memory map put. However, the lirp cost is also constant regardless of entity count — and critically, the SQL I/O cost is amortized across all inserts in a single batch transaction (see Section 5.3).
+
+---
+
+### 5.2 findById() Latency — lirp vs Direct JDBC (ns/op, p50)
+
+Direct JDBC `findById()` executes `SELECT ... WHERE id = ?` and reads the result set. lirp reads from a `ConcurrentHashMap`.
+
+| Entity Count | lirp SqlRepository (p50) | Direct JDBC (p50) |
+|-------------|--------------------------|-------------------|
+| 100         | {{ p50 | DirectJdbcBenchmark | lirpFindById | 100 | bare }} ns | {{ p50 | DirectJdbcBenchmark | directJdbcFindById | 100 }} ns |
+| 1,000       | {{ p50 | DirectJdbcBenchmark | lirpFindById | 1000 | bare }} ns | {{ p50 | DirectJdbcBenchmark | directJdbcFindById | 1000 }} ns |
+| 10,000      | {{ p50 | DirectJdbcBenchmark | lirpFindById | 10000 | bare }} ns | {{ p50 | DirectJdbcBenchmark | directJdbcFindById | 10000 }} ns |
+| 50,000      | {{ p50 | DirectJdbcBenchmark | lirpFindById | 50000 | bare }} ns | {{ p50 | DirectJdbcBenchmark | directJdbcFindById | 50000 }} ns |
+
+**Interpretation:** lirp's in-memory cache delivers O(1) hash-map lookups. Direct JDBC requires a connection checkout, statement preparation, SQL execution, network round-trip to H2, and result-set deserialization — all within the same process but still significantly slower due to the SQL engine overhead. In production against a remote database, the JDBC gap widens further.
+
+---
+
+### 5.3 Full Flush/Update Latency — lirp vs Direct JDBC (µs/op, p50)
+
+lirp `update` mutates one entity then calls `close()`, which flushes ALL entities in the repository as a batch transaction. Direct JDBC `update` executes a single `UPDATE WHERE id = ?` + autoCommit.
+
+| Entity Count | lirp flush (p50)  | Direct JDBC single UPDATE (p50) |
+|-------------|-------------------|---------------------------------|
+| 100         | {{ p50 | DirectJdbcBenchmark | lirpUpdate | 100 }} µs | {{ p50 | DirectJdbcBenchmark | directJdbcUpdate | 100 | bare }} µs |
+| 1,000       | {{ p50 | DirectJdbcBenchmark | lirpUpdate | 1000 }} µs | {{ p50 | DirectJdbcBenchmark | directJdbcUpdate | 1000 | bare }} µs |
+| 10,000      | {{ p50 | DirectJdbcBenchmark | lirpUpdate | 10000 }} µs | {{ p50 | DirectJdbcBenchmark | directJdbcUpdate | 10000 | bare }} µs |
+| 50,000      | {{ p50 | DirectJdbcBenchmark | lirpUpdate | 50000 }} µs | {{ p50 | DirectJdbcBenchmark | directJdbcUpdate | 50000 | bare }} µs |
+
+**Interpretation:** This comparison is asymmetric by design: the lirp `close()` flush writes the **entire** repository in one transaction, while the JDBC baseline writes **one** row. The lirp batch's per-entity cost approaches JDBC's per-row cost as batch size increases, because transaction overhead is amortized across all rows.
+
+---
+
+## Section 4 — How to Run
+
+Run all benchmarks (full production configuration: 5 warmup, 10 measurement, 1 fork):
+
+```bash
+gradle :lirp-benchmark:jmh
+```
+
+Run a specific benchmark class:
+
+```bash
+gradle :lirp-benchmark:jmh -Pjmh.includes='VolatileRepoBenchmark'
+```
+
+Run with reduced iterations for quick profiling (forces a re-run if results were cached):
+
+```bash
+gradle :lirp-benchmark:jmh -Pjmh.warmupIterations=2 -Pjmh.iterations=3 -Pjmh.fork=1 --rerun-tasks
+```
+
+After the JMH run, the `renderBenchmarkReport` task (wired via `finalizedBy`) regenerates:
+
+- `lirp-benchmark/build/reports/jmh/csv/*.csv` — one CSV per benchmark class
+- `lirp-benchmark/build/reports/jmh/Performance-Benchmarks.md` — this file, rendered from the template at `lirp-benchmark/scripts/Performance-Benchmarks.template.md`
+
+To publish to the wiki, copy the rendered file:
+
+```bash
+cp lirp-benchmark/build/reports/jmh/Performance-Benchmarks.md ../lirp.wiki/Performance-Benchmarks.md
+```
+
+> The benchmark module is **never published to Maven Central** and is **excluded from CI**. It is a local development tool only.

--- a/lirp-benchmark/scripts/README.md
+++ b/lirp-benchmark/scripts/README.md
@@ -1,0 +1,128 @@
+# Benchmark Report Automation
+
+Turns the raw `results.json` produced by `gradle :lirp-benchmark:jmh` into:
+
+1. **One CSV file per benchmark class** under `build/reports/jmh/csv/`
+   — suitable for archival, diffing across runs, or importing into Grafana / Excel.
+2. **A rendered `Performance-Benchmarks.md`** by token-substituting
+   `scripts/Performance-Benchmarks.template.md`.
+
+The script has no dependencies beyond the Python 3 stdlib. The
+`renderBenchmarkReport` Gradle task is wired to run automatically as a
+`finalizedBy` of `:lirp-benchmark:jmh` — see the **Gradle integration**
+section below.
+
+## Files
+
+- `render_benchmark_results.py` — the post-processor.
+- `Performance-Benchmarks.template.md` — a partial template demonstrating the
+  token syntax. Currently covers Section 1.1–1.3 as a proof of concept; extend
+  it to cover the full wiki page as a follow-up.
+
+## Token syntax
+
+```
+{{ METRIC | CLASS | METHOD | PARAMS | FORMAT? }}
+```
+
+| Field   | Example                              | Notes                                                                                          |
+|---------|--------------------------------------|------------------------------------------------------------------------------------------------|
+| METRIC  | `score`, `mean`, `p50`, `p95`, `p99` | `score` = throughput mean; `mean` = sample mean                                                |
+| CLASS   | `VolatileRepoBenchmark`              | The simple class name from the JMH benchmark                                                   |
+| METHOD  | `addEntity`                          | The `@Benchmark`-annotated method name                                                         |
+| PARAMS  | `100` / `opCount=10000,subscriberCount=5` / `` | Bare value is shorthand for `entityCount=<value>`; comma-separated `k=v` for multi-param benchmarks; empty for paramless |
+| FORMAT  | `int`, `thousand`, `ns`, `us`, `ms`, `bare` | Optional; defaults to a smart per-unit format. `bare` strips commas and rounds to int when fractional part is zero |
+
+Unresolved tokens emit a warning to stderr and render as `—`.
+
+**Environment placeholders** (substituted before benchmark tokens):
+
+| Token             | Source                                     |
+|-------------------|--------------------------------------------|
+| `{{ TODAY }}`     | `datetime.date.today().isoformat()`        |
+| `{{ JVM_VERSION }}` | first line of `java -version`            |
+| `{{ OS_VERSION }}`  | `platform.system()/release()/machine()`  |
+| `{{ CPU_MODEL }}`   | `/proc/cpuinfo` `model name` field       |
+| `{{ RAM_GB }}`      | `/proc/meminfo` `MemTotal`               |
+
+## Usage (manual)
+
+```bash
+gradle :lirp-benchmark:jmh -Pjmh.warmupIterations=2 -Pjmh.iterations=3 -Pjmh.fork=1 --rerun-tasks
+python3 lirp-benchmark/scripts/render_benchmark_results.py
+# CSVs in    lirp-benchmark/build/reports/jmh/csv/
+# Markdown in lirp-benchmark/build/reports/jmh/Performance-Benchmarks.md
+```
+
+CLI flags:
+
+```
+--results   PATH   default: lirp-benchmark/build/reports/jmh/results.json
+--template  PATH   default: lirp-benchmark/scripts/Performance-Benchmarks.template.md
+--out       PATH   default: lirp-benchmark/build/reports/jmh/Performance-Benchmarks.md
+--csv-dir   PATH   default: lirp-benchmark/build/reports/jmh/csv
+```
+
+## Gradle integration (wired)
+
+`lirp-benchmark/build.gradle` declares a `renderBenchmarkReport` task that
+runs the Python script and is registered as a `finalizedBy` of `:jmh`. After
+every successful JMH run, the CSVs and the rendered markdown are regenerated
+in `build/reports/jmh/`.
+
+You can also invoke it standalone — useful when you've already run the
+benchmark and only want to re-render after editing the template:
+
+```bash
+gradle :lirp-benchmark:renderBenchmarkReport
+```
+
+## Proposed wiki sync (separate repo)
+
+The wiki lives at `../lirp.wiki/` (a separate git repository). A sync step is
+intentionally **not** part of the Gradle task — automatic pushes to a wiki
+repo are surprising. A small one-shot script (or a manual `cp` + commit + push
+flow) keeps the trust boundary clean:
+
+```bash
+cp lirp-benchmark/build/reports/jmh/Performance-Benchmarks.md \
+   ../lirp.wiki/Performance-Benchmarks.md
+( cd ../lirp.wiki && git add Performance-Benchmarks.md \
+    && git commit -m "Refresh performance benchmarks ($(date -I))" \
+    && git push )
+```
+
+## Pre-run hygiene checklist
+
+To get repeatable numbers:
+
+- Close other GUI apps; disable browser tabs that auto-refresh.
+- Pin the CPU governor to `performance`: `sudo cpupower frequency-set -g performance`.
+- Disable Turbo Boost if you have a script for it (reduces variance further).
+- Always use `--rerun-tasks` so Gradle doesn't return a cached JMH result.
+- Consider longer config for "official" runs (`-Pjmh.warmupIterations=5 -Pjmh.iterations=10`).
+
+## Editorial layer
+
+The template intentionally renders only **data** — the prose interpretation
+notes that appeared in earlier wiki revisions (e.g. "SqlRepo add() is ~45%
+lower than the 2026-04-14 baseline") are not auto-generated, because they
+require human judgment about whether a delta is signal or noise.
+
+The current workflow is:
+
+1. `gradle :lirp-benchmark:jmh --rerun-tasks` regenerates the data.
+2. `cp build/reports/jmh/Performance-Benchmarks.md ../lirp.wiki/`.
+3. Read the diff; add or update interpretive notes by hand where deltas warrant them.
+
+## Follow-ups
+
+- **Regression detection**: emit a `diff.md` comparing each metric against the
+  previous run's CSV (kept in git or fetched from the wiki). Fail the task — or
+  just warn — if any metric regresses by more than a configured threshold.
+- **Trend chart generation**: archive each CSV under
+  `build/reports/jmh/history/<timestamp>/` and produce a small SVG sparkline
+  per metric for the README.
+- **Auto-publish**: a separate `publishBenchmarkReport` task (not wired) that
+  `cp`s into `../lirp.wiki/` and pushes — gated behind a `-Ppublish` flag so
+  it never runs unintentionally.

--- a/lirp-benchmark/scripts/README.md
+++ b/lirp-benchmark/scripts/README.md
@@ -15,13 +15,13 @@ section below.
 ## Files
 
 - `render_benchmark_results.py` — the post-processor.
-- `Performance-Benchmarks.template.md` — a partial template demonstrating the
-  token syntax. Currently covers Section 1.1–1.3 as a proof of concept; extend
-  it to cover the full wiki page as a follow-up.
+- `Performance-Benchmarks.template.md` — the canonical wiki template. Covers
+  the full report (repository microbenchmarks, comparative benchmarks, memory
+  profiling, JDBC baseline, and the how-to-run section).
 
 ## Token syntax
 
-```
+```text
 {{ METRIC | CLASS | METHOD | PARAMS | FORMAT? }}
 ```
 
@@ -56,7 +56,7 @@ python3 lirp-benchmark/scripts/render_benchmark_results.py
 
 CLI flags:
 
-```
+```text
 --results   PATH   default: lirp-benchmark/build/reports/jmh/results.json
 --template  PATH   default: lirp-benchmark/scripts/Performance-Benchmarks.template.md
 --out       PATH   default: lirp-benchmark/build/reports/jmh/Performance-Benchmarks.md
@@ -112,7 +112,7 @@ require human judgment about whether a delta is signal or noise.
 The current workflow is:
 
 1. `gradle :lirp-benchmark:jmh --rerun-tasks` regenerates the data.
-2. `cp build/reports/jmh/Performance-Benchmarks.md ../lirp.wiki/`.
+2. `cp lirp-benchmark/build/reports/jmh/Performance-Benchmarks.md ../lirp.wiki/` (run from repo root).
 3. Read the diff; add or update interpretive notes by hand where deltas warrant them.
 
 ## Follow-ups

--- a/lirp-benchmark/scripts/render_benchmark_results.py
+++ b/lirp-benchmark/scripts/render_benchmark_results.py
@@ -236,13 +236,17 @@ def write_csvs(rows: list[dict[str, Any]], csv_dir: Path) -> None:
     for r in rows:
         cls = r["benchmark"].split(".")[-2]
         by_class.setdefault(cls, []).append(r)
-    # Determine the union of param keys across all rows so the CSV header is stable per class
-    for cls, group in by_class.items():
-        param_keys: list[str] = []
-        for r in group:
-            for k in (r.get("params") or {}):
-                if k not in param_keys:
-                    param_keys.append(k)
+    # Deterministic class, header, and row ordering keeps archived CSV diffs stable across runs.
+    for cls in sorted(by_class.keys()):
+        group = sorted(
+            by_class[cls],
+            key=lambda r: (
+                r["benchmark"],
+                r.get("mode", ""),
+                json.dumps(r.get("params") or {}, sort_keys=True),
+            ),
+        )
+        param_keys = sorted({k for r in group for k in (r.get("params") or {})})
         out = csv_dir / f"{cls}.csv"
         with out.open("w", newline="") as f:
             w = csv.writer(f)

--- a/lirp-benchmark/scripts/render_benchmark_results.py
+++ b/lirp-benchmark/scripts/render_benchmark_results.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+Post-processes the JMH results.json from `gradle :lirp-benchmark:jmh` into:
+  1. One CSV file per benchmark class under build/reports/jmh/csv/
+  2. A rendered Performance-Benchmarks.md by substituting tokens in
+     scripts/Performance-Benchmarks.template.md
+
+Usage:
+    python3 render_benchmark_results.py [--results PATH] [--template PATH] [--out PATH]
+
+Token grammar in the template:
+    {{ METRIC | CLASS | METHOD | PARAMS | FORMAT? }}
+
+Where:
+    METRIC = score | mean | p50 | p95 | p99
+    CLASS  = simple class name, e.g. SqlRepoBenchmark
+    METHOD = benchmark method name, e.g. addEntity
+    PARAMS = "" for paramless | "<n>" shorthand for entityCount=<n>
+           | "k1=v1,k2=v2" for arbitrary param combinations
+    FORMAT = optional: int | thousand | us | ms | ns | bare
+             (default: smart, comma-separated thousands)
+
+Environment placeholders (substituted before benchmark tokens):
+    {{ TODAY }} {{ JVM_VERSION }} {{ OS_VERSION }} {{ CPU_MODEL }} {{ RAM_GB }}
+
+Examples:
+    {{ score | VolatileRepoBenchmark | addEntity | 100 }}
+    {{ p50 | MemoryProfilingBenchmark | peakMemoryDuringInit | entityCount=10000,subscriberCount=5 }}
+    {{ score | CollapseBenchmark | collapseOps | opCount=10000 }}
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime
+import json
+import platform
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# Matches {{ env_placeholder }} with no internal pipes.
+ENV_TOKEN_RE = re.compile(r"\{\{\s*(?P<name>[A-Z_][A-Z0-9_]*)\s*\}\}")
+
+# Matches {{ metric | class | method | params | format? }}
+BENCH_TOKEN_RE = re.compile(
+    r"\{\{\s*(?P<metric>score|mean|p50|p95|p99)\s*\|"
+    r"\s*(?P<cls>\w+)\s*\|"
+    r"\s*(?P<method>\w+)\s*\|"
+    r"\s*(?P<params>[^|}]*?)\s*"
+    r"(?:\|\s*(?P<fmt>\w+)\s*)?\}\}"
+)
+
+
+def parse_params(spec: str) -> dict[str, str]:
+    """Parse the params field of a token.
+
+    Empty -> {} (paramless benchmark)
+    Bare value (no '=') -> {'entityCount': value}  (shorthand)
+    Otherwise comma-separated key=value pairs
+    """
+    spec = spec.strip()
+    if not spec:
+        return {}
+    if "=" not in spec:
+        return {"entityCount": spec}
+    out: dict[str, str] = {}
+    for pair in spec.split(","):
+        if "=" not in pair:
+            raise ValueError(f"invalid param fragment: {pair!r}")
+        k, v = pair.split("=", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+def load(results_path: Path) -> list[dict[str, Any]]:
+    with results_path.open() as f:
+        return json.load(f)
+
+
+def index(rows: list[dict[str, Any]]) -> list[tuple[str, str, dict[str, str], dict[str, Any]]]:
+    """Linear index: [(class, method, params_dict, row), ...].
+
+    Multi-param benchmarks are kept as separate entries; lookup matches on
+    all key-value pairs requested by the token. This avoids the dedup
+    problem the first version had.
+    """
+    out: list[tuple[str, str, dict[str, str], dict[str, Any]]] = []
+    for r in rows:
+        full = r["benchmark"]
+        cls = full.split(".")[-2]
+        method = full.split(".")[-1]
+        params = {k: str(v) for k, v in (r.get("params") or {}).items()}
+        out.append((cls, method, params, r))
+    return out
+
+
+def lookup(
+    idx: list[tuple[str, str, dict[str, str], dict[str, Any]]],
+    cls: str,
+    method: str,
+    want: dict[str, str],
+) -> dict[str, Any] | None:
+    for c, m, p, row in idx:
+        if c != cls or m != method:
+            continue
+        if all(p.get(k) == v for k, v in want.items()) and set(p.keys()) >= set(want.keys()):
+            return row
+    return None
+
+
+def fmt_number(value: float, unit: str, fmt: str | None) -> str:
+    if value is None:
+        return "—"
+    if fmt == "int" or fmt == "thousand":
+        return f"{int(round(value)):,}"
+    if fmt == "bare":
+        # Integer-typed measurements (e.g. ns latency p50) come through as 26.0; show "26".
+        # Fractional values keep two decimals.
+        if abs(value - round(value)) < 1e-9:
+            return f"{int(round(value))}"
+        return f"{value:.2f}"
+    if fmt in ("us", "ms", "ns"):
+        return f"{value:,.2f}"
+    # smart default by unit
+    if unit == "ops/s":
+        return f"{int(round(value)):,}"
+    if value >= 1000:
+        return f"{value:,.0f}"
+    if value >= 1:
+        return f"{value:.2f}"
+    return f"{value:.3f}"
+
+
+def resolve(metric: str, row: dict[str, Any]) -> tuple[float | None, str]:
+    pm = row["primaryMetric"]
+    unit = pm["scoreUnit"]
+    if metric in ("score", "mean"):
+        return pm["score"], unit
+    pcts = pm.get("scorePercentiles") or {}
+    if metric == "p50":
+        return pcts.get("50.0"), unit
+    if metric == "p95":
+        return pcts.get("95.0"), unit
+    if metric == "p99":
+        return pcts.get("99.0"), unit
+    raise ValueError(f"unknown metric: {metric}")
+
+
+def gather_env() -> dict[str, str]:
+    today = datetime.date.today().isoformat()
+    # JVM
+    try:
+        jv = subprocess.run(
+            ["java", "-version"], capture_output=True, text=True, check=False
+        )
+        jvm_line = (jv.stderr or jv.stdout).splitlines()[0] if (jv.stderr or jv.stdout) else "unknown"
+    except FileNotFoundError:
+        jvm_line = "unknown"
+    # OS
+    os_version = f"{platform.system()} {platform.release()} ({platform.machine()})"
+    # CPU
+    cpu_model = "unknown"
+    try:
+        with open("/proc/cpuinfo") as f:
+            for line in f:
+                if line.startswith("model name"):
+                    cpu_model = line.split(":", 1)[1].strip()
+                    break
+    except FileNotFoundError:
+        pass
+    # RAM (Linux)
+    ram_gb = "unknown"
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemTotal:"):
+                    kb = int(line.split()[1])
+                    ram_gb = f"{kb / (1024 * 1024):.0f}"
+                    break
+    except FileNotFoundError:
+        pass
+
+    return {
+        "TODAY": today,
+        "JVM_VERSION": jvm_line,
+        "OS_VERSION": os_version,
+        "CPU_MODEL": cpu_model,
+        "RAM_GB": ram_gb,
+    }
+
+
+def render(
+    template: str,
+    idx: list[tuple[str, str, dict[str, str], dict[str, Any]]],
+    env: dict[str, str],
+) -> str:
+    def env_sub(m: re.Match[str]) -> str:
+        name = m.group("name")
+        if name in env:
+            return env[name]
+        # Leave unknown ALL_CAPS tokens untouched (so e.g. SQL examples aren't mangled).
+        return m.group(0)
+
+    def bench_sub(m: re.Match[str]) -> str:
+        metric = m.group("metric")
+        cls = m.group("cls")
+        method = m.group("method")
+        params_raw = m.group("params") or ""
+        fmt = m.group("fmt")
+        try:
+            want = parse_params(params_raw)
+        except ValueError as e:
+            sys.stderr.write(f"warning: bad params {params_raw!r}: {e}\n")
+            return "—"
+        row = lookup(idx, cls, method, want)
+        if row is None:
+            sys.stderr.write(
+                f"warning: missing benchmark {cls}.{method} (params={want!r})\n"
+            )
+            return "—"
+        value, unit = resolve(metric, row)
+        return fmt_number(value, unit, fmt) if value is not None else "—"
+
+    template = BENCH_TOKEN_RE.sub(bench_sub, template)
+    template = ENV_TOKEN_RE.sub(env_sub, template)
+    return template
+
+
+def write_csvs(rows: list[dict[str, Any]], csv_dir: Path) -> None:
+    csv_dir.mkdir(parents=True, exist_ok=True)
+    by_class: dict[str, list[dict[str, Any]]] = {}
+    for r in rows:
+        cls = r["benchmark"].split(".")[-2]
+        by_class.setdefault(cls, []).append(r)
+    # Determine the union of param keys across all rows so the CSV header is stable per class
+    for cls, group in by_class.items():
+        param_keys: list[str] = []
+        for r in group:
+            for k in (r.get("params") or {}):
+                if k not in param_keys:
+                    param_keys.append(k)
+        out = csv_dir / f"{cls}.csv"
+        with out.open("w", newline="") as f:
+            w = csv.writer(f)
+            header = ["benchmark", "method", "mode"] + param_keys + [
+                "score",
+                "scoreError",
+                "scoreUnit",
+                "p50",
+                "p95",
+                "p99",
+            ]
+            w.writerow(header)
+            for r in group:
+                method = r["benchmark"].split(".")[-1]
+                params = r.get("params") or {}
+                pm = r["primaryMetric"]
+                pcts = pm.get("scorePercentiles") or {}
+                row = [r["benchmark"], method, r["mode"]]
+                row += [params.get(k, "") for k in param_keys]
+                row += [
+                    pm["score"],
+                    pm.get("scoreError", ""),
+                    pm["scoreUnit"],
+                    pcts.get("50.0", ""),
+                    pcts.get("95.0", ""),
+                    pcts.get("99.0", ""),
+                ]
+                w.writerow(row)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--results",
+        type=Path,
+        default=Path("lirp-benchmark/build/reports/jmh/results.json"),
+    )
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=Path("lirp-benchmark/scripts/Performance-Benchmarks.template.md"),
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("lirp-benchmark/build/reports/jmh/Performance-Benchmarks.md"),
+    )
+    parser.add_argument(
+        "--csv-dir",
+        type=Path,
+        default=Path("lirp-benchmark/build/reports/jmh/csv"),
+    )
+    args = parser.parse_args()
+
+    if not args.results.exists():
+        sys.stderr.write(f"error: {args.results} does not exist\n")
+        return 1
+
+    rows = load(args.results)
+    write_csvs(rows, args.csv_dir)
+    idx = index(rows)
+    env = gather_env()
+
+    if args.template.exists():
+        rendered = render(args.template.read_text(), idx, env)
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(rendered)
+        print(f"wrote {args.out}")
+    else:
+        sys.stderr.write(
+            f"warning: template {args.template} not found; skipping markdown render\n"
+        )
+
+    print(f"wrote {len(rows)} benchmark rows to CSVs in {args.csv_dir}/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/BenchmarkEntityTableDef.kt
+++ b/lirp-benchmark/src/jmh/kotlin/net/transgressoft/lirp/benchmark/BenchmarkEntityTableDef.kt
@@ -40,4 +40,10 @@ object BenchmarkEntityTableDef : SqlTableDef<BenchmarkEntity> {
             cols["name"]!! to entity.name
         )
     }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun applyRow(entity: BenchmarkEntity, row: ResultRow, table: Table) {
+        val cols = table.columns.associateBy { it.name }
+        entity.name = row[cols["name"]!! as Column<String>]
+    }
 }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -293,13 +293,16 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
             mutationBlock()
             return
         }
+        if (!shouldEmit) {
+            mutationBlock()
+            lastDateModified = LocalDateTime.now()
+            return
+        }
         val entityBeforeChange = clone()
         mutationBlock()
         lastDateModified = LocalDateTime.now()
-        if (shouldEmit) {
-            log.trace { "Firing fx scalar mutation event from $entityBeforeChange to $this" }
-            publisher.emitAsync(ReactiveMutationEvent(this as R, entityBeforeChange as R))
-        }
+        log.trace { "Firing fx scalar mutation event from $entityBeforeChange to $this" }
+        publisher.emitAsync(ReactiveMutationEvent(this as R, entityBeforeChange as R))
     }
 
     override fun subscribe(action: suspend (MutationEvent<K, R>) -> Unit): LirpEventSubscription<in LirpEntity, MutationEvent.Type, MutationEvent<K, R>> {
@@ -486,13 +489,16 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
                     return
                 }
 
+                if (!shouldEmit) {
+                    storedValue = value
+                    lastDateModified = LocalDateTime.now()
+                    return
+                }
                 val entityBeforeChange = clone()
                 storedValue = value
                 lastDateModified = LocalDateTime.now()
-                if (shouldEmit) {
-                    log.trace { "Firing entity update event from $entityBeforeChange to ${this@ReactiveEntityBase}" }
-                    publisher.emitAsync(ReactiveMutationEvent(this@ReactiveEntityBase as R, entityBeforeChange as R))
-                }
+                log.trace { "Firing entity update event from $entityBeforeChange to ${this@ReactiveEntityBase}" }
+                publisher.emitAsync(ReactiveMutationEvent(this@ReactiveEntityBase as R, entityBeforeChange as R))
             }
         }
     }
@@ -515,13 +521,16 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
                     setter(value)
                     return
                 }
+                if (!shouldEmit) {
+                    setter(value)
+                    lastDateModified = LocalDateTime.now()
+                    return
+                }
                 val entityBeforeChange = clone()
                 setter(value)
                 lastDateModified = LocalDateTime.now()
-                if (shouldEmit) {
-                    log.trace { "Firing entity update event from $entityBeforeChange to ${this@ReactiveEntityBase}" }
-                    publisher.emitAsync(ReactiveMutationEvent(this@ReactiveEntityBase as R, entityBeforeChange as R))
-                }
+                log.trace { "Firing entity update event from $entityBeforeChange to ${this@ReactiveEntityBase}" }
+                publisher.emitAsync(ReactiveMutationEvent(this@ReactiveEntityBase as R, entityBeforeChange as R))
             }
         }
     }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/event/FlowEventPublisher.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/event/FlowEventPublisher.kt
@@ -225,6 +225,12 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
 
         override fun emitAsync(event: E) {
             check(!isClosed) { "Publisher '$id' is closed" }
+            // Short-circuit when nobody is listening and no replay is configured: the event would
+            // be funneled through eventChannel → changesFlow and dropped on the floor anyway.
+            // Skipping here avoids the trySend allocation, the activeTypes lookup, and the
+            // persistent-coroutine wakeup. Safe because replay == 0 means no late subscriber can
+            // observe events emitted before they subscribed.
+            if (_subscriberCount.get() == 0 && config.replay == 0) return
             // Read the volatile reference once to get a consistent snapshot; a concurrent disableEvents()
             // replacing the reference after this read will not affect the check or the send
             val activeTypes = activatedEventTypes

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PendingOp.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PendingOp.kt
@@ -154,8 +154,10 @@ private data class CollapseEntry<K : Comparable<K>, R : ReactiveEntity<K, R>>(
  */
 fun <K : Comparable<K>, R : ReactiveEntity<K, R>> collapse(ops: List<PendingOp<K, R>>): List<PendingOp<K, R>> {
     // Pre-size to ops.size so the map does not resize while folding large batches.
-    // Worst case the map ends up oversized (one op may touch many entities, e.g. PendingBatchInsert),
-    // but the over-allocation is bounded and far cheaper than the rehash storm at 10K+ ops.
+    // Heuristic works well when ops.size ≈ unique entity count (common case: many individual ops).
+    // Over-sizing happens when many ops target the same id (e.g. 100 PendingUpdates on entity#1 → capacity 100, 1 entry).
+    // Under-sizing happens for batch ops carrying many entities (e.g. one PendingBatchInsert with 100 entities → capacity 16, 100 entries),
+    // but bounded over-allocation and the occasional residual rehash are both far cheaper than the rehash storm at 10K+ ops.
     val state = LinkedHashMap<K, CollapseEntry<K, R>>(ops.size.coerceAtLeast(16))
     var hadClear = false
 

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PendingOp.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PendingOp.kt
@@ -153,7 +153,10 @@ private data class CollapseEntry<K : Comparable<K>, R : ReactiveEntity<K, R>>(
  * @return the minimal ordered list of operations to execute.
  */
 fun <K : Comparable<K>, R : ReactiveEntity<K, R>> collapse(ops: List<PendingOp<K, R>>): List<PendingOp<K, R>> {
-    val state = LinkedHashMap<K, CollapseEntry<K, R>>()
+    // Pre-size to ops.size so the map does not resize while folding large batches.
+    // Worst case the map ends up oversized (one op may touch many entities, e.g. PendingBatchInsert),
+    // but the over-allocation is bounded and far cheaper than the rehash storm at 10K+ ops.
+    val state = LinkedHashMap<K, CollapseEntry<K, R>>(ops.size.coerceAtLeast(16))
     var hadClear = false
 
     for (op in ops) {


### PR DESCRIPTION
Closes #197.

## Summary

- **Benchmark template auto-generation** — render `Performance-Benchmarks.md` from JMH JSON via a new Python script (`render_benchmark_results.py`) + Markdown template, wired into a Gradle task in `lirp-benchmark`.
- **Skip `clone()` in reactive setters when no subscribers; pre-size collapse map** — `ReactiveEntityBase` setters now check `shouldEmit` before allocating the entity clone + `ReactiveMutationEvent`. `PendingOp.collapse()`'s `LinkedHashMap` is pre-sized to `ops.size` to avoid rehash storms at large batches. `lastDateModified` is still updated regardless of subscriber state.
- **Short-circuit `FlowEventPublisher.emitAsync` when nobody is listening** — early-return when `subscriberCount == 0` and `config.replay == 0`, skipping the `activeTypes` lookup, channel `trySend`, and persistent coroutine wakeup. `replay > 0` keeps the original path so the `SharedFlow` replay cache still works.

Targets regressions observed between the 2026-04-14 and 2026-05-20 benchmark runs across `VolatileRepoBenchmark.addEntity`, `SqlRepoBenchmark.addEntity` / `mutationFlush`, `DirectJdbcBenchmark.lirpAdd` / `lirpUpdate`, `ComparativeJsonSerializationBenchmark.jsonRepoAdd`, and `CollapseBenchmark.collapseOps`.

## Test plan

- [ ] `gradle build` passes
- [ ] `gradle test` passes
- [ ] `gradle ktlintCheck` passes
- [ ] `gradle :lirp-benchmark:jmh` produces JMH output that the renderer can consume
- [ ] Spot-check `Performance-Benchmarks.md` rendering against a sample JMH JSON