### PR TITLE
#208 @PersistenceProperty(converter = …) — ColumnConverter for non-scalar domain types

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Deep coverage of the write pipeline, collapse algorithm, transactional guarantee
 - **Type-safe Query DSL** — Kotlin-native filtering, ordering, and pagination with automatic index routing
 - **Optimistic locking** — `@Version` triggers versioned UPDATE/DELETE; conflicts surface as `StandardCrudEvent.Conflict` with canonical state
 - **Convention-over-configuration KSP codegen** — `@PersistenceMapping` generates table definitions; annotations only when you need to customize
+- **Custom column converters** — route non-scalar domain types (`java.nio.file.Path`, `java.time.Duration`, value wrappers) through a consumer-supplied `ColumnConverter<D, S>` `object` referenced via `@PersistenceProperty(converter = MyConverter::class)`. The contract lives in `lirp-api`; currently consumed by the SQL persistence path, while JSON-backed entities continue to rely on `kotlinx.serialization`.
 - **JSON persistence** — debounced file writes via `JsonFileRepository`, zero-reflection `LirpEntitySerializer`
 - **Repository-as-factory** — typed `create()` methods with automatic `@LirpRepository` registration
 - **JavaFX integration** (`lirp-fx`) — `fxAggregateList`/`fxAggregateSet` bridging lirp collections with `ObservableList`/`ObservableSet`, scalar delegates (`fxString`, `fxInteger`, etc.), read-only `ObservableMap` projections

--- a/lirp-api/build.gradle
+++ b/lirp-api/build.gradle
@@ -1,1 +1,9 @@
 description = 'LIRP API'
+
+dependencies {
+    testImplementation platform(libs.junit.bom)
+    testImplementation libs.bundles.kotest
+    testImplementation libs.junit.jupiter
+    testImplementation libs.kotlin.reflect
+    testRuntimeOnly libs.junit.platform.launcher
+}

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ColumnConverter.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ColumnConverter.kt
@@ -1,0 +1,99 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+/**
+ * Bidirectional mapping between a domain type [D] and a persistence-facing scalar [S].
+ *
+ * Used by `@PersistenceProperty(converter = ...)` to persist non-scalar domain types
+ * (such as `java.nio.file.Path`, `java.time.Duration`, or custom value wrappers)
+ * without forcing the entity to expose a scalar field. KSP-generated `_LirpTableDef`
+ * code reads [sqlType] to derive the column shape, routes writes through [toSql],
+ * and reconstructs the domain value via [fromSql] on row reads.
+ *
+ * ### Implementation requirements
+ *
+ * Implementations must be Kotlin `object` declarations (singletons). KSP-generated
+ * code references the converter by its fully qualified name and never instantiates
+ * it. Declaring a converter as a regular class, abstract class, sealed parent, or
+ * anonymous object is rejected at compile time by the KSP processor.
+ *
+ * ### Supported scalar types
+ *
+ * [S] must resolve to one of the primitives natively supported by [ColumnType]:
+ * `String`, `Int`, `Long`, `Short`, `Byte`, `Boolean`, `Double`, `Float`,
+ * `java.math.BigDecimal`, `java.util.UUID`, `java.time.LocalDate`, and
+ * `java.time.LocalDateTime`. Any other type is rejected at compile time so that
+ * mismatches surface before a row read.
+ *
+ * ### Nullability
+ *
+ * Nullability is handled by codegen, not by the converter. The KSP-generated
+ * read/write code branches on the property's declared nullability and never invokes
+ * [toSql] or [fromSql] with a `null` argument. Implementations may therefore declare
+ * non-null `D` and `S` parameters and return types unconditionally.
+ *
+ * ### Scope
+ *
+ * Currently consumed by the SQL persistence path only. JSON-backed entities continue
+ * to rely on `kotlinx.serialization` (consumer-provided `KSerializer<T>`) for
+ * non-scalar fields.
+ *
+ * ### Example
+ *
+ * A converter that persists `java.nio.file.Path` as a textual column:
+ *
+ * ```kotlin
+ * object PathConverter : ColumnConverter<Path, String> {
+ *     override val sqlType = ColumnType.TextType
+ *     override fun toSql(value: Path): String = value.toString()
+ *     override fun fromSql(raw: String): Path = Path.of(raw)
+ * }
+ *
+ * @PersistenceMapping
+ * data class Track(
+ *     override val id: Int,
+ *     @PersistenceProperty(converter = PathConverter::class, length = 1024)
+ *     val location: Path
+ * ) : ReactiveEntityBase<Int, Track>()
+ * ```
+ *
+ * @param D the domain type exposed by the entity property.
+ * @param S the persistence-facing scalar type bound to a SQL column.
+ */
+interface ColumnConverter<D, S : Any> {
+    /**
+     * The [ColumnType] used by KSP-generated schema and read/write code for the column
+     * backing this converter. Annotation hints (`length`, `precision`, `scale`, `type`)
+     * may refine this value when compatible; see `@PersistenceProperty.converter`.
+     */
+    val sqlType: ColumnType
+
+    /**
+     * Converts a domain [value] to its persistence-facing representation [S]. Invoked
+     * by the SQL write pipeline before binding the parameter to the prepared statement.
+     */
+    fun toSql(value: D): S
+
+    /**
+     * Reconstructs the domain value from its persistence-facing [raw] representation.
+     * Invoked by the SQL read pipeline after the column has been read from the JDBC
+     * result set.
+     */
+    fun fromSql(raw: S): D
+}

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/PersistenceProperty.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/PersistenceProperty.kt
@@ -17,6 +17,8 @@
 
 package net.transgressoft.lirp.persistence
 
+import kotlin.reflect.KClass
+
 /**
  * Configures how an entity property maps to a persistence field or column.
  *
@@ -59,6 +61,15 @@ package net.transgressoft.lirp.persistence
  *   of `-1` means no explicit scale is set; the backend default applies.
  * @param type An optional override for the SQL type name (e.g., `"TEXT"`, `"JSONB"`). When empty,
  *   the KSP processor infers the type from the Kotlin property type.
+ * @param converter A [ColumnConverter] singleton (`object`) that maps a non-scalar domain type to a
+ *   persistence-facing scalar. The default value [ColumnConverter] itself is a sentinel meaning
+ *   "no converter declared — use type inference from the Kotlin property type." When a converter
+ *   is supplied, the KSP processor derives the column type from [ColumnConverter.sqlType] and
+ *   refines it with any compatible annotation hints: a positive `length` on a textual base type
+ *   widens it to `VARCHAR(length)`; `precision`/`scale` on a numeric base type widen it to
+ *   `DECIMAL(precision, scale)`; a non-empty `type` always overrides the converter's base type
+ *   to honor explicit consumer intent. Hints incompatible with the converter's base type
+ *   (for example, `length` on an integer converter) are reported as KSP errors at compile time.
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.BINARY)
@@ -67,5 +78,6 @@ annotation class PersistenceProperty(
     val length: Int = -1,
     val precision: Int = -1,
     val scale: Int = -1,
-    val type: String = ""
+    val type: String = "",
+    val converter: KClass<out ColumnConverter<*, *>> = ColumnConverter::class
 )

--- a/lirp-api/src/test/kotlin/net/transgressoft/lirp/persistence/ColumnConverterTest.kt
+++ b/lirp-api/src/test/kotlin/net/transgressoft/lirp/persistence/ColumnConverterTest.kt
@@ -1,0 +1,78 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import io.kotest.core.spec.style.StringSpec
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import kotlin.reflect.full.memberProperties
+
+/**
+ * Identity converter used to verify that a Kotlin `object` implementing [ColumnConverter]
+ * compiles against the published interface contract and round-trips values unchanged.
+ */
+object IdentityStringConverter : ColumnConverter<String, String> {
+    override val sqlType: ColumnType = ColumnType.TextType
+
+    override fun toSql(value: String): String = value
+
+    override fun fromSql(raw: String): String = raw
+}
+
+/**
+ * Entity-side fixture exercising the new `converter` annotation parameter. Compilation
+ * alone proves the annotation accepts a converter [kotlin.reflect.KClass] argument; the
+ * tests below assert presence and signature stability.
+ */
+@Suppress("unused")
+class ConverterAnnotationFixture {
+    @PersistenceProperty(converter = IdentityStringConverter::class)
+    val withConverter: String = ""
+
+    @PersistenceProperty(name = "plain")
+    val withoutConverter: String = ""
+}
+
+class ColumnConverterTest : StringSpec({
+
+    "ColumnConverter exposes sqlType toSql and fromSql members" {
+        val memberNames = ColumnConverter::class.java.methods.map { it.name }.toSet()
+        assertTrue(memberNames.containsAll(listOf("getSqlType", "toSql", "fromSql")))
+    }
+
+    "ColumnConverter round-trips identity values through toSql and fromSql" {
+        assertEquals(ColumnType.TextType, IdentityStringConverter.sqlType)
+        assertEquals("alpha", IdentityStringConverter.toSql("alpha"))
+        assertEquals("beta", IdentityStringConverter.fromSql("beta"))
+    }
+
+    "@PersistenceProperty accepts a converter KClass argument and defaults to ColumnConverter sentinel" {
+        // The annotation has BINARY retention (KSP reads source), so it is not visible to runtime
+        // reflection on annotated properties. Signature stability is asserted at the annotation
+        // interface level: presence of the `converter` accessor, its JVM-erased return type
+        // (`KClass<*>` lowers to `java.lang.Class`), and its default value (the sentinel).
+        val converterAccessor = PersistenceProperty::class.java.getMethod("converter")
+        assertEquals(Class::class.java, converterAccessor.returnType)
+        assertEquals(ColumnConverter::class.java, converterAccessor.defaultValue)
+
+        // The fixture's compilation proves the annotation accepts a converter KClass at the
+        // source level — a load-time class verifier would reject mismatched annotation types.
+        val propertyNames = ConverterAnnotationFixture::class.memberProperties.map { it.name }.toSet()
+        assertTrue(propertyNames.containsAll(setOf("withConverter", "withoutConverter")))
+    }
+})

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
@@ -45,10 +45,63 @@ private const val SQL_TABLE_DEF_FQN = "net.transgressoft.lirp.persistence.sql.Sq
 private const val UUID_FQN = "java.util.UUID"
 private const val LOCAL_DATE_FQN = "java.time.LocalDate"
 private const val LOCAL_DATE_TIME_FQN = "java.time.LocalDateTime"
