### PR TITLE
Phase 58.2: Cross-module @Embeddable annotation resolution (#217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,8 @@ data class Album(
 ) : ReactiveEntityBase<Int, Album>() { /* ... */ }
 ```
 
-- **Placement:** `@Embeddable` on a concrete `data class`; `@Embedded` on constructor-`val` parameters only.
+- **Placement:** `@Embeddable` on a concrete `data class`; `@Embedded` on constructor-`val`/`var` parameters or body-declared reactive `var` properties.
+- **Cross-module:** `@Embeddable` types may be defined in a separate module or library. KSP resolves their annotations at the embedding site without any extra configuration.
 - **Default prefix:** derived from the property name as `snake_case + "_"` (e.g. `performer` → `performer_`).
 - **Recursive nesting:** `@Embeddable` types may themselves declare `@Embedded` fields; prefixes concatenate parent-to-child.
 - **Composition with converters:** scalar fields inside an `@Embeddable` may carry `@PersistenceProperty(converter = MyConverter::class)` to route non-scalar domain types through a custom `ColumnConverter`.

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ElementCollection.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ElementCollection.kt
@@ -97,7 +97,7 @@ import kotlin.reflect.KClass
  *   interface is a compile-time error. The converter's `S` type determines the JSON element type
  *   (e.g. `String` elements produce `["a","b"]`; `Int` elements produce `[1,2,3]`).
  */
-@Target(AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.BINARY)
 annotation class ElementCollection(
     val elementConverter: KClass<out ColumnConverter<*, *>>

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/Embedded.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/Embedded.kt
@@ -70,6 +70,6 @@ package net.transgressoft.lirp.persistence
  *   shape validation. In recursive `@Embedded` chains, prefixes from outer to inner concatenate
  *   in declaration order to produce each leaf column's final name.
  */
-@Target(AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.BINARY)
 annotation class Embedded(val prefix: String = "")

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/PersistenceIgnore.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/PersistenceIgnore.kt
@@ -47,6 +47,6 @@ package net.transgressoft.lirp.persistence
  * ) : ReactiveEntityBase<Int, Customer>()
  * ```
  */
-@Target(AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.BINARY)
 annotation class PersistenceIgnore

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/PersistenceProperty.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/PersistenceProperty.kt
@@ -71,7 +71,7 @@ import kotlin.reflect.KClass
  *   to honor explicit consumer intent. Hints incompatible with the converter's base type
  *   (for example, `length` on an integer converter) are reported as KSP errors at compile time.
  */
