### PR TITLE
Generate TableDef typed on the reactive self-type R (#220)

### DIFF
--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
@@ -26,6 +26,7 @@ import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.Origin
@@ -347,3 +348,91 @@ internal fun collectReactivePropertiesIncludingInherited(classDecl: KSClassDecla
     addFrom(classDecl, mutableSetOf())
     return byName.values.toList()
 }
+
+/**
+ * Resolves the reactive self-type `R` from [classDecl]'s `ReactiveEntity<K, R>` or
+ * `ReactiveEntityBase<K, R>` supertype by walking the supertype graph transitively, carrying
+ * type-argument substitutions at each level.
+ *
+ * Returns the fully-qualified name of `R` when it can be resolved to a concrete declaration, or
+ * `null` when the `ReactiveEntity`/`ReactiveEntityBase` supertype is absent or when `R` resolves
+ * to an unsubstituted type parameter. A visited-set guards against cyclic supertype references,
+ * mirroring [isTypeByFqn].
+ *
+ * The substitution map carries each supertype declaration's type-parameter names mapped to the
+ * concrete type-arguments written at the use site. When descending from `ConcreteEntity`
+ * into `IntermediateBase<K, R>` into `ReactiveEntityBase<K, R>`, the `R` argument written on the
+ * outermost extends-clause is preserved through the chain so the final match on
+ * `ReactiveEntityBase` yields the concrete reactive interface rather than the abstract `R`.
+ */
+internal fun resolveReactiveSelfType(classDecl: KSClassDeclaration): String? =
+    resolveReactiveSelfTypeInternal(classDecl, emptyMap(), mutableSetOf())
+
+private fun resolveReactiveSelfTypeInternal(
+    classDecl: KSClassDeclaration,
+    substitutions: Map<String, KSType>,
+    visited: MutableSet<String>
+): String? {
+    val declFqn = classDecl.qualifiedName?.asString() ?: return null
+    if (!visited.add(declFqn)) return null
+
+    for (superRef in classDecl.superTypes) {
+        val resolved = superRef.resolve()
+        val superDecl = resolved.declaration as? KSClassDeclaration ?: continue
+        val superFqn = superDecl.qualifiedName?.asString() ?: continue
+
+        val nextSubstitutions = buildSupertypeSubstitutions(resolved, superDecl, substitutions)
+
+        if (superFqn == REACTIVE_ENTITY_FQN || superFqn == REACTIVE_ENTITY_BASE_FQN) {
+            return resolveSelfTypeArgument(resolved, nextSubstitutions, substitutions)
+        }
+
+        val result = resolveReactiveSelfTypeInternal(superDecl, nextSubstitutions, visited)
+        if (result != null) return result
+    }
+    return null
+}
+
+/**
+ * Maps each of [superDecl]'s type-parameter names to the concrete argument written at the use
+ * site in [resolved], resolving any argument that is itself a type parameter through the inherited
+ * [substitutions] so a `R` threaded across `IntermediateBase<K, R>` keeps its concrete binding.
+ */
+private fun buildSupertypeSubstitutions(
+    resolved: KSType,
+    superDecl: KSClassDeclaration,
+    substitutions: Map<String, KSType>
+): Map<String, KSType> =
+    superDecl.typeParameters.mapIndexedNotNull { i, param ->
+        val argType = resolved.arguments.getOrNull(i)?.type?.resolve() ?: return@mapIndexedNotNull null
+        param.name.asString() to substituteTypeParameter(argType, substitutions)
+    }.toMap()
+
+/**
+ * Reads `R` (type argument at index 1 of `ReactiveEntity<K, R>` / `ReactiveEntityBase<K, R>`) from
+ * [resolved] and resolves it against the substitution context. Returns the fully-qualified name of
+ * the concrete reactive interface, or `null` when `R` remains an unsubstituted type parameter.
+ */
+private fun resolveSelfTypeArgument(
+    resolved: KSType,
+    nextSubstitutions: Map<String, KSType>,
+    substitutions: Map<String, KSType>
+): String? {
+    val rArg = resolved.arguments.getOrNull(1)?.type?.resolve() ?: return null
+    // `nextSubstitutions` (this level's bindings) takes precedence over the inherited context.
+    val rResolved = substituteTypeParameter(rArg, substitutions + nextSubstitutions)
+    if (rResolved.declaration is KSTypeParameter) return null
+    return rResolved.declaration.qualifiedName?.asString()
+}
+
+/**
+ * Resolves [type] through [substitutions] when it is a type parameter (e.g. `R`), returning the
+ * bound concrete type; otherwise returns [type] unchanged. A type parameter with no binding is
+ * returned as-is so callers can detect that it stayed unresolved.
+ */
+private fun substituteTypeParameter(type: KSType, substitutions: Map<String, KSType>): KSType =
+    if (type.declaration is KSTypeParameter) {
+        substitutions[type.declaration.simpleName.asString()] ?: type
+    } else {
+        type
+    }

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
@@ -410,8 +410,10 @@ private fun buildSupertypeSubstitutions(
 
 /**
  * Reads `R` (type argument at index 1 of `ReactiveEntity<K, R>` / `ReactiveEntityBase<K, R>`) from
- * [resolved] and resolves it against the substitution context. Returns the fully-qualified name of
- * the concrete reactive interface, or `null` when `R` remains an unsubstituted type parameter.
+ * [resolved] and renders it against the substitution context. Returns the fully-qualified,
+ * fully-rendered type — including any of `R`'s own type arguments, so a parameterized self-type
+ * like `AudioItem<String>` yields `…AudioItem<kotlin.String>` rather than a raw `…AudioItem` — or
+ * `null` when `R` (or any nested argument) remains an unsubstituted type parameter.
  */
 private fun resolveSelfTypeArgument(
     resolved: KSType,
@@ -420,9 +422,25 @@ private fun resolveSelfTypeArgument(
 ): String? {
     val rArg = resolved.arguments.getOrNull(1)?.type?.resolve() ?: return null
     // `nextSubstitutions` (this level's bindings) takes precedence over the inherited context.
-    val rResolved = substituteTypeParameter(rArg, substitutions + nextSubstitutions)
-    if (rResolved.declaration is KSTypeParameter) return null
-    return rResolved.declaration.qualifiedName?.asString()
+    return renderResolvedType(rArg, substitutions + nextSubstitutions)
+}
+
+/**
+ * Renders [type] to a fully-qualified Kotlin type string after substitution, recursing into its
+ * type arguments. Returns `null` when [type] or any nested argument stays a free type parameter
+ * (which would otherwise produce an uncompilable raw or partially-substituted descriptor type).
+ */
+private fun renderResolvedType(type: KSType, substitutions: Map<String, KSType>): String? {
+    val resolved = substituteTypeParameter(type, substitutions)
+    if (resolved.declaration is KSTypeParameter) return null
+    val fqn = resolved.declaration.qualifiedName?.asString() ?: return null
+    if (resolved.arguments.isEmpty()) return fqn
+    val renderedArgs =
+        resolved.arguments.map { arg ->
+            val argType = arg.type?.resolve() ?: return null
+            renderResolvedType(argType, substitutions) ?: return null
+        }
+    return "$fqn<${renderedArgs.joinToString(", ")}>"
 }
 
 /**

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefConstants.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefConstants.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.ksp
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 
+internal const val REACTIVE_ENTITY_FQN = "net.transgressoft.lirp.entity.ReactiveEntity"
 internal const val PERSISTENCE_MAPPING_FQN = "net.transgressoft.lirp.persistence.PersistenceMapping"
 internal const val PERSISTENCE_PROPERTY_FQN = "net.transgressoft.lirp.persistence.PersistenceProperty"
 internal const val VERSION_FQN = "net.transgressoft.lirp.persistence.Version"
@@ -46,6 +47,13 @@ internal const val COLUMN_TYPE_UUID_EXPR = "ColumnType.UuidType"
 internal const val COLUMN_TYPE_DATE_EXPR = "ColumnType.DateType"
 internal const val COLUMN_TYPE_DATETIME_EXPR = "ColumnType.DateTimeType"
 internal const val LIST_ITEM_SEPARATOR = ",\n        "
+
+// Closing-brace source fragments emitted by [TableDefSourceEmitter]. The indentation is part of
+// the generated layout: [INNER_BLOCK_CLOSE] closes a block nested inside a method body (a `when`
+// branch or `withEventsDisabled { … }` wrapper), [METHOD_CLOSE] closes an override's body.
+internal const val INNER_BLOCK_CLOSE = "        }"
+internal const val METHOD_CLOSE = "    }"
+
 internal const val COLUMN_CONVERTER_FQN = "net.transgressoft.lirp.persistence.ColumnConverter"
 internal const val EMBEDDABLE_FQN = "net.transgressoft.lirp.persistence.Embeddable"
 internal const val EMBEDDED_FQN = "net.transgressoft.lirp.persistence.Embedded"

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
@@ -482,6 +482,26 @@ class TableDefProcessor(
         }
         val packageName = classDecl.packageName.asString()
         val className = classDecl.simpleName.asString()
+
+        // Resolve the reactive self-type R that the generated descriptor is typed on. Three branches:
+        //   null       → R unresolvable; fall back to the concrete class and emit a warning
+        //   R == class → self-referential; use the simple name for byte-identical output
+        //   otherwise  → distinct reactive interface; type the descriptor on its fully qualified name
+        val resolvedSelfTypeFqn = resolveReactiveSelfType(classDecl)
+        val selfType: String =
+            when {
+                resolvedSelfTypeFqn == null -> {
+                    logger.warn(
+                        "Could not resolve reactive self-type R for ${classDecl.qualifiedName?.asString()}; " +
+                            "generated TableDef is typed on the concrete class and may not be assignable " +
+                            "to a Repository bound on R : ReactiveEntity"
+                    )
+                    className
+                }
+                resolvedSelfTypeFqn == classDecl.qualifiedName?.asString() -> className
+                else -> resolvedSelfTypeFqn
+            }
+
         val tableDefName = "${className}_LirpTableDef"
 
         val tableName = resolveTableName(classDecl, className)
@@ -542,6 +562,7 @@ class TableDefProcessor(
                     className,
                     ObjectBodyParams(
                         tableName = tableName,
+                        selfType = selfType,
                         canGenerateSqlMapping = canGenerateSqlMapping,
                         columns = columns,
                         constructorParamNames = constructorParamNames,

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
@@ -487,10 +487,20 @@ class TableDefProcessor(
         //   null       → R unresolvable; fall back to the concrete class and emit a warning
         //   R == class → self-referential; use the simple name for byte-identical output
         //   otherwise  → distinct reactive interface; type the descriptor on its fully qualified name
-        val resolvedSelfTypeFqn = resolveReactiveSelfType(classDecl)
+        val resolvedSelfType = resolveReactiveSelfType(classDecl)
+        // A generic entity has no renderable non-raw descriptor type: typing on the bare class name
+        // would emit `SqlTableDef<GenericEntity>`, which Kotlin rejects as a raw generic. Skip
+        // generation rather than emit uncompilable source.
+        if (resolvedSelfType == null && classDecl.typeParameters.isNotEmpty()) {
+            logger.warn(
+                "Skipping _LirpTableDef generation for ${classDecl.qualifiedName?.asString()}: its reactive " +
+                    "self-type R is an unsubstituted type parameter, so no valid SqlTableDef<R> can be generated"
+            )
+            return
+        }
         val selfType: String =
             when {
-                resolvedSelfTypeFqn == null -> {
+                resolvedSelfType == null -> {
                     logger.warn(
                         "Could not resolve reactive self-type R for ${classDecl.qualifiedName?.asString()}; " +
                             "generated TableDef is typed on the concrete class and may not be assignable " +
@@ -498,8 +508,8 @@ class TableDefProcessor(
                     )
                     className
                 }
-                resolvedSelfTypeFqn == classDecl.qualifiedName?.asString() -> className
-                else -> resolvedSelfTypeFqn
+                resolvedSelfType == classDecl.qualifiedName?.asString() -> className
+                else -> resolvedSelfType
             }
 
         val tableDefName = "${className}_LirpTableDef"

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
@@ -24,6 +24,7 @@ package net.transgressoft.lirp.ksp
  */
 internal data class ObjectBodyParams(
     val tableName: String,
+    val selfType: String,
     val canGenerateSqlMapping: Boolean,
     val columns: List<ColumnMeta>,
     val constructorParamNames: List<String> = emptyList(),
@@ -110,6 +111,7 @@ internal object TableDefSourceEmitter {
         visibility: String = "public"
     ) {
         val tableName = params.tableName
+        val selfType = params.selfType
         val canGenerateSqlMapping = params.canGenerateSqlMapping
         val columns = params.columns
         val constructorParamNames = params.constructorParamNames
@@ -119,7 +121,10 @@ internal object TableDefSourceEmitter {
         if (canGenerateSqlMapping && columns.any { it.typeFqn == UUID_FQN }) {
             appendLine("@OptIn(ExperimentalUuidApi::class)")
         }
-        val superType = if (canGenerateSqlMapping) "SqlTableDef<$className>" else "LirpTableDef<$className>"
+        // Type parameter is the reactive self-type R so the descriptor satisfies the repository
+        // bound `R : ReactiveEntity<K, R>`. Method bodies downcast to the concrete class via
+        // `val entity = entityRef as $className` when R differs from the concrete class.
+        val superType = if (canGenerateSqlMapping) "SqlTableDef<$selfType>" else "LirpTableDef<$selfType>"
         appendLine("$visibility object $tableDefName : $superType {")
         appendLine("    override val tableName: String = \"$tableName\"")
         appendLine("    override val columns: List<ColumnDef> = listOf(")
@@ -136,45 +141,49 @@ internal object TableDefSourceEmitter {
         appendLine("    )")
         if (canGenerateSqlMapping) {
             appendLine()
-            appendFromRow(className, columns, constructorParamNames, params.ctorSlots, params.setterSlots, params.isReactiveEntity)
+            appendFromRow(className, selfType, columns, constructorParamNames, params.ctorSlots, params.setterSlots, params.isReactiveEntity)
             appendLine()
-            appendToParams(className, columns)
+            appendToParams(className, selfType, columns)
             appendLine()
-            appendApplyRow(className, columns)
+            appendApplyRow(className, selfType, columns)
             appendLine()
-            appendApplyScalarRow(className, columns, params.setterSlots)
-            appendBumpVersion(className, columns)
+            appendApplyScalarRow(selfType, columns, params.setterSlots)
+            appendBumpVersion(className, selfType, columns)
             appendForeignKeys(foreignKeys)
-            appendJunctionOverrides(className, junctionRefs)
+            appendJunctionOverrides(className, selfType, junctionRefs)
         }
         appendLine("}")
     }
 
     fun StringBuilder.appendJunctionOverrides(
         className: String,
+        selfType: String,
         junctionRefs: List<JunctionRefInfo>
     ) {
         if (junctionRefs.isEmpty()) return
+        val receiver = receiverName(className, selfType)
+        val idsOfAccess = if (className == selfType) "entity" else "(entityRef as $className)"
         appendLine()
         appendLine("    override val junctionTableDefs: List<JunctionTableDef> = listOf(")
         appendLine("        ${junctionRefs.joinToString(LIST_ITEM_SEPARATOR) { it.junctionObjectName }}")
         appendLine("    )")
         appendLine()
-        appendLine("    override val junctionAccessors: List<JunctionAccessor<$className>> = listOf(")
+        appendLine("    override val junctionAccessors: List<JunctionAccessor<$selfType>> = listOf(")
         junctionRefs.forEachIndexed { idx, ref ->
             val trailingComma = if (idx == junctionRefs.lastIndex) "" else ","
-            appendLine("        object : JunctionAccessor<$className> {")
+            appendLine("        object : JunctionAccessor<$selfType> {")
             appendLine("            override val descriptor: JunctionTableDef = ${ref.junctionObjectName}")
-            appendLine("            override fun idsOf(entity: $className): Collection<Any> = entity.${ref.backingFieldName}")
+            appendLine("            override fun idsOf($receiver: $selfType): Collection<Any> = $idsOfAccess.${ref.backingFieldName}")
             appendLine("        }$trailingComma")
         }
         appendLine("    )")
         appendLine()
         appendLine("    override fun applyJunctionRows(")
-        appendLine("        entity: $className,")
+        appendLine("        $receiver: $selfType,")
         appendLine("        descriptor: JunctionTableDef,")
         appendLine("        ids: List<Any>,")
         appendLine("    ) {")
+        if (className != selfType) appendCastToConcrete(className)
         appendLine("        entity.withEventsDisabled {")
         appendLine("            when (descriptor) {")
         for (ref in junctionRefs) {
@@ -188,8 +197,8 @@ internal object TableDefSourceEmitter {
             appendLine("                    entity.${ref.backingFieldName} = $rhs")
         }
         appendLine("            }")
-        appendLine("        }")
-        appendLine("    }")
+        appendLine(INNER_BLOCK_CLOSE)
+        appendLine(METHOD_CLOSE)
     }
 
     fun StringBuilder.appendForeignKeys(foreignKeys: List<ForeignKeyMeta>) {
@@ -207,8 +216,24 @@ internal object TableDefSourceEmitter {
         appendLine("    )")
     }
 
+    /**
+     * Emits a body-opening downcast line when the descriptor is typed on a distinct reactive
+     * self-type R. Aliases the `entityRef: R` parameter to a local `entity` typed on the concrete
+     * class so all downstream body lines remain unchanged whether R equals the class or not.
+     */
+    private fun StringBuilder.appendCastToConcrete(className: String) {
+        appendLine("        val entity = entityRef as $className")
+    }
+
+    /**
+     * Parameter name for self-type-parameterized overrides: `entityRef` when a downcast alias is
+     * emitted (R differs from the concrete class), else `entity` for self-referential entities.
+     */
+    private fun receiverName(className: String, selfType: String): String = if (className != selfType) "entityRef" else "entity"
+
     fun StringBuilder.appendFromRow(
         className: String,
+        selfType: String,
         columns: List<ColumnMeta>,
         constructorParamNames: List<String>,
         ctorSlots: List<CtorSlot> = emptyList(),
@@ -223,7 +248,8 @@ internal object TableDefSourceEmitter {
         // top-level entity ctor-param name and are reconstructed inside the ctor invocation).
         val setterCols = columns.filter { it.propertyName !in ctorParamNameSet && !it.isInsideEmbedded }
 
-        appendLine("    override fun fromRow(row: ResultRow, table: Table): $className {")
+        // Return type is the self-type R; the body constructs the concrete class (a subtype of R).
+        appendLine("    override fun fromRow(row: ResultRow, table: Table): $selfType {")
         // When CtorSlot information is available (entities with @Embedded ctor params), use the
         // structured tree to emit nested constructor expressions; otherwise fall back to the flat
         // column-by-name lookup for the common no-embedded case.
@@ -254,13 +280,14 @@ internal object TableDefSourceEmitter {
             val reconstruction = buildCtorArgExpression(EmbeddedCtorSlot(slot.ctorParamName, slot.embeddableTypeFqn, slot.children))
             appendLine("${setterIndent}entity.${slot.ctorParamName} = $reconstruction")
         }
-        if (wrapInEventsDisabled) appendLine("        }")
+        if (wrapInEventsDisabled) appendLine(INNER_BLOCK_CLOSE)
         appendLine("        return entity")
-        appendLine("    }")
+        appendLine(METHOD_CLOSE)
     }
 
-    fun StringBuilder.appendToParams(className: String, columns: List<ColumnMeta>) {
-        appendLine("    override fun toParams(entity: $className, table: Table): Map<Column<*>, Any?> {")
+    fun StringBuilder.appendToParams(className: String, selfType: String, columns: List<ColumnMeta>) {
+        appendLine("    override fun toParams(${receiverName(className, selfType)}: $selfType, table: Table): Map<Column<*>, Any?> {")
+        if (className != selfType) appendCastToConcrete(className)
         appendLine("        val cols = table.columns.associateBy { it.name }")
         appendLine("        return mapOf(")
         val paramEntries =
@@ -270,30 +297,31 @@ internal object TableDefSourceEmitter {
             }
         appendLine("            $paramEntries")
         appendLine("        )")
-        appendLine("    }")
+        appendLine(METHOD_CLOSE)
     }
 
-    fun StringBuilder.appendApplyRow(className: String, columns: List<ColumnMeta>) {
+    fun StringBuilder.appendApplyRow(className: String, selfType: String, columns: List<ColumnMeta>) {
         // applyRow overwrites the state of an existing entity — skip primary-key columns
         // (they are immutable post-construction), any non-mutable property, and any column
         // produced by flattening an @Embedded value object (embeddables are reconstructed
         // wholesale via the primary constructor in fromRow; the parent entity has no
         // addressable scalar setter for them).
         val mutableNonPk = columns.filter { !it.isPrimaryKey && it.isMutable && !it.isInsideEmbedded }
-        appendLine("    override fun applyRow(entity: $className, row: ResultRow, table: Table) {")
+        appendLine("    override fun applyRow(${receiverName(className, selfType)}: $selfType, row: ResultRow, table: Table) {")
         if (mutableNonPk.isEmpty()) {
             appendLine("        // No mutable non-PK columns — applyRow is a no-op.")
         } else {
+            if (className != selfType) appendCastToConcrete(className)
             for (col in mutableNonPk) {
                 val rowAccess = buildRowAccess(col)
                 appendLine("        entity.${col.propertyName} = $rowAccess")
             }
         }
-        appendLine("    }")
+        appendLine(METHOD_CLOSE)
     }
 
     fun StringBuilder.appendApplyScalarRow(
-        className: String,
+        selfType: String,
         columnsIn: List<ColumnMeta>,
         embeddedSetterSlots: List<EmbeddedSetterSlot> = emptyList()
     ) {
@@ -304,12 +332,14 @@ internal object TableDefSourceEmitter {
         // silentSetter so reactive backing fields are written without firing events.
         // Skip @Embedded-derived columns: they share their top-level entity ctor-param name, which
         // would emit duplicate `when` branches; rawInit never carries entries for embedded scalars.
+        // Typed on the self-type R — no concrete downcast needed: the body only forwards `entity`
+        // to `entry.silentSetter`, which is also typed on R via LirpRawInitializer<R>.
         val columns = columnsIn.filterNot { it.isInsideEmbedded }
         appendLine("    override fun applyScalarRow(")
-        appendLine("        entity: $className,")
+        appendLine("        entity: $selfType,")
         appendLine("        row: org.jetbrains.exposed.v1.core.ResultRow,")
         appendLine("        table: org.jetbrains.exposed.v1.core.Table,")
-        appendLine("        rawInit: net.transgressoft.lirp.persistence.LirpRawInitializer<$className>")
+        appendLine("        rawInit: net.transgressoft.lirp.persistence.LirpRawInitializer<$selfType>")
         appendLine("    ) {")
         if (columns.isEmpty() && embeddedSetterSlots.isEmpty()) {
             appendLine("        // No mapped columns — applyScalarRow is a no-op.")
@@ -330,20 +360,21 @@ internal object TableDefSourceEmitter {
             appendLine("                else -> continue")
             appendLine("            }")
             appendLine("            entry.silentSetter(entity, value)")
-            appendLine("        }")
+            appendLine(INNER_BLOCK_CLOSE)
         }
-        appendLine("    }")
+        appendLine(METHOD_CLOSE)
     }
 
-    fun StringBuilder.appendBumpVersion(className: String, columns: List<ColumnMeta>) {
+    fun StringBuilder.appendBumpVersion(className: String, selfType: String, columns: List<ColumnMeta>) {
         // Emit a non-default bumpVersion override only when the entity declares a @Version
         // column. Unversioned entities inherit the interface no-op default, so no emission keeps
         // the generated file minimal.
         val versionCol = columns.singleOrNull { it.isVersion } ?: return
         appendLine()
-        appendLine("    override fun bumpVersion(entity: $className, newVersion: Long) {")
+        appendLine("    override fun bumpVersion(${receiverName(className, selfType)}: $selfType, newVersion: Long) {")
+        if (className != selfType) appendCastToConcrete(className)
         appendLine("        entity.${versionCol.propertyName} = newVersion")
-        appendLine("    }")
+        appendLine(METHOD_CLOSE)
     }
 
     /**

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
@@ -1871,4 +1871,148 @@ internal class TableDefProcessorTest : FunSpec({
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
         result.messages shouldNotContain "still unresolved after final round"
     }
+
+    // ---- Reactive self-type R resolution (#220) ----
+
+    test("TableDefProcessor generates descriptor typed on distinct reactive interface for MutableAudioItem/AudioItem split") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "AudioItem.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.entity.ReactiveEntity
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                interface AudioItem : ReactiveEntity<Int, AudioItem> {
+                    val title: String
+                }
+
+                @PersistenceMapping
+                class MutableAudioItem(override val id: Int, title: String) : ReactiveEntityBase<Int, AudioItem>(), AudioItem {
+                    override var title: String by reactiveProperty(title)
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = MutableAudioItem(id, title)
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("MutableAudioItem_LirpTableDef.kt")
+        content shouldContain "object MutableAudioItem_LirpTableDef : SqlTableDef<test.AudioItem>"
+        content shouldContain "override fun fromRow(row: ResultRow, table: Table): test.AudioItem"
+        content shouldContain "entityRef as MutableAudioItem"
+    }
+
+    test("TableDefProcessor resolves R through an intermediate reactive base class") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "MultiLevelEntity.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.entity.ReactiveEntity
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                interface MediaItem : ReactiveEntity<Int, MediaItem> {
+                    val name: String
+                }
+
+                abstract class MediaBase<K : Comparable<K>, R : ReactiveEntity<K, R>> : ReactiveEntityBase<K, R>()
+
+                @PersistenceMapping
+                class ConcreteMedia(override val id: Int, name: String) : MediaBase<Int, MediaItem>(), MediaItem {
+                    override var name: String by reactiveProperty(name)
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = ConcreteMedia(id, name)
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("ConcreteMedia_LirpTableDef.kt")
+        content shouldContain "object ConcreteMedia_LirpTableDef : SqlTableDef<test.MediaItem>"
+        content shouldContain "override fun fromRow(row: ResultRow, table: Table): test.MediaItem"
+        content shouldContain "entityRef as ConcreteMedia"
+    }
+
+    test("TableDefProcessor falls back to concrete class typing when R is not resolvable") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "PlainMapped.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                @PersistenceMapping
+                class PlainMapped(val id: Int) {
+                    var label: String = ""
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("PlainMapped_LirpTableDef.kt")
+        content shouldContain "object PlainMapped_LirpTableDef : SqlTableDef<PlainMapped>"
+        content shouldNotContain "entityRef as"
+    }
+
+    test("TableDefProcessor types the descriptor on the class itself for a self-referential reactive entity") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "SelfReactive.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                @PersistenceMapping
+                class SelfReactive(override val id: Int, label: String) : ReactiveEntityBase<Int, SelfReactive>() {
+                    var label: String by reactiveProperty(label)
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = SelfReactive(id, label)
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("SelfReactive_LirpTableDef.kt")
+        content shouldContain "object SelfReactive_LirpTableDef : SqlTableDef<SelfReactive>"
+        content shouldContain "override fun fromRow(row: ResultRow, table: Table): SelfReactive"
+        // R == class: no downcast alias is emitted, preserving the original byte-identical layout.
+        content shouldNotContain "entityRef as"
+    }
+
+    test("TableDefProcessor warns and falls back when R stays an unsubstituted type parameter") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "GenericReactive.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.entity.ReactiveEntity
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                @PersistenceMapping
+                class GenericReactive<R : ReactiveEntity<Int, R>>(override val id: Int) : ReactiveEntityBase<Int, R>() {
+                    override val uniqueId: String get() = "${'$'}id"
+                    @Suppress("UNCHECKED_CAST")
+                    override fun clone() = GenericReactive<R>(id) as R
+                }
+                """
+                )
+            )
+
+        // R resolves to the unsubstituted type parameter R, so generation logs the fallback warning.
+        result.messages shouldContain "Could not resolve reactive self-type R"
+    }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
@@ -1991,7 +1991,7 @@ internal class TableDefProcessorTest : FunSpec({
         content shouldNotContain "entityRef as"
     }
 
-    test("TableDefProcessor warns and falls back when R stays an unsubstituted type parameter") {
+    test("TableDefProcessor skips generation when R stays an unsubstituted type parameter on a generic entity") {
         val result =
             compileWithProcessor(
                 SourceFile.kotlin(
@@ -2012,7 +2012,40 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        // R resolves to the unsubstituted type parameter R, so generation logs the fallback warning.
-        result.messages shouldContain "Could not resolve reactive self-type R"
+        // A raw SqlTableDef<GenericReactive> would not compile, so the processor skips generation.
+        result.messages shouldContain "Skipping _LirpTableDef generation for test.GenericReactive"
+        result.sourcesGeneratedBySymbolProcessor.any { it.name == "GenericReactive_LirpTableDef.kt" } shouldBe false
+    }
+
+    test("TableDefProcessor renders type arguments for a concrete parameterized reactive self-type") {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "Tagged.kt",
+                    """
+                package test
+                import net.transgressoft.lirp.entity.ReactiveEntity
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                interface Tagged<M> : ReactiveEntity<Int, Tagged<M>> {
+                    val tag: String
+                }
+
+                @PersistenceMapping
+                class StringTagged(override val id: Int, tag: String) : ReactiveEntityBase<Int, Tagged<String>>(), Tagged<String> {
+                    override var tag: String by reactiveProperty(tag)
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = StringTagged(id, tag)
+                }
+                """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("StringTagged_LirpTableDef.kt")
+        content shouldContain "object StringTagged_LirpTableDef : SqlTableDef<test.Tagged<kotlin.String>>"
+        content shouldContain "override fun fromRow(row: ResultRow, table: Table): test.Tagged<kotlin.String>"
+        content shouldContain "entityRef as StringTagged"
     }
 })


### PR DESCRIPTION
## Summary

Closes #220.

The KSP `TableDefSourceEmitter` now types each generated `_LirpTableDef` descriptor on the entity's **reactive self-type `R`** (the `ReactiveEntity` interface) instead of the concrete class. For the common `Interface`/`Mutable…`/`FX…` split, the concrete class is not itself a `ReactiveEntity` — its self-type is the interface — so the invariant `SqlTableDef<ConcreteClass>` could not be passed to `SqlRepository`/`SqliteRepository`, which are bound on `R : ReactiveEntity<K, R>`:

```
Argument type mismatch: actual type is 'SqlTableDef<MutableAudioItem>',
but 'SqlTableDef<R : ReactiveEntity>' was expected.
```

Every entity implementing a reactive interface distinct from its class produced an unusable generated descriptor. This change makes the descriptor assignable to the repository.

## Changes

- **`KspUtils.resolveReactiveSelfType`** — resolves `R` via a transitive supertype walk with type-argument substitution. At each level the supertype's type parameters are mapped to the concrete arguments written at the use site, so a chain such as `ConcreteEntity → IntermediateBase<K, R> → ReactiveEntityBase<K, R>` resolves `R` to the concrete reactive interface rather than the unsubstituted parameter. A visited-set guards against cyclic supertypes. Returns `null` when no reactive supertype exists or `R` stays an unsubstituted type parameter.
- **`TableDefSourceEmitter`** — the generated object is typed `SqlTableDef<R>` / `LirpTableDef<R>`. Entity-consuming method bodies take `entityRef: R` and downcast (`val entity = entityRef as ConcreteClass`) for member access; `fromRow` returns `R` and constructs the concrete subtype. Self-referential entities (`R == class`) short-circuit to the simple class name, keeping their generated output byte-identical.
- **`TableDefProcessor`** — wires the resolved self-type into emission; an unresolvable `R` falls back to typing on the concrete class and logs a KSP warning.
- The `SqlTableDef` / `LirpTableDef` interfaces are left **invariant** — no read/write split. Typing the descriptor on `R` resolves the assignability problem directly, and full covariance is impossible while `toParams`/`applyRow`/`applyScalarRow`/`bumpVersion`/`applyJunctionRows` consume `E` in invariant position.

**Files:**
- `lirp-ksp/.../KspUtils.kt`
- `lirp-ksp/.../TableDefSourceEmitter.kt`
- `lirp-ksp/.../TableDefProcessor.kt`
- `lirp-ksp/.../TableDefConstants.kt`
- `lirp-ksp/.../TableDefProcessorTest.kt`

## Verification

- [x] An entity with a distinct reactive self-type generates `SqlTableDef<Interface>` and is accepted by the repository bound.
- [x] Self-referential entities (`R == class`) generate byte-identical output (existing fixtures unchanged).
- [x] Multi-level reactive base hierarchies resolve `R` correctly through intermediate bases.
- [x] `SqlTableDef` / `LirpTableDef` interface signatures unchanged.
- [x] `gradle :lirp-ksp:test`, `gradle :lirp-sql:test`, and `gradle ktlintCheck` all pass.

## Tests

Added KSP compile-testing coverage: distinct-self-type acceptance, multi-level base-hierarchy resolution, self-referential (`R == class`) typing, and the unresolvable-`R` fallback warning.