+private const val KOTLIN_STRING_FQN = "kotlin.String"
+private const val KOTLIN_INT_FQN = "kotlin.Int"
 private const val KOTLIN_LONG_FQN = "kotlin.Long"
+private const val KOTLIN_SHORT_FQN = "kotlin.Short"
+private const val KOTLIN_BYTE_FQN = "kotlin.Byte"
+private const val KOTLIN_BOOLEAN_FQN = "kotlin.Boolean"
+private const val KOTLIN_DOUBLE_FQN = "kotlin.Double"
+private const val KOTLIN_FLOAT_FQN = "kotlin.Float"
 private const val KOTLIN_UUID_FQN = "kotlin.UUID"
+private const val BIG_DECIMAL_FQN = "java.math.BigDecimal"
 private const val COLUMN_TYPE_INT_EXPR = "ColumnType.IntType"
+private const val COLUMN_TYPE_TEXT_EXPR = "ColumnType.TextType"
+private const val COLUMN_TYPE_LONG_EXPR = "ColumnType.LongType"
+private const val COLUMN_TYPE_BOOLEAN_EXPR = "ColumnType.BooleanType"
+private const val COLUMN_TYPE_DOUBLE_EXPR = "ColumnType.DoubleType"
+private const val COLUMN_TYPE_FLOAT_EXPR = "ColumnType.FloatType"
+private const val COLUMN_TYPE_UUID_EXPR = "ColumnType.UuidType"
+private const val COLUMN_TYPE_DATE_EXPR = "ColumnType.DateType"
+private const val COLUMN_TYPE_DATETIME_EXPR = "ColumnType.DateTimeType"
 private const val LIST_ITEM_SEPARATOR = ",\n        "
