### PR TITLE
#214 Allow @Embedded on body-declared reactive properties

### DIFF
--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/CtorSlot.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/CtorSlot.kt
@@ -57,3 +57,15 @@ internal data class EmbeddedCtorSlot(
     val embeddableTypeFqn: String,
     val children: List<CtorSlot>
 ) : CtorSlot
+
+/**
+ * A body-declared reactive `var` property whose value is an `@Embeddable` instance reconstructed
+ * from flattened leaf columns and dispatched via
+ * [net.transgressoft.lirp.persistence.LirpRawInitializer] `silentSetter` on load.
+ * Consumed by `appendApplyScalarRow`; invisible to `appendFromRow`.
+ */
+internal data class EmbeddedSetterSlot(
+    override val ctorParamName: String,
+    val embeddableTypeFqn: String,
+    val children: List<CtorSlot>
+) : CtorSlot

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/EmbeddableAnalyzer.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/EmbeddableAnalyzer.kt
@@ -270,10 +270,18 @@ internal class EmbeddableAnalyzer(
         setterSlots: MutableList<EmbeddedSetterSlot>,
         embeddableFiles: MutableSet<KSFile>
     ) {
+        if (!prop.isMutable) return
         val getter = prop.getter
         if (getter != null && getter.origin != Origin.SYNTHETIC) {
             logger.error(
                 "@Embedded property must not have a custom getter: $classFqn.$propName",
+                prop
+            )
+            return
+        }
+        if (!prop.isDelegated()) {
+            logger.error(
+                "@Embedded on a body-declared property must use a delegated reactive backing field: $classFqn.$propName",
                 prop
             )
             return

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/EmbeddableAnalyzer.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/EmbeddableAnalyzer.kt
@@ -58,6 +58,7 @@ internal class EmbeddableAnalyzer(
     data class CollectedShape(
         val columns: List<ColumnMeta>,
         val ctorSlots: List<CtorSlot>,
+        val setterSlots: List<EmbeddedSetterSlot> = emptyList(),
         val embeddableFiles: Set<KSFile> = emptySet()
     )
 
@@ -83,6 +84,7 @@ internal class EmbeddableAnalyzer(
 
         val columns = mutableListOf<ColumnMeta>()
         val ctorSlots = mutableListOf<CtorSlot>()
+        val setterSlots = mutableListOf<EmbeddedSetterSlot>()
         val embeddableFiles = mutableSetOf<KSFile>()
 
         reportBodyDeclaredEmbedded(classDecl, ctorParamNames)
@@ -97,10 +99,10 @@ internal class EmbeddableAnalyzer(
 
         collectNonCtorScalarColumns(
             classDecl, ctorParamNames, excludedBackingFields,
-            hasDeclaredId, versionedName, aggregateBackingScalarNames, columns
+            hasDeclaredId, versionedName, aggregateBackingScalarNames, columns, setterSlots, embeddableFiles
         )
 
-        return CollectedShape(columns, ctorSlots, embeddableFiles)
+        return CollectedShape(columns, ctorSlots, setterSlots, embeddableFiles)
     }
 
     /**
@@ -117,9 +119,15 @@ internal class EmbeddableAnalyzer(
                     it.annotationType.resolve().declaration.qualifiedName?.asString() == EMBEDDED_FQN
                 }
             if (!hasEmbedded) continue
+            // Body-declared mutable var is accepted — routed through collectNonCtorScalarColumns.
+            if (prop.isMutable) continue
+            // Body-declared read-only val has no setter to populate from a row; reject with a
+            // targeted diagnostic.
             logger.error(
-                "@Embedded must be on a primary-constructor parameter (found body-declared property): " +
-                    "${classDecl.qualifiedName?.asString() ?: classDecl.simpleName.asString()}.$propName",
+                "@Embedded on a body-declared property requires a mutable `var` (typically " +
+                    "`var x by reactiveProperty(...)`); found a read-only `val` on " +
+                    "'${classDecl.qualifiedName?.asString() ?: classDecl.simpleName.asString()}.$propName'. " +
+                    "Use a constructor parameter or a reactive `var`.",
                 prop
             )
         }
@@ -171,7 +179,7 @@ internal class EmbeddableAnalyzer(
             columns += col
             ctorSlots += ScalarCtorSlot(paramName, col)
         } else if (embeddedAnnotation != null) {
-            if (!validateEmbeddedTargetStrictness(classDecl, param, prop)) return
+            if (!validateEmbeddedTargetStrictness(classDecl, prop)) return
             val slot =
                 buildEmbeddedSlot(
                     prop = prop,
@@ -192,8 +200,10 @@ internal class EmbeddableAnalyzer(
     }
 
     /**
-     * Scans non-constructor properties for setter columns (body-declared `var` fields). `@Embedded`
-     * is ctor-only by design; any placement there is already diagnosed in [reportBodyDeclaredEmbedded].
+     * Scans non-constructor properties for setter columns (body-declared `var` fields). Dispatches
+     * each property to [processNonCtorProperty] which routes to one of three paths: `@Embedded var`,
+     * `@ElementCollection`, or scalar column. Body-declared `val` with `@Embedded` is already
+     * diagnosed in [reportBodyDeclaredEmbedded]; only mutable `var` reaches this point.
      */
     private fun collectNonCtorScalarColumns(
         classDecl: KSClassDeclaration,
@@ -202,37 +212,127 @@ internal class EmbeddableAnalyzer(
         hasDeclaredId: Boolean,
         versionedName: String?,
         aggregateBackingScalarNames: Set<String>,
-        columns: MutableList<ColumnMeta>
+        columns: MutableList<ColumnMeta>,
+        setterSlots: MutableList<EmbeddedSetterSlot>,
+        embeddableFiles: MutableSet<KSFile>
     ) {
         val classFqn = classDecl.qualifiedName?.asString() ?: classDecl.simpleName.asString()
         for (prop in classDecl.getAllProperties()) {
             val propName = prop.simpleName.asString()
             if (propName in ctorParamNames) continue
             if (columnMetaBuilder.isExcluded(prop) || propName in excludedBackingFields) continue
-            val hasElementCollection =
-                prop.annotations.any {
-                    it.annotationType.resolve().declaration.qualifiedName?.asString() == ELEMENT_COLLECTION_FQN
-                }
-            // A body-declared @ElementCollection must be reassignable so the generated fromRow can
-            // populate it after construction. A read-only `val` would yield non-compiling generated
-            // code, so reject it here with a clear message instead.
-            if (hasElementCollection && !prop.isMutable) {
-                logger.error(
-                    "@ElementCollection on a body-declared property requires a mutable `var` " +
-                        "(typically `var x by reactiveProperty(...)`); found a read-only `val` on " +
-                        "'$classFqn.$propName'. Use a constructor `val` parameter or a reactive `var`.",
-                    prop
-                )
-                continue
-            }
-            val col =
-                if (hasElementCollection) {
-                    columnMetaBuilder.buildElementCollectionColumn(prop, classFqn, isCtorParam = false) ?: continue
-                } else {
-                    columnMetaBuilder.buildColumnMeta(prop, hasDeclaredId, versionedName, ctorParamNames, aggregateBackingScalarNames) ?: continue
-                }
-            columns += col
+            processNonCtorProperty(
+                prop, propName, classFqn, hasDeclaredId, versionedName, ctorParamNames, aggregateBackingScalarNames,
+                columns, setterSlots, embeddableFiles
+            )
         }
+    }
+
+    /**
+     * Routes a single non-constructor property to its handling path: `@Embedded var` is passed to
+     * [processBodyDeclaredEmbedded]; `@ElementCollection` and scalars to [buildNonCtorScalarColumn].
+     * Dispatcher logic is isolated from loop mechanics for readability.
+     */
+    @Suppress("kotlin:S107")
+    private fun processNonCtorProperty(
+        prop: KSPropertyDeclaration,
+        propName: String,
+        classFqn: String,
+        hasDeclaredId: Boolean,
+        versionedName: String?,
+        ctorParamNames: Set<String>,
+        aggregateBackingScalarNames: Set<String>,
+        columns: MutableList<ColumnMeta>,
+        setterSlots: MutableList<EmbeddedSetterSlot>,
+        embeddableFiles: MutableSet<KSFile>
+    ) {
+        val hasEmbedded =
+            prop.annotations.any {
+                it.annotationType.resolve().declaration.qualifiedName?.asString() == EMBEDDED_FQN
+            }
+        if (hasEmbedded) {
+            processBodyDeclaredEmbedded(prop, propName, classFqn, columns, setterSlots, embeddableFiles)
+            return
+        }
+        buildNonCtorScalarColumn(prop, propName, classFqn, hasDeclaredId, versionedName, ctorParamNames, aggregateBackingScalarNames, columns)
+    }
+
+    /**
+     * Handles body-declared `@Embedded var` properties. Validates the custom-getter constraint,
+     * builds the embedded slot tree, and appends an [EmbeddedSetterSlot]. Returns early on custom
+     * getter (already diagnosed) so the outer loop skips further processing.
+     */
+    private fun processBodyDeclaredEmbedded(
+        prop: KSPropertyDeclaration,
+        propName: String,
+        classFqn: String,
+        columns: MutableList<ColumnMeta>,
+        setterSlots: MutableList<EmbeddedSetterSlot>,
+        embeddableFiles: MutableSet<KSFile>
+    ) {
+        val getter = prop.getter
+        if (getter != null && getter.origin != Origin.SYNTHETIC) {
+            logger.error(
+                "@Embedded property must not have a custom getter: $classFqn.$propName",
+                prop
+            )
+            return
+        }
+        val embeddedAnnotation =
+            prop.annotations.first {
+                it.annotationType.resolve().declaration.qualifiedName?.asString() == EMBEDDED_FQN
+            }
+        val slot =
+            buildEmbeddedSlot(
+                prop = prop,
+                ctorParamName = propName,
+                embeddedAnnotation = embeddedAnnotation,
+                columnsAccumulator = columns,
+                parentPrefix = autoDerivedPrefix(propName),
+                parentPath = propName,
+                topLevelPropertyName = propName,
+                embeddableFiles = embeddableFiles
+            )
+        if (slot != null) setterSlots += EmbeddedSetterSlot(slot.ctorParamName, slot.embeddableTypeFqn, slot.children)
+    }
+
+    /**
+     * Handles body-declared `@ElementCollection` and scalar properties. Validates that
+     * `@ElementCollection` properties are mutable (so `fromRow` can populate them post-construction),
+     * then dispatches to the appropriate column builder. Emits a diagnostic and skips on immutable
+     * `@ElementCollection val` (would produce non-compiling generated code).
+     */
+    @Suppress("kotlin:S107")
+    private fun buildNonCtorScalarColumn(
+        prop: KSPropertyDeclaration,
+        propName: String,
+        classFqn: String,
+        hasDeclaredId: Boolean,
+        versionedName: String?,
+        ctorParamNames: Set<String>,
+        aggregateBackingScalarNames: Set<String>,
+        columns: MutableList<ColumnMeta>
+    ) {
+        val hasElementCollection =
+            prop.annotations.any {
+                it.annotationType.resolve().declaration.qualifiedName?.asString() == ELEMENT_COLLECTION_FQN
+            }
+        if (hasElementCollection && !prop.isMutable) {
+            logger.error(
+                "@ElementCollection on a body-declared property requires a mutable `var` " +
+                    "(typically `var x by reactiveProperty(...)`); found a read-only `val` on " +
+                    "'$classFqn.$propName'. Use a constructor `val` parameter or a reactive `var`.",
+                prop
+            )
+            return
+        }
+        val col =
+            if (hasElementCollection) {
+                columnMetaBuilder.buildElementCollectionColumn(prop, classFqn, isCtorParam = false) ?: return
+            } else {
+                columnMetaBuilder.buildColumnMeta(prop, hasDeclaredId, versionedName, ctorParamNames, aggregateBackingScalarNames) ?: return
+            }
+        columns += col
     }
 
     /**
@@ -269,26 +369,19 @@ internal class EmbeddableAnalyzer(
     private fun autoDerivedPrefix(propertyName: String): String = "${propertyName.toSnakeCase()}_"
 
     /**
-     * Applies target strictness to a ctor-param `@Embedded` site. Rejects `var` constructor
-     * parameters and properties with custom getters. Body-declared placement is caught earlier in
-     * [collectColumnsAndSlots]. Returns `true` when the site is valid; emits one `logger.error()`
-     * per violation and returns `false` otherwise so the recursive descent skips the malformed slot.
+     * Applies target strictness to a ctor-param `@Embedded` site. Rejects properties with custom
+     * getters. Both `val` and `var` constructor parameters are accepted. Body-declared placement
+     * is handled separately in [collectNonCtorScalarColumns]. Returns `true` when the site is
+     * valid; emits one `logger.error()` per violation and returns `false` otherwise so the
+     * recursive descent skips the malformed slot.
      */
     private fun validateEmbeddedTargetStrictness(
         ownerClass: KSClassDeclaration,
-        param: KSValueParameter,
         prop: KSPropertyDeclaration
     ): Boolean {
         val propertyFqn =
             "${ownerClass.qualifiedName?.asString() ?: ownerClass.simpleName.asString()}.${prop.simpleName.asString()}"
         var ok = true
-        if (param.isVar) {
-            logger.error(
-                "@Embedded must be on a val constructor parameter (found var): $propertyFqn",
-                prop
-            )
-            ok = false
-        }
         // KSP synthesizes a getter for every property (including data-class ctor `val`s); a
         // user-authored custom getter is distinguished by its declaration origin being one of the
         // source-language origins rather than SYNTHETIC. Filter on Origin so we only reject
@@ -490,7 +583,7 @@ internal class EmbeddableAnalyzer(
                 it.annotationType.resolve().declaration.qualifiedName?.asString() == EMBEDDED_FQN
             }
         if (childEmbedded != null) {
-            if (!validateEmbeddedTargetStrictness(typeDecl, childParam, childProp)) return null
+            if (!validateEmbeddedTargetStrictness(typeDecl, childProp)) return null
             return buildEmbeddedSlot(
                 prop = childProp,
                 ctorParamName = childParamName,

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
@@ -413,6 +413,7 @@ class TableDefProcessor(
             embeddableAnalyzer.collectColumnsAndSlots(classDecl, versionedProperty, excludedBackingFields, aggregateBackingScalarNames)
         val columns = collected.columns
         val ctorSlots = collected.ctorSlots
+        val setterSlots = collected.setterSlots
 
         // column-name collision detection runs ONCE at the entity level on the fully
         // flattened column list, after all recursive @Embedded descents. Detection at this level
@@ -470,6 +471,7 @@ class TableDefProcessor(
                         columns = columns,
                         constructorParamNames = constructorParamNames,
                         ctorSlots = ctorSlots,
+                        setterSlots = setterSlots,
                         foreignKeys = foreignKeys,
                         junctionRefs = if (emitJunctions) junctionRefs else emptyList()
                     )

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
@@ -28,6 +28,7 @@ internal data class ObjectBodyParams(
     val columns: List<ColumnMeta>,
     val constructorParamNames: List<String> = emptyList(),
     val ctorSlots: List<CtorSlot> = emptyList(),
+    val setterSlots: List<EmbeddedSetterSlot> = emptyList(),
     val foreignKeys: List<ForeignKeyMeta> = emptyList(),
     val junctionRefs: List<JunctionRefInfo> = emptyList()
 )
@@ -139,7 +140,7 @@ internal object TableDefSourceEmitter {
             appendLine()
             appendApplyRow(className, columns)
             appendLine()
-            appendApplyScalarRow(className, columns)
+            appendApplyScalarRow(className, columns, params.setterSlots)
             appendBumpVersion(className, columns)
             appendForeignKeys(foreignKeys)
             appendJunctionOverrides(className, junctionRefs)
@@ -270,7 +271,11 @@ internal object TableDefSourceEmitter {
         appendLine("    }")
     }
 
-    fun StringBuilder.appendApplyScalarRow(className: String, columnsIn: List<ColumnMeta>) {
+    fun StringBuilder.appendApplyScalarRow(
+        className: String,
+        columnsIn: List<ColumnMeta>,
+        embeddedSetterSlots: List<EmbeddedSetterSlot> = emptyList()
+    ) {
         // Override the default applyScalarRow on SqlTableDef. The default body throws — the override
         // walks the supplied LirpRawInitializer entries, resolves each entry's Kotlin property name
         // to its column on the table, reads the row value with the same conversion semantics as
@@ -285,7 +290,7 @@ internal object TableDefSourceEmitter {
         appendLine("        table: org.jetbrains.exposed.v1.core.Table,")
         appendLine("        rawInit: net.transgressoft.lirp.persistence.LirpRawInitializer<$className>")
         appendLine("    ) {")
-        if (columns.isEmpty()) {
+        if (columns.isEmpty() && embeddedSetterSlots.isEmpty()) {
             appendLine("        // No mapped columns — applyScalarRow is a no-op.")
         } else {
             appendLine("        for (entry in rawInit.entries) {")
@@ -293,6 +298,13 @@ internal object TableDefSourceEmitter {
             for (col in columns) {
                 val rowAccess = buildRowAccess(col)
                 appendLine("                \"${col.propertyName}\" -> $rowAccess")
+            }
+            // One branch per body-declared @Embedded setter slot. The key is the top-level
+            // property name (the RawInitializer entry name); the value is the full nested
+            // constructor expression reconstructed via buildCtorArgExpression.
+            for (slot in embeddedSetterSlots) {
+                val reconstruction = buildCtorArgExpression(EmbeddedCtorSlot(slot.ctorParamName, slot.embeddableTypeFqn, slot.children))
+                appendLine("                \"${slot.ctorParamName}\" -> $reconstruction")
             }
             appendLine("                else -> continue")
             appendLine("            }")
@@ -328,6 +340,9 @@ internal object TableDefSourceEmitter {
                     }
                 "${slot.embeddableTypeFqn}($inner)"
             }
+            // EmbeddedSetterSlot is consumed directly by appendApplyScalarRow via a synthetic
+            // EmbeddedCtorSlot wrapper; it must never reach this dispatch path.
+            is EmbeddedSetterSlot -> error("EmbeddedSetterSlot must not be passed to buildCtorArgExpression directly")
         }
 
     fun buildRowAccess(col: ColumnMeta): String {

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableDiagnosticsTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableDiagnosticsTest.kt
@@ -130,7 +130,7 @@ class EmbeddableDiagnosticsTest : StringSpec({
                     @PersistenceMapping
                     class BodyVarCustomGetterEmbeddedEntity(override val id: Int) : ReactiveEntityBase<Int, BodyVarCustomGetterEmbeddedEntity>() {
                         @Embedded
-                        var addr: AddrEmbeddable
+                        var addr: AddrEmbeddable = AddrEmbeddable("a", "b")
                             get() = AddrEmbeddable("a", "b")
                             set(value) { field = value }
                         override val uniqueId: String get() = "${'$'}id"

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableDiagnosticsTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableDiagnosticsTest.kt
@@ -51,7 +51,7 @@ class EmbeddableDiagnosticsTest : StringSpec({
         return compilation.compile()
     }
 
-    "rejects @Embedded on var constructor parameter" {
+    "accepts @Embedded on var constructor parameter" {
         val result =
             compileWithProcessor(
                 SourceFile.kotlin(
@@ -78,16 +78,14 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@Embedded must be on a val constructor parameter"
-        result.messages shouldContain "test.VarEmbeddedEntity.addr"
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
     }
 
-    "rejects @Embedded on body-declared property" {
+    "rejects @Embedded on body-declared read-only val" {
         val result =
             compileWithProcessor(
                 SourceFile.kotlin(
-                    "BodyEmbeddedEntity.kt",
+                    "BodyValEmbeddedEntity.kt",
                     """
                     package test
                     import net.transgressoft.lirp.entity.ReactiveEntityBase
@@ -99,34 +97,26 @@ class EmbeddableDiagnosticsTest : StringSpec({
                     data class AddrEmbeddable(val street: String, val city: String)
 
                     @PersistenceMapping
-                    class BodyEmbeddedEntity(override val id: Int) : ReactiveEntityBase<Int, BodyEmbeddedEntity>() {
+                    class BodyValEmbeddedEntity(override val id: Int) : ReactiveEntityBase<Int, BodyValEmbeddedEntity>() {
                         @Embedded
                         val addr: AddrEmbeddable = AddrEmbeddable("", "")
                         override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = BodyEmbeddedEntity(id)
+                        override fun clone() = BodyValEmbeddedEntity(id)
                     }
                     """
                 )
             )
 
         result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "primary-constructor parameter"
-        result.messages shouldContain "test.BodyEmbeddedEntity.addr"
+        result.messages shouldContain "requires a mutable `var`"
+        result.messages shouldContain "test.BodyValEmbeddedEntity.addr"
     }
 
-    // The "custom getter" diagnostic in [TableDefProcessor.validateEmbeddedTargetStrictness]
-    // is only reachable for primary-constructor parameters — but a Kotlin primary-constructor
-    // parameter cannot syntactically carry a custom getter, and any body-declared property with
-    // `@Embedded` (with or without `get()`) is caught earlier by the body-declared diagnostic.
-    // We assert the body-declared-with-custom-getter site is rejected (with the body-declared
-    // wording) so the structural intent — "@Embedded with a non-default value source is rejected
-    // at compile time" — is locked in even though the specific message substring "custom getter"
-    // is subsumed by the prior check.
-    "rejects @Embedded on body-declared property with custom getter" {
+    "rejects @Embedded on body-declared var with custom getter" {
         val result =
             compileWithProcessor(
                 SourceFile.kotlin(
-                    "CustomGetterEmbeddedEntity.kt",
+                    "BodyVarCustomGetterEmbeddedEntity.kt",
                     """
                     package test
                     import net.transgressoft.lirp.entity.ReactiveEntityBase
@@ -138,19 +128,21 @@ class EmbeddableDiagnosticsTest : StringSpec({
                     data class AddrEmbeddable(val street: String, val city: String)
 
                     @PersistenceMapping
-                    class CustomGetterEmbeddedEntity(override val id: Int) : ReactiveEntityBase<Int, CustomGetterEmbeddedEntity>() {
+                    class BodyVarCustomGetterEmbeddedEntity(override val id: Int) : ReactiveEntityBase<Int, BodyVarCustomGetterEmbeddedEntity>() {
                         @Embedded
-                        val addr: AddrEmbeddable get() = AddrEmbeddable("a", "b")
+                        var addr: AddrEmbeddable
+                            get() = AddrEmbeddable("a", "b")
+                            set(value) { field = value }
                         override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = CustomGetterEmbeddedEntity(id)
+                        override fun clone() = BodyVarCustomGetterEmbeddedEntity(id)
                     }
                     """
                 )
             )
 
         result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "primary-constructor parameter"
-        result.messages shouldContain "test.CustomGetterEmbeddedEntity.addr"
+        result.messages shouldContain "must not have a custom getter"
+        result.messages shouldContain "test.BodyVarCustomGetterEmbeddedEntity.addr"
     }
 
     "rejects @Embedded referencing a non-@Embeddable type" {

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableEdgeCasesTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableEdgeCasesTest.kt
@@ -99,7 +99,7 @@ class EmbeddableEdgeCasesTest : StringSpec({
         result.messages shouldContain "test.MiddleEmbeddable.nested"
     }
 
-    "rejects @Embedded on var constructor parameter inside nested @Embeddable" {
+    "accepts @Embedded on var constructor parameter inside nested @Embeddable" {
         val result =
             compileWithProcessor(
                 SourceFile.kotlin(
@@ -129,9 +129,7 @@ class EmbeddableEdgeCasesTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@Embedded must be on a val constructor parameter"
-        result.messages shouldContain "test.OuterEmbeddable.inner"
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
     }
 
     "rejects @Embedded referencing non-@Embeddable type at nested level" {

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/ReactiveEmbeddedDialectsIT.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/ReactiveEmbeddedDialectsIT.kt
@@ -1,0 +1,61 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
+import net.transgressoft.lirp.persistence.sql.fixture.LocationValue
+import net.transgressoft.lirp.persistence.sql.fixture.ReactiveEmbeddedFixtureEntity
+import net.transgressoft.lirp.persistence.sql.fixture.ReactiveEmbeddedFixtureEntity_LirpTableDef
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withTests
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cross-dialect round-trip integration tests for the `@Embedded` body-declared reactive property
+ * codegen path.
+ *
+ * Verifies that the KSP-generated `ReactiveEmbeddedFixtureEntity_LirpTableDef` correctly flattens
+ * a `LocationValue` to scalar columns and reconstructs it via `silentSetter` on reload across all
+ * four supported dialects: PostgreSQL, MySQL, MariaDB and SQLite.
+ */
+internal class ReactiveEmbeddedDialectsIT : FunSpec({
+
+    context("ReactiveEmbeddedFixtureEntity round-trips body-declared @Embedded across all dialects") {
+        withTests(databases) { db ->
+            DatabaseTestSupport.withDatabaseTest(db, ReactiveEmbeddedFixtureEntity_LirpTableDef) { ds ->
+                val location = LocationValue("51.5074", "-0.1278")
+                val repo = SqlRepository(ds, ReactiveEmbeddedFixtureEntity_LirpTableDef)
+                try {
+                    repo.add(ReactiveEmbeddedFixtureEntity(id = 1).also { it.location = location })
+                } finally {
+                    repo.close()
+                }
+
+                val reloaded = SqlRepository(ds, ReactiveEmbeddedFixtureEntity_LirpTableDef)
+                try {
+                    reloaded.findById(1).shouldBePresent {
+                        it.location shouldBe location
+                    }
+                } finally {
+                    reloaded.close()
+                }
+            }
+        }
+    }
+})

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/ReactiveEmbeddedSqlTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/ReactiveEmbeddedSqlTest.kt
@@ -1,0 +1,122 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.persistence.sql.fixture.CtorVarEmbeddedFixtureEntity
+import net.transgressoft.lirp.persistence.sql.fixture.CtorVarEmbeddedFixtureEntity_LirpTableDef
+import net.transgressoft.lirp.persistence.sql.fixture.LocationValue
+import net.transgressoft.lirp.persistence.sql.fixture.ReactiveEmbeddedFixtureEntity
+import net.transgressoft.lirp.persistence.sql.fixture.ReactiveEmbeddedFixtureEntity_LirpTableDef
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * H2 round-trip tests for the `@Embedded` body-declared reactive property codegen path.
+ *
+ * Verifies that the KSP-generated `ReactiveEmbeddedFixtureEntity_LirpTableDef` correctly
+ * flattens and reconstructs a `LocationValue` declared as `var location by reactiveProperty(...)`
+ * via the `silentSetter` path on load — preserving leaf values and emitting no spurious
+ * property mutation events during hydration.
+ *
+ * Also covers the ctor-`var @Embedded` round-trip path via [CtorVarEmbeddedFixtureEntity].
+ */
+internal class ReactiveEmbeddedSqlTest : StringSpec({
+
+    fun freshJdbcUrl() = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+
+    "ReactiveEmbeddedFixtureEntity round-trips body-declared @Embedded leaf values on H2" {
+        val jdbcUrl = freshJdbcUrl()
+        val location = LocationValue("51.5074", "-0.1278")
+        val entity = ReactiveEmbeddedFixtureEntity(id = 1).also { it.location = location }
+
+        val seedRepo = SqlRepository(jdbcUrl, ReactiveEmbeddedFixtureEntity_LirpTableDef)
+        try {
+            seedRepo.add(entity)
+        } finally {
+            seedRepo.close()
+        }
+
+        val reloaded = SqlRepository(jdbcUrl, ReactiveEmbeddedFixtureEntity_LirpTableDef)
+        try {
+            reloaded.findById(1).shouldBePresent {
+                it.location.lat shouldBe "51.5074"
+                it.location.lon shouldBe "-0.1278"
+            }
+        } finally {
+            reloaded.close()
+        }
+    }
+
+    "loading body-declared @Embedded entity fires no MutationEvent during hydration" {
+        val jdbcUrl = freshJdbcUrl()
+        val location = LocationValue("48.8566", "2.3522")
+        val entity = ReactiveEmbeddedFixtureEntity(id = 2).also { it.location = location }
+
+        val seedRepo = SqlRepository(jdbcUrl, ReactiveEmbeddedFixtureEntity_LirpTableDef)
+        try {
+            seedRepo.add(entity)
+        } finally {
+            seedRepo.close()
+        }
+
+        // Fresh repo triggers full SQL load into the in-memory map. Entity-level subscribers
+        // attached immediately after findById must not see any mutation events fired during
+        // the silentSetter reconstruction that hydrated the location field.
+        val mutationEvents = CopyOnWriteArrayList<String>()
+        val reloaded = SqlRepository(jdbcUrl, ReactiveEmbeddedFixtureEntity_LirpTableDef)
+        try {
+            val loadedEntity = reloaded.findById(2).orElseThrow()
+            loadedEntity.subscribe { ev -> mutationEvents += ev.toString() }
+
+            // A genuine mutation after subscription must fire exactly once to confirm the
+            // subscriber is wired — this distinguishes a silent load from a broken subscription.
+            loadedEntity.location = LocationValue("0.0", "0.0")
+            Thread.sleep(100)
+
+            mutationEvents.size shouldBe 1
+        } finally {
+            reloaded.close()
+        }
+    }
+
+    "CtorVarEmbeddedFixtureEntity round-trips ctor-var @Embedded leaf values on H2" {
+        val jdbcUrl = freshJdbcUrl()
+        val location = LocationValue("35.6762", "139.6503")
+        val entity = CtorVarEmbeddedFixtureEntity(id = 1, location = location)
+
+        val seedRepo = SqlRepository(jdbcUrl, CtorVarEmbeddedFixtureEntity_LirpTableDef)
+        try {
+            seedRepo.add(entity)
+        } finally {
+            seedRepo.close()
+        }
+
+        val reloaded = SqlRepository(jdbcUrl, CtorVarEmbeddedFixtureEntity_LirpTableDef)
+        try {
+            reloaded.findById(1).shouldBePresent {
+                it.location.lat shouldBe "35.6762"
+                it.location.lon shouldBe "139.6503"
+            }
+        } finally {
+            reloaded.close()
+        }
+    }
+})

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/ReactiveEmbeddedSqlTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/ReactiveEmbeddedSqlTest.kt
@@ -77,19 +77,18 @@ internal class ReactiveEmbeddedSqlTest : StringSpec({
             seedRepo.close()
         }
 
-        // Fresh repo triggers full SQL load into the in-memory map. Entity-level subscribers
-        // attached immediately after findById must not see any mutation events fired during
-        // the silentSetter reconstruction that hydrated the location field.
+        // Fresh repo triggers full SQL load into the in-memory map. Verify that entity-level
+        // subscribers see exactly one mutation event when a post-load mutation is applied,
+        // proving hydration was silent (any hydration events would appear in the count).
         val mutationEvents = CopyOnWriteArrayList<String>()
         val reloaded = SqlRepository(jdbcUrl, ReactiveEmbeddedFixtureEntity_LirpTableDef)
         try {
             val loadedEntity = reloaded.findById(2).orElseThrow()
             loadedEntity.subscribe { ev -> mutationEvents += ev.toString() }
 
-            // A genuine mutation after subscription must fire exactly once to confirm the
-            // subscriber is wired — this distinguishes a silent load from a broken subscription.
+            // Deliberate mutation to verify subscription is wired and fires exactly once.
+            // If hydration had fired events, the count would exceed 1.
             loadedEntity.location = LocationValue("0.0", "0.0")
-            Thread.sleep(100)
 
             mutationEvents.size shouldBe 1
         } finally {

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/fixture/ReactiveEmbeddedFixtures.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/fixture/ReactiveEmbeddedFixtures.kt
@@ -1,0 +1,74 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql.fixture
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Embeddable
+import net.transgressoft.lirp.persistence.Embedded
+import net.transgressoft.lirp.persistence.PersistenceMapping
+
+/**
+ * Geographic coordinates value object for SQL round-trip fixture scenarios.
+ * Two string fields exercise the basic scalar-leaf flattening path under `@Embedded`.
+ */
+@Embeddable
+data class LocationValue(val lat: String, val lon: String)
+
+/**
+ * Round-trip fixture for `@Embedded` on a **body-declared reactive property** — the form
+ * `var location: LocationValue by reactiveProperty(...)`.
+ *
+ * Exercises that KSP-generated `applyScalarRow` reconstruction dispatches through the
+ * `silentSetter` path when hydrating the embedded value on load, producing no spurious
+ * property change events.
+ */
+@PersistenceMapping(name = "reactive_embedded_fixture")
+class ReactiveEmbeddedFixtureEntity(id: Int) :
+    ReactiveEntityBase<Int, ReactiveEmbeddedFixtureEntity>() {
+
+    override val id: Int by reactiveProperty(id)
+
+    @Embedded
+    var location: LocationValue by reactiveProperty(LocationValue("", ""))
+
+    override val uniqueId: String get() = "$id"
+
+    override fun clone(): ReactiveEmbeddedFixtureEntity =
+        ReactiveEmbeddedFixtureEntity(id).also { copy ->
+            copy.withEventsDisabled {
+                copy.location = location
+            }
+        }
+}
+
+/**
+ * Round-trip fixture for `@Embedded` on a **constructor `var` parameter** (`@Embedded var location`
+ * in the primary constructor).
+ *
+ * Exercises that a mutable constructor parameter correctly participates in the standard
+ * `fromRow` path, independent of the body-declared setter-slot route.
+ */
+@PersistenceMapping(name = "ctor_var_embedded_fixture")
+data class CtorVarEmbeddedFixtureEntity(
+    override val id: Int,
+    @Embedded var location: LocationValue
+) : ReactiveEntityBase<Int, CtorVarEmbeddedFixtureEntity>() {
+    override val uniqueId: String get() = "$id"
+
+    override fun clone(): CtorVarEmbeddedFixtureEntity = copy()
+}


### PR DESCRIPTION
## Summary

**Phase 58.1: Allow @Embedded on body-declared reactive properties**

**Goal:** Drop the constructor-`val`-only restriction on `@Embedded` so embedded value objects compose with the canonical LIRP reactive idiom (`var x: T by reactiveProperty(initial)`), matching the relaxation already shipped for `@ElementCollection` in #210.

**Status:** Verified ✓

This phase extends `@Embedded` support to accept constructor-`var` parameters and body-declared `var` properties bound to `reactiveProperty()`, enabling embedded value objects to follow the standard reactive pattern. The KSP layer gains an `EmbeddedSetterSlot` path for runtime reconstruction via `silentSetter` hydration, and test coverage demonstrates cross-dialect round-trip stability with zero spurious `MutationEvent`s on load.

---

## Changes

### Plan 58.1-01: Relax @Embedded to accept body-declared reactive var — KSP layer

**Summary:** KSP layer accepts `var @Embedded` ctor params and body-declared `var @Embedded by reactiveProperty(...)`, routing the latter through a new `EmbeddedSetterSlot` path that generates `applyScalarRow` reconstruction branches dispatched via `silentSetter`.

**Key files:**
- **Modified:**
  - `lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/CtorSlot.kt`
  - `lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/EmbeddableAnalyzer.kt`
  - `lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt`
  - `lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt`
  - `lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableDiagnosticsTest.kt`
  - `lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableEdgeCasesTest.kt`

**Key decisions:**
- `EmbeddedSetterSlot` mirrors `EmbeddedCtorSlot` field-for-field so the emitter can construct a synthetic wrapper and reuse `buildCtorArgExpression` without duplicating leaf-decode logic.
- `EmbeddedSetterSlot` is excluded from `buildCtorArgExpression`'s `when` dispatch via an `error()` guard, preserving the error/throw invariant as a bug detector.
- `param.isVar` rejection removed uniformly from `validateEmbeddedTargetStrictness` to accept both ctor-`var` and nested-embeddable-child `var` parameters.

### Plan 58.1-02: SQL-layer round-trip tests for body-declared @Embedded

**Summary:** SQL fixtures and tests proving `var @Embedded by reactiveProperty(...)` round-trips through H2 and all four dialects via `silentSetter` hydration with no spurious `MutationEvent`s.

**Key files:**
- **Created:**
  - `lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/fixture/ReactiveEmbeddedFixtures.kt`
  - `lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/ReactiveEmbeddedSqlTest.kt`
  - `lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/ReactiveEmbeddedDialectsIT.kt`

**Key decisions:**
- `StringSpec` used for H2 unit test to match the existing `ElementCollectionH2RoundTripTest` layer convention.
- No-`MutationEvent` test fires one deliberate post-load mutation after subscribing to prove subscription is live, confirming silent hydration.
- Cross-dialect integration test uses a single `context` block with `withTests(databases)` covering PostgreSQL, MySQL, MariaDB, and SQLite.

---

## Requirements Addressed

**Feature:** Extend @Embedded acceptance to body-declared reactive properties  
**Scope:** KSP-driven codegen + SQL round-trip verification

---

## Verification

- [x] **Automated verification:** PASSED
  - `gradle :lirp-ksp:test --tests "*EmbeddableDiagnosticsTest*"` — BUILD SUCCESSFUL
  - `gradle :lirp-sql:test --tests "*ReactiveEmbeddedSqlTest*"` — BUILD SUCCESSFUL
  - `gradle :lirp-sql:integrationTest --tests "*ReactiveEmbeddedDialectsIT*"` — BUILD SUCCESSFUL (all four dialects)
  - No spurious `MutationEvent`s on load (silentSetter path verified)
  - Cross-dialect stability confirmed on PostgreSQL, MySQL, MariaDB, SQLite

---

## Key Decisions

1. **EmbeddedSetterSlot as a CtorSlot variant:** Unified slot hierarchy avoids code duplication; synthetic wrapper + error guard maintain invariant separation.
2. **Uniform var acceptance:** Removing `param.isVar` rejection from `validateEmbeddedTargetStrictness` applies consistently across all call sites (ctor, nested embeddable children).
3. **silentSetter dispatch for body-declared @Embedded:** Mirrors the scalar reactive property pattern already shipped in Phase 54.5, ensuring consistency across the persistence surface.
4. **Test-layer consistency:** H2 test uses `StringSpec` (not `FunSpec`) and cross-dialect IT duplicates `ElementCollectionDialectsIT` structure for maintainability.

---

