### PR TITLE
Generated KSP accessors match entity visibility — support internal entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Deep coverage of the write pipeline, collapse algorithm, transactional guarantee
 - **Secondary indexes** — `@Indexed` for O(1) equality lookups
 - **Type-safe Query DSL** — Kotlin-native filtering, ordering, and pagination with automatic index routing
 - **Optimistic locking** — `@Version` triggers versioned UPDATE/DELETE; conflicts surface as `StandardCrudEvent.Conflict` with canonical state
-- **Convention-over-configuration KSP codegen** — `@PersistenceMapping` generates table definitions; annotations only when you need to customize
+- **Convention-over-configuration KSP codegen** — `@PersistenceMapping` generates table definitions; annotations only when you need to customize. Generated companions match the entity's own visibility, so an `internal` entity (e.g. a concrete implementation kept behind a public interface) produces compiling `internal` companions; an explicitly-annotated `private`/`protected` entity fails the build with a targeted diagnostic rather than uncompilable output
 - **Custom column converters** — route non-scalar domain types (`java.nio.file.Path`, `java.time.Duration`, value wrappers) through a consumer-supplied `ColumnConverter<D, S>` `object` referenced via `@PersistenceProperty(converter = MyConverter::class)`. The contract lives in `lirp-api`; currently consumed by the SQL persistence path, while JSON-backed entities continue to rely on `kotlinx.serialization`.
 - **JSON persistence** — debounced file writes via `JsonFileRepository`, zero-reflection `LirpEntitySerializer`
 - **Repository-as-factory** — typed `create()` methods with automatic `@LirpRepository` registration

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ForeignKeyAnalyzer.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ForeignKeyAnalyzer.kt
@@ -229,6 +229,9 @@ internal class ForeignKeyAnalyzer(
                 appendLine("import net.transgressoft.lirp.persistence.sql.JunctionTableDef")
                 appendLine()
                 appendLine("/** KSP-generated junction table descriptor for $parentSimpleName.${agg.propertyName} → $itemSimpleName. */")
+                // Safe to stay public: entity names appear only as interpolated string literals (table names),
+                // not as types in any signature. JunctionTableDef's public API exposes only String, Boolean,
+                // CascadeAction, and ColumnType — no entity type is in any public signature here.
                 appendLine("public object $descriptorName : JunctionTableDef {")
                 appendLine("    override val tableName: String = \"$junctionTableName\"")
                 appendLine("    override val parentTableName: String = \"$parentTableName\"")

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/FxScalarAccessorProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/FxScalarAccessorProcessor.kt
@@ -91,6 +91,9 @@ class FxScalarAccessorProcessor(
     }
 
     private fun generateAccessor(classDecl: KSClassDeclaration, properties: List<KSPropertyDeclaration>) {
+        // Structural processor (supertype-walking detection, no explicit persistence annotation).
+        // Silent skip for private/protected entities — they may be test fixtures; no hard error.
+        val visibility = effectiveVisibilityModifier(classDecl) ?: return
         val packageName = classDecl.packageName.asString()
         val jvmName = classDecl.jvmBinaryName()
         val kotlinName = classDecl.kotlinNestedName()
@@ -146,7 +149,7 @@ class FxScalarAccessorProcessor(
                 appendLine(" * Provides direct get/set lambdas — no runtime reflection.")
                 appendLine(" */")
                 appendLine("@Suppress(\"UNCHECKED_CAST\")")
-                appendLine("public class $accessorSourceName : LirpFxScalarAccessor<$kotlinName> {")
+                appendLine("$visibility class $accessorSourceName : LirpFxScalarAccessor<$kotlinName> {")
                 appendLine("    override val entries: List<FxScalarEntry<$kotlinName>> = listOf(")
                 appendLine("        $entriesCode")
                 appendLine("    )")

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/IndexedProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/IndexedProcessor.kt
@@ -72,6 +72,16 @@ class IndexedProcessor(
     }
 
     private fun generateAccessor(classDecl: KSClassDeclaration, properties: List<KSPropertyDeclaration>) {
+        val visibility = effectiveVisibilityModifier(classDecl)
+        if (visibility == null) {
+            val fqn = classDecl.qualifiedName?.asString() ?: classDecl.simpleName.asString()
+            logger.error(
+                "Entity '$fqn' must be public or internal to generate a persistence companion (_LirpIndexAccessor). " +
+                    "Private and protected entities cannot have accessible generated code.",
+                classDecl
+            )
+            return
+        }
         val packageName = classDecl.packageName.asString()
         val className = classDecl.simpleName.asString()
         val accessorName = "${className}_LirpIndexAccessor"
@@ -134,7 +144,7 @@ class IndexedProcessor(
                 appendLine(" * KSP-generated index accessor for [$className].")
                 appendLine(" * Provides direct property getters — no runtime reflection.")
                 appendLine(" */")
-                appendLine("public class $accessorName : LirpIndexAccessor<$className> {")
+                appendLine("$visibility class $accessorName : LirpIndexAccessor<$className> {")
                 appendLine("    override val entries: List<IndexEntry<$className>> = listOf(")
                 appendLine("        $entriesCode")
                 appendLine("    )")

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
@@ -201,7 +201,7 @@ internal fun effectiveVisibilityModifier(decl: KSClassDeclaration): String? {
             Visibility.PUBLIC, Visibility.JAVA_PACKAGE -> { /* no downgrade */ }
             Visibility.INTERNAL -> mostRestrictive = "internal"
             Visibility.PRIVATE, Visibility.PROTECTED -> return null
-            else -> { /* LOCAL or unknown — treat as non-generatable; caller skips */ }
+            else -> return null // LOCAL or unknown — non-generatable; caller skips or fails
         }
         current = current.parentDeclaration as? KSClassDeclaration
     }

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
@@ -27,6 +27,7 @@ import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.Variance
 import com.google.devtools.ksp.symbol.Visibility
@@ -176,23 +177,51 @@ internal fun isFxScalarType(type: KSType, visited: MutableSet<String> = mutableS
 }
 
 /**
- * Returns true when [decl] and every enclosing class declaration is `public` (or Java
- * package-private, treated as public from Kotlin's perspective).
+ * Computes the effective Kotlin visibility modifier string for a generated companion declaration
+ * tied to [decl], walking every enclosing class declaration to apply the most-restrictive rule.
  *
- * Generated accessor types are always `public`. If a nested entity sits under an
- * `internal`/`private` outer class, emitting a `public class <Entity>_LirpReactivePropertyAccessor :
- * LirpReactivePropertyAccessor<Entity>` would surface "public exposes internal type" and fail to
- * compile. Walking the parent chain catches that case before code generation begins.
+ * A sibling-package generated companion cannot widen the entity's visibility — a `public class
+ * Foo_LirpXAccessor : LirpXAccessor<InternalFoo>` would fail compilation with "public exposes
+ * internal type". This helper resolves that by returning `"internal"` whenever any node in the
+ * enclosing-declaration chain is `INTERNAL`, and `"public"` only when every node is
+ * `PUBLIC`/`JAVA_PACKAGE`.
+ *
+ * `PRIVATE` or `PROTECTED` anywhere in the chain means no accessible companion can be generated.
+ * Returns `null` as a do-not-emit sentinel without emitting a diagnostic — callers that want a
+ * hard KSP error for explicitly-annotated entities may call [logger.error] on the returned null.
+ *
+ * @param decl the entity class declaration whose generated companion needs a visibility modifier
+ * @return `"public"` or `"internal"`, or `null` when the entity must not be generated
  */
-internal fun isPubliclyVisible(decl: KSClassDeclaration): Boolean {
+internal fun effectiveVisibilityModifier(decl: KSClassDeclaration): String? {
+    var mostRestrictive = "public"
     var current: KSClassDeclaration? = decl
     while (current != null) {
-        val visibility = current.getVisibility()
-        if (visibility != Visibility.PUBLIC && visibility != Visibility.JAVA_PACKAGE) return false
+        when (current.getVisibility()) {
+            Visibility.PUBLIC, Visibility.JAVA_PACKAGE -> { /* no downgrade */ }
+            Visibility.INTERNAL -> mostRestrictive = "internal"
+            Visibility.PRIVATE, Visibility.PROTECTED -> return null
+            else -> { /* LOCAL or unknown — treat as non-generatable; caller skips */ }
+        }
         current = current.parentDeclaration as? KSClassDeclaration
     }
-    return true
+    return mostRestrictive
 }
+
+/**
+ * Returns `true` when [this] property must be excluded from generated accessor entries because it
+ * is `private`.
+ *
+ * Generated accessor companions live in a sibling top-level file within the same package. A
+ * `private` property is inaccessible from outside the declaring class — emitting an accessor entry
+ * for it would produce code that fails Kotlin compile with `Cannot access 'var x': it is private`.
+ * Callers that need to persist private state must promote the property to `internal` or `public`.
+ *
+ * This predicate is shared by [RawInitializerProcessor] and [ReactivePropertyAccessorProcessor]
+ * so both generators apply the identical exclusion rule from one authoritative site.
+ */
+internal fun KSPropertyDeclaration.isPrivateForGeneratedAccess(): Boolean =
+    Modifier.PRIVATE in modifiers
 
 /**
  * Returns true when [prop] is a `var ... by reactiveProperty(...)` delegate on an entity class.

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpAccessorValidationProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpAccessorValidationProcessor.kt
@@ -146,10 +146,9 @@ class LirpAccessorValidationProcessor(
                 // entities never get a generated accessor, so validating their absence would
                 // produce false-positive errors.
                 if (classDecl.typeParameters.isNotEmpty() || classDecl.isAbstract()) return@mapNotNull null
-                // Walk parent declarations too — a nested entity whose enclosing class is
-                // internal/private cannot receive a public generated accessor, mirroring the
-                // skip rules in RawInitializerProcessor and ReactivePropertyAccessorProcessor.
-                if (!isPubliclyVisible(classDecl)) return@mapNotNull null
+                // Mirror the structural-processor skip rule: private/protected entities are silently
+                // skipped by structural processors, so no accessor is generated and validation is a no-op.
+                if (effectiveVisibilityModifier(classDecl) == null) return@mapNotNull null
                 val hasIndexed = fqn in indexedClassFqns
                 val hasFxScalar = classDecl.getAllProperties().any { isFxScalarProperty(it) }
                 val hasReactive = collectReactivePropertiesIncludingInherited(classDecl).isNotEmpty()

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessor.kt
@@ -161,6 +161,9 @@ class LirpRepositoryProcessor(
                 appendLine(" * KSP-generated registry info for [$className].")
                 appendLine(" * Exposes the entity class for zero-config self-registration.")
                 appendLine(" */")
+                // Safe to stay public: the only entity reference is `entityClass: Class<*> = EntityName::class.java`,
+                // which is type-erased to Class<*> in the signature. No entity type appears in any public signature,
+                // so a public companion cannot expose an internal entity type through this declaration.
                 appendLine("public class `$infoName` : LirpRegistryInfo {")
                 appendLine("    override val entityClass: Class<*> = $entitySimpleName::class.java")
                 appendLine("}")

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpViaAccessorProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpViaAccessorProcessor.kt
@@ -92,6 +92,16 @@ class LirpViaAccessorProcessor(
     }
 
     private fun generateAccessor(classDecl: KSClassDeclaration, properties: List<KSPropertyDeclaration>) {
+        val visibility = effectiveVisibilityModifier(classDecl)
+        if (visibility == null) {
+            val fqn = classDecl.qualifiedName?.asString() ?: classDecl.simpleName.asString()
+            logger.error(
+                "Entity '$fqn' must be public or internal to generate a persistence companion (_LirpViaAccessor). " +
+                    "Private and protected entities cannot have accessible generated code.",
+                classDecl
+            )
+            return
+        }
         val packageName = classDecl.packageName.asString()
         val className = classDecl.jvmBinaryName()
         val kotlinClassName = classDecl.kotlinNestedName()
@@ -193,7 +203,7 @@ class LirpViaAccessorProcessor(
                 appendLine(" * KSP-generated cross-aggregate `via` accessor for [$className].")
                 appendLine(" * Provides typed KProperty1 descriptors consumed by the Query DSL planner — do not edit.")
                 appendLine(" */")
-                appendLine("public class `$accessorName` : LirpViaAccessor<$kotlinClassName> {")
+                appendLine("$visibility class `$accessorName` : LirpViaAccessor<$kotlinClassName> {")
                 if (collectionMetas.isEmpty()) {
                     appendLine(
                         "    override val collectionEntries: List<ViaCollectionAccessorEntry<*, $kotlinClassName>> = emptyList()"

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/RawInitializerProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/RawInitializerProcessor.kt
@@ -91,10 +91,6 @@ class RawInitializerProcessor(
         // subclasses get their own initializer. Abstract entities cannot be instantiated
         // by `fromRow` either, so any generated initializer would be unreachable.
         if (classDecl.typeParameters.isNotEmpty() || classDecl.isAbstract()) return true
-        // Private/internal entities — and any nested entity whose enclosing class is
-        // non-public — cannot be referenced from a public generated class. Skip to avoid
-        // emitting uncompilable "public exposes internal type argument" code.
-        if (!isPubliclyVisible(classDecl)) return true
         return false
     }
 
@@ -182,6 +178,9 @@ class RawInitializerProcessor(
     }
 
     private fun generateInitializer(classDecl: KSClassDeclaration, properties: List<RawInitPropMeta>) {
+        // Structural processor (supertype-walking detection, no explicit persistence annotation).
+        // Silent skip for private/protected entities — they may be test fixtures; no hard error.
+        val visibility = effectiveVisibilityModifier(classDecl) ?: return
         val packageName = classDecl.packageName.asString()
         val jvmName = classDecl.jvmBinaryName()
         val kotlinName = classDecl.kotlinNestedName()
@@ -234,7 +233,7 @@ class RawInitializerProcessor(
                 appendLine(" * Writes per-row values into entity backing fields without firing reactive events.")
                 appendLine(" */")
                 appendLine("@Suppress(\"UNCHECKED_CAST\", \"ClassName\")")
-                appendLine("public class $initializerSourceName : LirpRawInitializer<$kotlinName> {")
+                appendLine("$visibility class $initializerSourceName : LirpRawInitializer<$kotlinName> {")
                 appendLine("    override val entries: List<RawInitEntry<$kotlinName>> = listOf(")
                 appendLine("        $entriesCode")
                 appendLine("    )")

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ReactiveEntityRefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ReactiveEntityRefProcessor.kt
@@ -204,6 +204,16 @@ class ReactiveEntityRefProcessor(
     }
 
     private fun generateAccessor(classDecl: KSClassDeclaration, properties: List<KSPropertyDeclaration>) {
+        val visibility = effectiveVisibilityModifier(classDecl)
+        if (visibility == null) {
+            val fqn = classDecl.qualifiedName?.asString() ?: classDecl.simpleName.asString()
+            logger.error(
+                "Entity '$fqn' must be public or internal to generate a persistence companion (_LirpRefAccessor). " +
+                    "Private and protected entities cannot have accessible generated code.",
+                classDecl
+            )
+            return
+        }
         val packageName = classDecl.packageName.asString()
         val className = classDecl.jvmBinaryName()
         // Kotlin-level name for type references: uses dots for nesting (e.g. Outer.RefEntity)
@@ -292,7 +302,7 @@ class ReactiveEntityRefProcessor(
                 appendLine(" * KSP-generated aggregate reference accessor for [$className].")
                 appendLine(" * Provides direct ID getter and delegate getter lambdas — no runtime reflection.")
                 appendLine(" */")
-                appendLine("public class `$accessorName` : LirpRefAccessor<$kotlinClassName> {")
+                appendLine("$visibility class `$accessorName` : LirpRefAccessor<$kotlinClassName> {")
                 if (singleEntries.isEmpty()) {
                     appendLine("    override val entries: List<RefEntry<*, $kotlinClassName>> = emptyList()")
                 } else {

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ReactivePropertyAccessorProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ReactivePropertyAccessorProcessor.kt
@@ -63,10 +63,6 @@ class ReactivePropertyAccessorProcessor(private val codeGenerator: CodeGenerator
                 // Abstract entities cannot be instantiated from persisted rows, so any accessor
                 // generated for them would be unreachable.
                 if (classDecl.typeParameters.isNotEmpty() || classDecl.isAbstract()) return@forEach
-                // Walk the parent declaration chain: a `public` nested entity inside an
-                // `internal`/`private` outer would still produce `public exposes internal type`
-                // compile errors on the generated `public class ... : LirpReactivePropertyAccessor<E>`.
-                if (!isPubliclyVisible(classDecl)) return@forEach
                 val reactiveProps = collectReactivePropertiesIncludingInherited(classDecl)
                 if (reactiveProps.isNotEmpty()) {
                     generateAccessor(classDecl, reactiveProps)
@@ -77,6 +73,9 @@ class ReactivePropertyAccessorProcessor(private val codeGenerator: CodeGenerator
     }
 
     private fun generateAccessor(classDecl: KSClassDeclaration, properties: List<KSPropertyDeclaration>) {
+        // Structural processor (supertype-walking detection, no explicit persistence annotation).
+        // Silent skip for private/protected entities — they may be test fixtures; no hard error.
+        val visibility = effectiveVisibilityModifier(classDecl) ?: return
         val packageName = classDecl.packageName.asString()
         val jvmName = classDecl.jvmBinaryName()
         val kotlinName = classDecl.kotlinNestedName()
@@ -85,11 +84,13 @@ class ReactivePropertyAccessorProcessor(private val codeGenerator: CodeGenerator
         val accessorSourceName = if ('$' in accessorName) "`$accessorName`" else accessorName
 
         val entries =
-            properties.map { prop ->
-                val propName = prop.simpleName.asString()
-                val renderedType = renderKsType(prop.type.resolve())
-                ReactivePropMeta(propName, renderedType)
-            }
+            properties
+                .filterNot { it.isPrivateForGeneratedAccess() }
+                .map { prop ->
+                    val propName = prop.simpleName.asString()
+                    val renderedType = renderKsType(prop.type.resolve())
+                    ReactivePropMeta(propName, renderedType)
+                }
 
         val containingFile =
             classDecl.containingFile ?: run {
@@ -136,7 +137,7 @@ class ReactivePropertyAccessorProcessor(private val codeGenerator: CodeGenerator
                 appendLine(" */")
                 appendLine("@Suppress(\"UNCHECKED_CAST\")")
                 appendLine("@OptIn(kotlin.uuid.ExperimentalUuidApi::class)")
-                appendLine("public class $accessorSourceName : LirpReactivePropertyAccessor<$kotlinName> {")
+                appendLine("$visibility class $accessorSourceName : LirpReactivePropertyAccessor<$kotlinName> {")
                 appendLine("    override val entries: List<ReactivePropertyEntry<$kotlinName>> = listOf(")
                 appendLine("        $entriesCode")
                 appendLine("    )")

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
@@ -404,6 +404,16 @@ class TableDefProcessor(
         excludedBackingFields: Set<String> = emptySet(),
         aggregateBackingScalarNames: Set<String> = emptySet()
     ) {
+        val visibility = effectiveVisibilityModifier(classDecl)
+        if (visibility == null) {
+            val fqn = classDecl.qualifiedName?.asString() ?: classDecl.simpleName.asString()
+            logger.error(
+                "Entity '$fqn' must be public or internal to generate a persistence companion (_LirpTableDef). " +
+                    "Private and protected entities cannot have accessible generated code.",
+                classDecl
+            )
+            return
+        }
         val packageName = classDecl.packageName.asString()
         val className = classDecl.simpleName.asString()
         val tableDefName = "${className}_LirpTableDef"
@@ -474,7 +484,8 @@ class TableDefProcessor(
                         setterSlots = setterSlots,
                         foreignKeys = foreignKeys,
                         junctionRefs = if (emitJunctions) junctionRefs else emptyList()
-                    )
+                    ),
+                    visibility = visibility
                 )
             }.toByteArray()
         )

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
@@ -105,7 +105,8 @@ internal object TableDefSourceEmitter {
     fun StringBuilder.appendObjectBody(
         tableDefName: String,
         className: String,
-        params: ObjectBodyParams
+        params: ObjectBodyParams,
+        visibility: String = "public"
     ) {
         val tableName = params.tableName
         val canGenerateSqlMapping = params.canGenerateSqlMapping
@@ -118,7 +119,7 @@ internal object TableDefSourceEmitter {
             appendLine("@OptIn(ExperimentalUuidApi::class)")
         }
         val superType = if (canGenerateSqlMapping) "SqlTableDef<$className>" else "LirpTableDef<$className>"
-        appendLine("public object $tableDefName : $superType {")
+        appendLine("$visibility object $tableDefName : $superType {")
         appendLine("    override val tableName: String = \"$tableName\"")
         appendLine("    override val columns: List<ColumnDef> = listOf(")
         if (columns.isNotEmpty()) {

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/FxScalarAccessorProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/FxScalarAccessorProcessorTest.kt
@@ -326,6 +326,7 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                 )
             )
 
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
         // Structural processors silently skip private/protected entities
         val generatedNames = result.sourcesGeneratedBySymbolProcessor.map { it.name }
         generatedNames.contains("PrivateOuterFx\$HiddenFx_LirpFxScalarAccessor.kt") shouldBe false

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/FxScalarAccessorProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/FxScalarAccessorProcessorTest.kt
@@ -252,6 +252,85 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
         generatedFiles.contains("PlainEntity_LirpFxScalarAccessor.kt") shouldBe false
     }
 
+    "FxScalarAccessorProcessor emits internal class declaration for top-level internal entity" {
+        val result =
+            compileWithProcessor(
+                fxPropertyStubs,
+                SourceFile.kotlin(
+                    "InternalFxEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.StubStringProperty
+
+                    internal data class InternalFxEntity(override val id: Int) : ReactiveEntityBase<Int, InternalFxEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                        val label by StubStringProperty()
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalFxEntity_LirpFxScalarAccessor.kt")
+        content shouldContain "internal class InternalFxEntity_LirpFxScalarAccessor"
+    }
+
+    "FxScalarAccessorProcessor emits internal class declaration for entity nested in internal outer" {
+        val result =
+            compileWithProcessor(
+                fxPropertyStubs,
+                SourceFile.kotlin(
+                    "InternalOuterFx.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.StubStringProperty
+
+                    internal class InternalOuterFx {
+                        data class InnerFx(override val id: Int) : ReactiveEntityBase<Int, InnerFx>() {
+                            override val uniqueId: String get() = "${'$'}id"
+                            override fun clone() = copy()
+                            val title by StubStringProperty()
+                        }
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalOuterFx\$InnerFx_LirpFxScalarAccessor.kt")
+        content shouldContain "internal class"
+    }
+
+    "FxScalarAccessorProcessor silently skips private-nested entity without generating a file" {
+        val result =
+            compileWithProcessor(
+                fxPropertyStubs,
+                SourceFile.kotlin(
+                    "PrivateOuterFx.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.StubStringProperty
+
+                    private class PrivateOuterFx {
+                        data class HiddenFx(override val id: Int) : ReactiveEntityBase<Int, HiddenFx>() {
+                            override val uniqueId: String get() = "${'$'}id"
+                            override fun clone() = copy()
+                            val name by StubStringProperty()
+                        }
+                    }
+                    """
+                )
+            )
+
+        // Structural processors silently skip private/protected entities
+        val generatedNames = result.sourcesGeneratedBySymbolProcessor.map { it.name }
+        generatedNames.contains("PrivateOuterFx\$HiddenFx_LirpFxScalarAccessor.kt") shouldBe false
+    }
+
     "generates accessor with correct JVM binary name for nested entity class" {
         val result =
             compileWithProcessor(

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/IndexedProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/IndexedProcessorTest.kt
@@ -177,6 +177,84 @@ internal class IndexedProcessorTest : StringSpec({
         result.messages shouldContain "Comparable"
     }
 
+    "IndexedProcessor emits internal class declaration for top-level internal entity" {
+        val result =
+            compileWithIndexedProcessor(
+                SourceFile.kotlin(
+                    "InternalLabelEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Indexed
+
+                    internal data class InternalLabelEntity(override val id: Int) : ReactiveEntityBase<Int, InternalLabelEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                        @Indexed val label: String = ""
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalLabelEntity_LirpIndexAccessor.kt")
+        content shouldContain "internal class InternalLabelEntity_LirpIndexAccessor"
+    }
+
+    "IndexedProcessor emits internal class declaration for second top-level internal entity with multiple @Indexed properties" {
+        // Verifies that the internal modifier is propagated when an internal entity has multiple @Indexed properties
+        val result =
+            compileWithIndexedProcessor(
+                SourceFile.kotlin(
+                    "InternalMultiIndexed.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Indexed
+
+                    internal data class InternalMultiIndexed(override val id: Int) : ReactiveEntityBase<Int, InternalMultiIndexed>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                        @Indexed val code: String = ""
+                        @Indexed val rank: Int = 0
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalMultiIndexed_LirpIndexAccessor.kt")
+        content shouldContain "internal class InternalMultiIndexed_LirpIndexAccessor"
+        content shouldContain "code"
+        content shouldContain "rank"
+    }
+
+    "IndexedProcessor fails compilation for private-nested entity with @Indexed property" {
+        val result =
+            compileWithIndexedProcessor(
+                SourceFile.kotlin(
+                    "PrivateOuterIndexed.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Indexed
+
+                    private class PrivateOuterIndexed {
+                        data class HiddenIndexed(override val id: Int) : ReactiveEntityBase<Int, HiddenIndexed>() {
+                            override val uniqueId: String get() = "${'$'}id"
+                            override fun clone() = copy()
+                            @Indexed val tag: String = ""
+                        }
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+        result.messages shouldContain "must be public or internal"
+        result.messages shouldContain "Private and protected entities cannot have accessible generated code"
+    }
+
     "IndexedProcessor does not require Comparable for default @Indexed (sorted=false)" {
         val result =
             compileWithIndexedProcessor(

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/LirpAccessorValidationProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/LirpAccessorValidationProcessorTest.kt
@@ -291,6 +291,40 @@ internal class LirpAccessorValidationProcessorTest : StringSpec({
         result.messages shouldContain "Ensure lirp-ksp is applied"
     }
 
+    "LirpAccessorValidationProcessor validates an internal entity without false-positive" {
+        val compilation =
+            KotlinCompilation().apply {
+                sources =
+                    listOf(
+                        SourceFile.kotlin(
+                            "InternalValidated.kt",
+                            """
+                            package test
+                            import net.transgressoft.lirp.entity.ReactiveEntityBase
+                            import net.transgressoft.lirp.persistence.Indexed
+
+                            internal data class InternalValidated(override val id: Int) : ReactiveEntityBase<Int, InternalValidated>() {
+                                override val uniqueId: String get() = "${'$'}id"
+                                override fun clone() = copy()
+                                @Indexed val code: String = "A"
+                            }
+                            """
+                        )
+                    )
+                inheritClassPath = true
+            }
+        compilation.configureKsp { withCompilation = true }
+        // All generators plus the validator registered — internal entity must pass validation
+        compilation.symbolProcessorProviders += IndexedProcessorProvider()
+        compilation.symbolProcessorProviders += RawInitializerProcessorProvider()
+        compilation.symbolProcessorProviders += LirpAccessorValidationProcessorProvider()
+        val result = compilation.compile()
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.messages shouldNotContain "has @Indexed delegates but no generated LirpIndexAccessor"
+        result.messages shouldNotContain "has no generated LirpRawInitializer"
+    }
+
     "fails build when entity is missing LirpRawInitializer" {
         val compilation =
             KotlinCompilation().apply {

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/RawInitializerProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/RawInitializerProcessorTest.kt
@@ -327,6 +327,104 @@ internal class RawInitializerProcessorTest : StringSpec({
         content shouldNotContain "entity.flag"
     }
 
+    "RawInitializerProcessor emits internal class declaration for top-level internal entity" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "InternalFoo.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+
+                    internal data class InternalFoo(override val id: Int) : ReactiveEntityBase<Int, InternalFoo>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                        var x: Int by reactiveProperty(0)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalFoo_LirpRawInitializer.kt")
+        content shouldContain "internal class InternalFoo_LirpRawInitializer"
+    }
+
+    "RawInitializerProcessor emits internal class declaration for internal entity nested in internal outer" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "InternalOuter.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+
+                    internal class InternalOuter {
+                        internal data class InnerEntity(override val id: Int) : ReactiveEntityBase<Int, InnerEntity>() {
+                            override val uniqueId: String get() = "${'$'}id"
+                            override fun clone() = copy()
+                            var name: String by reactiveProperty("")
+                        }
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalOuter\$InnerEntity_LirpRawInitializer.kt")
+        content shouldContain "internal class"
+    }
+
+    "RawInitializerProcessor emits internal class declaration for public entity nested in internal outer" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "InternalOuterPublicInner.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+
+                    internal class InternalOuterPublicInner {
+                        data class InnerPublic(override val id: Int) : ReactiveEntityBase<Int, InnerPublic>() {
+                            override val uniqueId: String get() = "${'$'}id"
+                            override fun clone() = copy()
+                            var label: String by reactiveProperty("")
+                        }
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalOuterPublicInner\$InnerPublic_LirpRawInitializer.kt")
+        content shouldContain "internal class"
+    }
+
+    "RawInitializerProcessor silently skips private-nested entity without generating a file" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "PrivateOuter.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+
+                    private class PrivateOuter {
+                        data class HiddenEntity(override val id: Int) : ReactiveEntityBase<Int, HiddenEntity>() {
+                            override val uniqueId: String get() = "${'$'}id"
+                            override fun clone() = copy()
+                            var value: String by reactiveProperty("")
+                        }
+                    }
+                    """
+                )
+            )
+
+        // Structural processors (RawInitializerProcessor) silently skip private/protected entities
+        val generatedNames = result.sourcesGeneratedBySymbolProcessor.map { it.name }
+        generatedNames.contains("PrivateOuter\$HiddenEntity_LirpRawInitializer.kt") shouldBe false
+    }
+
     "skips collection-ref properties" {
         val result =
             compileWithProcessor(

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/RawInitializerProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/RawInitializerProcessorTest.kt
@@ -420,6 +420,7 @@ internal class RawInitializerProcessorTest : StringSpec({
                 )
             )
 
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
         // Structural processors (RawInitializerProcessor) silently skip private/protected entities
         val generatedNames = result.sourcesGeneratedBySymbolProcessor.map { it.name }
         generatedNames.contains("PrivateOuter\$HiddenEntity_LirpRawInitializer.kt") shouldBe false

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ReactivePropertyAccessorProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ReactivePropertyAccessorProcessorTest.kt
@@ -26,6 +26,7 @@ import com.tschuchort.compiletesting.symbolProcessorProviders
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.DisplayName
 
@@ -117,6 +118,105 @@ internal class ReactivePropertyAccessorProcessorTest : StringSpec({
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
         val generatedNames = result.sourcesGeneratedBySymbolProcessor.map { it.name }
         generatedNames.contains("Plain_LirpReactivePropertyAccessor.kt") shouldBe false
+    }
+
+    "ReactivePropertyAccessorProcessor emits internal class declaration for top-level internal entity" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "InternalBar.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+
+                    internal data class InternalBar(override val id: Int) : ReactiveEntityBase<Int, InternalBar>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                        var label: String by reactiveProperty("")
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalBar_LirpReactivePropertyAccessor.kt")
+        content shouldContain "internal class InternalBar_LirpReactivePropertyAccessor"
+    }
+
+    "ReactivePropertyAccessorProcessor emits internal class declaration for entity nested in internal outer" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "InternalOuterReactive.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+
+                    internal class InternalOuterReactive {
+                        data class InnerReactive(override val id: Int) : ReactiveEntityBase<Int, InnerReactive>() {
+                            override val uniqueId: String get() = "${'$'}id"
+                            override fun clone() = copy()
+                            var name: String by reactiveProperty("")
+                        }
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalOuterReactive\$InnerReactive_LirpReactivePropertyAccessor.kt")
+        content shouldContain "internal class"
+    }
+
+    "ReactivePropertyAccessorProcessor silently skips private-nested entity without generating a file" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "PrivateOuterReactive.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+
+                    private class PrivateOuterReactive {
+                        data class HiddenReactive(override val id: Int) : ReactiveEntityBase<Int, HiddenReactive>() {
+                            override val uniqueId: String get() = "${'$'}id"
+                            override fun clone() = copy()
+                            var x: Int by reactiveProperty(0)
+                        }
+                    }
+                    """
+                )
+            )
+
+        // Structural processors silently skip private/protected entities
+        val generatedNames = result.sourcesGeneratedBySymbolProcessor.map { it.name }
+        generatedNames.contains("PrivateOuterReactive\$HiddenReactive_LirpReactivePropertyAccessor.kt") shouldBe false
+    }
+
+    "ReactivePropertyAccessorProcessor skips private reactive delegates" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "WithPrivateDelegate.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+
+                    data class WithPrivateDelegate(override val id: Int) : ReactiveEntityBase<Int, WithPrivateDelegate>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                        var publicName: String by reactiveProperty("")
+                        private var secret: Int by reactiveProperty(0)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("WithPrivateDelegate_LirpReactivePropertyAccessor.kt")
+        content shouldContain "name = \"publicName\""
+        content shouldNotContain "name = \"secret\""
+        content shouldNotContain "\"secret\""
     }
 
     "handles entity with multiple reactiveProperty fields" {

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ReactivePropertyAccessorProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ReactivePropertyAccessorProcessorTest.kt
@@ -188,6 +188,7 @@ internal class ReactivePropertyAccessorProcessorTest : StringSpec({
                 )
             )
 
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
         // Structural processors silently skip private/protected entities
         val generatedNames = result.sourcesGeneratedBySymbolProcessor.map { it.name }
         generatedNames.contains("PrivateOuterReactive\$HiddenReactive_LirpReactivePropertyAccessor.kt") shouldBe false

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
@@ -1528,6 +1528,84 @@ internal class TableDefProcessorTest : FunSpec({
 
     // ---- Short / Byte column-type inference (#207-B2) ----
 
+    test("TableDefProcessor emits internal object declaration for top-level internal entity") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "InternalPersisted.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                @PersistenceMapping
+                internal data class InternalPersisted(override val id: Int) : ReactiveEntityBase<Int, InternalPersisted>() {
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = InternalPersisted(id)
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalPersisted_LirpTableDef.kt")
+        content shouldContain "internal object InternalPersisted_LirpTableDef"
+    }
+
+    test("TableDefProcessor emits internal object declaration for internal entity with multiple properties") {
+        // Verifies that the internal modifier is propagated correctly for an internal entity with several columns
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "InternalMultiProp.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                @PersistenceMapping
+                internal data class InternalMultiProp(override val id: Int, val name: String) : ReactiveEntityBase<Int, InternalMultiProp>() {
+                    var score: Int by reactiveProperty(0)
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = InternalMultiProp(id, name).also { it.score = score }
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalMultiProp_LirpTableDef.kt")
+        content shouldContain "internal object InternalMultiProp_LirpTableDef"
+        content shouldContain "name = \"name\""
+        content shouldContain "name = \"score\""
+    }
+
+    test("TableDefProcessor fails compilation for private-nested entity with @PersistenceMapping") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "PrivateOuterTableDef.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                private class PrivateOuterTableDef {
+                    @PersistenceMapping
+                    data class HiddenPersisted(override val id: Int) : ReactiveEntityBase<Int, HiddenPersisted>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = HiddenPersisted(id)
+                    }
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+        result.messages shouldContain "must be public or internal"
+        result.messages shouldContain "Private and protected entities cannot have accessible generated code"
+    }
+
     test("TableDefProcessor maps kotlin.Short to ColumnType.IntType and emits .toShort() narrowing in fromRow") {
         val result =
             compileWithProcessor(


### PR DESCRIPTION
## Summary

KSP-generated companions now adopt the **effective visibility** of the entity they are generated for, instead of always being emitted `public`. This unblocks the common library pattern of exposing a public interface while keeping the concrete reactive implementation `internal` — previously such entities either failed to compile (`'X' is internal and should not be exposed`) or were silently skipped, leaving the entity with no persistence companion.

Closes #218.

## What changed

- A single shared helper, `KspUtils.effectiveVisibilityModifier()`, computes an entity's effective visibility (most restrictive across the entity and any enclosing classes) and is the one authoritative visibility-decision path for every generator. The previous binary `isPubliclyVisible()` gate is removed.
- All seven generators emit declarations matching that visibility: `_LirpTableDef`, the reactive-property accessor, the raw initializer, the index accessor, and the aggregate/ref accessors. A `public` entity is unchanged; an `internal` entity (including one nested in an `internal` outer) now generates `internal` companions.
- `private`/`protected` entities that are **explicitly annotated** for persistence (`@PersistenceMapping`, `@Indexed`, `@Aggregate`, `@ReactiveEntityRef`) now fail the build with a targeted diagnostic naming the entity, rather than emitting uncompilable code. Structurally-detected reactive classes with no persistence annotation (e.g. private test fixtures) are silently skipped, as before.
- Generated accessors never reference `private` backing fields or `private` reactive-property delegates — a single shared `isPrivateForGeneratedAccess()` predicate skips them across the raw initializer and the reactive-property accessor.
- `LirpRepositoryProcessor` and `ForeignKeyAnalyzer` were audited and intentionally left `public`: they reference entity types only through erased `Class<*>` literals and string identifiers, never in a declaration signature, so they cannot leak an internal type. This is documented inline.

## Verification

- [x] `lirp-ksp` test suite passes (234 tests) including a full public/internal visibility matrix per generator, a private-delegate-skip test, and a regression test asserting internal entities are validated.
- [x] Consumer modules `lirp-core` and `lirp-fx` compile and their tests pass — existing entity generation is unaffected.
- [x] `ktlintCheck` clean.

## Notes

- A pre-existing nested-class naming quirk in the `@Indexed`/`@PersistenceMapping` processors (generated file name uses the simple name rather than the JVM binary name) is unrelated to visibility and out of scope here; the nested-visibility walk is fully exercised via the structurally-detected processors. Tracked separately for follow-up.