-@Target(AnnotationTarget.PROPERTY)
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.BINARY)
 annotation class PersistenceProperty(
     val name: String = "",

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ColumnMetaBuilder.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ColumnMetaBuilder.kt
@@ -24,12 +24,11 @@ import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.validate
 
 private const val AGGREGATE_ANNOTATION_FQN = "net.transgressoft.lirp.persistence.Aggregate"
-private const val PERSISTENCE_IGNORE_FQN = "net.transgressoft.lirp.persistence.PersistenceIgnore"
-private const val TRANSIENT_FQN = "kotlin.jvm.Transient"
 
 /**
  * Builds [ColumnMeta] instances from KSP property declarations. Handles converter resolution,
@@ -52,10 +51,7 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
         aggregateBackingScalarNames: Set<String> = emptySet()
     ): ColumnMeta? {
         val propName = prop.simpleName.asString()
-        val persistenceAnnotation =
-            prop.annotations.firstOrNull {
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == PERSISTENCE_PROPERTY_FQN
-            }
+        val persistenceAnnotation = resolvePersistenceAnnotations(prop).firstWithFqn(PERSISTENCE_PROPERTY_FQN)
         val resolvedType = prop.type.resolve()
         val notNullableType = resolvedType.makeNotNullable()
         val typeFqn = notNullableType.declaration.qualifiedName?.asString() ?: "kotlin.Any"
@@ -111,15 +107,8 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
         val hasExplicitConverter = hasNonSentinelConverterArgument(persistenceAnnotation)
         val typeExpression =
             if (converterInfo != null) {
-                val hints =
-                    PersistencePropertyHints(
-                        length = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "length" }?.value as? Int ?: -1,
-                        precision = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "precision" }?.value as? Int ?: -1,
-                        scale = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "scale" }?.value as? Int ?: -1,
-                        typeHint = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "type" }?.value as? String ?: ""
-                    )
                 refineConverterSqlType(
-                    converterInfo = converterInfo, hints = hints, propertyFqn = propertyFqn, propName = propName
+                    converterInfo = converterInfo, hints = extractHints(persistenceAnnotation), propertyFqn = propertyFqn, propName = propName
                 ) ?: return null
             } else if (hasExplicitConverter) {
                 // Converter declared but unresolved/invalid this round; avoid non-converter fallback.
@@ -156,12 +145,10 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
         childParamName: String,
         prefix: String,
         parentPath: String,
-        topLevelPropertyName: String
+        topLevelPropertyName: String,
+        ctorParam: KSValueParameter? = null
     ): ColumnMeta? {
-        val persistenceAnnotation =
-            childProp.annotations.firstOrNull {
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == PERSISTENCE_PROPERTY_FQN
-            }
+        val persistenceAnnotation = resolvePersistenceAnnotations(childProp, ctorParam).firstWithFqn(PERSISTENCE_PROPERTY_FQN)
         val propertyFqn = "${childProp.parentDeclaration?.qualifiedName?.asString() ?: ""}.$childParamName".trimStart('.')
 
         val resolvedType = childProp.type.resolve()
@@ -183,14 +170,7 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
         val hasExplicitConverter = hasNonSentinelConverterArgument(persistenceAnnotation)
         val typeExpression =
             if (converterInfo != null) {
-                val hints =
-                    PersistencePropertyHints(
-                        length = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "length" }?.value as? Int ?: -1,
-                        precision = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "precision" }?.value as? Int ?: -1,
-                        scale = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "scale" }?.value as? Int ?: -1,
-                        typeHint = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "type" }?.value as? String ?: ""
-                    )
-                refineConverterSqlType(converterInfo, hints, propertyFqn, childParamName) ?: return null
+                refineConverterSqlType(converterInfo, extractHints(persistenceAnnotation), propertyFqn, childParamName) ?: return null
             } else if (hasExplicitConverter) {
                 return null
             } else {
@@ -234,16 +214,17 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
     fun buildElementCollectionColumn(
         prop: KSPropertyDeclaration,
         classFqn: String,
-        isCtorParam: Boolean
+        isCtorParam: Boolean,
+        ctorParam: KSValueParameter? = null
     ): ColumnMeta? {
         val propertyFqn = "$classFqn.${prop.simpleName.asString()}"
         val resolvedType = prop.type.resolve()
 
         val collectionKind = resolveElementCollectionKind(resolvedType, propertyFqn, prop) ?: return null
         if (!elementTypeIsNonNullable(resolvedType, propertyFqn, prop)) return null
-        if (rejectsPersistencePropertyComposition(prop, propertyFqn)) return null
-        val sFqn = resolveElementConverterSqlType(prop, propertyFqn) ?: return null
-        val elementConverterFqn = elementConverterFqn(prop)
+        if (rejectsPersistencePropertyComposition(prop, propertyFqn, ctorParam)) return null
+        val sFqn = resolveElementConverterSqlType(prop, propertyFqn, ctorParam) ?: return null
+        val elementConverterFqn = elementConverterFqn(prop, ctorParam)
 
         return ColumnMeta(
             name = prop.simpleName.asString().toSnakeCase(),
@@ -253,6 +234,10 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
             nullable = false,
             isPrimaryKey = false,
             isEnum = false,
+            // isMutable gates applyRow write-back. Body-declared element collections (isCtorParam=false)
+            // are always var (val is rejected before this point), so they must be mutable for
+            // post-construction population. Ctor-param collections are mutable only when declared
+            // var; val ctor params are populated via the constructor call and need no setter.
             isMutable = !isCtorParam || prop.isMutable,
             isCtorParam = isCtorParam,
             isVersion = false,
@@ -275,13 +260,24 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
         prop: KSPropertyDeclaration
     ): String? {
         if (resolvedType.isMarkedNullable) {
-            val shortKind = if (resolvedType.makeNotNullable().declaration.qualifiedName?.asString()?.contains("Set") == true) "Set" else "List"
-            logger.error(
-                "@ElementCollection property type must be non-nullable; found `$shortKind<E>?` on '$propertyFqn'. " +
-                    "The column carries an empty array '[]' for the empty case.",
-                prop
-            )
-            return null
+            val nonNullFqn = resolvedType.makeNotNullable().declaration.qualifiedName?.asString()
+            // Use exact FQN matching to derive the kind label so types whose name merely contains
+            // "Set" are not mislabelled. Non-collection nullable types (e.g. Map?) fall through
+            // to the non-null when-block's else branch for a targeted "requires List/Set" diagnostic.
+            when (nonNullFqn) {
+                KOTLIN_SET_FQN, KOTLIN_LIST_FQN -> {
+                    val shortKind = if (nonNullFqn == KOTLIN_SET_FQN) "Set" else "List"
+                    logger.error(
+                        "@ElementCollection property type must be non-nullable; found `$shortKind<E>?` on '$propertyFqn'. " +
+                            "The column carries an empty array '[]' for the empty case.",
+                        prop
+                    )
+                    return null
+                }
+                else -> {
+                    // Delegate to the non-null branch for a precise diagnostic about the unsupported type.
+                }
+            }
         }
         return when (val collectionFqn = resolvedType.makeNotNullable().declaration.qualifiedName?.asString()) {
             KOTLIN_LIST_FQN -> "List"
@@ -332,11 +328,12 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
     }
 
     /** Returns `true` (after logging) when the property also carries `@PersistenceProperty`. */
-    private fun rejectsPersistencePropertyComposition(prop: KSPropertyDeclaration, propertyFqn: String): Boolean {
-        val hasPersistenceProperty =
-            prop.annotations.any {
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == PERSISTENCE_PROPERTY_FQN
-            }
+    private fun rejectsPersistencePropertyComposition(
+        prop: KSPropertyDeclaration,
+        propertyFqn: String,
+        ctorParam: KSValueParameter? = null
+    ): Boolean {
+        val hasPersistenceProperty = resolvePersistenceAnnotations(prop, ctorParam).has(PERSISTENCE_PROPERTY_FQN)
         if (hasPersistenceProperty) {
             logger.error(
                 "@ElementCollection and @PersistenceProperty cannot be combined on '$propertyFqn'. " +
@@ -348,12 +345,12 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
     }
 
     /** Reads the `elementConverter` argument FQN from the `@ElementCollection` annotation. */
-    private fun elementConverterFqn(prop: KSPropertyDeclaration): String? =
-        (elementConverterArg(prop)?.declaration?.qualifiedName?.asString())
+    private fun elementConverterFqn(prop: KSPropertyDeclaration, ctorParam: KSValueParameter? = null): String? =
+        (elementConverterArg(prop, ctorParam)?.declaration?.qualifiedName?.asString())
 
-    private fun elementConverterArg(prop: KSPropertyDeclaration): KSType? =
-        prop.annotations
-            .firstOrNull { it.annotationType.resolve().declaration.qualifiedName?.asString() == ELEMENT_COLLECTION_FQN }
+    private fun elementConverterArg(prop: KSPropertyDeclaration, ctorParam: KSValueParameter? = null): KSType? =
+        resolvePersistenceAnnotations(prop, ctorParam)
+            .firstWithFqn(ELEMENT_COLLECTION_FQN)
             ?.arguments
             ?.firstOrNull { it.name?.asString() == "elementConverter" }
             ?.value as? KSType
@@ -365,8 +362,12 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
      * (`UUID`, `BigDecimal`, `LocalDate`, `LocalDateTime`) must be wrapped in a String-shaped
      * converter, since they have no built-in `kotlinx.serialization` JSON-array support.
      */
-    private fun resolveElementConverterSqlType(prop: KSPropertyDeclaration, propertyFqn: String): String? {
-        val elementConverterArg = elementConverterArg(prop)
+    private fun resolveElementConverterSqlType(
+        prop: KSPropertyDeclaration,
+        propertyFqn: String,
+        ctorParam: KSValueParameter? = null
+    ): String? {
+        val elementConverterArg = elementConverterArg(prop, ctorParam)
         val elementConverterFqn = elementConverterArg?.declaration?.qualifiedName?.asString()
         if (elementConverterFqn == null || elementConverterFqn == COLUMN_CONVERTER_FQN) {
             logger.error(
@@ -415,17 +416,29 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
         return sFqn
     }
 
-    /** Returns `true` when [prop] should be excluded from the persisted column set. */
-    fun isExcluded(prop: KSPropertyDeclaration): Boolean {
+    /**
+     * Returns `true` when [prop] should be excluded from the persisted column set.
+     *
+     * The optional [ctorParam] enables cross-module `@PersistenceIgnore` detection: for properties
+     * compiled into a dependency jar, annotations live on the `VALUE_PARAMETER` rather than the
+     * synthesized property declaration. Callers with access to the matched constructor parameter
+     * should always supply it so the [PERSISTENCE_IGNORE_FQN] check is cross-module safe.
+     *
+     * This is the single seam through which column eligibility is decided, so later predicates
+     * (e.g. `@Transient` or error-type handling) can extend exclusion logic in one place.
+     */
+    fun isExcluded(prop: KSPropertyDeclaration, ctorParam: KSValueParameter? = null): Boolean {
         // Private backing fields are encapsulated implementation state — no public surface for
         // persistence to bind through. Mirrors the exclusion applied by `RawInitializerProcessor`
         // so the two processors agree on the persisted column set for a given entity shape.
         if (Modifier.PRIVATE in prop.modifiers) return true
+        // PERSISTENCE_IGNORE_FQN routed through resolver so cross-module @PersistenceIgnore
+        // on VALUE_PARAMETER is visible — the single eligibility seam for exclusion checks.
+        if (resolvePersistenceAnnotations(prop, ctorParam).has(PERSISTENCE_IGNORE_FQN)) return true
         val annotationFqns =
             prop.annotations
                 .map { it.annotationType.resolve().declaration.qualifiedName?.asString() }
                 .toSet()
-        if (PERSISTENCE_IGNORE_FQN in annotationFqns) return true
         if (AGGREGATE_ANNOTATION_FQN in annotationFqns) return true
         if (TRANSIENT_FQN in annotationFqns) return true
         // Exclude computed properties (no backing field, not delegated), but include delegate-backed properties
@@ -447,10 +460,11 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
         val notNullableType = resolvedType.makeNotNullable()
         val fqn = notNullableType.declaration.qualifiedName?.asString()
 
-        val length = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "length" }?.value as? Int ?: -1
-        val precision = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "precision" }?.value as? Int ?: -1
-        val scale = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "scale" }?.value as? Int ?: -1
-        val typeHint = persistenceAnnotation?.arguments?.firstOrNull { it.name?.asString() == "type" }?.value as? String ?: ""
+        val hints = extractHints(persistenceAnnotation)
+        val length = hints.length
+        val precision = hints.precision
+        val scale = hints.scale
+        val typeHint = hints.typeHint
 
         // Explicit type hint takes precedence over FQN-based inference
         if (typeHint.isNotEmpty()) {
@@ -646,6 +660,14 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
         prop.setter?.modifiers?.none {
             it == Modifier.PROTECTED || it == Modifier.PRIVATE || it == Modifier.INTERNAL
         } ?: true
+
+    private fun extractHints(annotation: KSAnnotation?): PersistencePropertyHints =
+        PersistencePropertyHints(
+            length = annotation?.arguments?.firstOrNull { it.name?.asString() == "length" }?.value as? Int ?: -1,
+            precision = annotation?.arguments?.firstOrNull { it.name?.asString() == "precision" }?.value as? Int ?: -1,
+            scale = annotation?.arguments?.firstOrNull { it.name?.asString() == "scale" }?.value as? Int ?: -1,
+            typeHint = annotation?.arguments?.firstOrNull { it.name?.asString() == "type" }?.value as? String ?: ""
+        )
 
     private fun mapTypeHintToExpression(
         hint: String,

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/CtorSlot.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/CtorSlot.kt
@@ -59,6 +59,16 @@ internal data class EmbeddedCtorSlot(
 ) : CtorSlot
 
 /**
+ * A primary-constructor parameter annotated with `@PersistenceIgnore` inside an `@Embeddable`
+ * class. Not mapped to any column; the generated `fromRow` emits `null` for this parameter
+ * position. Only nullable parameters are safe today — the named-argument omission for parameters
+ * with defaults is handled separately.
+ */
+internal data class IgnoredCtorSlot(
+    override val ctorParamName: String
+) : CtorSlot
+
+/**
  * A body-declared reactive `var` property whose value is an `@Embeddable` instance reconstructed
  * from flattened leaf columns and dispatched via
  * [net.transgressoft.lirp.persistence.LirpRawInitializer] `silentSetter` on load.

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/EmbeddableAnalyzer.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/EmbeddableAnalyzer.kt
@@ -27,7 +27,6 @@ import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Modifier
-import com.google.devtools.ksp.symbol.Origin
 
 /**
  * Analyzes `@Embedded` / `@Embeddable` sites on entity primary-constructor parameters.
@@ -114,10 +113,7 @@ internal class EmbeddableAnalyzer(
         for (prop in classDecl.getAllProperties()) {
             val propName = prop.simpleName.asString()
             if (propName in ctorParamNames) continue
-            val hasEmbedded =
-                prop.annotations.any {
-                    it.annotationType.resolve().declaration.qualifiedName?.asString() == EMBEDDED_FQN
-                }
+            val hasEmbedded = resolvePersistenceAnnotations(prop).has(EMBEDDED_FQN)
             if (!hasEmbedded) continue
             // Body-declared mutable var is accepted — routed through collectNonCtorScalarColumns.
             if (prop.isMutable) continue
@@ -155,19 +151,13 @@ internal class EmbeddableAnalyzer(
         val paramName = param.name?.asString() ?: return
         if (paramName in excludedBackingFields) return
         val prop = propertiesByName[paramName] ?: return
-        if (columnMetaBuilder.isExcluded(prop)) return
+        if (columnMetaBuilder.isExcluded(prop, param)) return
 
         // Dispatch order: @ElementCollection BEFORE @Embedded BEFORE plain scalar.
         // An @ElementCollection annotation preempts the plain-scalar branch so a List/Set property
         // with the annotation is never silently passed through buildColumnMeta as an unsupported type.
-        val elementCollectionAnnotation =
-            prop.annotations.firstOrNull {
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == ELEMENT_COLLECTION_FQN
-            }
-        val embeddedAnnotation =
-            prop.annotations.firstOrNull {
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == EMBEDDED_FQN
-            }
+        val elementCollectionAnnotation = resolvePersistenceAnnotations(prop, param).firstWithFqn(ELEMENT_COLLECTION_FQN)
+        val embeddedAnnotation = resolvePersistenceAnnotations(prop, param).firstWithFqn(EMBEDDED_FQN)
 
         if (elementCollectionAnnotation != null) {
             val col =
@@ -205,6 +195,7 @@ internal class EmbeddableAnalyzer(
      * `@ElementCollection`, or scalar column. Body-declared `val` with `@Embedded` is already
      * diagnosed in [reportBodyDeclaredEmbedded]; only mutable `var` reaches this point.
      */
+    @Suppress("kotlin:S107")
     private fun collectNonCtorScalarColumns(
         classDecl: KSClassDeclaration,
         ctorParamNames: Set<String>,
@@ -246,10 +237,7 @@ internal class EmbeddableAnalyzer(
         setterSlots: MutableList<EmbeddedSetterSlot>,
         embeddableFiles: MutableSet<KSFile>
     ) {
-        val hasEmbedded =
-            prop.annotations.any {
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == EMBEDDED_FQN
-            }
+        val hasEmbedded = resolvePersistenceAnnotations(prop).has(EMBEDDED_FQN)
         if (hasEmbedded) {
             processBodyDeclaredEmbedded(prop, propName, classFqn, columns, setterSlots, embeddableFiles)
             return
@@ -271,8 +259,7 @@ internal class EmbeddableAnalyzer(
         embeddableFiles: MutableSet<KSFile>
     ) {
         if (!prop.isMutable) return
-        val getter = prop.getter
-        if (getter != null && getter.origin != Origin.SYNTHETIC) {
+        if (isSourceDeclaredCustomGetter(prop)) {
             logger.error(
                 "@Embedded property must not have a custom getter: $classFqn.$propName",
                 prop
@@ -287,9 +274,8 @@ internal class EmbeddableAnalyzer(
             return
         }
         val embeddedAnnotation =
-            prop.annotations.first {
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == EMBEDDED_FQN
-            }
+            resolvePersistenceAnnotations(prop).firstWithFqn(EMBEDDED_FQN)
+                ?: return
         val slot =
             buildEmbeddedSlot(
                 prop = prop,
@@ -321,10 +307,7 @@ internal class EmbeddableAnalyzer(
         aggregateBackingScalarNames: Set<String>,
         columns: MutableList<ColumnMeta>
     ) {
-        val hasElementCollection =
-            prop.annotations.any {
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == ELEMENT_COLLECTION_FQN
-            }
+        val hasElementCollection = resolvePersistenceAnnotations(prop).has(ELEMENT_COLLECTION_FQN)
         if (hasElementCollection && !prop.isMutable) {
             logger.error(
                 "@ElementCollection on a body-declared property requires a mutable `var` " +
@@ -390,12 +373,10 @@ internal class EmbeddableAnalyzer(
         val propertyFqn =
             "${ownerClass.qualifiedName?.asString() ?: ownerClass.simpleName.asString()}.${prop.simpleName.asString()}"
         var ok = true
-        // KSP synthesizes a getter for every property (including data-class ctor `val`s); a
-        // user-authored custom getter is distinguished by its declaration origin being one of the
-        // source-language origins rather than SYNTHETIC. Filter on Origin so we only reject
-        // explicitly-declared getters.
-        val getter = prop.getter
-        if (getter != null && getter.origin != Origin.SYNTHETIC) {
+        // isSourceDeclaredCustomGetter detects only getters written in source (Origin.KOTLIN).
+        // Synthesized data-class getters (SYNTHETIC) and cross-module compiled accessors
+        // (KOTLIN_LIB) are both accepted — see isSourceDeclaredCustomGetter KDoc for ceiling note.
+        if (isSourceDeclaredCustomGetter(prop)) {
             logger.error(
                 "@Embedded property must not have a custom getter: $propertyFqn",
                 prop
@@ -537,11 +518,10 @@ internal class EmbeddableAnalyzer(
         val childCtorNames =
             typeDecl.primaryConstructor?.parameters.orEmpty().mapNotNull { it.name?.asString() }.toSet()
         for (childProp in typeDecl.getAllProperties()) {
-            if (childProp.simpleName.asString() in childCtorNames) continue
-            val hasEmbedded =
-                childProp.annotations.any {
-                    it.annotationType.resolve().declaration.qualifiedName?.asString() == EMBEDDED_FQN
-                }
+            val childPropName = childProp.simpleName.asString()
+            if (childPropName in childCtorNames) continue
+            val childParam = typeDecl.primaryConstructor?.parameters?.firstOrNull { it.name?.asString() == childPropName }
+            val hasEmbedded = resolvePersistenceAnnotations(childProp, childParam).has(EMBEDDED_FQN)
             if (!hasEmbedded) continue
             logger.error(
                 "@Embedded must be on a primary-constructor parameter (found body-declared property): " +
@@ -572,10 +552,29 @@ internal class EmbeddableAnalyzer(
         val childProp =
             typeDecl.getDeclaredProperties().firstOrNull { it.simpleName.asString() == childParamName } ?: return null
 
-        val childHasElementCollection =
-            childProp.annotations.any {
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == ELEMENT_COLLECTION_FQN
+        // Check exclusion via the centralized resolver so cross-module @PersistenceIgnore on
+        // VALUE_PARAMETER is visible.
+        if (columnMetaBuilder.isExcluded(childProp, childParam)) {
+            // IgnoredCtorSlot emits `null` for the param in generated fromRow. That is only safe
+            // when the param is nullable or has a default value — a non-nullable no-default param
+            // with null would produce code that either fails to compile or throws NullPointerException
+            // at instantiation time. Reject the embeddable early with a clear diagnostic so the
+            // developer is informed rather than getting cryptic downstream failures.
+            val isNullable = childParam.type.resolve().isMarkedNullable
+            if (!isNullable && !childParam.hasDefault) {
+                logger.error(
+                    "@PersistenceIgnore on '$typeFqn.$childParamName' cannot be applied: the parameter " +
+                        "is non-nullable and has no default value. Emitting null for it in `fromRow` would " +
+                        "produce non-compiling or crashing generated code. Make the parameter nullable, " +
+                        "provide a default value, or remove @PersistenceIgnore.",
+                    childProp
+                )
+                return null
             }
+            return IgnoredCtorSlot(childParamName)
+        }
+
+        val childHasElementCollection = resolvePersistenceAnnotations(childProp, childParam).has(ELEMENT_COLLECTION_FQN)
         if (childHasElementCollection) {
             logger.error(
                 "@ElementCollection is not supported inside an @Embeddable. " +
@@ -586,10 +585,7 @@ internal class EmbeddableAnalyzer(
             return null
         }
 
-        val childEmbedded =
-            childProp.annotations.firstOrNull {
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == EMBEDDED_FQN
-            }
+        val childEmbedded = resolvePersistenceAnnotations(childProp, childParam).firstWithFqn(EMBEDDED_FQN)
         if (childEmbedded != null) {
             if (!validateEmbeddedTargetStrictness(typeDecl, childProp)) return null
             return buildEmbeddedSlot(
@@ -608,6 +604,7 @@ internal class EmbeddableAnalyzer(
             columnMetaBuilder.buildEmbeddedLeafColumn(
                 childProp = childProp,
                 childParamName = childParamName,
+                ctorParam = childParam,
                 prefix = effectivePrefix,
                 parentPath = parentPath,
                 topLevelPropertyName = topLevelPropertyName

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
@@ -20,11 +20,14 @@ package net.transgressoft.lirp.ksp
 import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.Variance
 import com.google.devtools.ksp.symbol.Visibility
 
@@ -32,17 +35,46 @@ internal const val REACTIVE_ENTITY_BASE_FQN = "net.transgressoft.lirp.entity.Rea
 internal const val IDENTIFIABLE_ENTITY_FQN = "net.transgressoft.lirp.entity.IdentifiableEntity"
 internal const val FX_SCALAR_DELEGATE_FQN = "net.transgressoft.lirp.persistence.FxScalarPropertyDelegate"
 
-private val KOTLIN_COLLECTION_FQNS =
-    setOf(
-        "kotlin.collections.List",
-        "kotlin.collections.MutableList",
-        "kotlin.collections.Set",
-        "kotlin.collections.MutableSet",
-        "kotlin.collections.Collection",
-        "kotlin.collections.MutableCollection",
-        "kotlin.collections.Map",
-        "kotlin.collections.MutableMap"
-    )
+/**
+ * Merges annotations from [prop]'s declaration site and, when [ctorParam] is supplied, its
+ * value-parameter site. For properties compiled into a dependency jar (`Origin.KOTLIN_LIB`),
+ * Kotlin metadata surfaces data-class constructor annotations on the `VALUE_PARAMETER` rather
+ * than the synthesized property declaration. Providing the matched [ctorParam] ensures those
+ * annotations are visible to every persistence-annotation read.
+ *
+ * Same-module callers may pass `ctorParam = null`; the result is then identical to
+ * `prop.annotations`.
+ */
+internal fun resolvePersistenceAnnotations(
+    prop: KSPropertyDeclaration,
+    ctorParam: KSValueParameter? = null
+): Sequence<KSAnnotation> =
+    prop.annotations + (ctorParam?.annotations ?: emptySequence())
+
+/** Returns `true` if any annotation in this sequence has the given fully-qualified name. */
+internal fun Sequence<KSAnnotation>.has(fqn: String): Boolean =
+    any { it.annotationType.resolve().declaration.qualifiedName?.asString() == fqn }
+
+/** Returns the first annotation with the given fully-qualified name, or `null`. */
+internal fun Sequence<KSAnnotation>.firstWithFqn(fqn: String): KSAnnotation? =
+    firstOrNull { it.annotationType.resolve().declaration.qualifiedName?.asString() == fqn }
+
+/**
+ * Returns `true` when [prop] has a custom getter written in source.
+ *
+ * KSP assigns [Origin.KOTLIN] to a getter declared in the current compilation unit's source.
+ * Synthesized data-class accessors (same-module) report [Origin.SYNTHETIC]; compiled
+ * accessors from a dependency jar report [Origin.KOTLIN_LIB]. The old `!= SYNTHETIC` check
+ * misfired on cross-module compiled types, falsely rejecting every nested `@Embedded` imported
+ * from another module. Using `== KOTLIN` accepts both synthesized ([Origin.SYNTHETIC]) and
+ * cross-module compiled ([Origin.KOTLIN_LIB]) getters as non-custom.
+ *
+ * Limitation: a hand-written custom getter on a value type compiled in another module also
+ * reports [Origin.KOTLIN_LIB] and is therefore indistinguishable from a synthesized accessor.
+ * This is a Kotlin metadata ceiling — do not tighten this predicate back to `!= SYNTHETIC`.
+ */
+internal fun isSourceDeclaredCustomGetter(prop: KSPropertyDeclaration): Boolean =
+    prop.getter?.origin == Origin.KOTLIN
 
 /**
  * Returns true if [decl] extends `ReactiveEntityBase` or implements `IdentifiableEntity` anywhere
@@ -186,7 +218,7 @@ internal fun isReactivePropertyDelegate(prop: KSPropertyDeclaration): Boolean {
     // have a null qualifiedName because `V` has no FQN. They are still reactive — concrete
     // subclasses inherit them as reactive-backed fields and need accessor/raw-init entries.
     val typeFqn = resolvedType.declaration.qualifiedName?.asString()
-    if (typeFqn != null && typeFqn in KOTLIN_COLLECTION_FQNS) return false
+    if (typeFqn != null && typeFqn in LIRP_COLLECTION_FQNS) return false
     return true
 }
 

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/RawInitializerProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/RawInitializerProcessor.kt
@@ -28,21 +28,6 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.Modifier
 
-private const val PERSISTENCE_IGNORE_FQN = "net.transgressoft.lirp.persistence.PersistenceIgnore"
-private const val TRANSIENT_FQN = "kotlin.jvm.Transient"
-
-private val COLLECTION_FQNS =
-    setOf(
-        "kotlin.collections.List",
-        "kotlin.collections.MutableList",
-        "kotlin.collections.Set",
-        "kotlin.collections.MutableSet",
-        "kotlin.collections.Collection",
-        "kotlin.collections.MutableCollection",
-        "kotlin.collections.Map",
-        "kotlin.collections.MutableMap"
-    )
-
 /**
  * KSP processor that generates [LirpRawInitializer][net.transgressoft.lirp.persistence.LirpRawInitializer]
  * implementations for entity classes, used by `SqlRepository.loadFromStore` and
@@ -154,7 +139,7 @@ class RawInitializerProcessor(
 
     private fun KSPropertyDeclaration.isCollectionTyped(): Boolean {
         val fqn = type.resolve().makeNotNullable().declaration.qualifiedName?.asString() ?: return false
-        return fqn in COLLECTION_FQNS
+        return fqn in LIRP_COLLECTION_FQNS
     }
 
     // A `var x; private set` declaration is mutable from the type's own perspective but cannot be
@@ -182,11 +167,16 @@ class RawInitializerProcessor(
      */
     private fun KSPropertyDeclaration.isExcluded(): Boolean {
         if (Modifier.PRIVATE in modifiers) return true
+        // Route @PersistenceIgnore through the centralized resolver so cross-module
+        // @PersistenceIgnore on a VALUE_PARAMETER (KOTLIN_LIB origin) is visible.
+        val matchedCtorParam =
+            (parentDeclaration as? KSClassDeclaration)?.primaryConstructor
+                ?.parameters?.firstOrNull { it.name?.asString() == simpleName.asString() }
+        if (resolvePersistenceAnnotations(this, matchedCtorParam).has(PERSISTENCE_IGNORE_FQN)) return true
         val annotationFqns =
             annotations
                 .map { it.annotationType.resolve().declaration.qualifiedName?.asString() }
                 .toSet()
-        if (PERSISTENCE_IGNORE_FQN in annotationFqns) return true
         if (TRANSIENT_FQN in annotationFqns) return true
         return false
     }

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefConstants.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefConstants.kt
@@ -50,11 +50,25 @@ internal const val COLUMN_CONVERTER_FQN = "net.transgressoft.lirp.persistence.Co
 internal const val EMBEDDABLE_FQN = "net.transgressoft.lirp.persistence.Embeddable"
 internal const val EMBEDDED_FQN = "net.transgressoft.lirp.persistence.Embedded"
 internal const val ELEMENT_COLLECTION_FQN = "net.transgressoft.lirp.persistence.ElementCollection"
+internal const val PERSISTENCE_IGNORE_FQN = "net.transgressoft.lirp.persistence.PersistenceIgnore"
 internal const val KOTLIN_LIST_FQN = "kotlin.collections.List"
 internal const val KOTLIN_SET_FQN = "kotlin.collections.Set"
 internal const val KOTLIN_MUTABLE_LIST_FQN = "kotlin.collections.MutableList"
 internal const val KOTLIN_MUTABLE_SET_FQN = "kotlin.collections.MutableSet"
 internal const val KOTLIN_MAP_FQN = "kotlin.collections.Map"
+internal const val TRANSIENT_FQN = "kotlin.jvm.Transient"
+
+internal val LIRP_COLLECTION_FQNS: Set<String> =
+    setOf(
+        "kotlin.collections.List",
+        "kotlin.collections.MutableList",
+        "kotlin.collections.Set",
+        "kotlin.collections.MutableSet",
+        "kotlin.collections.Collection",
+        "kotlin.collections.MutableCollection",
+        "kotlin.collections.Map",
+        "kotlin.collections.MutableMap"
+    )
 
 // Allow-list of supported S type FQNs for ColumnConverter<D, S>, mapped to the canonical
 // ColumnType expression. Keys gate validation; values seed the codegen path that

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
@@ -340,6 +340,9 @@ internal object TableDefSourceEmitter {
                     }
                 "${slot.embeddableTypeFqn}($inner)"
             }
+            // @PersistenceIgnore on a nested @Embeddable constructor param: emit null so the
+            // ignored param is excluded from SQL column mapping while the constructor still compiles.
+            is IgnoredCtorSlot -> "null"
             // EmbeddedSetterSlot is consumed directly by appendApplyScalarRow via a synthetic
             // EmbeddedCtorSlot wrapper; it must never reach this dispatch path.
             is EmbeddedSetterSlot -> error("EmbeddedSetterSlot must not be passed to buildCtorArgExpression directly")
@@ -376,17 +379,17 @@ internal object TableDefSourceEmitter {
 
     // Converter-routed columns short-circuit the FQN-driven cast table: read the raw scalar,
     // cast to the converter's S type, then route through the consumer's fromSql. Short/Byte
-    // converters need the same INT → narrow-typed conversion that non-converter columns get
-    // (the JDBC layer boxes the column value as Int regardless of declared width), or the cast
-    // would throw ClassCastException at row time.
+    // converters need the same narrowing conversion that non-converter columns get. Casting
+    // to Number rather than Int tolerates JDBC drivers that box integral values as Long or
+    // Short instead of Int, avoiding ClassCastException at row time.
     fun buildConverterRowAccess(col: ColumnMeta, rawAccess: String): String? {
         if (col.converterFqn == null || col.converterSqlFqn == null) return null
         val converterInput =
             when (col.converterSqlFqn) {
                 KOTLIN_SHORT_FQN ->
-                    if (col.nullable) "($rawAccess as? Int)?.toShort()" else "($rawAccess as Int).toShort()"
+                    if (col.nullable) "($rawAccess as? Number)?.toShort()" else "($rawAccess as Number).toShort()"
                 KOTLIN_BYTE_FQN ->
-                    if (col.nullable) "($rawAccess as? Int)?.toByte()" else "($rawAccess as Int).toByte()"
+                    if (col.nullable) "($rawAccess as? Number)?.toByte()" else "($rawAccess as Number).toByte()"
                 else ->
                     if (col.nullable) "($rawAccess as? ${col.converterSqlFqn})" else "($rawAccess as ${col.converterSqlFqn})"
             }
@@ -397,14 +400,15 @@ internal object TableDefSourceEmitter {
         }
     }
 
-    // Short / Byte are stored as INT; narrow on read via Kotlin's truncating conversion.
-    // A raw `as Short` would fail at runtime because the JDBC value is boxed as Int.
+    // Short / Byte are stored as INT; narrow on read via Kotlin's truncating conversion. Casting
+    // to Number rather than Int tolerates JDBC drivers that box integral values as Long or Short
+    // instead of Int, so .toShort()/.toByte() works regardless of the boxed numeric type returned.
     fun buildNarrowingIntRowAccess(col: ColumnMeta, rawAccess: String): String? =
         when (col.typeFqn) {
             KOTLIN_SHORT_FQN ->
-                if (col.nullable) "($rawAccess as? Int)?.toShort()" else "($rawAccess as Int).toShort()"
+                if (col.nullable) "($rawAccess as? Number)?.toShort()" else "($rawAccess as Number).toShort()"
             KOTLIN_BYTE_FQN ->
-                if (col.nullable) "($rawAccess as? Int)?.toByte()" else "($rawAccess as Int).toByte()"
+                if (col.nullable) "($rawAccess as? Number)?.toByte()" else "($rawAccess as Number).toByte()"
             else -> null
         }
 

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ColumnTypeInferenceTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ColumnTypeInferenceTest.kt
@@ -147,8 +147,8 @@ class ColumnTypeInferenceTest : StringSpec({
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
         val content = result.generatedContent("NullableShortEntity_LirpTableDef.kt")
         content shouldContain "ColumnType.IntType"
-        // Nullable narrowing: (rawAccess as? Int)?.toShort()
-        content shouldContain "as? Int"
+        // Nullable narrowing: (rawAccess as? Number)?.toShort()
+        content shouldContain "as? Number"
         content shouldContain ".toShort()"
         // Nullable widening: entity.rank?.toInt()
         content shouldContain "?.toInt()"

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableCrossModuleTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableCrossModuleTest.kt
@@ -1,0 +1,502 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.ksp
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.addPreviousResultToClasspath
+import com.tschuchort.compiletesting.configureKsp
+import com.tschuchort.compiletesting.sourcesGeneratedBySymbolProcessor
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+/**
+ * Two-stage KSP compilation-testing fixture for cross-module `@Embeddable` annotation resolution.
+ *
+ * Each test compiles an `@Embeddable` value type in stage 1 (no KSP, producing compiled bytecode),
+ * feeds that output directory into stage 2's classpath via [addPreviousResultToClasspath], then runs
+ * KSP with [TableDefProcessorProvider] in stage 2. This wiring causes KSP to read the stage-1
+ * classes with `Origin.KOTLIN_LIB`, where data-class constructor annotations are placed on the
+ * `VALUE_PARAMETER` rather than the synthesized property — the real cross-module shape that a single
+ * compilation cannot reproduce.
+ *
+ * The KOTLIN_LIB probe (the first test) de-risks the assumption that kctfork's classpath mechanism
+ * produces genuine cross-module metadata before any behavioral test is trusted.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+class EmbeddableCrossModuleTest : StringSpec({
+
+    // Stage 1: compile the @Embeddable with no KSP — produces KOTLIN_LIB metadata for stage 2
+    fun compileEmbeddableLib(vararg sources: SourceFile): JvmCompilationResult {
+        val compilation =
+            KotlinCompilation().apply {
+                this.sources = sources.toList()
+                inheritClassPath = true
+            }
+        // No symbolProcessorProviders — intentionally no KSP so stage-2 reads this as KOTLIN_LIB
+        return compilation.compile()
+    }
+
+    // Stage 2: compile the entity + KSP, with the embeddable lib on the classpath
+    fun compileEntityWithProcessor(
+        libResult: JvmCompilationResult,
+        vararg sources: SourceFile
+    ): JvmCompilationResult {
+        val compilation =
+            KotlinCompilation().apply {
+                this.sources = sources.toList()
+                inheritClassPath = true
+            }
+        compilation.addPreviousResultToClasspath(libResult) // feeds KOTLIN_LIB classes into KSP
+        compilation.configureKsp { withCompilation = true }
+        compilation.symbolProcessorProviders += TableDefProcessorProvider()
+        return compilation.compile()
+    }
+
+    fun JvmCompilationResult.generatedFileContent(name: String): String {
+        val file =
+            sourcesGeneratedBySymbolProcessor.firstOrNull { it.name == name }
+                ?: error(
+                    "Generated file '$name' not found among: " +
+                        sourcesGeneratedBySymbolProcessor.map { it.name }.toList()
+                )
+        return file.readText()
+    }
+
+    // ── KOTLIN_LIB probe ────────────────────────────────────────────────────────────────────────
+    // This is the de-risking probe for the cross-module annotation-resolution mechanism.
+    //
+    // A stage-1 @Embeddable carries @PersistenceProperty(converter = ...) on its ctor val. In a
+    // classpath-supplied class (KOTLIN_LIB origin), Kotlin metadata places constructor annotations
+    // on the VALUE_PARAMETER only — not on the synthesized property. If KSP were to read only
+    // prop.annotations (the pre-fix path), it would miss the converter annotation entirely and
+    // fall back to generating a plain String column with no converter round-trip calls.
+    //
+    // The assertion that the generated _LirpTableDef calls UriConverter.fromSql / UriConverter.toSql
+    // is only satisfiable if resolvePersistenceAnnotations merged prop.annotations + ctorParam.annotations
+    // and found the @PersistenceProperty(converter = ...) on the VALUE_PARAMETER. A passing assertion
+    // here proves KOTLIN_LIB param-only placement was handled correctly.
+    "cross-module @Embeddable flattens scalar fields using KOTLIN_LIB annotation resolution" {
+        val libResult =
+            compileEmbeddableLib(
+                SourceFile.kotlin(
+                    "Track.kt",
+                    """
+                    package lib
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+
+                    object TrackIdConverter : ColumnConverter<Int, String> {
+                        override val sqlType = ColumnType.TextType
+                        override fun toSql(value: Int): String = value.toString()
+                        override fun fromSql(raw: String): Int = raw.toInt()
+                    }
+
+                    @Embeddable
+                    data class Track(
+                        @PersistenceProperty(converter = TrackIdConverter::class) val externalId: Int,
+                        val durationMs: Int
+                    )
+                    """
+                )
+            )
+        libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        val entityResult =
+            compileEntityWithProcessor(
+                libResult,
+                SourceFile.kotlin(
+                    "Album.kt",
+                    """
+                    package test
+                    import lib.Track
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    data class Album(
+                        override val id: Int,
+                        @Embedded val track: Track
+                    ) : ReactiveEntityBase<Int, Album>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+                    """
+                )
+            )
+        entityResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = entityResult.generatedFileContent("Album_LirpTableDef.kt")
+        // Converter round-trip calls are only emitted if KSP resolved @PersistenceProperty(converter=...)
+        // from the VALUE_PARAMETER of the KOTLIN_LIB class (prop.annotations is empty for it).
+        // A plain Int column with no converter would be generated if the annotation were missed.
+        content shouldContain "lib.TrackIdConverter.fromSql("
+        content shouldContain "lib.TrackIdConverter.toSql("
+        content shouldContain "track_duration_ms"
+    }
+
+    // ── @PersistenceIgnore cross-module ─────────────────────────────────────────────────────────
+    "cross-module @PersistenceIgnore on constructor parameter excludes field from generated columns" {
+        val libResult =
+            compileEmbeddableLib(
+                SourceFile.kotlin(
+                    "Coordinate.kt",
+                    """
+                    package lib
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.PersistenceIgnore
+
+                    @Embeddable
+                    data class Coordinate(
+                        val latitude: Double,
+                        @PersistenceIgnore val internalTag: String?
+                    )
+                    """
+                )
+            )
+        libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        val entityResult =
+            compileEntityWithProcessor(
+                libResult,
+                SourceFile.kotlin(
+                    "Location.kt",
+                    """
+                    package test
+                    import lib.Coordinate
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    data class Location(
+                        override val id: Int,
+                        @Embedded val position: Coordinate
+                    ) : ReactiveEntityBase<Int, Location>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+                    """
+                )
+            )
+        entityResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = entityResult.generatedFileContent("Location_LirpTableDef.kt")
+        content shouldContain "position_latitude"
+        // @PersistenceIgnore on VALUE_PARAMETER of KOTLIN_LIB class must produce IgnoredCtorSlot
+        // which emits null in fromRow but must not generate a ColumnDef for the ignored field
+        content shouldNotContain "position_internal_tag"
+        content shouldNotContain "\"internal_tag\""
+        // IgnoredCtorSlot correctly emits null for the nullable ctor param in fromRow
+        content shouldContain "internalTag = null"
+    }
+
+    // ── @PersistenceProperty(converter) cross-module leaf ───────────────────────────────────────
+    "cross-module @PersistenceProperty(converter) at leaf resolves converter type in generated code" {
+        val libResult =
+            compileEmbeddableLib(
+                SourceFile.kotlin(
+                    "MediaFile.kt",
+                    """
+                    package lib
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+
+                    object UriConverter : ColumnConverter<String, String> {
+                        override val sqlType = ColumnType.TextType
+                        override fun toSql(value: String): String = value
+                        override fun fromSql(raw: String): String = raw
+                    }
+
+                    @Embeddable
+                    data class MediaFile(
+                        val name: String,
+                        @PersistenceProperty(converter = UriConverter::class) val uri: String
+                    )
+                    """
+                )
+            )
+        libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        val entityResult =
+            compileEntityWithProcessor(
+                libResult,
+                SourceFile.kotlin(
+                    "Catalogue.kt",
+                    """
+                    package test
+                    import lib.MediaFile
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    data class Catalogue(
+                        override val id: Int,
+                        @Embedded val file: MediaFile
+                    ) : ReactiveEntityBase<Int, Catalogue>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+                    """
+                )
+            )
+        entityResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = entityResult.generatedFileContent("Catalogue_LirpTableDef.kt")
+        // The converter is found on the VALUE_PARAMETER of the KOTLIN_LIB class; if it were missed
+        // the column would be generated as a plain String column without converter round-trip calls
+        content shouldContain "\"file_uri\""
+        content shouldContain "lib.UriConverter.fromSql("
+        content shouldContain "lib.UriConverter.toSql("
+    }
+
+    // ── Cross-module @Embeddable with @PersistenceIgnore on its own ctor VALUE_PARAMETER (WR-01) ──
+    // Proves that processCtorParam in EmbeddableAnalyzer forwards `param` to isExcluded so
+    // @PersistenceIgnore on a cross-module @Embeddable VALUE_PARAMETER is detected at the
+    // top-level entity's ctor-param dispatch (not just in buildEmbeddableChildSlot).
+    // Stage 1 compiles an @Embeddable with @PersistenceIgnore on a nullable ctor param.
+    // Stage 2 processes the entity and must exclude that column from the generated TableDef.
+    "cross-module @Embeddable top-level ctor @PersistenceIgnore on VALUE_PARAMETER excludes column from generated TableDef" {
+        val libResult =
+            compileEmbeddableLib(
+                SourceFile.kotlin(
+                    "PluginLib.kt",
+                    """
+                    package lib
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.PersistenceIgnore
+
+                    @Embeddable
+                    data class Plugin(
+                        val version: String,
+                        @PersistenceIgnore val debugInfo: String?
+                    )
+                    """
+                )
+            )
+        libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        val entityResult =
+            compileEntityWithProcessor(
+                libResult,
+                SourceFile.kotlin(
+                    "Extension.kt",
+                    """
+                    package test
+                    import lib.Plugin
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    data class Extension(
+                        override val id: Int,
+                        @Embedded val plugin: Plugin
+                    ) : ReactiveEntityBase<Int, Extension>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+                    """
+                )
+            )
+        entityResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = entityResult.generatedFileContent("Extension_LirpTableDef.kt")
+        content shouldContain "plugin_version"
+        // @PersistenceIgnore on VALUE_PARAMETER of KOTLIN_LIB @Embeddable must be excluded
+        content shouldNotContain "plugin_debug_info"
+        content shouldNotContain "\"debug_info\""
+        // IgnoredCtorSlot emits null for the nullable param
+        content shouldContain "debugInfo = null"
+    }
+
+    // ── Non-nullable no-default @PersistenceIgnore embeddable ctor param guard (CR-01) ──────────
+    // A nullable @PersistenceIgnore embeddable ctor param is accepted (IgnoredCtorSlot emits null).
+    // A non-nullable no-default @PersistenceIgnore ctor param must fail with a clear diagnostic.
+    "cross-module @Embeddable with nullable @PersistenceIgnore ctor param produces valid TableDef" {
+        val libResult =
+            compileEmbeddableLib(
+                SourceFile.kotlin(
+                    "NullableIgnoreLib.kt",
+                    """
+                    package lib
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.PersistenceIgnore
+
+                    @Embeddable
+                    data class Metadata(
+                        val title: String,
+                        @PersistenceIgnore val optionalTag: String?
+                    )
+                    """
+                )
+            )
+        libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        val entityResult =
+            compileEntityWithProcessor(
+                libResult,
+                SourceFile.kotlin(
+                    "Document.kt",
+                    """
+                    package test
+                    import lib.Metadata
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    data class Document(
+                        override val id: Int,
+                        @Embedded val meta: Metadata
+                    ) : ReactiveEntityBase<Int, Document>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+                    """
+                )
+            )
+        entityResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = entityResult.generatedFileContent("Document_LirpTableDef.kt")
+        content shouldContain "meta_title"
+        content shouldNotContain "optional_tag"
+        // IgnoredCtorSlot emits null for the nullable param in the nested ctor expression
+        content shouldContain "optionalTag = null"
+    }
+
+    "cross-module @Embeddable with non-nullable no-default @PersistenceIgnore ctor param fails with diagnostic" {
+        val libResult =
+            compileEmbeddableLib(
+                SourceFile.kotlin(
+                    "NonNullableIgnoreLib.kt",
+                    """
+                    package lib
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.PersistenceIgnore
+
+                    @Embeddable
+                    data class Config(
+                        val name: String,
+                        @PersistenceIgnore val requiredSecret: String
+                    )
+                    """
+                )
+            )
+        libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        val entityResult =
+            compileEntityWithProcessor(
+                libResult,
+                SourceFile.kotlin(
+                    "Service.kt",
+                    """
+                    package test
+                    import lib.Config
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    data class Service(
+                        override val id: Int,
+                        @Embedded val config: Config
+                    ) : ReactiveEntityBase<Int, Service>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+                    """
+                )
+            )
+        // The guard rejects the non-nullable no-default ignored param and emits a KSP error,
+        // which causes the overall compilation to fail.
+        entityResult.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+        entityResult.messages shouldContain "non-nullable and has no default value"
+    }
+
+    // ── ≥2-level nested cross-module @Embedded ──────────────────────────────────────────────────
+    // This test covers the prefix-concatenation rule for a cross-module value graph.
+    // Entity → Album → albumArtist: Artist / label: Label mirrors the music-commons shape without
+    // literal coupling to that project's class names.
+    "cross-module nested @Embedded two levels produces correctly prefixed column names" {
+        val libResult =
+            compileEmbeddableLib(
+                SourceFile.kotlin(
+                    "AlbumLib.kt",
+                    """
+                    package lib
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.Embedded
+
+                    @Embeddable
+                    data class Artist(val name: String, val countryCode: String)
+
+                    @Embeddable
+                    data class Label(val title: String, val countryCode: String)
+
+                    @Embeddable
+                    data class Album(
+                        @Embedded val albumArtist: Artist,
+                        @Embedded val label: Label
+                    )
+                    """
+                )
+            )
+        libResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        val entityResult =
+            compileEntityWithProcessor(
+                libResult,
+                SourceFile.kotlin(
+                    "Release.kt",
+                    """
+                    package test
+                    import lib.Album
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    data class Release(
+                        override val id: Int,
+                        @Embedded val album: Album
+                    ) : ReactiveEntityBase<Int, Release>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+                    """
+                )
+            )
+        // A clean exit confirms the nested cross-module embeddable is NOT rejected as a
+        // custom-getter type: isSourceDeclaredCustomGetter uses Origin.KOTLIN, so KOTLIN_LIB
+        // compiled accessors are accepted, not falsely flagged as custom getters.
+        entityResult.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = entityResult.generatedFileContent("Release_LirpTableDef.kt")
+        // Prefix concatenation: entity_field + _ + embeddable_field + _ + leaf_field
+        content shouldContain "album_album_artist_name"
+        content shouldContain "album_album_artist_country_code"
+        content shouldContain "album_label_title"
+        content shouldContain "album_label_country_code"
+    }
+})

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
@@ -1551,7 +1551,7 @@ internal class TableDefProcessorTest : FunSpec({
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
         val content = result.generatedFileContent("ShortEntity_LirpTableDef.kt")
         content shouldContain "name = \"year\", type = ColumnType.IntType"
-        content shouldContain "as Int).toShort()"
+        content shouldContain "as Number).toShort()"
         content shouldContain "entity.year.toInt()"
     }
 
@@ -1578,7 +1578,7 @@ internal class TableDefProcessorTest : FunSpec({
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
         val content = result.generatedFileContent("ByteEntity_LirpTableDef.kt")
         content shouldContain "name = \"flag\", type = ColumnType.IntType"
-        content shouldContain "as Int).toByte()"
+        content shouldContain "as Number).toByte()"
         content shouldContain "entity.flag.toInt()"
     }
 
@@ -1605,7 +1605,7 @@ internal class TableDefProcessorTest : FunSpec({
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
         val content = result.generatedFileContent("NullableShortEntity_LirpTableDef.kt")
         content shouldContain "name = \"year\", type = ColumnType.IntType, nullable = true"
-        content shouldContain "as? Int)?.toShort()"
+        content shouldContain "as? Number)?.toShort()"
         content shouldContain "entity.year?.toInt()"
     }
 
@@ -1632,7 +1632,7 @@ internal class TableDefProcessorTest : FunSpec({
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
         val content = result.generatedFileContent("NullableByteEntity_LirpTableDef.kt")
         content shouldContain "name = \"flag\", type = ColumnType.IntType, nullable = true"
-        content shouldContain "as? Int)?.toByte()"
+        content shouldContain "as? Number)?.toByte()"
         content shouldContain "entity.flag?.toInt()"
     }
 
@@ -1670,8 +1670,8 @@ internal class TableDefProcessorTest : FunSpec({
         content shouldContain "entity.a = row[table.columns.first { it.name == \"a\" }] as Int"
         content shouldContain "cols[\"a\"]!! to entity.a"
         // Short/Byte still get the narrowing/widening treatment.
-        content shouldContain "as Int).toShort()"
-        content shouldContain "as Int).toByte()"
+        content shouldContain "as Number).toShort()"
+        content shouldContain "as Number).toByte()"
         content shouldContain "entity.b.toInt()"
         content shouldContain "entity.c.toInt()"
     }


### PR DESCRIPTION
## Summary

**Cross-module `@Embeddable` annotation resolution — centralized property + value-parameter merge**

When a `@Embeddable` value type is compiled in a separate module, KSP sees its annotations on the constructor parameter (via `Origin.KOTLIN_LIB` metadata) rather than the synthesized property declaration. This causes per-call-site annotation reads to silently miss cross-module `@PersistenceIgnore`, `@ElementCollection`, and `@PersistenceProperty` annotations.

This change centralizes all persistence-annotation reads through a single `resolvePersistenceAnnotations(prop, ctorParam?)` helper and adds structural support for ignored nested-embeddable constructor parameters. It includes a two-stage `kotlin-compile-testing` integration test that produces genuine cross-module metadata to validate the fix end-to-end.

## Changes

### Core centralization
- Added `@Target(VALUE_PARAMETER)` to `@PersistenceIgnore` and `@PersistenceProperty` (alongside existing `FIELD` target)
- All four persistence annotations now also declare `AnnotationTarget.FIELD` explicitly
- `resolvePersistenceAnnotations()` helper in `KspUtils` merges property and constructor parameter annotations for cross-module safety
- `isSourceDeclaredCustomGetter()` predicate added to distinguish synthesized properties from user-declared getters
- `IgnoredCtorSlot` type added for constructor parameters marked with `@PersistenceIgnore`

### Integration throughout the codebase
- `EmbeddableAnalyzer`: all 9 annotation-read sites now use the centralized resolver; both getter checks use the new predicate
- `ColumnMetaBuilder`: CM-1 through CM-5 routing added; `isExcluded()` method extended with constructor parameter awareness
- `RawInitializerProcessor`: exclusion checks updated to use centralized resolver
- Constants consolidated in `TableDefConstants.kt` to eliminate duplication

### Quality improvements
- **Non-nullable ignored parameter safety**: Added validation to fail fast when a `@PersistenceIgnore` parameter is non-nullable with no default value (prevents non-compiling generated code)
- **Dialect-safe numeric handling**: Short/Byte narrowing updated to use `Number` casting instead of hardcoding `Int` (compatible with any JDBC driver's numeric boxing)
- **Code deduplication**: Extracted hint-extraction logic into a single helper; consolidated duplicated constants
- **Improved collection-kind detection**: Fixed fragile substring matching for `Set` vs `List` detection

## Testing

Added `EmbeddableCrossModuleTest` — a two-stage `kotlin-compile-testing` integration test that:
1. Compiles a `@Embeddable` type in isolation (no KSP processor)
2. Feeds its compiled output as a classpath dependency into a second compilation
3. Runs KSP in the second compilation, producing genuine `Origin.KOTLIN_LIB` metadata with annotations on constructor parameters only

The fixture validates:
- Scalar field flattening via `KOTLIN_LIB` annotation resolution
- Nested `@Embedded` two-levels deep with correct prefixed column names
- `@PersistenceIgnore` exclusion of ignored embeddable fields
- `@PersistenceProperty(converter=...)` type resolution for leaf columns

All existing `Embeddable*` test suites remain green with no regressions.

## Verification

- Full test suite passes: `gradle test` BUILD SUCCESSFUL
- Code style: `gradle ktlintCheck` BUILD SUCCESSFUL
- Coverage: 7 new cross-module scenarios + 212 existing tests all pass

Closes #217