+private const val COLUMN_CONVERTER_FQN = "net.transgressoft.lirp.persistence.ColumnConverter"
+
+// Allow-list of supported S type FQNs for ColumnConverter<D, S>, mapped to the canonical
+// ColumnType expression. Keys gate D-08 validation; values seed the codegen path that
+// emits the column type from the converter's base scalar.
+private val SUPPORTED_CONVERTER_S_TYPES: Map<String, String> =
+    mapOf(
+        KOTLIN_STRING_FQN to COLUMN_TYPE_TEXT_EXPR,
+        KOTLIN_INT_FQN to COLUMN_TYPE_INT_EXPR,
+        KOTLIN_LONG_FQN to COLUMN_TYPE_LONG_EXPR,
+        KOTLIN_SHORT_FQN to COLUMN_TYPE_INT_EXPR,
+        KOTLIN_BYTE_FQN to COLUMN_TYPE_INT_EXPR,
+        KOTLIN_BOOLEAN_FQN to COLUMN_TYPE_BOOLEAN_EXPR,
+        KOTLIN_DOUBLE_FQN to COLUMN_TYPE_DOUBLE_EXPR,
+        KOTLIN_FLOAT_FQN to COLUMN_TYPE_FLOAT_EXPR,
+        BIG_DECIMAL_FQN to "ColumnType.DecimalType",
+        UUID_FQN to COLUMN_TYPE_UUID_EXPR,
+        LOCAL_DATE_FQN to COLUMN_TYPE_DATE_EXPR,
+        LOCAL_DATE_TIME_FQN to COLUMN_TYPE_DATETIME_EXPR
+    )
+
+internal data class ConverterInfo(
+    val converterFqn: String,
+    val sqlTypeFqn: String
+)
+
+/**
+ * Bundle of `@PersistenceProperty` hint values consumed by the codegen path that derives
+ * a column's `typeExpression`. Carrying them as a single value keeps refinement-helper
+ * signatures focused — see [TableDefProcessor.refineConverterSqlType].
+ */
+internal data class PersistencePropertyHints(
+    val length: Int,
+    val precision: Int,
+    val scale: Int,
+    val typeHint: String
+)
 
 /**
  * KSP processor that generates `_LirpTableDef` descriptor objects for entity classes annotated with
@@ -105,13 +158,19 @@ class TableDefProcessor(
             // 'kotlin.collections.List'" errors.
             val excludedBackingFields =
                 aggregates.mapNotNullTo(mutableSetOf()) { if (it.isCollection) it.backingCollectionName else null }
+            // D-06 inputs: backing scalar names for single-entity aggregates (FK columns). These are
+            // excluded from converter routing because the FK column type is dictated by the
+            // referenced entity's primary key type, not by a domain-to-scalar converter.
+            val aggregateBackingScalarNames =
+                aggregates.filter { !it.isCollection }.mapNotNull { it.backingScalarName }.toSet()
             generateTableDef(
                 classDecl,
                 sqlTableDefAvailable,
                 versionedByClass[classDecl],
                 foreignKeys,
                 junctionRefs,
-                excludedBackingFields
+                excludedBackingFields,
+                aggregateBackingScalarNames
             )
 
             if (sqlTableDefAvailable) {
@@ -402,14 +461,15 @@ class TableDefProcessor(
         versionedProperty: KSPropertyDeclaration?,
         foreignKeys: List<ForeignKeyMeta> = emptyList(),
         junctionRefs: List<JunctionRefInfo> = emptyList(),
-        excludedBackingFields: Set<String> = emptySet()
+        excludedBackingFields: Set<String> = emptySet(),
+        aggregateBackingScalarNames: Set<String> = emptySet()
     ) {
         val packageName = classDecl.packageName.asString()
         val className = classDecl.simpleName.asString()
         val tableDefName = "${className}_LirpTableDef"
 
         val tableName = resolveTableName(classDecl, className)
-        val columns = collectColumns(classDecl, versionedProperty, excludedBackingFields)
+        val columns = collectColumns(classDecl, versionedProperty, excludedBackingFields, aggregateBackingScalarNames)
         // Ordered constructor parameter names — preserves declaration order for correct fromRow() generation.
         val constructorParamNames =
             classDecl.primaryConstructor?.parameters
@@ -654,15 +714,47 @@ class TableDefProcessor(
 
     private fun buildRowAccess(col: ColumnMeta): String {
         val rawAccess = "row[table.columns.first { it.name == \"${col.name}\" }]"
-        // Short / Byte are stored as INT; narrow on read via Kotlin's truncating conversion.
-        // A raw `as Short` would fail at runtime because the JDBC value is boxed as Int.
-        if (col.typeFqn == "kotlin.Short") {
-            return if (col.nullable) "($rawAccess as? Int)?.toShort()" else "($rawAccess as Int).toShort()"
+        return buildConverterRowAccess(col, rawAccess)
+            ?: buildNarrowingIntRowAccess(col, rawAccess)
+            ?: buildBuiltInRowAccess(col, rawAccess)
+    }
+
+    // Converter-routed columns short-circuit the FQN-driven cast table: read the raw scalar,
+    // cast to the converter's S type, then route through the consumer's fromSql. Short/Byte
+    // converters need the same INT → narrow-typed conversion that non-converter columns get
+    // (the JDBC layer boxes the column value as Int regardless of declared width), or the cast
+    // would throw ClassCastException at row time.
+    private fun buildConverterRowAccess(col: ColumnMeta, rawAccess: String): String? {
+        if (col.converterFqn == null || col.converterSqlFqn == null) return null
+        val converterInput =
+            when (col.converterSqlFqn) {
+                KOTLIN_SHORT_FQN ->
+                    if (col.nullable) "($rawAccess as? Int)?.toShort()" else "($rawAccess as Int).toShort()"
+                KOTLIN_BYTE_FQN ->
+                    if (col.nullable) "($rawAccess as? Int)?.toByte()" else "($rawAccess as Int).toByte()"
+                else ->
+                    if (col.nullable) "($rawAccess as? ${col.converterSqlFqn})" else "($rawAccess as ${col.converterSqlFqn})"
+            }
+        return if (col.nullable) {
+            "$converterInput?.let { ${col.converterFqn}.fromSql(it) }"
+        } else {
+            "${col.converterFqn}.fromSql($converterInput)"
         }
-        if (col.typeFqn == "kotlin.Byte") {
-            return if (col.nullable) "($rawAccess as? Int)?.toByte()" else "($rawAccess as Int).toByte()"
+    }
+
+    // Short / Byte are stored as INT; narrow on read via Kotlin's truncating conversion.
+    // A raw `as Short` would fail at runtime because the JDBC value is boxed as Int.
+    private fun buildNarrowingIntRowAccess(col: ColumnMeta, rawAccess: String): String? =
+        when (col.typeFqn) {
+            KOTLIN_SHORT_FQN ->
+                if (col.nullable) "($rawAccess as? Int)?.toShort()" else "($rawAccess as Int).toShort()"
+            KOTLIN_BYTE_FQN ->
+                if (col.nullable) "($rawAccess as? Int)?.toByte()" else "($rawAccess as Int).toByte()"
+            else -> null
         }
-        return when {
+
+    private fun buildBuiltInRowAccess(col: ColumnMeta, rawAccess: String): String =
+        when {
             col.typeFqn == UUID_FQN && col.nullable -> "($rawAccess as? kotlin.uuid.Uuid)?.toJavaUuid()"
             col.typeFqn == UUID_FQN -> "($rawAccess as kotlin.uuid.Uuid).toJavaUuid()"
             col.typeFqn == LOCAL_DATE_FQN && col.nullable -> "($rawAccess as? kotlinx.datetime.LocalDate)?.toJavaLocalDate()"
@@ -680,7 +772,6 @@ class TableDefProcessor(
             col.nullable -> "$rawAccess as? ${col.typeFqn.substringAfterLast(".")}"
             else -> "$rawAccess as ${col.typeFqn.substringAfterLast(".")}"
         }
-    }
 
     private fun StringBuilder.appendToParams(className: String, columns: List<ColumnMeta>) {
         appendLine("    override fun toParams(entity: $className, table: Table): Map<Column<*>, Any?> {")
@@ -698,11 +789,24 @@ class TableDefProcessor(
 
     private fun buildEntityAccess(col: ColumnMeta): String {
         val prop = "entity.${col.propertyName}"
+        // Converter-routed columns short-circuit the FQN-driven write table: route the domain
+        // value through toSql before binding. Short/Byte converters then widen to Int to match
+        // the IntType column the JDBC layer expects (symmetric to buildConverterRowAccess).
+        if (col.converterFqn != null) {
+            val sqlValue =
+                if (col.nullable) "$prop?.let { ${col.converterFqn}.toSql(it) }"
+                else "${col.converterFqn}.toSql($prop)"
+            return when (col.converterSqlFqn) {
+                KOTLIN_SHORT_FQN, KOTLIN_BYTE_FQN ->
+                    if (col.nullable) "$sqlValue?.toInt()" else "$sqlValue.toInt()"
+                else -> sqlValue
+            }
+        }
         // Short / Byte are stored as INT — widen on write so the bound parameter matches the column.
-        if (col.typeFqn == "kotlin.Short") {
+        if (col.typeFqn == KOTLIN_SHORT_FQN) {
             return if (col.nullable) "$prop?.toInt()" else "$prop.toInt()"
         }
-        if (col.typeFqn == "kotlin.Byte") {
+        if (col.typeFqn == KOTLIN_BYTE_FQN) {
             return if (col.nullable) "$prop?.toInt()" else "$prop.toInt()"
         }
         return when {
@@ -787,7 +891,8 @@ class TableDefProcessor(
     private fun collectColumns(
         classDecl: KSClassDeclaration,
         versionedProperty: KSPropertyDeclaration?,
-        excludedBackingFields: Set<String> = emptySet()
+        excludedBackingFields: Set<String> = emptySet(),
+        aggregateBackingScalarNames: Set<String> = emptySet()
     ): List<ColumnMeta> {
         // Detect PK: look for a concrete (non-abstract) 'id' property declared directly on the class.
         // Using getDeclaredProperties() avoids the hasBackingField pitfall on abstract interface properties
@@ -801,7 +906,7 @@ class TableDefProcessor(
                 ?: emptySet()
         return classDecl.getAllProperties()
             .filterNot { it.isExcluded() || it.simpleName.asString() in excludedBackingFields }
-            .mapNotNull { buildColumnMeta(it, hasDeclaredId, versionedName, ctorParamNames) }
+            .mapNotNull { buildColumnMeta(it, hasDeclaredId, versionedName, ctorParamNames, aggregateBackingScalarNames) }
             .toList()
     }
 
@@ -809,19 +914,86 @@ class TableDefProcessor(
         prop: KSPropertyDeclaration,
         hasDeclaredId: Boolean,
         versionedName: String?,
-        ctorParamNames: Set<String>
+        ctorParamNames: Set<String>,
+        aggregateBackingScalarNames: Set<String> = emptySet()
     ): ColumnMeta? {
         val propName = prop.simpleName.asString()
         val persistenceAnnotation =
             prop.annotations.firstOrNull {
                 it.annotationType.resolve().declaration.qualifiedName?.asString() == PERSISTENCE_PROPERTY_FQN
             }
-        val typeExpression = mapToColumnTypeExpression(prop, persistenceAnnotation) ?: return null
-
         val resolvedType = prop.type.resolve()
         val notNullableType = resolvedType.makeNotNullable()
         val typeFqn = notNullableType.declaration.qualifiedName?.asString() ?: "kotlin.Any"
         val isEnum = (notNullableType.declaration as? KSClassDeclaration)?.classKind == ClassKind.ENUM_CLASS
+
+        val propertyFqn = "${prop.parentDeclaration?.qualifiedName?.asString() ?: ""}.$propName".trimStart('.')
+
+        val isPrimaryKey = propName == "id" && hasDeclaredId && !prop.isAbstract()
+        val isVersion = versionedName != null && propName == versionedName
+        val isAggregateBackingScalar = propName in aggregateBackingScalarNames
+
+        // D-06: reject converter arguments on PK / @Version / @Aggregate single-ref FK columns
+        // BEFORE invoking resolveConverter (which carries D-07 / D-08). This preserves the
+        // one-diagnostic-per-site invariant: a misplaced converter on a rejected target emits
+        // the target rejection, not the kind/S diagnostics.
+        val converterInfo =
+            if (hasNonSentinelConverterArgument(persistenceAnnotation)) {
+                when {
+                    isPrimaryKey -> {
+                        logger.error(
+                            "@PersistenceProperty(converter = …) is not allowed on primary key column '$propertyFqn'. " +
+                                "Converters apply only to non-PK scalar columns; domain-typed identifiers are deferred to a future phase."
+                        )
+                        null
+                    }
+                    isVersion -> {
+                        logger.error(
+                            "@PersistenceProperty(converter = …) is not allowed on @Version column '$propertyFqn'. " +
+                                "@Version columns require a numeric (Long) scalar type; converter routing on optimistic-locking columns is out of scope."
+                        )
+                        null
+                    }
+                    isAggregateBackingScalar -> {
+                        logger.error(
+                            "@PersistenceProperty(converter = …) is not allowed on @Aggregate single-ref FK scalar column '$propertyFqn'. " +
+                                "Converter routing on aggregate FK columns is out of scope; the FK column type is dictated by the referenced entity's primary key type."
+                        )
+                        null
+                    }
+                    else -> resolveConverter(persistenceAnnotation, propertyFqn)
+                }
+            } else {
+                null
+            }
+
+        // When a converter is bound, derive the column type from the converter's declared sqlType
+        // (and refine it via compatible @PersistenceProperty hints). Otherwise fall back to the
+        // FQN-driven base expression. A null refinement result means a hint/converter mismatch was
+        // diagnosed via logger.error — drop the column so codegen does not emit a malformed file.
+        // The non-converter branch invokes mapToColumnTypeExpression lazily so a converter-bound
+        // column with a non-scalar Kotlin type (e.g. a value class) bypasses the
+        // "unsupported column type" diagnostic that path would otherwise emit.
+        val hasExplicitConverter = hasNonSentinelConverterArgument(persistenceAnnotation)
+        val typeExpression =
+            if (converterInfo != null) {
+                val hints =
+                    PersistencePropertyHints(
+                        length = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "length" }?.value as? Int ?: -1,
+                        precision = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "precision" }?.value as? Int ?: -1,
+                        scale = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "scale" }?.value as? Int ?: -1,
+                        typeHint = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "type" }?.value as? String ?: ""
+                    )
+                refineConverterSqlType(
+                    converterInfo = converterInfo, hints = hints, propertyFqn = propertyFqn, propName = propName
+                ) ?: return null
+            } else if (hasExplicitConverter) {
+                // Converter declared but unresolved/invalid this round; avoid non-converter fallback.
+                // Invalid converters already emitted diagnostics in resolveConverter.
+                return null
+            } else {
+                mapToColumnTypeExpression(prop, persistenceAnnotation) ?: return null
+            }
 
         return ColumnMeta(
             name = columnNameFor(persistenceAnnotation, propName),
@@ -829,12 +1001,164 @@ class TableDefProcessor(
             typeExpression = typeExpression,
             typeFqn = typeFqn,
             nullable = resolvedType.isMarkedNullable,
-            isPrimaryKey = propName == "id" && hasDeclaredId && !prop.isAbstract(),
+            isPrimaryKey = isPrimaryKey,
             isEnum = isEnum,
             isMutable = prop.isMutable && hasPublicSetter(prop),
             isCtorParam = propName in ctorParamNames,
-            isVersion = versionedName != null && propName == versionedName
+            isVersion = isVersion,
+            converterFqn = converterInfo?.converterFqn,
+            converterSqlFqn = converterInfo?.sqlTypeFqn
         )
+    }
+
+    /**
+     * Resolves the generated `typeExpression` for a converter-bearing column.
+     *
+     * The converter's declared `sqlType` (resolved at KSP time via `converterSqlFqn`) is the base.
+     * `@PersistenceProperty` hints layer on top:
+     *  - non-empty `type=...` always wins (explicit consumer intent — delegates to the shared
+     *    [mapTypeHintToExpression] helper used by non-converter columns);
+     *  - `length` on a `TextType` base refines to `VarcharType(length)`;
+     *  - `precision`/`scale` on a numeric base (Int/Short/Byte/Long/Double/Float/BigDecimal) refines
+     *    to `DecimalType(precision, scale)` — overrides the converter's declared precision/scale
+     *    when both are present;
+     *  - any other base + any hint set is rejected with a KSP error naming the property, the
+     *    converter, and the resolved sqlType.
+     *
+     * Returns null when an incompatible hint was diagnosed; in that case the caller drops the
+     * column so codegen does not emit a malformed file.
+     */
+    private fun refineConverterSqlType(
+        converterInfo: ConverterInfo,
+        hints: PersistencePropertyHints,
+        propertyFqn: String,
+        propName: String
+    ): String? {
+        val converterFqn = converterInfo.converterFqn
+        val converterSqlFqn = converterInfo.sqlTypeFqn
+        val length = hints.length
+        val precision = hints.precision
+        val scale = hints.scale
+        // Non-empty `type = "..."` is explicit consumer intent — delegate to the existing hint
+        // mapper so converter columns honor the same vocabulary (TEXT/VARCHAR/INT/...) as
+        // non-converter columns.
+        if (hints.typeHint.isNotEmpty()) {
+            return mapTypeHintToExpression(hints.typeHint, length, precision, scale, propName)
+        }
+
+        val baseExpression = "$converterFqn.sqlType"
+        val hasLength = length > 0
+        val hasPrecisionOrScale = precision > 0 || scale >= 0
+        if (!hasLength && !hasPrecisionOrScale) return baseExpression
+
+        val resolvedBase = SUPPORTED_CONVERTER_S_TYPES[converterSqlFqn]
+        return when (converterSqlFqn) {
+            KOTLIN_STRING_FQN -> {
+                if (hasPrecisionOrScale) {
+                    logger.error(
+                        "@PersistenceProperty hint precision/scale on property '$propertyFqn' is " +
+                            "incompatible with converter '$converterFqn' whose sqlType resolves to " +
+                            "$resolvedBase. Remove the hint or pick a converter with a numeric sqlType."
+                    )
+                    return null
+                }
+                "ColumnType.VarcharType($length)"
+            }
+            KOTLIN_INT_FQN, KOTLIN_SHORT_FQN, KOTLIN_BYTE_FQN, KOTLIN_LONG_FQN,
+            KOTLIN_DOUBLE_FQN, KOTLIN_FLOAT_FQN, BIG_DECIMAL_FQN -> {
+                if (hasLength) {
+                    logger.error(
+                        "@PersistenceProperty hint length on property '$propertyFqn' is " +
+                            "incompatible with converter '$converterFqn' whose sqlType resolves to " +
+                            "$resolvedBase. Remove the hint or pick a converter with a textual sqlType."
+                    )
+                    return null
+                }
+                val p = if (precision > 0) precision else 19
+                val s = if (scale >= 0) scale else 2
+                "ColumnType.DecimalType($p, $s)"
+            }
+            else -> {
+                logger.error(
+                    "@PersistenceProperty hints (length/precision/scale) on property '$propertyFqn' are " +
+                        "incompatible with converter '$converterFqn' whose sqlType resolves to " +
+                        "$resolvedBase. Remove the hint or pick a converter with a compatible sqlType."
+                )
+                null
+            }
+        }
+    }
+
+    /**
+     * Tests whether the `converter` argument of `@PersistenceProperty` resolves to a non-sentinel
+     * class declaration. The sentinel [ColumnConverter][net.transgressoft.lirp.persistence.ColumnConverter]
+     * interface FQN means "no converter declared"; any other class triggers D-06 / D-07 / D-08
+     * validation downstream.
+     */
+    private fun hasNonSentinelConverterArgument(annotation: KSAnnotation?): Boolean {
+        if (annotation == null) return false
+        val converterArg = annotation.arguments.firstOrNull { it.name?.asString() == "converter" }?.value as? KSType ?: return false
+        val converterFqn = converterArg.declaration.qualifiedName?.asString() ?: return false
+        return converterFqn != COLUMN_CONVERTER_FQN
+    }
+
+    /**
+     * Reads the `converter` argument from a `@PersistenceProperty` annotation and validates
+     * the referenced [ColumnConverter][net.transgressoft.lirp.persistence.ColumnConverter]
+     * singleton against the structural contract (D-07 object kind, D-08 supported S type).
+     *
+     * Returns null when no converter is declared (sentinel), when the converter cannot yet
+     * be resolved in this round (validate() guard so cross-round resolution does not produce
+     * spurious diagnostics), or when validation fails after a diagnostic has been logged.
+     */
+    private fun resolveConverter(annotation: KSAnnotation?, propertyFqn: String): ConverterInfo? {
+        if (annotation == null) return null
+        val converterArg = annotation.arguments.firstOrNull { it.name?.asString() == "converter" }?.value as? KSType ?: return null
+        val converterDecl = converterArg.declaration as? KSClassDeclaration ?: return null
+        val converterFqn = converterDecl.qualifiedName?.asString() ?: return null
+
+        // Sentinel: the interface itself means "no converter declared" — silent skip.
+        if (converterFqn == COLUMN_CONVERTER_FQN) return null
+
+        // Defer to a later KSP round when the converter type cannot yet be fully resolved.
+        if (!converterDecl.validate()) return null
+
+        if (converterDecl.classKind != ClassKind.OBJECT) {
+            logger.error(
+                "Converter '$converterFqn' for property '$propertyFqn' must be a Kotlin `object` " +
+                    "(singleton) so KSP-generated code can reference it without instantiation."
+            )
+            return null
+        }
+
+        val columnConverterSuperType =
+            converterDecl.superTypes
+                .map { it.resolve() }
+                .firstOrNull { it.declaration.qualifiedName?.asString() == COLUMN_CONVERTER_FQN }
+
+        // S is the SECOND type argument of ColumnConverter<D, S> (index 1, not 0).
+        val sTypeArg = columnConverterSuperType?.arguments?.getOrNull(1)?.type?.resolve()
+        val sFqn = sTypeArg?.declaration?.qualifiedName?.asString()
+
+        if (columnConverterSuperType == null || sFqn == null) {
+            logger.error(
+                "Converter '$converterFqn' does not declare ColumnConverter<D, S> as a supertype " +
+                    "with both type arguments resolved."
+            )
+            return null
+        }
+
+        if (sFqn !in SUPPORTED_CONVERTER_S_TYPES) {
+            logger.error(
+                "Converter '$converterFqn' declares S=$sFqn which is not supported. Supported types: " +
+                    "kotlin.String, kotlin.Int, kotlin.Long, kotlin.Short, kotlin.Byte, kotlin.Boolean, " +
+                    "kotlin.Double, kotlin.Float, java.math.BigDecimal, java.util.UUID, " +
+                    "java.time.LocalDate, java.time.LocalDateTime."
+            )
+            return null
+        }
+
+        return ConverterInfo(converterFqn = converterFqn, sqlTypeFqn = sFqn)
     }
 
     private fun columnNameFor(persistenceAnnotation: KSAnnotation?, propName: String): String {
@@ -890,18 +1214,18 @@ class TableDefProcessor(
         // The Kotlin side narrows on read (`Int.toShort()` / `Int.toByte()`) and widens on write
         // (`Short.toInt()` / `Byte.toInt()`) — see buildRowAccess and buildEntityAccess below.
         return when (fqn) {
-            "kotlin.Int" -> COLUMN_TYPE_INT_EXPR
-            "kotlin.Short" -> COLUMN_TYPE_INT_EXPR
-            "kotlin.Byte" -> COLUMN_TYPE_INT_EXPR
-            KOTLIN_LONG_FQN -> "ColumnType.LongType"
-            "kotlin.String" -> if (length > 0) "ColumnType.VarcharType($length)" else "ColumnType.TextType"
-            "kotlin.Boolean" -> "ColumnType.BooleanType"
-            "kotlin.Double" -> "ColumnType.DoubleType"
-            "kotlin.Float" -> "ColumnType.FloatType"
-            UUID_FQN -> "ColumnType.UuidType"
-            LOCAL_DATE_TIME_FQN -> "ColumnType.DateTimeType"
-            LOCAL_DATE_FQN -> "ColumnType.DateType"
-            "java.math.BigDecimal" -> {
+            KOTLIN_INT_FQN -> COLUMN_TYPE_INT_EXPR
+            KOTLIN_SHORT_FQN -> COLUMN_TYPE_INT_EXPR
+            KOTLIN_BYTE_FQN -> COLUMN_TYPE_INT_EXPR
+            KOTLIN_LONG_FQN -> COLUMN_TYPE_LONG_EXPR
+            KOTLIN_STRING_FQN -> if (length > 0) "ColumnType.VarcharType($length)" else COLUMN_TYPE_TEXT_EXPR
+            KOTLIN_BOOLEAN_FQN -> COLUMN_TYPE_BOOLEAN_EXPR
+            KOTLIN_DOUBLE_FQN -> COLUMN_TYPE_DOUBLE_EXPR
+            KOTLIN_FLOAT_FQN -> COLUMN_TYPE_FLOAT_EXPR
+            UUID_FQN -> COLUMN_TYPE_UUID_EXPR
+            LOCAL_DATE_TIME_FQN -> COLUMN_TYPE_DATETIME_EXPR
+            LOCAL_DATE_FQN -> COLUMN_TYPE_DATE_EXPR
+            BIG_DECIMAL_FQN -> {
                 val p = if (precision > 0) precision else 19
                 val s = if (scale >= 0) scale else 2
                 "ColumnType.DecimalType($p, $s)"
@@ -926,7 +1250,7 @@ class TableDefProcessor(
         propName: String
     ): String? =
         when (hint.uppercase()) {
-            "TEXT" -> "ColumnType.TextType"
+            "TEXT" -> COLUMN_TYPE_TEXT_EXPR
             "VARCHAR" -> {
                 if (length <= 0) {
                     logger.error("@PersistenceProperty(type=\"VARCHAR\") requires length > 0 on property '$propName'")
@@ -935,13 +1259,13 @@ class TableDefProcessor(
                 "ColumnType.VarcharType($length)"
             }
             "INT" -> COLUMN_TYPE_INT_EXPR
-            "BIGINT" -> "ColumnType.LongType"
-            "BOOLEAN" -> "ColumnType.BooleanType"
-            "DOUBLE" -> "ColumnType.DoubleType"
-            "FLOAT" -> "ColumnType.FloatType"
-            "UUID" -> "ColumnType.UuidType"
-            "DATE" -> "ColumnType.DateType"
-            "DATETIME" -> "ColumnType.DateTimeType"
+            "BIGINT" -> COLUMN_TYPE_LONG_EXPR
+            "BOOLEAN" -> COLUMN_TYPE_BOOLEAN_EXPR
+            "DOUBLE" -> COLUMN_TYPE_DOUBLE_EXPR
+            "FLOAT" -> COLUMN_TYPE_FLOAT_EXPR
+            "UUID" -> COLUMN_TYPE_UUID_EXPR
+            "DATE" -> COLUMN_TYPE_DATE_EXPR
+            "DATETIME" -> COLUMN_TYPE_DATETIME_EXPR
             "DECIMAL" -> {
                 val p = if (precision > 0) precision else 19
                 val s = if (scale >= 0) scale else 2
@@ -1216,9 +1540,9 @@ class TableDefProcessor(
 
     private fun elementFqnToSimpleName(elementFqn: String?): String =
         when (elementFqn) {
-            "kotlin.Int" -> "Int"
+            KOTLIN_INT_FQN -> "Int"
             KOTLIN_LONG_FQN -> "Long"
-            "kotlin.String" -> "String"
+            KOTLIN_STRING_FQN -> "String"
             KOTLIN_UUID_FQN, UUID_FQN -> "java.util.UUID"
             null -> "Any"
             else -> elementFqn.substringAfterLast(".")
@@ -1333,7 +1657,9 @@ private data class ColumnMeta(
     val isEnum: Boolean = false,
     val isMutable: Boolean = false,
     val isCtorParam: Boolean = false,
-    val isVersion: Boolean = false
+    val isVersion: Boolean = false,
+    val converterFqn: String? = null,
+    val converterSqlFqn: String? = null
 )
 
 private data class AggregatePropertyMeta(

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ConverterCodegenTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ConverterCodegenTest.kt
@@ -1,0 +1,402 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.ksp
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.configureKsp
+import com.tschuchort.compiletesting.sourcesGeneratedBySymbolProcessor
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+/**
+ * KSP compilation tests for the converter-resolution machinery in [TableDefProcessor],
+ * exercising D-07 (object-only converters), D-08 (supported S allow-list), and the
+ * sentinel `ColumnConverter::class` default that means "no converter declared".
+ */
+@OptIn(ExperimentalCompilerApi::class)
+class ConverterCodegenTest : StringSpec({
+
+    fun compileWithProcessor(vararg sources: SourceFile): JvmCompilationResult {
+        val compilation =
+            KotlinCompilation().apply {
+                this.sources = sources.toList()
+                inheritClassPath = true
+            }
+        compilation.configureKsp { withCompilation = true }
+        compilation.symbolProcessorProviders += TableDefProcessorProvider()
+        return compilation.compile()
+    }
+
+    "TableDefProcessor accepts sentinel converter default and emits no converter codegen" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "SentinelEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+
+                    @PersistenceMapping
+                    data class SentinelEntity(
+                        override val id: Int,
+                        @PersistenceProperty val tag: String
+                    ) : ReactiveEntityBase<Int, SentinelEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = SentinelEntity(id, tag)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val generated =
+            result.sourcesGeneratedBySymbolProcessor
+                .firstOrNull { it.name == "SentinelEntity_LirpTableDef.kt" }
+                ?.readText()
+                ?: error("SentinelEntity_LirpTableDef.kt not generated")
+        generated shouldNotContain ".fromSql("
+        generated shouldNotContain ".toSql("
+    }
+
+    "TableDefProcessor rejects non-object converter with D-07 diagnostic naming the converter" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "NonObjectConverterEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+
+                    class NotAnObjectConverter : ColumnConverter<String, String> {
+                        override val sqlType = ColumnType.TextType
+                        override fun toSql(value: String): String = value
+                        override fun fromSql(raw: String): String = raw
+                    }
+
+                    @PersistenceMapping
+                    data class NonObjectConverterEntity(
+                        override val id: Int,
+                        @PersistenceProperty(converter = NotAnObjectConverter::class) val tag: String
+                    ) : ReactiveEntityBase<Int, NonObjectConverterEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = NonObjectConverterEntity(id, tag)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+        result.messages shouldContain "test.NotAnObjectConverter"
+        result.messages shouldContain "must be a Kotlin"
+        result.messages shouldContain "object"
+    }
+
+    "TableDefProcessor rejects converter with unsupported S type via D-08 diagnostic" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "BadSEntity.kt",
+                    """
+                    package test
+                    import java.util.Date
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+
+                    object BadSConverter : ColumnConverter<String, Date> {
+                        override val sqlType = ColumnType.TextType
+                        override fun toSql(value: String): Date = Date()
+                        override fun fromSql(raw: Date): String = raw.toString()
+                    }
+
+                    @PersistenceMapping
+                    data class BadSEntity(
+                        override val id: Int,
+                        @PersistenceProperty(converter = BadSConverter::class) val tag: String
+                    ) : ReactiveEntityBase<Int, BadSEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = BadSEntity(id, tag)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+        result.messages shouldContain "test.BadSConverter"
+        result.messages shouldContain "java.util.Date"
+        result.messages shouldContain "not supported"
+    }
+
+    "TableDefProcessor emits converter-routed fromRow and toParams for non-null scalar" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "TagEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+
+                    object UpperCaseConverter : ColumnConverter<String, String> {
+                        override val sqlType = ColumnType.TextType
+                        override fun toSql(value: String): String = value.uppercase()
+                        override fun fromSql(raw: String): String = raw.lowercase()
+                    }
+
+                    @PersistenceMapping
+                    data class TagEntity(
+                        override val id: Int,
+                        @PersistenceProperty(converter = UpperCaseConverter::class) val tag: String
+                    ) : ReactiveEntityBase<Int, TagEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = TagEntity(id, tag)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val generated =
+            result.sourcesGeneratedBySymbolProcessor
+                .firstOrNull { it.name == "TagEntity_LirpTableDef.kt" }
+                ?.readText()
+                ?: error("TagEntity_LirpTableDef.kt not generated")
+        generated shouldContain "test.UpperCaseConverter.sqlType"
+        generated shouldContain "test.UpperCaseConverter.fromSql("
+        generated shouldContain "as kotlin.String"
+        generated shouldContain "test.UpperCaseConverter.toSql(entity.tag)"
+    }
+
+    "TableDefProcessor emits nullable converter-routed fromRow and toParams" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "NullableTagEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+
+                    object NullableConverter : ColumnConverter<String, String> {
+                        override val sqlType = ColumnType.TextType
+                        override fun toSql(value: String): String = value
+                        override fun fromSql(raw: String): String = raw
+                    }
+
+                    @PersistenceMapping
+                    data class NullableTagEntity(
+                        override val id: Int,
+                        @PersistenceProperty(converter = NullableConverter::class) val nickname: String?
+                    ) : ReactiveEntityBase<Int, NullableTagEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = NullableTagEntity(id, nickname)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val generated =
+            result.sourcesGeneratedBySymbolProcessor
+                .firstOrNull { it.name == "NullableTagEntity_LirpTableDef.kt" }
+                ?.readText()
+                ?: error("NullableTagEntity_LirpTableDef.kt not generated")
+        generated shouldContain "as? kotlin.String"
+        generated shouldContain "?.let { test.NullableConverter.fromSql(it) }"
+        generated shouldContain "entity.nickname?.let { test.NullableConverter.toSql(it) }"
+    }
+
+    "TableDefProcessor refines TextType converter sqlType to VarcharType when length hint is set" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "VarcharTagEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+
+                    object PathLikeConverter : ColumnConverter<String, String> {
+                        override val sqlType = ColumnType.TextType
+                        override fun toSql(value: String): String = value
+                        override fun fromSql(raw: String): String = raw
+                    }
+
+                    @PersistenceMapping
+                    data class VarcharTagEntity(
+                        override val id: Int,
+                        @PersistenceProperty(converter = PathLikeConverter::class, length = 64) val tag: String
+                    ) : ReactiveEntityBase<Int, VarcharTagEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = VarcharTagEntity(id, tag)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val generated =
+            result.sourcesGeneratedBySymbolProcessor
+                .firstOrNull { it.name == "VarcharTagEntity_LirpTableDef.kt" }
+                ?.readText()
+                ?: error("VarcharTagEntity_LirpTableDef.kt not generated")
+        generated shouldContain "ColumnType.VarcharType(64)"
+        // The base converter sqlType reference must NOT appear for this column — the refinement
+        // supersedes it. Search for "PathLikeConverter.sqlType" specifically because the
+        // converter is still referenced in fromSql / toSql calls.
+        generated shouldNotContain "PathLikeConverter.sqlType"
+    }
+
+    "TableDefProcessor refines numeric converter sqlType to DecimalType when precision and scale hints are set" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "MoneyEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+
+                    data class Money(val cents: Long)
+
+                    object MoneyConverter : ColumnConverter<Money, Long> {
+                        override val sqlType = ColumnType.LongType
+                        override fun toSql(value: Money): Long = value.cents
+                        override fun fromSql(raw: Long): Money = Money(raw)
+                    }
+
+                    @PersistenceMapping
+                    data class MoneyEntity(
+                        override val id: Int,
+                        @PersistenceProperty(converter = MoneyConverter::class, precision = 19, scale = 4) val amount: Money
+                    ) : ReactiveEntityBase<Int, MoneyEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = MoneyEntity(id, amount)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val generated =
+            result.sourcesGeneratedBySymbolProcessor
+                .firstOrNull { it.name == "MoneyEntity_LirpTableDef.kt" }
+                ?.readText()
+                ?: error("MoneyEntity_LirpTableDef.kt not generated")
+        generated shouldContain "ColumnType.DecimalType(19, 4)"
+    }
+
+    "TableDefProcessor rejects length hint on BooleanType converter as incompatible" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "BadHintEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+
+                    object FlagConverter : ColumnConverter<Boolean, Boolean> {
+                        override val sqlType = ColumnType.BooleanType
+                        override fun toSql(value: Boolean): Boolean = value
+                        override fun fromSql(raw: Boolean): Boolean = raw
+                    }
+
+                    @PersistenceMapping
+                    data class BadHintEntity(
+                        override val id: Int,
+                        @PersistenceProperty(converter = FlagConverter::class, length = 32) val flag: Boolean
+                    ) : ReactiveEntityBase<Int, BadHintEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = BadHintEntity(id, flag)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+        result.messages shouldContain "incompatible with converter"
+        result.messages shouldContain "test.BadHintEntity.flag"
+        result.messages shouldContain "test.FlagConverter"
+    }
+
+    "TableDefProcessor accepts converter with supported S type kotlin.Short" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "ShortEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+
+                    data class MyShortWrapper(val value: Short)
+
+                    object ShortConverter : ColumnConverter<MyShortWrapper, Short> {
+                        override val sqlType = ColumnType.IntType
+                        override fun toSql(value: MyShortWrapper): Short = value.value
+                        override fun fromSql(raw: Short): MyShortWrapper = MyShortWrapper(raw)
+                    }
+
+                    @PersistenceMapping
+                    data class ShortEntity(
+                        override val id: Int,
+                        @PersistenceProperty(converter = ShortConverter::class) val wrapped: MyShortWrapper
+                    ) : ReactiveEntityBase<Int, ShortEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = ShortEntity(id, wrapped)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+    }
+})

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ConverterRejectedTargetTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ConverterRejectedTargetTest.kt
@@ -1,0 +1,165 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.ksp
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.configureKsp
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+/**
+ * KSP compilation tests for D-06 enforcement in [TableDefProcessor]: converters are rejected
+ * on primary key columns, `@Version` columns, and `@Aggregate` single-ref FK scalar columns.
+ * Each rejection emits a distinct diagnostic naming the property FQN and the kind of column.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+class ConverterRejectedTargetTest : StringSpec({
+
+    fun compileWithProcessor(vararg sources: SourceFile): JvmCompilationResult {
+        val compilation =
+            KotlinCompilation().apply {
+                this.sources = sources.toList()
+                inheritClassPath = true
+            }
+        compilation.configureKsp { withCompilation = true }
+        compilation.symbolProcessorProviders += TableDefProcessorProvider()
+        return compilation.compile()
+    }
+
+    "TableDefProcessor rejects converter on primary key column with D-06 diagnostic naming the property FQN" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "PkConverterEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+
+                    object PkConverter : ColumnConverter<Int, Int> {
+                        override val sqlType = ColumnType.IntType
+                        override fun toSql(value: Int): Int = value
+                        override fun fromSql(raw: Int): Int = raw
+                    }
+
+                    @PersistenceMapping
+                    data class PkConverterEntity(
+                        @PersistenceProperty(converter = PkConverter::class) override val id: Int
+                    ) : ReactiveEntityBase<Int, PkConverterEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = PkConverterEntity(id)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+        result.messages shouldContain "primary key column"
+        result.messages shouldContain "test.PkConverterEntity.id"
+    }
+
+    "TableDefProcessor rejects converter on @Version column with D-06 diagnostic naming the property FQN" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "VersionConverterEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+                    import net.transgressoft.lirp.persistence.Version
+
+                    object VersionConverter : ColumnConverter<Long, Long> {
+                        override val sqlType = ColumnType.LongType
+                        override fun toSql(value: Long): Long = value
+                        override fun fromSql(raw: Long): Long = raw
+                    }
+
+                    @PersistenceMapping
+                    class VersionConverterEntity(override val id: Int) : ReactiveEntityBase<Int, VersionConverterEntity>() {
+                        @Version
+                        @PersistenceProperty(converter = VersionConverter::class)
+                        var version: Long by reactiveProperty(0L)
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = VersionConverterEntity(id)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+        result.messages shouldContain "@Version column"
+        result.messages shouldContain "test.VersionConverterEntity.version"
+    }
+
+    "TableDefProcessor rejects converter on @Aggregate single-ref FK scalar column with D-06 diagnostic naming the property FQN" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "AggregateFkConverterEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Aggregate
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+                    import net.transgressoft.lirp.persistence.aggregate
+
+                    object FkConverter : ColumnConverter<Int, Int> {
+                        override val sqlType = ColumnType.IntType
+                        override fun toSql(value: Int): Int = value
+                        override fun fromSql(raw: Int): Int = raw
+                    }
+
+                    @PersistenceMapping
+                    class Customer(override val id: Int) : ReactiveEntityBase<Int, Customer>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = Customer(id)
+                    }
+
+                    @PersistenceMapping
+                    class Order(override val id: Long, customerId: Int) : ReactiveEntityBase<Long, Order>() {
+                        @PersistenceProperty(converter = FkConverter::class)
+                        var customerId: Int by reactiveProperty(customerId)
+                        @Aggregate
+                        val customer by aggregate<Int, Customer> { customerId }
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = Order(id, customerId)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+        result.messages shouldContain "@Aggregate single-ref FK"
+        result.messages shouldContain "test.Order.customerId"
+    }
+})

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryConverterIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryConverterIntegrationTest.kt
@@ -1,0 +1,93 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import java.nio.file.Paths
+import java.time.Duration
+
+/**
+ * Cross-dialect round-trip integration test asserting that `@PersistenceProperty(converter = …)`
+ * routes non-scalar domain types (`java.nio.file.Path`, `java.time.Duration`) through the
+ * KSP-generated `_LirpTableDef` correctly on every supported SQL backend.
+ *
+ * Each dialect runs two scenarios: a non-null round-trip exercising both [PathConverter] and
+ * [DurationConverter], and a nullable round-trip preserving `null` through write and read.
+ */
+internal class SqlRepositoryConverterIntegrationTest : StringSpec({
+
+    databases.forEach { db ->
+        "SqlRepository round-trips ConverterFixtureEntity with non-null converter-routed fields on ${db.name}" {
+            DatabaseTestSupport.withDatabaseTest(db, ConverterFixtureEntity_LirpTableDef) { ds ->
+                val originalPath = Paths.get("/tmp/song.mp3")
+                val originalCover = Paths.get("/tmp/cover.png")
+                val originalLength = Duration.ofSeconds(180)
+                // PathConverter canonicalises through URI; assertions compare against the same
+                // normalised form to avoid platform-separator drift on round-trip.
+                val expectedPath = Paths.get(originalPath.toUri())
+                val expectedCover = Paths.get(originalCover.toUri())
+
+                val repo = SqlRepository(ds, ConverterFixtureEntity_LirpTableDef)
+                try {
+                    repo.add(ConverterFixtureEntity(1, originalPath, originalLength, originalCover))
+                } finally {
+                    repo.close()
+                }
+
+                val reloaded = SqlRepository(ds, ConverterFixtureEntity_LirpTableDef)
+                try {
+                    reloaded.findById(1).shouldBePresent {
+                        it.path shouldBe expectedPath
+                        it.length shouldBe originalLength
+                        it.coverPath shouldBe expectedCover
+                    }
+                } finally {
+                    reloaded.close()
+                }
+            }
+        }
+
+        "SqlRepository preserves null in a nullable converter-routed column on ${db.name}" {
+            DatabaseTestSupport.withDatabaseTest(db, ConverterFixtureEntity_LirpTableDef) { ds ->
+                val originalPath = Paths.get("/tmp/song.mp3")
+                val originalLength = Duration.ofSeconds(60)
+
+                val repo = SqlRepository(ds, ConverterFixtureEntity_LirpTableDef)
+                try {
+                    repo.add(ConverterFixtureEntity(2, originalPath, originalLength, coverPath = null))
+                } finally {
+                    repo.close()
+                }
+
+                val reloaded = SqlRepository(ds, ConverterFixtureEntity_LirpTableDef)
+                try {
+                    reloaded.findById(2).shouldBePresent {
+                        it.coverPath shouldBe null
+                        it.path shouldBe Paths.get(originalPath.toUri())
+                        it.length shouldBe originalLength
+                    }
+                } finally {
+                    reloaded.close()
+                }
+            }
+        }
+    }
+})

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryConverterTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryConverterTest.kt
@@ -1,0 +1,134 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Duration
+import java.util.UUID
+
+/**
+ * H2 round-trip unit tests for the `@PersistenceProperty(converter = …)` codegen path —
+ * verifies that the KSP-generated `_LirpTableDef` routes non-null and nullable converter-bearing
+ * columns through `PathConverter` / `DurationConverter` in both directions (fromRow / toParams).
+ */
+internal class SqlRepositoryConverterTest : StringSpec({
+
+    fun freshJdbcUrl() = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+
+    "SqlRepository round-trips ConverterFixtureEntity with non-null converter-routed fields on H2" {
+        val jdbcUrl = freshJdbcUrl()
+        val originalPath = Paths.get("/tmp/song.mp3")
+        val originalCover = Paths.get("/tmp/cover.png")
+        val originalLength = Duration.ofSeconds(180)
+        // Compare against URI-normalised forms — PathConverter encodes via toUri() / parses
+        // via Paths.get(URI(…)), so the round-trip canonicalises platform-specific separators.
+        val expectedPath = Paths.get(originalPath.toUri())
+        val expectedCover = Paths.get(originalCover.toUri())
+
+        val repo = SqlRepository(jdbcUrl, ConverterFixtureEntity_LirpTableDef)
+        try {
+            repo.add(ConverterFixtureEntity(1, originalPath, originalLength, originalCover))
+        } finally {
+            repo.close()
+        }
+
+        val reloaded = SqlRepository(jdbcUrl, ConverterFixtureEntity_LirpTableDef)
+        try {
+            reloaded.findById(1).shouldBePresent {
+                it.path shouldBe expectedPath
+                it.length shouldBe originalLength
+                it.coverPath shouldBe expectedCover
+            }
+        } finally {
+            reloaded.close()
+        }
+    }
+
+    "SqlRepository preserves null in a nullable converter-routed column on H2" {
+        val jdbcUrl = freshJdbcUrl()
+        val originalPath = Paths.get("/tmp/song.mp3")
+        val originalLength = Duration.ofSeconds(60)
+
+        val repo = SqlRepository(jdbcUrl, ConverterFixtureEntity_LirpTableDef)
+        try {
+            repo.add(ConverterFixtureEntity(2, originalPath, originalLength, coverPath = null))
+        } finally {
+            repo.close()
+        }
+
+        val reloaded = SqlRepository(jdbcUrl, ConverterFixtureEntity_LirpTableDef)
+        try {
+            reloaded.findById(2).shouldBePresent {
+                it.coverPath shouldBe null
+                it.path shouldBe Paths.get(originalPath.toUri())
+                it.length shouldBe originalLength
+            }
+        } finally {
+            reloaded.close()
+        }
+    }
+
+    "SqlRepository persists a non-null cover path after the entity was first stored with null" {
+        val jdbcUrl = freshJdbcUrl()
+        val basePath = Paths.get("/tmp/song.mp3")
+
+        // Seed phase: insert the entity with coverPath = null and flush via close().
+        val seedRepo = SqlRepository(jdbcUrl, ConverterFixtureEntity_LirpTableDef)
+        try {
+            seedRepo.add(ConverterFixtureEntity(3, basePath, Duration.ofSeconds(90), coverPath = null))
+        } finally {
+            seedRepo.close()
+        }
+
+        // Delete phase: open a fresh repo, remove the entity, and close() to flush the delete
+        // before any subsequent insert can race the PK constraint check.
+        val deletingRepo = SqlRepository(jdbcUrl, ConverterFixtureEntity_LirpTableDef)
+        val loaded: ConverterFixtureEntity
+        try {
+            loaded = deletingRepo.findById(3).get()
+            loaded.coverPath shouldBe null
+            deletingRepo.remove(loaded)
+        } finally {
+            deletingRepo.close()
+        }
+
+        // Re-insert phase: ConverterFixtureEntity is a data class with constructor `val`s, so
+        // the null→non-null transition is expressed as delete-then-reinsert; data-class copy()
+        // produces the updated entity carrying a non-null coverPath.
+        val newCover: Path = Paths.get("/tmp/cover-new.png")
+        val rewriteRepo = SqlRepository(jdbcUrl, ConverterFixtureEntity_LirpTableDef)
+        try {
+            rewriteRepo.add(loaded.copy(coverPath = newCover))
+        } finally {
+            rewriteRepo.close()
+        }
+
+        val verifier = SqlRepository(jdbcUrl, ConverterFixtureEntity_LirpTableDef)
+        try {
+            verifier.findById(3).shouldBePresent {
+                it.coverPath shouldBe Paths.get(newCover.toUri())
+            }
+        } finally {
+            verifier.close()
+        }
+    }
+})

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/ConverterFixtureEntity.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/ConverterFixtureEntity.kt
@@ -1,0 +1,45 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.PersistenceProperty
+import java.nio.file.Path
+import java.time.Duration
+
+/**
+ * Round-trip fixture for `ColumnConverter` — exercises non-null [Path], non-null [Duration], and
+ * nullable [Path] columns across SQL dialects.
+ *
+ * The entity is consumed by H2 unit tests and Testcontainers integration tests to verify that the
+ * KSP-generated `_LirpTableDef` routes column reads through [PathConverter.fromSql] /
+ * [DurationConverter.fromSql] and writes through the symmetric `toSql` calls, with nullable values
+ * preserving `null` end-to-end.
+ */
+@PersistenceMapping(name = "converter_entity")
+data class ConverterFixtureEntity(
+    override val id: Int,
+    @PersistenceProperty(converter = PathConverter::class) val path: Path,
+    @PersistenceProperty(converter = DurationConverter::class) val length: Duration,
+    @PersistenceProperty(converter = PathConverter::class) val coverPath: Path?
+) : ReactiveEntityBase<Int, ConverterFixtureEntity>() {
+    override val uniqueId: String get() = "$id"
+
+    override fun clone(): ConverterFixtureEntity = copy()
+}

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/ConverterFixtures.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/ConverterFixtures.kt
@@ -1,0 +1,54 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.persistence.ColumnConverter
+import net.transgressoft.lirp.persistence.ColumnType
+import java.net.URI
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Duration
+
+/**
+ * Test fixture only — not shipped from production `lirp-*` modules.
+ *
+ * Persists a [Path] as its URI textual representation, allowing absolute paths to round-trip
+ * across platforms without dialect-specific encoding concerns. Used by SQL round-trip tests to
+ * exercise the `@PersistenceProperty(converter = …)` codegen path on non-scalar domain types.
+ */
+object PathConverter : ColumnConverter<Path, String> {
+    override val sqlType: ColumnType = ColumnType.TextType
+
+    override fun toSql(value: Path): String = value.toUri().toString()
+
+    override fun fromSql(raw: String): Path = Paths.get(URI(raw))
+}
+
+/**
+ * Test fixture only — not shipped from production `lirp-*` modules.
+ *
+ * Persists a [Duration] as a `Long` count of seconds. Used by SQL round-trip tests to
+ * exercise the converter codegen path on a numeric persistence-facing scalar.
+ */
+object DurationConverter : ColumnConverter<Duration, Long> {
+    override val sqlType: ColumnType = ColumnType.LongType
+
+    override fun toSql(value: Duration): Long = value.toSeconds()
+
+    override fun fromSql(raw: Long): Duration = Duration.ofSeconds(raw)
+}


### PR DESCRIPTION
## Summary

**Phase 56: `@PersistenceProperty(converter = …)` — `ColumnConverter` for non-scalar domain types**
**Closes:** #208
**Depends on:** #207 (KSP robustness fixes, already merged)

Introduces `ColumnConverter<D, S>` in `lirp-api` and a new `converter` parameter on `@PersistenceProperty` so entities can persist non-scalar domain types (`java.nio.file.Path`, `java.time.Duration`, custom value wrappers) without refactoring the entity. KSP detects the converter argument, derives the column type from the converter's `sqlType`, and emits symmetric `fromRow` / `toParams` code that routes values through `toSql` / `fromSql`. Nullable converter-routed columns store and restore `null` end-to-end.

## Changes

### `lirp-api` — public contract
- New `interface ColumnConverter<D, S : Any>` with `sqlType` / `toSql` / `fromSql`. Implementations are required to be Kotlin `object` singletons.
- `@PersistenceProperty` gains an optional `converter: KClass<out ColumnConverter<*, *>>` parameter. `ColumnConverter::class` is the sentinel for "no converter declared".
- Signature stability test in `lirp-api/src/test`.

### `lirp-ksp` — codegen + validation
`TableDefProcessor` extended with the converter pipeline:
- `resolveConverter` walks the converter's `ColumnConverter<D, S>` supertype to extract `S`'s FQN.
- Converter codegen branch in `mapToColumnTypeExpression` / `buildRowAccess` / `buildEntityAccess`.
- Hint refinement: `length` on a `TextType`-based converter → `VarcharType(length)`; `precision` / `scale` on a numeric base → `DecimalType(p, s)`; explicit `type = "..."` overrides; incompatible hints raise `logger.error()`.

KSP-time validation:
- Converter must be a Kotlin `object` singleton (`ClassKind.OBJECT`).
- `S` must resolve to one of the supported persistence-facing primitives (`String`, `Int`, `Long`, `Short`, `Byte`, `Boolean`, `Double`, `Float`, `BigDecimal`, `UUID`, `LocalDate`, `LocalDateTime`).
- Converters are rejected on primary key, `@Version`, and `@Aggregate` single-ref FK columns with three distinct property-FQN-bearing diagnostics.

### `lirp-sql` — runtime coverage
- `PathConverter` and `DurationConverter` test fixtures + a converter-bearing `ConverterFixtureEntity`.
- H2 unit round-trip in `SqlRepositoryConverterTest`.
- Testcontainers cross-dialect round-trip in `SqlRepositoryConverterIntegrationTest` (PostgreSQL 16, MySQL 8, MariaDB 11, SQLite, H2).

### Documentation
- README: brief mention of `@PersistenceProperty(converter = …)`.
- `SQL-Persistence` wiki page: new "Custom column converters" section with the interface, a worked `PathConverter` example, the supported-`S` table, the hint-refinement matrix, the rejected-target rules, and the JSON-deferral note.

## Out of scope

- **JSON persistence pipeline.** `LirpEntitySerializer` and `JsonFileRepository` continue to rely on `kotlinx.serialization` for non-scalar fields. Wiring `ColumnConverter` into the JSON path is non-trivial (different abstraction — `KSerializer<T>` vs `sqlType` / `toSql` / `fromSql`) and is deferred to a follow-up.
- **Built-in converters** shipped from `lirp-core`. Per #208's "Open questions", they remain in consumer code for v1.
- **Domain-typed IDs** (converters on primary keys, `@Version`, or `@Aggregate` FK refs). Rejected at KSP time; revisit in a future phase if there is consumer demand.

## Requirements Addressed

- **REQ-208** — all five success criteria from issue #208:
  1. `ColumnConverter<D, S>` interface published from `lirp-api`. ✓
  2. `@PersistenceProperty(converter = …)` parameter accepted by KSP. ✓
  3. Generated `_LirpTableDef` routes the column through the converter in `fromRow` / `toParams`. ✓
  4. Nullable domain types round-trip (`val x: Path?` → null in/out). ✓
  5. Signature stable for composition with `@Embeddable` (#209) and `@ElementCollection` (#210). ✓

## Verification

- [x] `gradle :lirp-api:test :lirp-ksp:test :lirp-core:test :lirp-sql:test` — all green.
- [x] `gradle :lirp-sql:integrationTest --tests "*Converter*"` — 10/10 cases green across PostgreSQL 16, MySQL 8, MariaDB 11, SQLite, H2.
- [x] `gradle build` — full project green.
- [x] `gradle ktlintCheck` — repo-wide green.
- [x] 18 SonarQube findings on the branch resolved (15× `kotlin:S1192` string-literal duplication via 16 extracted constants; 1× `kotlin:S3776` `buildRowAccess` cognitive complexity reduced by extracting three single-purpose helpers; 1× `kotlin:S107` `refineConverterSqlType` parameter count reduced from 8 to 4 via a `PersistencePropertyHints` value bundle).

## Notes for reviewers

- Phase planning context lives under `.planning/phases/56-persistenceproperty-converter-columnconverter-for-non-scalar/` (CONTEXT, RESEARCH, PLAN, SUMMARY files) but is git-ignored — not part of the PR diff.
- The hint-refinement matrix in `refineConverterSqlType` deliberately diverges from the original #208 step-6 wording ("hints are ignored") in favor of "refine when compatible, error when not" — agreed during phase discussion as more useful for consumers.
- The KDoc on `ColumnConverter` calls out the SQL-only scope explicitly so consumers don't expect `JsonFileRepository` to consume the converter.
