### PR TITLE
#221 Reconstruct entities and @Embeddables via @PersistenceCreator factory methods

### DIFF
--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/PersistenceCreator.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/PersistenceCreator.kt
@@ -1,0 +1,41 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+/**
+ * Designates the factory the KSP-generated `fromRow` calls when reconstructing an entity or
+ * `@Embeddable` value object from a database row, instead of invoking the primary constructor
+ * directly.
+ *
+ * The annotated target must be a companion-object function or a secondary constructor of the
+ * class. Top-level package functions are not supported. Its parameters must be a name-subset of
+ * the primary constructor's parameters so the existing `CtorSlot` tree can supply each argument
+ * by name. Parameters absent from the primary constructor's slot tree are an error unless they
+ * carry a default value, in which case they are omitted from the generated named-argument call
+ * and the default applies at instantiation time.
+ *
+ * Uses [AnnotationRetention.BINARY] retention — the annotation is stored in the class file and
+ * read by the KSP processor at compile time. Runtime reflection does not need to see it, so
+ * runtime retention is unnecessary.
+ *
+ * **Requires the `lirp-ksp` processor** to be applied via the KSP Gradle plugin. Without it,
+ * this annotation has no effect and `fromRow` will continue to call the primary constructor.
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CONSTRUCTOR)
+@Retention(AnnotationRetention.BINARY)
+annotation class PersistenceCreator

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/CtorSlot.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/CtorSlot.kt
@@ -38,7 +38,7 @@ internal sealed interface CtorSlot {
 
 /**
  * A primary-constructor parameter backed by exactly one flattened column. Carries the resolved
- * [ColumnMeta] (including a `ColumnConverter` FQN when a Phase 56 converter is bound). Used both
+ * [ColumnMeta] (including a `ColumnConverter` FQN when a converter is bound). Used both
  * for top-level entity scalars and for scalar leaves inside an `@Embedded` value object.
  */
 internal data class ScalarCtorSlot(
@@ -50,32 +50,48 @@ internal data class ScalarCtorSlot(
  * A primary-constructor parameter whose value is an `@Embeddable` instance reconstructed from
  * flattened columns. The [embeddableTypeFqn] names the embeddable's fully-qualified class so
  * `fromRow` can emit a constructor invocation; [children] holds the nested slots in declaration
- * order — they may themselves be [EmbeddedCtorSlot]s for recursive nesting.
+ * order — they may themselves be [EmbeddedCtorSlot]s for recursive nesting. When a
+ * `@PersistenceCreator` factory is designated on the embeddable, [creatorCallExpression] holds the
+ * call expression (e.g. `"Artist.of"`) to emit instead of the bare [embeddableTypeFqn].
  */
 internal data class EmbeddedCtorSlot(
     override val ctorParamName: String,
     val embeddableTypeFqn: String,
-    val children: List<CtorSlot>
+    val children: List<CtorSlot>,
+    val creatorCallExpression: String? = null
 ) : CtorSlot
 
 /**
  * A primary-constructor parameter annotated with `@PersistenceIgnore` inside an `@Embeddable`
- * class. Not mapped to any column; the generated `fromRow` emits `null` for this parameter
- * position. Only nullable parameters are safe today — the named-argument omission for parameters
- * with defaults is handled separately.
+ * class and whose type is nullable. Not mapped to any column; the generated `fromRow` emits
+ * `null` for this parameter position. Non-null parameters with a default value use
+ * [OmittedCtorSlot] instead so the default applies at instantiation time.
  */
 internal data class IgnoredCtorSlot(
     override val ctorParamName: String
 ) : CtorSlot
 
 /**
+ * Sentinel for a primary-constructor parameter that is excluded from the generated named-argument
+ * call because it is non-nullable, has a default value, and is either `@PersistenceIgnore`d or
+ * absent from the `@PersistenceCreator`'s parameter list. The generated `fromRow` omits the
+ * argument entirely so the default applies at instantiation time.
+ */
+internal data object OmittedCtorSlot : CtorSlot {
+    override val ctorParamName: String get() = "<omitted>"
+}
+
+/**
  * A body-declared reactive `var` property whose value is an `@Embeddable` instance reconstructed
  * from flattened leaf columns and dispatched via
  * [net.transgressoft.lirp.persistence.LirpRawInitializer] `silentSetter` on load.
- * Consumed by `appendApplyScalarRow`; invisible to `appendFromRow`.
+ * Consumed by `appendApplyScalarRow`; invisible to `appendFromRow`. When a `@PersistenceCreator`
+ * factory is designated on the embeddable, [creatorCallExpression] holds the call expression to
+ * emit instead of the bare [embeddableTypeFqn].
  */
 internal data class EmbeddedSetterSlot(
     override val ctorParamName: String,
     val embeddableTypeFqn: String,
-    val children: List<CtorSlot>
+    val children: List<CtorSlot>,
+    val creatorCallExpression: String? = null
 ) : CtorSlot

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/EmbeddableAnalyzer.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/EmbeddableAnalyzer.kt
@@ -68,6 +68,19 @@ internal class EmbeddableAnalyzer(
     )
 
     /**
+     * Carries the state that stays constant across a single `@Embedded` recursive descent — the
+     * owning entity ([rootClass]), the flat column accumulator, the visited-`@Embeddable`-files set,
+     * and the deferral slot. Bundling these into one object keeps the recursive
+     * [buildEmbeddedSlot] / [buildEmbeddableChildSlot] signatures small.
+     */
+    private class EmbeddedDescent(
+        val rootClass: KSClassDeclaration,
+        val columnsAccumulator: MutableList<ColumnMeta>,
+        val embeddableFiles: MutableSet<KSFile>,
+        val deferralHolder: Array<Pair<KSClassDeclaration, Triple<String, String, String>>?>?
+    )
+
+    /**
      * Walks the entity's primary constructor in declaration order, routing each parameter to one
      * of three paths: an `@Embedded` parameter triggers recursive descent into the referenced
      * `@Embeddable` (flattening its scalars and recording an [EmbeddedCtorSlot]); a regular
@@ -194,13 +207,10 @@ internal class EmbeddableAnalyzer(
                     prop = prop,
                     ctorParamName = paramName,
                     embeddedAnnotation = embeddedAnnotation,
-                    rootClass = classDecl,
-                    columnsAccumulator = columns,
                     parentPrefix = autoDerivedPrefix(paramName),
                     parentPath = paramName,
                     topLevelPropertyName = paramName,
-                    embeddableFiles = embeddableFiles,
-                    deferralHolder = deferralHolder
+                    descent = EmbeddedDescent(classDecl, columns, embeddableFiles, deferralHolder)
                 )
             deferralHolder[0]?.let { return it }
             if (slot != null) ctorSlots += slot
@@ -328,16 +338,18 @@ internal class EmbeddableAnalyzer(
                 prop = prop,
                 ctorParamName = propName,
                 embeddedAnnotation = embeddedAnnotation,
-                rootClass = classDecl,
-                columnsAccumulator = columns,
                 parentPrefix = autoDerivedPrefix(propName),
                 parentPath = propName,
                 topLevelPropertyName = propName,
-                embeddableFiles = embeddableFiles,
-                deferralHolder = deferralHolder
+                descent = EmbeddedDescent(classDecl, columns, embeddableFiles, deferralHolder)
             )
         deferralHolder[0]?.let { return it }
-        if (slot != null) setterSlots += EmbeddedSetterSlot(slot.ctorParamName, slot.embeddableTypeFqn, slot.children)
+        // Propagate the resolved @PersistenceCreator call expression so a body-declared @Embedded var
+        // reconstructs through the factory just like a ctor-param @Embedded; dropping it here would
+        // fall back to the (possibly non-public) primary constructor.
+        if (slot != null) {
+            setterSlots += EmbeddedSetterSlot(slot.ctorParamName, slot.embeddableTypeFqn, slot.children, slot.creatorCallExpression)
+        }
         return null
     }
 
@@ -521,53 +533,138 @@ internal class EmbeddableAnalyzer(
      *
      * Returns `null` when the referenced type is not a class or lacks a qualified name.
      */
-    @Suppress("kotlin:S107")
     private fun buildEmbeddedSlot(
         prop: KSPropertyDeclaration,
         ctorParamName: String,
         embeddedAnnotation: KSAnnotation,
-        rootClass: KSClassDeclaration,
-        columnsAccumulator: MutableList<ColumnMeta>,
         parentPrefix: String,
         parentPath: String,
         topLevelPropertyName: String,
-        embeddableFiles: MutableSet<KSFile> = mutableSetOf(),
-        deferralHolder: Array<Pair<KSClassDeclaration, Triple<String, String, String>>?>? = null
+        descent: EmbeddedDescent
     ): EmbeddedCtorSlot? {
         // An @Embedded container type that is still a KSP error type this round must be deferred
         // (re-queued for a later round), not run through structural validation — which would treat
         // it as "must reference a class type" and emit a spurious diagnostic while skipping the
         // deferral path entirely. Mirrors the scalar/leaf error-type deferral in ColumnMetaBuilder.
         if (prop.type.resolve().isError) {
-            deferralHolder?.set(
+            descent.deferralHolder?.set(
                 0,
-                rootClass to deferralDetail(rootClass, topLevelPropertyName, prop, unresolvedAnnotation = false)
+                descent.rootClass to deferralDetail(descent.rootClass, topLevelPropertyName, prop, unresolvedAnnotation = false)
             )
             return null
         }
         // Kind checks run before descent so the recursion only ever visits well-formed embeddables.
         val typeDecl = validateEmbeddableTarget(prop) ?: return null
         val typeFqn = typeDecl.qualifiedName?.asString() ?: return null
-        typeDecl.containingFile?.let { embeddableFiles += it }
+        typeDecl.containingFile?.let { descent.embeddableFiles += it }
 
         val effectivePrefix = effectivePrefix(embeddedAnnotation, ctorParamName, parentPrefix)
         reportBodyDeclaredEmbeddedInEmbeddable(typeDecl, typeFqn)
 
+        val childSlots =
+            buildChildSlots(typeDecl, typeFqn, effectivePrefix, parentPath, topLevelPropertyName, descent)
+                ?: return null
+        return applyCreatorToEmbeddedSlot(typeDecl, typeFqn, ctorParamName, childSlots)
+    }
+
+    /**
+     * Builds one [CtorSlot] per primary-constructor parameter of [typeDecl], appending flattened
+     * leaf columns to the accumulator. Returns `null` when any child parameter fails to resolve so
+     * the caller aborts the whole slot rather than emitting an incomplete constructor tree. All
+     * children are visited even after a failure so every malformed parameter is diagnosed.
+     */
+    private fun buildChildSlots(
+        typeDecl: KSClassDeclaration,
+        typeFqn: String,
+        effectivePrefix: String,
+        parentPath: String,
+        topLevelPropertyName: String,
+        descent: EmbeddedDescent
+    ): List<CtorSlot>? {
         val childSlots = mutableListOf<CtorSlot>()
         var anyChildFailed = false
         for (childParam in typeDecl.primaryConstructor?.parameters.orEmpty()) {
             val slot =
-                buildEmbeddableChildSlot(
-                    typeDecl, typeFqn, childParam, effectivePrefix,
-                    parentPath, topLevelPropertyName, rootClass, columnsAccumulator, embeddableFiles,
-                    deferralHolder
-                )
+                buildEmbeddableChildSlot(typeDecl, typeFqn, childParam, effectivePrefix, parentPath, topLevelPropertyName, descent)
             if (slot == null) anyChildFailed = true else childSlots += slot
         }
-        // When any child fails, abort the whole slot so the outer entity is reported as unmapped
-        // rather than silently emitting partial codegen with an incomplete constructor tree.
-        if (anyChildFailed) return null
-        return EmbeddedCtorSlot(ctorParamName, typeFqn, childSlots)
+        return if (anyChildFailed) null else childSlots
+    }
+
+    /**
+     * Routes the embeddable's reconstruction through its `@PersistenceCreator` when present and
+     * falls back to the primary constructor otherwise. A present creator's parameters are matched
+     * by name against [childSlots]; an ambiguous creator or an unmatched non-defaulted parameter is
+     * a hard error (returns `null` to abort). A non-public reconstruction seam on an internal type
+     * is a warning, since the descriptor still compiles inside the declaring module.
+     */
+    private fun applyCreatorToEmbeddedSlot(
+        typeDecl: KSClassDeclaration,
+        typeFqn: String,
+        ctorParamName: String,
+        childSlots: List<CtorSlot>
+    ): EmbeddedCtorSlot? {
+        return when (val resolution = resolveCreator(typeDecl)) {
+            is CreatorResolution.Ambiguous -> {
+                logger.error(
+                    "Multiple @PersistenceCreator targets on ${typeDecl.qualifiedName?.asString()}: " +
+                        "${resolution.conflicting.formatCreatorOffenders()}; exactly one is required.",
+                    typeDecl
+                )
+                null
+            }
+            is CreatorResolution.Found -> {
+                val creatorChildren = matchCreatorChildren(typeDecl, resolution, childSlots) ?: return null
+                if (typeDecl.hasInternalNonPublicCreator(resolution.callExpression)) {
+                    logger.warn(
+                        "${typeDecl.qualifiedName?.asString()} is internal and its @PersistenceCreator " +
+                            "'${resolution.callExpression}' is not public; the generated descriptor may not compile " +
+                            "outside its own module. Add a public @PersistenceCreator to make it cross-module usable."
+                    )
+                }
+                EmbeddedCtorSlot(ctorParamName, typeFqn, creatorChildren, resolution.callExpression)
+            }
+            CreatorResolution.None -> {
+                if (typeDecl.hasNonPublicPrimaryConstructor()) {
+                    logger.warn(
+                        "${typeDecl.qualifiedName?.asString()} has a non-public primary constructor and no " +
+                            "@PersistenceCreator; the generated descriptor may not compile outside its own module."
+                    )
+                }
+                EmbeddedCtorSlot(ctorParamName, typeFqn, childSlots)
+            }
+        }
+    }
+
+    /**
+     * Matches creator parameters by name against [childSlots], preserving creator-parameter order;
+     * child slots absent from the creator signature are dropped. A defaulted parameter with no
+     * mapped slot is omitted so its default applies at instantiation; a non-defaulted one with no
+     * mapped slot is a hard error and returns `null` to abort.
+     */
+    private fun matchCreatorChildren(
+        typeDecl: KSClassDeclaration,
+        resolution: CreatorResolution.Found,
+        childSlots: List<CtorSlot>
+    ): List<CtorSlot>? {
+        val slotByName = childSlots.associateBy { it.ctorParamName }
+        val creatorChildren = mutableListOf<CtorSlot>()
+        for (param in resolution.params) {
+            val paramName = param.name?.asString() ?: continue
+            when (val slot = slotByName[paramName]) {
+                is ScalarCtorSlot, is EmbeddedCtorSlot -> creatorChildren += slot
+                else ->
+                    if (!param.hasDefault) {
+                        logger.error(
+                            "@PersistenceCreator param '$paramName' on ${typeDecl.qualifiedName?.asString()} " +
+                                "has no mapped column source.",
+                            typeDecl
+                        )
+                        return null
+                    }
+            }
+        }
+        return creatorChildren
     }
 
     /**
@@ -611,7 +708,6 @@ internal class EmbeddableAnalyzer(
      * Returns `null` (after logging where applicable) when the parameter is unresolvable, carries an
      * unsupported `@ElementCollection`, or fails leaf-column construction.
      */
-    @Suppress("kotlin:S107")
     private fun buildEmbeddableChildSlot(
         typeDecl: KSClassDeclaration,
         typeFqn: String,
@@ -619,10 +715,7 @@ internal class EmbeddableAnalyzer(
         effectivePrefix: String,
         parentPath: String,
         topLevelPropertyName: String,
-        rootClass: KSClassDeclaration,
-        columnsAccumulator: MutableList<ColumnMeta>,
-        embeddableFiles: MutableSet<KSFile>,
-        deferralHolder: Array<Pair<KSClassDeclaration, Triple<String, String, String>>?>? = null
+        descent: EmbeddedDescent
     ): CtorSlot? {
         val childParamName = childParam.name?.asString() ?: return null
         val childProp =
@@ -634,9 +727,9 @@ internal class EmbeddableAnalyzer(
             is Eligibility.Deferred -> {
                 // Attribute the deferral to the owning @PersistenceMapping entity (rootClass), not
                 // the nested @Embeddable: TableDefProcessor re-queues and prunes by the entity FQN.
-                deferralHolder?.set(
+                descent.deferralHolder?.set(
                     0,
-                    rootClass to deferralDetail(rootClass, childParamName, childProp, childEligibility.unresolvedAnnotation)
+                    descent.rootClass to deferralDetail(descent.rootClass, childParamName, childProp, childEligibility.unresolvedAnnotation)
                 )
                 return null
             }
@@ -657,6 +750,9 @@ internal class EmbeddableAnalyzer(
                     )
                     return null
                 }
+                // Non-null param with default: omit from the named-arg call so the default applies.
+                if (!isNullable && childParam.hasDefault) return OmittedCtorSlot
+                // Nullable param: emit null.
                 return IgnoredCtorSlot(childParamName)
             }
             is Eligibility.Column -> { /* property is eligible — proceed */ }
@@ -680,13 +776,10 @@ internal class EmbeddableAnalyzer(
                 prop = childProp,
                 ctorParamName = childParamName,
                 embeddedAnnotation = childEmbedded,
-                rootClass = rootClass,
-                columnsAccumulator = columnsAccumulator,
                 parentPrefix = "${effectivePrefix}${autoDerivedPrefix(childParamName)}",
                 parentPath = "$parentPath.$childParamName",
                 topLevelPropertyName = topLevelPropertyName,
-                embeddableFiles = embeddableFiles,
-                deferralHolder = deferralHolder
+                descent = descent
             )
         }
 
@@ -702,15 +795,15 @@ internal class EmbeddableAnalyzer(
             )
         return when (leafEligibility) {
             is Eligibility.Deferred -> {
-                deferralHolder?.set(
+                descent.deferralHolder?.set(
                     0,
-                    rootClass to deferralDetail(rootClass, childParamName, childProp, leafEligibility.unresolvedAnnotation)
+                    descent.rootClass to deferralDetail(descent.rootClass, childParamName, childProp, leafEligibility.unresolvedAnnotation)
                 )
                 null
             }
             is Eligibility.Excluded -> null
             is Eligibility.Column -> {
-                columnsAccumulator += leafEligibility.meta
+                descent.columnsAccumulator += leafEligibility.meta
                 ScalarCtorSlot(childParamName, leafEligibility.meta)
             }
         }

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/EmbeddableAnalyzer.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/EmbeddableAnalyzer.kt
@@ -615,7 +615,7 @@ internal class EmbeddableAnalyzer(
             }
             is CreatorResolution.Found -> {
                 val creatorChildren = matchCreatorChildren(typeDecl, resolution, childSlots) ?: return null
-                if (typeDecl.hasInternalNonPublicCreator(resolution.callExpression)) {
+                if (typeDecl.hasInternalNonPublicCreator()) {
                     logger.warn(
                         "${typeDecl.qualifiedName?.asString()} is internal and its @PersistenceCreator " +
                             "'${resolution.callExpression}' is not public; the generated descriptor may not compile " +

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
@@ -160,17 +160,19 @@ internal fun List<KSAnnotated>.formatCreatorOffenders(): String =
     }
 
 /**
- * True when [this] is `internal` and the resolved creator named by [callExpression] is itself not
- * publicly accessible — the generated descriptor would then fail to compile outside the declaring
- * module. The creator's simple name is the segment after the last `.` in [callExpression].
+ * True when [this] is `internal` and its resolved `@PersistenceCreator` — a companion-object
+ * function or a secondary constructor — is itself not publicly accessible, so the generated
+ * descriptor would fail to compile outside the declaring module. Resolves the annotated declaration
+ * directly (the same way [resolveCreator] does), so it covers both creator kinds. Must be called
+ * only after ambiguity has been ruled out, since at most one annotated target is expected.
  */
-internal fun KSClassDeclaration.hasInternalNonPublicCreator(callExpression: String): Boolean {
+internal fun KSClassDeclaration.hasInternalNonPublicCreator(): Boolean {
     if (getVisibility() != Visibility.INTERNAL) return false
-    val creatorName = callExpression.substringAfterLast('.')
     val companion = declarations.filterIsInstance<KSClassDeclaration>().firstOrNull { it.isCompanionObject }
-    val creatorVis =
-        companion?.getDeclaredFunctions()?.firstOrNull { it.simpleName.asString() == creatorName }?.getVisibility()
-    return creatorVis != null && creatorVis != Visibility.PUBLIC && creatorVis != Visibility.JAVA_PACKAGE
+    val annotatedFn = companion?.getDeclaredFunctions()?.firstOrNull { it.annotations.has(PERSISTENCE_CREATOR_FQN) }
+    val annotatedCtor = getConstructors().firstOrNull { it != primaryConstructor && it.annotations.has(PERSISTENCE_CREATOR_FQN) }
+    val creatorVis = (annotatedFn ?: annotatedCtor)?.getVisibility() ?: return false
+    return creatorVis != Visibility.PUBLIC && creatorVis != Visibility.JAVA_PACKAGE
 }
 
 /**

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/KspUtils.kt
@@ -17,11 +17,15 @@
 
 package net.transgressoft.lirp.ksp
 
+import com.google.devtools.ksp.getConstructors
+import com.google.devtools.ksp.getDeclaredFunctions
 import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
@@ -36,6 +40,147 @@ import com.google.devtools.ksp.symbol.Visibility
 internal const val REACTIVE_ENTITY_BASE_FQN = "net.transgressoft.lirp.entity.ReactiveEntityBase"
 internal const val IDENTIFIABLE_ENTITY_FQN = "net.transgressoft.lirp.entity.IdentifiableEntity"
 internal const val FX_SCALAR_DELEGATE_FQN = "net.transgressoft.lirp.persistence.FxScalarPropertyDelegate"
+
+/**
+ * Outcome of [resolveCreator] for a single class declaration.
+ *
+ * Callers pattern-match on the sealed subtypes to drive codegen:
+ * - [Found] — exactly one `@PersistenceCreator`-annotated target was located; the caller should
+ *   use [Found.callExpression] as the reconstruction call target in the generated `fromRow`.
+ * - [None] — no `@PersistenceCreator` annotation is present; the caller falls back to the
+ *   primary constructor and may emit a [com.google.devtools.ksp.processing.KSPLogger.warn] when
+ *   the primary constructor is non-public.
+ * - [Ambiguous] — more than one `@PersistenceCreator`-annotated target was found on the same
+ *   type. This is a configuration bug: reconstruction is undefined. Callers must emit a hard
+ *   `logger.error` naming every declaration in [Ambiguous.conflicting] (so the developer can
+ *   locate all offenders) and abort code generation for the affected type.
+ */
+internal sealed interface CreatorResolution {
+
+    /**
+     * A single `@PersistenceCreator`-annotated companion-object function or secondary constructor
+     * was found.
+     *
+     * @param callExpression Fully-qualified Kotlin source expression used as the call target in the
+     *   generated `fromRow` (e.g. `com.acme.Artist.of` for a companion function, or `com.acme.Artist`
+     *   for a secondary constructor). Derived from [KSClassDeclaration.creatorCallQualifier] so the
+     *   generated `_LirpTableDef` — which lives in a different package and does not import the type —
+     *   resolves the reference, mirroring the FQN-qualified constructor path.
+     * @param params The value parameters of the annotated function or constructor, in declaration
+     *   order. Callers match these by name against the existing [CtorSlot] tree and use each
+     *   parameter's default-value presence to decide whether an unmatched parameter may be omitted.
+     */
+    data class Found(val callExpression: String, val params: List<KSValueParameter>) : CreatorResolution
+
+    /**
+     * No `@PersistenceCreator` annotation was found on any companion-object function or secondary
+     * constructor. The primary constructor is the only available reconstruction seam.
+     */
+    data object None : CreatorResolution
+
+    /**
+     * More than one `@PersistenceCreator`-annotated target was found on the same type. This is a
+     * configuration bug — the reconstruction seam is ambiguous and codegen must be aborted.
+     *
+     * [conflicting] carries every annotated declaration so the caller can name all offenders in
+     * the `logger.error` message. Reporting only one would leave the developer hunting for the
+     * second. The caller is responsible for rendering each offender (e.g. via its `location`) in
+     * the emitted diagnostic.
+     *
+     * @param conflicting all `@PersistenceCreator`-annotated declarations found on the type
+     */
+    data class Ambiguous(val conflicting: List<KSAnnotated>) : CreatorResolution
+}
+
+/**
+ * Resolves the `@PersistenceCreator`-annotated reconstruction target for [classDecl].
+ *
+ * Scans two locations in declaration order:
+ * 1. The companion object's declared functions filtered by `@PersistenceCreator`.
+ * 2. The class's secondary constructors filtered by `@PersistenceCreator` (the primary constructor
+ *    is excluded by identity to avoid treating a primary-ctor annotation as a creator target).
+ *
+ * Returns [CreatorResolution.Ambiguous] (carrying all offenders) when more than one annotated
+ * target is found — callers must turn this into a `logger.error` naming every offender.
+ * Returns [CreatorResolution.Found] when exactly one target is found, with a
+ * [KSClassDeclaration.creatorCallQualifier]-based call expression that resolves from the generated
+ * file regardless of its package. Returns [CreatorResolution.None] when no annotated target exists.
+ *
+ * @param classDecl the entity or `@Embeddable` class to inspect
+ * @return the resolution outcome; never `null`
+ */
+internal fun resolveCreator(classDecl: KSClassDeclaration): CreatorResolution {
+    val companion =
+        classDecl.declarations
+            .filterIsInstance<KSClassDeclaration>()
+            .firstOrNull { it.isCompanionObject }
+
+    val annotatedFns: List<KSAnnotated> =
+        companion
+            ?.getDeclaredFunctions()
+            ?.filter { fn -> fn.annotations.has(PERSISTENCE_CREATOR_FQN) }
+            ?.toList()
+            ?: emptyList()
+
+    val annotatedCtors: List<KSAnnotated> =
+        classDecl.getConstructors()
+            .filter { it != classDecl.primaryConstructor }
+            .filter { ctor -> ctor.annotations.has(PERSISTENCE_CREATOR_FQN) }
+            .toList()
+
+    val annotated: List<KSAnnotated> = annotatedFns + annotatedCtors
+    return when {
+        annotated.size > 1 -> CreatorResolution.Ambiguous(annotated)
+        annotated.size == 1 && annotatedFns.isNotEmpty() -> {
+            val fn = annotatedFns.first() as KSFunctionDeclaration
+            CreatorResolution.Found(
+                callExpression = "${classDecl.creatorCallQualifier()}.${fn.simpleName.asString()}",
+                params = fn.parameters
+            )
+        }
+        annotated.size == 1 -> {
+            val ctor = annotatedCtors.first() as KSFunctionDeclaration
+            CreatorResolution.Found(
+                callExpression = classDecl.creatorCallQualifier(),
+                params = ctor.parameters
+            )
+        }
+        else -> CreatorResolution.None
+    }
+}
+
+/**
+ * Renders the conflicting `@PersistenceCreator` declarations for the ambiguity diagnostic, naming
+ * each function by simple name and source location so every offender is locatable.
+ */
+internal fun List<KSAnnotated>.formatCreatorOffenders(): String =
+    joinToString(", ") { offender ->
+        (offender as? KSFunctionDeclaration)?.let { "${it.simpleName.asString()} at ${it.location}" }
+            ?: offender.location.toString()
+    }
+
+/**
+ * True when [this] is `internal` and the resolved creator named by [callExpression] is itself not
+ * publicly accessible — the generated descriptor would then fail to compile outside the declaring
+ * module. The creator's simple name is the segment after the last `.` in [callExpression].
+ */
+internal fun KSClassDeclaration.hasInternalNonPublicCreator(callExpression: String): Boolean {
+    if (getVisibility() != Visibility.INTERNAL) return false
+    val creatorName = callExpression.substringAfterLast('.')
+    val companion = declarations.filterIsInstance<KSClassDeclaration>().firstOrNull { it.isCompanionObject }
+    val creatorVis =
+        companion?.getDeclaredFunctions()?.firstOrNull { it.simpleName.asString() == creatorName }?.getVisibility()
+    return creatorVis != null && creatorVis != Visibility.PUBLIC && creatorVis != Visibility.JAVA_PACKAGE
+}
+
+/**
+ * True when the primary constructor is not publicly accessible. With no `@PersistenceCreator` seam,
+ * a generated descriptor that calls this constructor compiles only inside the declaring module.
+ */
+internal fun KSClassDeclaration.hasNonPublicPrimaryConstructor(): Boolean {
+    val vis = primaryConstructor?.getVisibility() ?: return false
+    return vis != Visibility.PUBLIC && vis != Visibility.JAVA_PACKAGE
+}
 
 /**
  * Merges annotations from [prop]'s declaration site and, when [ctorParam] is supplied, its
@@ -162,6 +307,18 @@ internal fun KSClassDeclaration.kotlinNestedName(): String {
         simpleName.asString()
     }
 }
+
+/**
+ * Returns the fully-qualified call qualifier for a `@PersistenceCreator` reconstruction target.
+ *
+ * Unlike [kotlinNestedName] (which assumes the generated file shares the entity's package), a
+ * generated `_LirpTableDef` for a cross-module entity lives in a different package and does not
+ * import the embeddable/entity type. The creator call must therefore be fully qualified — mirroring
+ * the constructor path, which already emits the embeddable's FQN. Falls back to [kotlinNestedName]
+ * only for the rare local/anonymous declaration with no qualified name.
+ */
+internal fun KSClassDeclaration.creatorCallQualifier(): String =
+    qualifiedName?.asString() ?: kotlinNestedName()
 
 /**
  * Returns true when [type]'s declaration (or any supertype reachable via FQN walk) implements

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefConstants.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefConstants.kt
@@ -59,6 +59,7 @@ internal const val EMBEDDABLE_FQN = "net.transgressoft.lirp.persistence.Embeddab
 internal const val EMBEDDED_FQN = "net.transgressoft.lirp.persistence.Embedded"
 internal const val ELEMENT_COLLECTION_FQN = "net.transgressoft.lirp.persistence.ElementCollection"
 internal const val PERSISTENCE_IGNORE_FQN = "net.transgressoft.lirp.persistence.PersistenceIgnore"
+internal const val PERSISTENCE_CREATOR_FQN = "net.transgressoft.lirp.persistence.PersistenceCreator"
 internal const val KOTLIN_LIST_FQN = "kotlin.collections.List"
 internal const val KOTLIN_SET_FQN = "kotlin.collections.Set"
 internal const val KOTLIN_MUTABLE_LIST_FQN = "kotlin.collections.MutableList"

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
@@ -463,6 +463,98 @@ class TableDefProcessor(
         return true
     }
 
+    /**
+     * Resolves the reactive self-type `R` the generated descriptor is typed on. Returns the
+     * concrete class name when `R` equals the class (self-referential) or cannot be resolved (with
+     * a warning that the descriptor may not be assignable to a `Repository` bound on `R`), the
+     * resolved interface name otherwise, or `null` to signal that generation must be skipped — the
+     * one unrenderable case being a generic entity whose `R` is an unsubstituted type parameter.
+     */
+    private fun resolveDescriptorSelfType(classDecl: KSClassDeclaration, className: String): String? {
+        val resolvedSelfType = resolveReactiveSelfType(classDecl)
+        if (resolvedSelfType == null && classDecl.typeParameters.isNotEmpty()) {
+            logger.warn(
+                "Skipping _LirpTableDef generation for ${classDecl.qualifiedName?.asString()}: its reactive " +
+                    "self-type R is an unsubstituted type parameter, so no valid SqlTableDef<R> can be generated"
+            )
+            return null
+        }
+        return when {
+            resolvedSelfType == null -> {
+                logger.warn(
+                    "Could not resolve reactive self-type R for ${classDecl.qualifiedName?.asString()}; " +
+                        "generated TableDef is typed on the concrete class and may not be assignable " +
+                        "to a Repository bound on R : ReactiveEntity"
+                )
+                className
+            }
+            resolvedSelfType == classDecl.qualifiedName?.asString() -> className
+            else -> resolvedSelfType
+        }
+    }
+
+    /** Entity-level `@PersistenceCreator` resolution outcome consumed by `fromRow` emission. */
+    private data class EntityCreator(val callExpression: String?, val paramNames: List<String>?)
+
+    /**
+     * Resolves the entity-level `@PersistenceCreator` reconstruction target. Returns `null` to abort
+     * generation when the configuration is invalid (more than one creator, or a creator parameter
+     * with no mapped column source) — both surfaced as compilation errors. A present creator always
+     * takes precedence over the primary constructor; its parameters are matched by name against the
+     * entity's constructor params, omitting any defaulted parameter that has no column source. When
+     * no creator exists, falls back to the primary constructor and warns if that constructor is not
+     * public. A non-public resolved creator on an internal entity warns rather than fails, since the
+     * descriptor still compiles inside the declaring module.
+     */
+    private fun resolveEntityCreator(classDecl: KSClassDeclaration, className: String): EntityCreator? {
+        when (val resolution = resolveCreator(classDecl)) {
+            is CreatorResolution.Ambiguous -> {
+                logger.error(
+                    "Multiple @PersistenceCreator targets on $className: " +
+                        "${resolution.conflicting.formatCreatorOffenders()}; exactly one is required.",
+                    classDecl
+                )
+                return null
+            }
+            is CreatorResolution.Found -> {
+                val entityCtorParamNames =
+                    classDecl.primaryConstructor?.parameters?.mapNotNull { it.name?.asString() }?.toSet() ?: emptySet()
+                val resolvedParamNames = mutableListOf<String>()
+                for (param in resolution.params) {
+                    val paramName = param.name?.asString() ?: continue
+                    when {
+                        paramName in entityCtorParamNames -> resolvedParamNames += paramName
+                        param.hasDefault -> { /* omit so the default value applies at instantiation */ }
+                        else -> {
+                            logger.error(
+                                "@PersistenceCreator param '$paramName' on $className has no mapped column source.",
+                                classDecl
+                            )
+                            return null
+                        }
+                    }
+                }
+                if (classDecl.hasInternalNonPublicCreator(resolution.callExpression)) {
+                    logger.warn(
+                        "$className is internal and its @PersistenceCreator '${resolution.callExpression}' is not " +
+                            "public; the generated descriptor may not compile outside its own module. Add a public " +
+                            "@PersistenceCreator to make it cross-module usable."
+                    )
+                }
+                return EntityCreator(resolution.callExpression, resolvedParamNames)
+            }
+            CreatorResolution.None -> {
+                if (classDecl.hasNonPublicPrimaryConstructor()) {
+                    logger.warn(
+                        "$className has a non-public primary constructor and no @PersistenceCreator; " +
+                            "the generated descriptor may not compile outside its own module."
+                    )
+                }
+                return EntityCreator(null, null)
+            }
+        }
+    }
+
     private fun generateTableDef(
         classDecl: KSClassDeclaration,
         sqlTableDefAvailable: Boolean,
@@ -483,36 +575,10 @@ class TableDefProcessor(
         val packageName = classDecl.packageName.asString()
         val className = classDecl.simpleName.asString()
 
-        // Resolve the reactive self-type R that the generated descriptor is typed on. Three branches:
-        //   null       → R unresolvable; fall back to the concrete class and emit a warning
-        //   R == class → self-referential; use the simple name for byte-identical output
-        //   otherwise  → distinct reactive interface; type the descriptor on its fully qualified name
-        val resolvedSelfType = resolveReactiveSelfType(classDecl)
-        // A generic entity has no renderable non-raw descriptor type: typing on the bare class name
-        // would emit `SqlTableDef<GenericEntity>`, which Kotlin rejects as a raw generic. Skip
-        // generation rather than emit uncompilable source.
-        if (resolvedSelfType == null && classDecl.typeParameters.isNotEmpty()) {
-            logger.warn(
-                "Skipping _LirpTableDef generation for ${classDecl.qualifiedName?.asString()}: its reactive " +
-                    "self-type R is an unsubstituted type parameter, so no valid SqlTableDef<R> can be generated"
-            )
-            return
-        }
-        val selfType: String =
-            when {
-                resolvedSelfType == null -> {
-                    logger.warn(
-                        "Could not resolve reactive self-type R for ${classDecl.qualifiedName?.asString()}; " +
-                            "generated TableDef is typed on the concrete class and may not be assignable " +
-                            "to a Repository bound on R : ReactiveEntity"
-                    )
-                    className
-                }
-                resolvedSelfType == classDecl.qualifiedName?.asString() -> className
-                else -> resolvedSelfType
-            }
-
+        val selfType = resolveDescriptorSelfType(classDecl, className) ?: return
         val tableDefName = "${className}_LirpTableDef"
+
+        val creator = resolveEntityCreator(classDecl, className) ?: return
 
         val tableName = resolveTableName(classDecl, className)
         val resolvedShape = collected
@@ -580,7 +646,9 @@ class TableDefProcessor(
                         setterSlots = setterSlots,
                         foreignKeys = foreignKeys,
                         junctionRefs = if (emitJunctions) junctionRefs else emptyList(),
-                        isReactiveEntity = extendsReactiveEntityBase(classDecl)
+                        isReactiveEntity = extendsReactiveEntityBase(classDecl),
+                        creatorCallExpression = creator.callExpression,
+                        creatorParamNames = creator.paramNames
                     ),
                     visibility = visibility
                 )

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
@@ -506,7 +506,11 @@ class TableDefProcessor(
      * public. A non-public resolved creator on an internal entity warns rather than fails, since the
      * descriptor still compiles inside the declaring module.
      */
-    private fun resolveEntityCreator(classDecl: KSClassDeclaration, className: String): EntityCreator? {
+    private fun resolveEntityCreator(
+        classDecl: KSClassDeclaration,
+        className: String,
+        availableParamNames: Set<String>
+    ): EntityCreator? {
         when (val resolution = resolveCreator(classDecl)) {
             is CreatorResolution.Ambiguous -> {
                 logger.error(
@@ -517,13 +521,14 @@ class TableDefProcessor(
                 return null
             }
             is CreatorResolution.Found -> {
-                val entityCtorParamNames =
-                    classDecl.primaryConstructor?.parameters?.mapNotNull { it.name?.asString() }?.toSet() ?: emptySet()
                 val resolvedParamNames = mutableListOf<String>()
                 for (param in resolution.params) {
                     val paramName = param.name?.asString() ?: continue
                     when {
-                        paramName in entityCtorParamNames -> resolvedParamNames += paramName
+                        // Validate against the emitted slot names, not raw ctor param names: an
+                        // excluded ctor param (e.g. @PersistenceIgnore) produces no slot/column, so
+                        // fromRow would have no source to bind the creator parameter to.
+                        paramName in availableParamNames -> resolvedParamNames += paramName
                         param.hasDefault -> { /* omit so the default value applies at instantiation */ }
                         else -> {
                             logger.error(
@@ -534,7 +539,7 @@ class TableDefProcessor(
                         }
                     }
                 }
-                if (classDecl.hasInternalNonPublicCreator(resolution.callExpression)) {
+                if (classDecl.hasInternalNonPublicCreator()) {
                     logger.warn(
                         "$className is internal and its @PersistenceCreator '${resolution.callExpression}' is not " +
                             "public; the generated descriptor may not compile outside its own module. Add a public " +
@@ -578,7 +583,10 @@ class TableDefProcessor(
         val selfType = resolveDescriptorSelfType(classDecl, className) ?: return
         val tableDefName = "${className}_LirpTableDef"
 
-        val creator = resolveEntityCreator(classDecl, className) ?: return
+        // Validate creator params against the names that actually produce a slot/column source,
+        // so a creator referencing an excluded (e.g. @PersistenceIgnore'd) ctor param is rejected.
+        val mappableParamNames = collected.ctorSlots.mapTo(mutableSetOf()) { it.ctorParamName }
+        val creator = resolveEntityCreator(classDecl, className, mappableParamNames) ?: return
 
         val tableName = resolveTableName(classDecl, className)
         val resolvedShape = collected

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
@@ -259,7 +259,11 @@ internal object TableDefSourceEmitter {
 
         // Return type is the self-type R; the body constructs the concrete class (a subtype of R).
         appendLine("    override fun fromRow(row: ResultRow, table: Table): $selfType {")
-        appendLine("        val entity = ${buildEntityConstruction(creatorCallExpression ?: className, ctorSlots, orderedCtorCols)}")
+        appendLine(
+            "        val entity = ${
+                buildEntityConstruction(className, creatorCallExpression, constructorParamNames, creatorParamNames, ctorSlots, orderedCtorCols)
+            }"
+        )
 
         // Body-declared (non-ctor) reactive properties are assigned with events disabled: emitting
         // during hydration would schedule a stray write-back that races the repository's mutation
@@ -275,17 +279,40 @@ internal object TableDefSourceEmitter {
     }
 
     /**
-     * Builds the entity-construction expression for `fromRow`: a `@PersistenceCreator` call when
-     * [callTarget] is a factory, otherwise the primary constructor. Uses the structured
-     * [ctorSlots] tree to emit nested constructor expressions for `@Embedded` parameters, falling
-     * back to flat column-by-name lookup ([orderedCtorCols]) for the common no-embedded case.
+     * Builds the entity-construction expression for `fromRow`.
+     *
+     * When a `@PersistenceCreator` is present ([creatorCallExpression] non-null), the creator may
+     * take a subset of the entity's parameters in a different order, so arguments are emitted as
+     * **named** arguments in the creator's own parameter order ([creatorParamNames]); binding
+     * positionally to the primary constructor would misbind or fail to compile. Without a creator,
+     * the primary constructor is called positionally — using the structured [ctorSlots] tree to
+     * emit nested constructor expressions for `@Embedded` parameters, or falling back to flat
+     * column-by-name lookup ([orderedCtorCols]) for the common no-embedded case.
      */
-    private fun buildEntityConstruction(callTarget: String, ctorSlots: List<CtorSlot>, orderedCtorCols: List<ColumnMeta>): String {
+    private fun buildEntityConstruction(
+        className: String,
+        creatorCallExpression: String?,
+        constructorParamNames: List<String>,
+        creatorParamNames: List<String>?,
+        ctorSlots: List<CtorSlot>,
+        orderedCtorCols: List<ColumnMeta>
+    ): String {
+        val callTarget = creatorCallExpression ?: className
         val ctorArgs =
-            if (ctorSlots.isNotEmpty()) {
-                ctorSlots.joinToString(", ") { buildCtorArgExpression(it) }
-            } else {
-                orderedCtorCols.joinToString(", ") { buildRowAccess(it) }
+            when {
+                creatorCallExpression != null -> {
+                    val slotByName = ctorSlots.associateBy { it.ctorParamName }
+                    val colByName = orderedCtorCols.associateBy { it.propertyName }
+                    (creatorParamNames ?: constructorParamNames).joinToString(", ") { name ->
+                        val arg =
+                            slotByName[name]?.let { buildCtorArgExpression(it) }
+                                ?: colByName[name]?.let { buildRowAccess(it) }
+                                ?: error("No slot or column source for @PersistenceCreator parameter '$name'")
+                        "$name = $arg"
+                    }
+                }
+                ctorSlots.isNotEmpty() -> ctorSlots.joinToString(", ") { buildCtorArgExpression(it) }
+                else -> orderedCtorCols.joinToString(", ") { buildRowAccess(it) }
             }
         return "$callTarget($ctorArgs)"
     }

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
@@ -32,7 +32,9 @@ internal data class ObjectBodyParams(
     val setterSlots: List<EmbeddedSetterSlot> = emptyList(),
     val foreignKeys: List<ForeignKeyMeta> = emptyList(),
     val junctionRefs: List<JunctionRefInfo> = emptyList(),
-    val isReactiveEntity: Boolean = true
+    val isReactiveEntity: Boolean = true,
+    val creatorCallExpression: String? = null,
+    val creatorParamNames: List<String>? = null
 )
 
 /**
@@ -141,7 +143,11 @@ internal object TableDefSourceEmitter {
         appendLine("    )")
         if (canGenerateSqlMapping) {
             appendLine()
-            appendFromRow(className, selfType, columns, constructorParamNames, params.ctorSlots, params.setterSlots, params.isReactiveEntity)
+            appendFromRow(
+                className, selfType, columns, constructorParamNames,
+                params.ctorSlots, params.setterSlots, params.isReactiveEntity,
+                params.creatorCallExpression, params.creatorParamNames
+            )
             appendLine()
             appendToParams(className, selfType, columns)
             appendLine()
@@ -238,11 +244,14 @@ internal object TableDefSourceEmitter {
         constructorParamNames: List<String>,
         ctorSlots: List<CtorSlot> = emptyList(),
         embeddedSetterSlots: List<EmbeddedSetterSlot> = emptyList(),
-        isReactiveEntity: Boolean = true
+        isReactiveEntity: Boolean = true,
+        creatorCallExpression: String? = null,
+        creatorParamNames: List<String>? = null
     ) {
         val columnsByName = columns.associateBy { it.propertyName }
-        // Preserve constructor parameter declaration order for correct positional arguments
-        val orderedCtorCols = constructorParamNames.mapNotNull { columnsByName[it] }
+        // When a creator is present, its param list may be a subset of the primary-ctor params;
+        // use it to drive the flat column-lookup order so unlisted params are omitted.
+        val orderedCtorCols = (creatorParamNames ?: constructorParamNames).mapNotNull { columnsByName[it] }
         val ctorParamNameSet = constructorParamNames.toSet()
         // Setter cols exclude both ctor params and embedded-derived columns (the latter share their
         // top-level entity ctor-param name and are reconstructed inside the ctor invocation).
@@ -250,39 +259,58 @@ internal object TableDefSourceEmitter {
 
         // Return type is the self-type R; the body constructs the concrete class (a subtype of R).
         appendLine("    override fun fromRow(row: ResultRow, table: Table): $selfType {")
-        // When CtorSlot information is available (entities with @Embedded ctor params), use the
-        // structured tree to emit nested constructor expressions; otherwise fall back to the flat
-        // column-by-name lookup for the common no-embedded case.
+        appendLine("        val entity = ${buildEntityConstruction(creatorCallExpression ?: className, ctorSlots, orderedCtorCols)}")
+
+        // Body-declared (non-ctor) reactive properties are assigned with events disabled: emitting
+        // during hydration would schedule a stray write-back that races the repository's mutation
+        // subscription. Non-reactive @PersistenceMapping classes lack withEventsDisabled, so they
+        // assign directly.
+        val wrapInEventsDisabled = isReactiveEntity && (setterCols.isNotEmpty() || embeddedSetterSlots.isNotEmpty())
+        val setterIndent = if (wrapInEventsDisabled) "            " else "        "
+        if (wrapInEventsDisabled) appendLine("        entity.withEventsDisabled {")
+        appendSetterAssignments(setterCols, embeddedSetterSlots, setterIndent)
+        if (wrapInEventsDisabled) appendLine(INNER_BLOCK_CLOSE)
+        appendLine("        return entity")
+        appendLine(METHOD_CLOSE)
+    }
+
+    /**
+     * Builds the entity-construction expression for `fromRow`: a `@PersistenceCreator` call when
+     * [callTarget] is a factory, otherwise the primary constructor. Uses the structured
+     * [ctorSlots] tree to emit nested constructor expressions for `@Embedded` parameters, falling
+     * back to flat column-by-name lookup ([orderedCtorCols]) for the common no-embedded case.
+     */
+    private fun buildEntityConstruction(callTarget: String, ctorSlots: List<CtorSlot>, orderedCtorCols: List<ColumnMeta>): String {
         val ctorArgs =
             if (ctorSlots.isNotEmpty()) {
                 ctorSlots.joinToString(", ") { buildCtorArgExpression(it) }
             } else {
                 orderedCtorCols.joinToString(", ") { buildRowAccess(it) }
             }
-        appendLine("        val entity = $className($ctorArgs)")
-        // Populate body-declared (non-ctor) columns with events disabled for reactive entities.
-        // These are reactive property setters; emitting during hydration would schedule a stray
-        // write-back of the just-loaded values that races the repository's mutation subscription.
-        // Mirrors the withEventsDisabled guard applied in applyScalarRow / applyJunctionRows.
-        // Non-reactive `@PersistenceMapping` classes lack withEventsDisabled, so set directly.
-        val wrapInEventsDisabled = isReactiveEntity && (setterCols.isNotEmpty() || embeddedSetterSlots.isNotEmpty())
-        val setterIndent = if (wrapInEventsDisabled) "            " else "        "
-        if (wrapInEventsDisabled) appendLine("        entity.withEventsDisabled {")
+        return "$callTarget($ctorArgs)"
+    }
+
+    /**
+     * Emits the post-construction reactive-property assignments inside `fromRow`: flat setter
+     * columns and the reconstruction of each body-declared `@Embedded var`. Body-declared
+     * `@Embedded var` leaves are `isInsideEmbedded`, so they are excluded from [setterCols] and
+     * rebuilt here from their nested constructor expression (routing through the creator when
+     * present) — this hydrates the var on a standalone `fromRow()` (e.g. conflict-recovery reload)
+     * rather than leaving it at its default.
+     */
+    private fun StringBuilder.appendSetterAssignments(
+        setterCols: List<ColumnMeta>,
+        embeddedSetterSlots: List<EmbeddedSetterSlot>,
+        indent: String
+    ) {
         for (col in setterCols) {
-            val rowAccess = buildRowAccess(col)
-            appendLine("${setterIndent}entity.${col.propertyName} = $rowAccess")
+            appendLine("${indent}entity.${col.propertyName} = ${buildRowAccess(col)}")
         }
-        // Body-declared `@Embedded var` properties are excluded from setterCols (their leaves are
-        // isInsideEmbedded); reconstruct each from its nested constructor expression so a standalone
-        // fromRow() (e.g. the conflict-recovery reload) hydrates them instead of leaving the var at
-        // its default. Mirrors the reconstruction already emitted in applyScalarRow.
         for (slot in embeddedSetterSlots) {
-            val reconstruction = buildCtorArgExpression(EmbeddedCtorSlot(slot.ctorParamName, slot.embeddableTypeFqn, slot.children))
-            appendLine("${setterIndent}entity.${slot.ctorParamName} = $reconstruction")
+            val reconstruction =
+                buildCtorArgExpression(EmbeddedCtorSlot(slot.ctorParamName, slot.embeddableTypeFqn, slot.children, slot.creatorCallExpression))
+            appendLine("${indent}entity.${slot.ctorParamName} = $reconstruction")
         }
-        if (wrapInEventsDisabled) appendLine(INNER_BLOCK_CLOSE)
-        appendLine("        return entity")
-        appendLine(METHOD_CLOSE)
     }
 
     fun StringBuilder.appendToParams(className: String, selfType: String, columns: List<ColumnMeta>) {
@@ -354,7 +382,8 @@ internal object TableDefSourceEmitter {
             // property name (the RawInitializer entry name); the value is the full nested
             // constructor expression reconstructed via buildCtorArgExpression.
             for (slot in embeddedSetterSlots) {
-                val reconstruction = buildCtorArgExpression(EmbeddedCtorSlot(slot.ctorParamName, slot.embeddableTypeFqn, slot.children))
+                val reconstruction =
+                    buildCtorArgExpression(EmbeddedCtorSlot(slot.ctorParamName, slot.embeddableTypeFqn, slot.children, slot.creatorCallExpression))
                 appendLine("                \"${slot.ctorParamName}\" -> $reconstruction")
             }
             appendLine("                else -> continue")
@@ -386,15 +415,21 @@ internal object TableDefSourceEmitter {
         when (slot) {
             is ScalarCtorSlot -> buildRowAccess(slot.column)
             is EmbeddedCtorSlot -> {
+                val callTarget = slot.creatorCallExpression ?: slot.embeddableTypeFqn
                 val inner =
-                    slot.children.joinToString(", ") { child ->
-                        "${child.ctorParamName} = ${buildCtorArgExpression(child)}"
-                    }
-                "${slot.embeddableTypeFqn}($inner)"
+                    slot.children
+                        .filterNot { it is OmittedCtorSlot }
+                        .joinToString(", ") { child ->
+                            "${child.ctorParamName} = ${buildCtorArgExpression(child)}"
+                        }
+                "$callTarget($inner)"
             }
-            // @PersistenceIgnore on a nested @Embeddable constructor param: emit null so the
+            // @PersistenceIgnore on a nullable @Embeddable constructor param: emit null so the
             // ignored param is excluded from SQL column mapping while the constructor still compiles.
             is IgnoredCtorSlot -> "null"
+            // OmittedCtorSlot must be filtered from EmbeddedCtorSlot.children before dispatch so
+            // the default applies at instantiation time; reaching here is an invariant violation.
+            is OmittedCtorSlot -> error("OmittedCtorSlot must be filtered before buildCtorArgExpression dispatch")
             // EmbeddedSetterSlot is consumed directly by appendApplyScalarRow via a synthetic
             // EmbeddedCtorSlot wrapper; it must never reach this dispatch path.
             is EmbeddedSetterSlot -> error("EmbeddedSetterSlot must not be passed to buildCtorArgExpression directly")

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableTableDefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableTableDefProcessorTest.kt
@@ -26,6 +26,7 @@ import com.tschuchort.compiletesting.symbolProcessorProviders
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
 /**
@@ -236,9 +237,9 @@ class EmbeddableTableDefProcessorTest : StringSpec({
     }
 
     "flattens @Embedded scalar leaf with @PersistenceProperty converter" {
-        // fix-up: lirp-ksp does NOT depend on lirp-sql, so the Phase 56 PathConverter
-        // testFixture is unreachable. Inline a minimal String→String converter as a stand-in;
-        // the codegen path is identical regardless of the S/T types involved.
+        // lirp-ksp does NOT depend on lirp-sql, so the shared PathConverter test fixture is
+        // unreachable here. Inline a minimal String→String converter as a stand-in; the codegen
+        // path is identical regardless of the S/T types involved.
         val result =
             compileWithProcessor(
                 SourceFile.kotlin(
@@ -396,6 +397,47 @@ class EmbeddableTableDefProcessorTest : StringSpec({
         // preserved — producing "address_geo_lat", not "geo_lat".
         content shouldContain "name = \"address_geo_lat\""
         content shouldContain "name = \"address_geo_lng\""
+    }
+
+    "@PersistenceIgnore non-null defaulted embeddable ctor param omitted from fromRow" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "IgnoredDefaultedParamEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceIgnore
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @Embeddable
+                    data class TagEmbeddable(
+                        val name: String,
+                        @PersistenceIgnore val cachedHash: Int = 0
+                    )
+
+                    @PersistenceMapping
+                    data class IgnoredDefaultedParamEntity(
+                        override val id: Int,
+                        @Embedded val tag: TagEmbeddable
+                    ) : ReactiveEntityBase<Int, IgnoredDefaultedParamEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = IgnoredDefaultedParamEntity(id, tag)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("IgnoredDefaultedParamEntity_LirpTableDef.kt")
+        val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
+        // The persisted scalar must appear in the embeddable reconstruction expression.
+        fromRowBlock shouldContain "name = "
+        // The @PersistenceIgnore non-null defaulted param must be omitted entirely — neither named
+        // nor passed null — so the default value applies at instantiation time.
+        fromRowBlock shouldNotContain "cachedHash"
     }
 
     "top-level explicit prefix does not bleed into nested auto-derived prefix" {

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/PersistenceCreatorProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/PersistenceCreatorProcessorTest.kt
@@ -132,9 +132,120 @@ class PersistenceCreatorProcessorTest : StringSpec({
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
         val content = result.generatedFileContent("InternalTrackEntity_LirpTableDef.kt")
         val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
-        // The creator uses only (id, title); durationMs is omitted — it has the default 0L.
-        fromRowBlock shouldContain "InternalTrackEntity("
-        fromRowBlock shouldNotContain "durationMs = "
+        // The creator takes only (id, title); the call must be by NAMED args limited to those two so
+        // it binds to the secondary @PersistenceCreator (not positionally to the 3-arg primary ctor).
+        // durationMs is omitted entirely — it has the default 0L.
+        fromRowBlock shouldContain "InternalTrackEntity(id = "
+        fromRowBlock shouldContain "title = "
+        fromRowBlock shouldNotContain "durationMs"
+    }
+
+    // a creator taking a reordered subset of the entity's params binds by name, not positionally
+    "entity @PersistenceCreator with reordered subset binds by named args" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "ReorderedCreatorEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    data class ReorderedCreatorEntity(
+                        override val id: Int,
+                        val first: String,
+                        val second: String
+                    ) : ReactiveEntityBase<Int, ReorderedCreatorEntity>() {
+                        companion object {
+                            // Declared in (second, id, first) order — deliberately not the ctor order.
+                            @PersistenceCreator
+                            fun of(second: String, id: Int, first: String): ReorderedCreatorEntity =
+                                ReorderedCreatorEntity(id, first, second)
+                        }
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = ReorderedCreatorEntity(id, first, second)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("ReorderedCreatorEntity_LirpTableDef.kt")
+        val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
+        // Args emitted in the creator's declared order (second, id, first), each named.
+        fromRowBlock shouldContain "ReorderedCreatorEntity.of(second = "
+        val secondIdx = fromRowBlock.indexOf("second = ")
+        val idIdx = fromRowBlock.indexOf("id = ")
+        val firstIdx = fromRowBlock.indexOf("first = ")
+        (secondIdx < idIdx && idIdx < firstIdx) shouldBe true
+    }
+
+    // an internal entity whose @PersistenceCreator is a non-public SECONDARY CONSTRUCTOR warns
+    "internal entity with non-public secondary-ctor creator warns only" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "InternalSecondaryCtorEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    internal data class InternalSecondaryCtorEntity internal constructor(
+                        override val id: Int,
+                        val name: String,
+                        val extra: Int
+                    ) : ReactiveEntityBase<Int, InternalSecondaryCtorEntity>() {
+                        @PersistenceCreator
+                        internal constructor(id: Int, name: String) : this(id, name, 0)
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = InternalSecondaryCtorEntity(id, name, extra)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.messages shouldContain "not public"
+    }
+
+    // a creator referencing a @PersistenceIgnore'd (unmapped) ctor param without a default errors
+    "entity creator param bound to an excluded ctor param produces compilation error" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "ExcludedParamCreatorEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceIgnore
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    data class ExcludedParamCreatorEntity(
+                        override val id: Int,
+                        @PersistenceIgnore val transientNote: String
+                    ) : ReactiveEntityBase<Int, ExcludedParamCreatorEntity>() {
+                        companion object {
+                            @PersistenceCreator
+                            fun of(id: Int, transientNote: String): ExcludedParamCreatorEntity =
+                                ExcludedParamCreatorEntity(id, transientNote)
+                        }
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = ExcludedParamCreatorEntity(id, transientNote)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+        result.messages shouldContain "transientNote"
+        result.messages shouldContain "no mapped column source"
     }
 
     // @PersistenceIgnore non-null defaulted embeddable ctor param omitted from fromRow

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/PersistenceCreatorProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/PersistenceCreatorProcessorTest.kt
@@ -1,0 +1,554 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.ksp
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.configureKsp
+import com.tschuchort.compiletesting.sourcesGeneratedBySymbolProcessor
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+/**
+ * KSP compilation tests for the `@PersistenceCreator` code-generation path in
+ * [TableDefProcessor] and [EmbeddableAnalyzer]: companion-factory and secondary-constructor
+ * emission, defaulted-parameter omission, creator precedence over a public primary constructor,
+ * the multiple-creator and unmatched-parameter hard errors, primary-constructor fallback with a
+ * warning, and the internal-entity non-public-creator warning.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+class PersistenceCreatorProcessorTest : StringSpec({
+
+    fun compileWithProcessor(vararg sources: SourceFile): JvmCompilationResult {
+        val compilation =
+            KotlinCompilation().apply {
+                this.sources = sources.toList()
+                inheritClassPath = true
+            }
+        compilation.configureKsp { withCompilation = true }
+        compilation.symbolProcessorProviders += TableDefProcessorProvider()
+        return compilation.compile()
+    }
+
+    fun JvmCompilationResult.generatedFileContent(name: String): String {
+        val file =
+            sourcesGeneratedBySymbolProcessor.firstOrNull { it.name == name }
+                ?: error(
+                    "Generated file '$name' not found among: " +
+                        sourcesGeneratedBySymbolProcessor.map { it.name }.toList()
+                )
+        return file.readText()
+    }
+
+    // flyweight @Embeddable (internal ctor) reconstructed via its companion @PersistenceCreator
+    "flyweight @Embeddable with internal ctor uses companion factory in fromRow" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "FlyweightArtistEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @Embeddable
+                    data class Artist internal constructor(val name: String, val countryCode: String) {
+                        companion object {
+                            @PersistenceCreator
+                            fun of(name: String, countryCode: String): Artist = Artist(name, countryCode)
+                        }
+                    }
+
+                    @PersistenceMapping
+                    data class FlyweightArtistEntity(
+                        override val id: Int,
+                        @Embedded val artist: Artist
+                    ) : ReactiveEntityBase<Int, FlyweightArtistEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = FlyweightArtistEntity(id, artist)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("FlyweightArtistEntity_LirpTableDef.kt")
+        val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
+        fromRowBlock shouldContain "Artist.of(name = "
+        fromRowBlock shouldNotContain "Artist(name = "
+    }
+
+    // internal entity reconstructed via a public secondary-constructor @PersistenceCreator
+    "internal entity uses public secondary ctor @PersistenceCreator in fromRow" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "InternalTrackEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    internal data class InternalTrackEntity internal constructor(
+                        override val id: Int,
+                        val title: String,
+                        val durationMs: Long
+                    ) : ReactiveEntityBase<Int, InternalTrackEntity>() {
+                        @PersistenceCreator
+                        constructor(id: Int, title: String) : this(id, title, 0L)
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = InternalTrackEntity(id, title, durationMs)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalTrackEntity_LirpTableDef.kt")
+        val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
+        // The creator uses only (id, title); durationMs is omitted — it has the default 0L.
+        fromRowBlock shouldContain "InternalTrackEntity("
+        fromRowBlock shouldNotContain "durationMs = "
+    }
+
+    // @PersistenceIgnore non-null defaulted embeddable ctor param omitted from fromRow
+    "@PersistenceIgnore non-null param with default is omitted from fromRow" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "ConfigEmbeddableEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceIgnore
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @Embeddable
+                    data class Config(
+                        val host: String,
+                        @PersistenceIgnore val timeout: Int = 5000
+                    )
+
+                    @PersistenceMapping
+                    data class ConfigEmbeddableEntity(
+                        override val id: Int,
+                        @Embedded val config: Config
+                    ) : ReactiveEntityBase<Int, ConfigEmbeddableEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = ConfigEmbeddableEntity(id, config)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("ConfigEmbeddableEntity_LirpTableDef.kt")
+        val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
+        fromRowBlock shouldContain "host = "
+        fromRowBlock shouldNotContain "timeout = "
+        fromRowBlock shouldNotContain "timeout = null"
+    }
+
+    // @PersistenceCreator wins over a public primary constructor
+    "@PersistenceCreator wins over a public primary ctor" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "PublicCtorWithCreatorEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @Embeddable
+                    data class Label(val name: String, val country: String) {
+                        companion object {
+                            @PersistenceCreator
+                            fun of(name: String, country: String): Label = Label(name, country)
+                        }
+                    }
+
+                    @PersistenceMapping
+                    data class PublicCtorWithCreatorEntity(
+                        override val id: Int,
+                        @Embedded val label: Label
+                    ) : ReactiveEntityBase<Int, PublicCtorWithCreatorEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = PublicCtorWithCreatorEntity(id, label)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("PublicCtorWithCreatorEntity_LirpTableDef.kt")
+        val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
+        // The companion factory wins even though the primary ctor is also public.
+        fromRowBlock shouldContain "Label.of("
+        fromRowBlock shouldNotContain "Label(name = "
+    }
+
+    // multiple @PersistenceCreator on the same type produces a compilation error
+    "multiple @PersistenceCreator on same type produces compilation error" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "AmbiguousCreatorEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    data class AmbiguousCreatorEntity(
+                        override val id: Int,
+                        val name: String
+                    ) : ReactiveEntityBase<Int, AmbiguousCreatorEntity>() {
+                        @PersistenceCreator
+                        constructor(id: Int) : this(id, "")
+                        companion object {
+                            @PersistenceCreator
+                            fun of(id: Int, name: String): AmbiguousCreatorEntity = AmbiguousCreatorEntity(id, name)
+                        }
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = AmbiguousCreatorEntity(id, name)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+        result.messages shouldContain "Multiple @PersistenceCreator"
+    }
+
+    // unmatched creator param without a default produces a compilation error
+    "unmatched creator param without default produces compilation error" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "UnmatchedParamEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    data class UnmatchedParamEntity(
+                        override val id: Int,
+                        val title: String
+                    ) : ReactiveEntityBase<Int, UnmatchedParamEntity>() {
+                        companion object {
+                            @PersistenceCreator
+                            fun of(id: Int, title: String, unmappedExtra: String): UnmatchedParamEntity =
+                                UnmatchedParamEntity(id, title)
+                        }
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = UnmatchedParamEntity(id, title)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+        result.messages shouldContain "unmappedExtra"
+    }
+
+    // non-public primary ctor without a creator falls back to the primary ctor and warns
+    "non-public primary ctor without creator falls back to primary ctor with warning" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "NonPublicCtorEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    data class NonPublicCtorEntity internal constructor(
+                        override val id: Int,
+                        val name: String
+                    ) : ReactiveEntityBase<Int, NonPublicCtorEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = NonPublicCtorEntity(id, name)
+                    }
+                    """
+                )
+            )
+
+        // Codegen continues (fallback to primary ctor); the warn path does not abort.
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("NonPublicCtorEntity_LirpTableDef.kt")
+        val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
+        // Bare ctor call is used (no creator, so className is the call target).
+        fromRowBlock shouldContain "NonPublicCtorEntity("
+        // The warn message is emitted about the non-public ctor.
+        result.messages shouldContain "non-public primary constructor"
+    }
+
+    // internal entity with a non-public resolved creator warns only (no error; codegen proceeds)
+    "internal entity with non-public resolved creator warns only" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "InternalEntityInternalCreator.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @PersistenceMapping
+                    internal data class InternalEntityInternalCreator(
+                        override val id: Int,
+                        val value: String
+                    ) : ReactiveEntityBase<Int, InternalEntityInternalCreator>() {
+                        companion object {
+                            @PersistenceCreator
+                            internal fun create(id: Int, value: String): InternalEntityInternalCreator =
+                                InternalEntityInternalCreator(id, value)
+                        }
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = InternalEntityInternalCreator(id, value)
+                    }
+                    """
+                )
+            )
+
+        // Warn only — codegen proceeds, no error.
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("InternalEntityInternalCreator_LirpTableDef.kt")
+        content shouldContain "InternalEntityInternalCreator"
+        result.messages shouldContain "not public"
+    }
+
+    // Gap A + Gap B regression: a top-level body-declared @Embedded var whose @Embeddable has a
+    // companion @PersistenceCreator must reconstruct through the factory (not the internal primary
+    // ctor), and the factory reference must be fully qualified so the generated descriptor — emitted
+    // into a different package without an import — compiles.
+    "body-declared @Embedded var uses fully-qualified companion factory in fromRow" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "BodyFlyweightEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @Embeddable
+                    data class FlyLabel internal constructor(val name: String, val countryCode: String) {
+                        companion object {
+                            @PersistenceCreator
+                            fun of(name: String, countryCode: String): FlyLabel = FlyLabel(name, countryCode)
+                        }
+                    }
+
+                    @PersistenceMapping
+                    class BodyFlyweightEntity(override val id: Int) : ReactiveEntityBase<Int, BodyFlyweightEntity>() {
+                        @Embedded var label: FlyLabel by reactiveProperty(FlyLabel.of("", ""))
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = BodyFlyweightEntity(id).also { it.label = label }
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("BodyFlyweightEntity_LirpTableDef.kt")
+        val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
+        // Gap A: setter reconstruction routes through the factory, not the internal primary ctor.
+        fromRowBlock shouldContain "entity.label = test.FlyLabel.of(name = "
+        // Gap B: the factory owner is fully qualified (no bare `FlyLabel.of` that would be unresolved).
+        fromRowBlock shouldNotContain "entity.label = FlyLabel.of"
+        fromRowBlock shouldNotContain "entity.label = test.FlyLabel(name = "
+    }
+
+    // multiple @PersistenceCreator on a nested @Embeddable produces a compilation error naming both
+    "multiple @PersistenceCreator on an @Embeddable produces compilation error" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "AmbiguousEmbeddableEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @Embeddable
+                    data class Coord internal constructor(val lat: Double, val lng: Double) {
+                        companion object {
+                            @PersistenceCreator fun of(lat: Double, lng: Double): Coord = Coord(lat, lng)
+                            @PersistenceCreator fun create(lat: Double, lng: Double): Coord = Coord(lat, lng)
+                        }
+                    }
+
+                    @PersistenceMapping
+                    data class AmbiguousEmbeddableEntity(
+                        override val id: Int,
+                        @Embedded val coord: Coord
+                    ) : ReactiveEntityBase<Int, AmbiguousEmbeddableEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = AmbiguousEmbeddableEntity(id, coord)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+        result.messages shouldContain "Multiple @PersistenceCreator"
+        result.messages shouldContain "of"
+        result.messages shouldContain "create"
+    }
+
+    // a creator param on an @Embeddable with no mapped column and no default is a compilation error
+    "unmatched @Embeddable creator param without default produces compilation error" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "UnmatchedEmbeddableEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @Embeddable
+                    data class Money(val amount: Long) {
+                        companion object {
+                            @PersistenceCreator
+                            fun of(amount: Long, currency: String): Money = Money(amount)
+                        }
+                    }
+
+                    @PersistenceMapping
+                    data class UnmatchedEmbeddableEntity(
+                        override val id: Int,
+                        @Embedded val price: Money
+                    ) : ReactiveEntityBase<Int, UnmatchedEmbeddableEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = UnmatchedEmbeddableEntity(id, price)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldNotBe KotlinCompilation.ExitCode.OK
+        result.messages shouldContain "currency"
+        result.messages shouldContain "no mapped column source"
+    }
+
+    // an internal @Embeddable whose resolved creator is not public warns only; codegen proceeds
+    "internal @Embeddable with non-public creator warns only" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "InternalEmbeddableEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceCreator
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @Embeddable
+                    internal data class Tag internal constructor(val value: String) {
+                        companion object {
+                            @PersistenceCreator internal fun of(value: String): Tag = Tag(value)
+                        }
+                    }
+
+                    @PersistenceMapping
+                    internal data class InternalEmbeddableEntity(
+                        override val id: Int,
+                        @Embedded val tag: Tag
+                    ) : ReactiveEntityBase<Int, InternalEmbeddableEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = InternalEmbeddableEntity(id, tag)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.messages shouldContain "not public"
+        val content = result.generatedFileContent("InternalEmbeddableEntity_LirpTableDef.kt")
+        content.substringAfter("override fun fromRow") shouldContain "test.Tag.of(value = "
+    }
+
+    // an @Embeddable with a non-public primary ctor and no creator falls back and warns
+    "@Embeddable with non-public primary ctor and no creator falls back with warning" {
+        val result =
+            compileWithProcessor(
+                SourceFile.kotlin(
+                    "NoCreatorEmbeddableEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+
+                    @Embeddable
+                    data class Ratio internal constructor(val numerator: Int, val denominator: Int)
+
+                    @PersistenceMapping
+                    data class NoCreatorEmbeddableEntity(
+                        override val id: Int,
+                        @Embedded val ratio: Ratio
+                    ) : ReactiveEntityBase<Int, NoCreatorEmbeddableEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = NoCreatorEmbeddableEntity(id, ratio)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.messages shouldContain "non-public primary constructor and no"
+        val content = result.generatedFileContent("NoCreatorEmbeddableEntity_LirpTableDef.kt")
+        content.substringAfter("override fun fromRow") shouldContain "test.Ratio(numerator = "
+    }
+})


### PR DESCRIPTION
## Summary

The KSP-generated `fromRow` reconstructed entities and `@Embeddable` value objects by invoking their **primary constructor**. That broke two legitimate patterns:

1. **Flyweight value objects** with non-public (`internal`) constructors exposed only through caching factories (e.g. `Artist.of(name, cc)`) — generated `Artist(...)` failed to compile (`Cannot access <init>: it is internal`).
2. **`internal` entities consumed externally** — a generated descriptor that calls an `internal` constructor only compiles inside the entity's own module, leaving no public reconstruction seam for a separate `*-sql` module or downstream consumer.

This PR introduces `@PersistenceCreator` to designate a public reconstruction entry point, closing both gaps. Closes #221.

## What changed

- **New `@PersistenceCreator` annotation** (`lirp-api`, `@Target(FUNCTION, CONSTRUCTOR)`, `@Retention(BINARY)`) marks a companion-object function or a secondary constructor as the reconstruction target.
- **KSP resolution** — `resolveCreator()` + a `CreatorResolution` sealed type (`Found` / `None` / `Ambiguous`) in `KspUtils`; `EmbeddableAnalyzer` and `TableDefProcessor` route `fromRow` through the resolved creator for both entities and nested `@Embeddable`s.
- **Behavior:**
  - A present `@PersistenceCreator` always takes precedence over the primary constructor.
  - No creator + a non-public primary constructor → falls back to the primary constructor with a warning.
  - More than one `@PersistenceCreator` on a type → compile-time error naming every offender.
  - Creator parameters match by name against the constructor/slot tree; an unmatched parameter is an error unless it has a default (then it is omitted so the default applies).
  - A `@PersistenceIgnore`d non-null parameter that has a default is omitted from the call rather than passed `null`.
  - An `internal` type whose resolved creator is not public warns (the descriptor still compiles in-module) rather than failing.
- **Body-declared top-level `@Embedded var`** properties now reconstruct through the creator, and factory calls are emitted **fully qualified** so the generated descriptor compiles in any consuming package.

## Verification

- [x] `:lirp-ksp` unit suite green, including a dedicated `PersistenceCreatorProcessorTest` covering companion-factory and secondary-constructor emission, defaulted-parameter omission, creator precedence, the ambiguous-creator and unmatched-parameter errors, the fallback/internal warnings, and fully-qualified body-declared `@Embedded var` reconstruction.
- [x] Full `gradle build` (unit tests) green; no regressions in existing `@Embedded` / TableDef tests.
- [x] **End-to-end validated against a real consumer:** in `music-commons`, the hand-written `FXAudioItemSqlTableDef` was removed and the generated descriptor reconstructs `FXAudioItem` and its flyweight `Artist` / `Label` value objects through their factories. Two issues surfaced during that validation (top-level `@Embedded` bypassing the creator; factory calls not fully qualified) and are fixed here.

## Key files

- `lirp-api/.../persistence/PersistenceCreator.kt` — new annotation
- `lirp-ksp/.../KspUtils.kt` — `resolveCreator`, `CreatorResolution`, FQN call-qualifier, shared visibility/diagnostic helpers
- `lirp-ksp/.../EmbeddableAnalyzer.kt`, `TableDefProcessor.kt`, `TableDefSourceEmitter.kt`, `CtorSlot.kt` — creator-aware reconstruction
- `lirp-ksp/.../PersistenceCreatorProcessorTest.kt` — coverage
