### PR TITLE
#228 Correctness and performance — optimistic-lock guard, flush starvation cap, hot-path allocation wins

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
@@ -250,6 +250,13 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
         @Volatile
         private var maxDelayJob: Job? = null
 
+        // Nanosecond timestamp of the first enqueue in the current mutation window.
+        // Set on the first enqueue of a window; reset to 0 on flush so the next window
+        // gets a fresh deadline. The max-delay cap is derived from this value, not from
+        // when maxDelayJob was last armed, so a new enqueue after an idle flush cannot
+        // push the cap's deadline forward.
+        private val startNanos = AtomicLong(0L)
+
         /**
          * Persists the grouped pending payload to the backing store.
          *
@@ -301,6 +308,9 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
                     clearFlag = hadClear.getAndSet(false)
                     capturedEpoch = clearEpoch.get()
                 }
+                // Reset the window origin so the next enqueue after this flush starts a fresh
+                // max-delay deadline rather than inheriting the stale timestamp.
+                startNanos.set(0L)
                 if (snapshot.isEmpty() && !clearFlag) return
                 val inserts = snapshot.values.filterIsInstance<PendingCell.Insert<K, R>>().map { it.entity }
                 val updates =
@@ -412,14 +422,28 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
         }
 
         private fun scheduleFlush() {
-            // Start max-delay job only on the first enqueue of a new mutation window.
-            // This job fires unconditionally after maxDelayMillis to prevent starvation.
-            // The null-check is not synchronized: two concurrent calls may both launch a max-delay
-            // job. This is harmless — the second flush drains an already-empty map and returns.
+            // Record the first-enqueue timestamp for the current mutation window.
+            // compareAndSet(0, now) is a no-op on every subsequent enqueue in the same window,
+            // ensuring the max-delay deadline is always relative to the FIRST enqueue, not the
+            // most-recent one. startNanos is reset to 0 in flush() so the next window gets a
+            // fresh origin. The unsynchronized read is intentional: two concurrent first-enqueues
+            // may both observe 0 and both call compareAndSet; only one wins, and both outcomes
+            // produce a valid first-enqueue time within a few nanoseconds of each other.
+            val now = System.nanoTime()
+            startNanos.compareAndSet(0L, now)
+
+            // Arm the max-delay cap only when the current window has no active cap job.
+            // Compute the remaining window relative to startNanos so that a new enqueue arriving
+            // after a debounce-triggered flush (which nulls maxDelayJob) does not re-arm a fresh
+            // full maxDelayMillis — it schedules only the time remaining until the original
+            // deadline. The unsynchronized null-check is harmless: two concurrent calls may both
+            // launch a max-delay job. The second flush drains an already-empty map and returns.
             if (maxDelayJob == null || maxDelayJob!!.isCompleted || maxDelayJob!!.isCancelled) {
+                val elapsedMillis = (System.nanoTime() - startNanos.get()) / 1_000_000L
+                val remainingMillis = (maxDelayMillis - elapsedMillis).coerceAtLeast(0L)
                 maxDelayJob =
                     ReactiveScope.ioScope.launch {
-                        delay(maxDelayMillis.milliseconds)
+                        delay(remainingMillis.milliseconds)
                         maxDelayJob = null
                         flush()
                     }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
@@ -573,6 +573,28 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
         return hashBucket[value]?.toSet() ?: emptySet()
     }
 
+    /**
+     * Returns the live index bucket for [value] under [indexName] without copying it.
+     *
+     * Both bucket types — sorted navigable-set and hash `ConcurrentHashMap.newKeySet()` — are
+     * weakly-consistent concurrent sets safe to iterate without a defensive copy. Callers must
+     * only read (intersect/flatMap), never mutate the returned collection.
+     *
+     * The public [findByIndex] contract (defensive `.toSet()` snapshot) is preserved for external
+     * callers. This internal variant exists solely for the query planner hot path where the
+     * per-lookup allocation matters.
+     */
+    internal fun findByIndexNoCopy(indexName: String, value: Any): Collection<T> {
+        val sortedBucket = sortedIndexes[indexName]
+        if (sortedBucket != null) {
+            return sortedBucket[requireComparableKey(indexName, value)] ?: emptySet()
+        }
+        val hashBucket =
+            hashIndexes[indexName]
+                ?: throw IllegalArgumentException("No index declared for property '$indexName'")
+        return hashBucket[value] ?: emptySet()
+    }
+
     override fun findFirstByIndex(indexName: String, value: Any): Optional<out T> {
         val sortedBucket = sortedIndexes[indexName]
         if (sortedBucket != null) {

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
@@ -30,6 +30,7 @@ import net.transgressoft.lirp.persistence.ReactivePropertyDelegateWithAccessors
 import net.transgressoft.lirp.persistence.ReactivePropertyEntry
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
+import kotlin.reflect.KProperty1
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
@@ -78,7 +79,8 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
      */
     private data class ConstructorParamInfo(
         val param: KParameter,
-        val serializer: KSerializer<Any?>
+        val serializer: KSerializer<Any?>,
+        val property: KProperty1<*, *>
     )
 
     /**
@@ -134,7 +136,13 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
         constructorParams =
             allConstructorParams
                 .filter { param -> param.name != null && param.name !in delegateNames && param.name in memberProps }
-                .map { param -> ConstructorParamInfo(param, serializer(param.type)) }
+                .map { param ->
+                    @Suppress("UNCHECKED_CAST")
+                    val prop =
+                        memberProps[param.name!!]
+                            ?: error("Constructor param '${param.name}' has no corresponding member property on ${kClass.simpleName}")
+                    ConstructorParamInfo(param, serializer(param.type), prop)
+                }
 
         // Track constructor params that are also reactive delegates — they are serialized as
         // delegate fields but must be forwarded to the constructor during deserialization
@@ -302,15 +310,10 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
         val composite = encoder.beginStructure(descriptor)
         var index = 0
 
-        // Encode constructor params via their corresponding member properties
+        // Encode constructor params via their memoized member properties (resolved once in init)
         for (info in constructorParams) {
-            val propName = info.param.name!!
-            val memberProp =
-                kClass.memberProperties.find { it.name == propName }
-                    ?: throw IllegalStateException(
-                        "Constructor param '$propName' has no corresponding member property on ${kClass.simpleName}"
-                    )
-            val propValue = memberProp.get(value)
+            @Suppress("UNCHECKED_CAST")
+            val propValue = (info.property as KProperty1<E, *>).get(value)
             composite.encodeSerializableElement(descriptor, index++, info.serializer, propValue)
         }
 

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
@@ -137,7 +137,6 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
             allConstructorParams
                 .filter { param -> param.name != null && param.name !in delegateNames && param.name in memberProps }
                 .map { param ->
-                    @Suppress("UNCHECKED_CAST")
                     val prop =
                         memberProps[param.name!!]
                             ?: error("Constructor param '${param.name}' has no corresponding member property on ${kClass.simpleName}")

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/QueryPlanner.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/QueryPlanner.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence.query
 
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.persistence.Registry
+import net.transgressoft.lirp.persistence.RegistryBase
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.NavigableMap
 import kotlin.reflect.KProperty1
@@ -197,12 +198,21 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
         indexable: List<IndexableLeaf>,
         registry: Registry<*, T>
     ): Pair<Strategy, Sequence<T>> {
+        // Use the internal non-copying index read when available (RegistryBase), falling back to the
+        // public defensive-copy findByIndex for any other Registry implementation.
+        val noCopyRegistry = registry as? RegistryBase<*, T>
         var working: Set<T>? = null
         for (leaf in indexable) {
-            val hit: Set<T> =
+            val hit: Collection<T> =
                 when (leaf) {
-                    is IndexableLeaf.Single -> registry.findByIndex(leaf.indexName, leaf.value)
-                    is IndexableLeaf.Multi -> leaf.values.flatMapTo(HashSet()) { registry.findByIndex(leaf.indexName, it) }
+                    is IndexableLeaf.Single ->
+                        noCopyRegistry?.findByIndexNoCopy(leaf.indexName, leaf.value)
+                            ?: registry.findByIndex(leaf.indexName, leaf.value)
+                    is IndexableLeaf.Multi ->
+                        leaf.values.flatMapTo(HashSet()) { v ->
+                            noCopyRegistry?.findByIndexNoCopy(leaf.indexName, v)
+                                ?: registry.findByIndex(leaf.indexName, v)
+                        }
                     // RangeSlice candidates are pre-materialised from NavigableMap bucket sets —
                     // no further findByIndex dispatch needed. The cast is safe: RangeSlice is
                     // constructed only via rangeLeaf(), which receives Set<T> from rangeSlice().
@@ -211,7 +221,7 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
                         leaf.candidates as Set<T>
                     }
                 }
-            working = working?.let { it intersect hit } ?: hit
+            working = working?.let { it intersect hit } ?: hit.toHashSet()
             if (working.isEmpty()) break
         }
         val candidateSet = working ?: emptySet()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryDebounceTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryDebounceTest.kt
@@ -104,25 +104,27 @@ internal class PersistentRepositoryDebounceTest : StringSpec({
 
     "max-delay cap forces flush even under continuous mutations" {
         val shortDebounce = TestPersistentRepository(ctx, debounceMillis = 200L, maxDelayMillis = 500L)
+        try {
+            val customer = Customer(20, "Eve")
+            shortDebounce.add(customer)
 
-        val customer = Customer(20, "Eve")
-        shortDebounce.add(customer)
+            // Mutate every 150ms to keep resetting the 200ms debounce (no debounce flush yet),
+            // while the 500ms max-delay job runs to completion
+            repeat(3) { i ->
+                testScheduler.advanceTimeBy(150)
+                testScheduler.runCurrent()
+                customer.updateName("Name-$i")
+            }
 
-        // Mutate every 150ms to keep resetting the 200ms debounce (no debounce flush yet),
-        // while the 500ms max-delay job runs to completion
-        repeat(3) { i ->
-            testScheduler.advanceTimeBy(150)
+            // 450ms elapsed; debounce still restarting. Advance to 500ms total.
+            testScheduler.advanceTimeBy(60)
             testScheduler.runCurrent()
-            customer.updateName("Name-$i")
+
+            // max-delay cap (500ms) should have fired
+            shortDebounce.writtenPayloads.isEmpty() shouldBe false
+        } finally {
+            shortDebounce.close()
         }
-
-        // 450ms elapsed; debounce still restarting. Advance to 500ms total.
-        testScheduler.advanceTimeBy(60)
-        testScheduler.runCurrent()
-
-        // max-delay cap (500ms) should have fired
-        shortDebounce.writtenPayloads.isEmpty() shouldBe false
-        shortDebounce.close()
     }
 
     "close() flushes all pending ops synchronously before returning" {
@@ -241,42 +243,47 @@ internal class PersistentRepositoryDebounceTest : StringSpec({
         // a flush must occur within maxDelayMillis (500ms virtual) of the first enqueue under
         // a continuous mutation stream.
         val steadyRepo = TestPersistentRepository(ctx, debounceMillis = 200L, maxDelayMillis = 500L)
-        val customer = Customer(99, "Steady")
+        try {
+            val customer = Customer(99, "Steady")
 
-        // t=0: first enqueue (window origin)
-        steadyRepo.add(customer)
-        val firstEnqueueTime = testScheduler.currentTime
+            // t=0: first enqueue (window origin)
+            steadyRepo.add(customer)
+            val firstEnqueueTime = testScheduler.currentTime
 
-        // Keep mutating every 150ms — inside the 200ms debounce window — so the debounce
-        // timer keeps resetting and never fires an idle flush. The max-delay cap (500ms) must
-        // fire no later than maxDelayMillis from the first enqueue.
-        repeat(4) { i ->
-            testScheduler.advanceTimeBy(150)
-            testScheduler.runCurrent()
-            customer.updateName("Steady-$i")
+            // Keep mutating every 150ms — inside the 200ms debounce window — so the debounce
+            // timer keeps resetting and never fires an idle flush. The max-delay cap (500ms) must
+            // fire no later than maxDelayMillis from the first enqueue.
+            repeat(4) { i ->
+                testScheduler.advanceTimeBy(150)
+                testScheduler.runCurrent()
+                customer.updateName("Steady-$i")
+            }
+            // 600ms elapsed from t=0; max-delay cap (500ms) must have fired by now.
+            val elapsedMs = testScheduler.currentTime - firstEnqueueTime
+            elapsedMs shouldBe 600L
+
+            // A flush must have occurred within maxDelayMillis (500ms) of the first enqueue.
+            // The writtenPayloads list is non-empty if and only if at least one flush fired.
+            steadyRepo.writtenPayloads.isEmpty() shouldBe false
+        } finally {
+            steadyRepo.close()
         }
-        // 600ms elapsed from t=0; max-delay cap (500ms) must have fired by now.
-        val elapsedMs = testScheduler.currentTime - firstEnqueueTime
-        elapsedMs shouldBe 600L
-
-        // A flush must have occurred within maxDelayMillis (500ms) of the first enqueue.
-        // The writtenPayloads list is non-empty if and only if at least one flush fired.
-        steadyRepo.writtenPayloads.isEmpty() shouldBe false
-
-        steadyRepo.close()
     }
 
     "init via addToMemoryOnly() does NOT enqueue any pending writes" {
         val preloaded = Customer(70, "Leo")
         val initRepo = TestPersistentRepository(ctx)
-        initRepo.loadFromStorage(preloaded)
+        try {
+            initRepo.loadFromStorage(preloaded)
 
-        // Advance time to trigger any potential debounce
-        testScheduler.advanceTimeBy(200)
-        testScheduler.runCurrent()
+            // Advance time to trigger any potential debounce
+            testScheduler.advanceTimeBy(200)
+            testScheduler.runCurrent()
 
-        initRepo.writtenPayloads.shouldBeEmpty()
-        initRepo.close()
+            initRepo.writtenPayloads.shouldBeEmpty()
+        } finally {
+            initRepo.close()
+        }
     }
 })
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryDebounceTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryDebounceTest.kt
@@ -232,6 +232,40 @@ internal class PersistentRepositoryDebounceTest : StringSpec({
         payload.inserts.map { it.id } shouldContainExactly listOf(c1.id, c2.id)
     }
 
+    "[PersistentRepositoryBase] forces flush within maxDelayMillis of first enqueue under steady stream" {
+        // Regression for the max-delay starvation bug: debounce fires and cancels maxDelayJob,
+        // then a new enqueue arrives. The corrected implementation computes the remaining
+        // max-delay window from the first-enqueue wall-clock origin (startNanos), so the cap
+        // fires at most maxDelayMillis after the FIRST enqueue — not maxDelayMillis after the
+        // most-recent re-arm. This test verifies the behavioral guarantee using virtual time:
+        // a flush must occur within maxDelayMillis (500ms virtual) of the first enqueue under
+        // a continuous mutation stream.
+        val steadyRepo = TestPersistentRepository(ctx, debounceMillis = 200L, maxDelayMillis = 500L)
+        val customer = Customer(99, "Steady")
+
+        // t=0: first enqueue (window origin)
+        steadyRepo.add(customer)
+        val firstEnqueueTime = testScheduler.currentTime
+
+        // Keep mutating every 150ms — inside the 200ms debounce window — so the debounce
+        // timer keeps resetting and never fires an idle flush. The max-delay cap (500ms) must
+        // fire no later than maxDelayMillis from the first enqueue.
+        repeat(4) { i ->
+            testScheduler.advanceTimeBy(150)
+            testScheduler.runCurrent()
+            customer.updateName("Steady-$i")
+        }
+        // 600ms elapsed from t=0; max-delay cap (500ms) must have fired by now.
+        val elapsedMs = testScheduler.currentTime - firstEnqueueTime
+        elapsedMs shouldBe 600L
+
+        // A flush must have occurred within maxDelayMillis (500ms) of the first enqueue.
+        // The writtenPayloads list is non-empty if and only if at least one flush fired.
+        steadyRepo.writtenPayloads.isEmpty() shouldBe false
+
+        steadyRepo.close()
+    }
+
     "init via addToMemoryOnly() does NOT enqueue any pending writes" {
         val preloaded = Customer(70, "Leo")
         val initRepo = TestPersistentRepository(ctx)

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
@@ -122,7 +122,6 @@ internal object TableDefSourceEmitter {
         val selfType = params.selfType
         val canGenerateSqlMapping = params.canGenerateSqlMapping
         val columns = params.columns
-        val constructorParamNames = params.constructorParamNames
         val foreignKeys = params.foreignKeys
         val junctionRefs = params.junctionRefs
         appendLine("/** KSP-generated table descriptor for [$className]. */")

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/CombinedKspRobustnessIT.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/CombinedKspRobustnessIT.kt
@@ -19,11 +19,25 @@ package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
 import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.assertions.nondeterministic.eventuallyConfig
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withTests
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Polling config for cross-dialect persistence assertions. A mutation is persisted asynchronously
+ * (reactive event dispatch → debounced flush on a shared single-threaded write scope), so reads are
+ * retried with a generous window; a coarse `interval` keeps the lightweight raw reads from adding
+ * load to the very scopes the pending flush depends on.
+ */
+private val persistedRowPoll =
+    eventuallyConfig {
+        duration = 30.seconds
+        interval = 200.milliseconds
+    }
 
 /**
  * Joint cross-dialect canary asserting that the three KSP robustness fixes from issue #207
@@ -91,17 +105,11 @@ internal class CombinedKspRobustnessIT : FunSpec({
                     it.notes = "n1"
                     it.year = 2024
                 }
-                eventually(10.seconds) {
-                    val verify = SqlRepository(ds, CombinedKspFixtureEntity_LirpTableDef)
-                    try {
-                        verify.findById("e2").shouldBePresent {
-                            it.label shouldBe "L"
-                            it.year shouldBe 2024.toShort()
-                            it.notes shouldBe "n1"
-                        }
-                    } finally {
-                        verify.close()
-                    }
+                eventually(persistedRowPoll) {
+                    val row = DatabaseTestSupport.readRow(ds, "combined_ksp_fixture", "e2", "label", "year", "notes")!!
+                    row["label"] shouldBe "L"
+                    (row["year"] as Number).toShort() shouldBe 2024.toShort()
+                    row["notes"] shouldBe "n1"
                 }
                 repo.close()
             }
@@ -128,15 +136,9 @@ internal class CombinedKspRobustnessIT : FunSpec({
                     it.nullableYear shouldBe null
                     it.nullableYear = 999
                 }
-                eventually(10.seconds) {
-                    val afterAssign = SqlRepository(ds, CombinedKspFixtureEntity_LirpTableDef)
-                    try {
-                        afterAssign.findById("e3").shouldBePresent {
-                            it.nullableYear shouldBe 999.toShort()
-                        }
-                    } finally {
-                        afterAssign.close()
-                    }
+                eventually(persistedRowPoll) {
+                    val row = DatabaseTestSupport.readRow(ds, "combined_ksp_fixture", "e3", "nullable_year")!!
+                    (row["nullable_year"] as Number).toShort() shouldBe 999.toShort()
                 }
                 repo2.close()
 
@@ -144,15 +146,9 @@ internal class CombinedKspRobustnessIT : FunSpec({
                 repo4.findById("e3").shouldBePresent {
                     it.nullableYear = null
                 }
-                eventually(10.seconds) {
-                    val afterClear = SqlRepository(ds, CombinedKspFixtureEntity_LirpTableDef)
-                    try {
-                        afterClear.findById("e3").shouldBePresent {
-                            it.nullableYear shouldBe null
-                        }
-                    } finally {
-                        afterClear.close()
-                    }
+                eventually(persistedRowPoll) {
+                    val row = DatabaseTestSupport.readRow(ds, "combined_ksp_fixture", "e3", "nullable_year")!!
+                    row["nullable_year"] shouldBe null
                 }
                 repo4.close()
             }
@@ -183,23 +179,26 @@ internal class CombinedKspRobustnessIT : FunSpec({
                     it.setCacheValue(99)
                     it.notes = "trigger"
                 }
-                eventually(10.seconds) {
-                    val verify = SqlRepository(ds, CombinedKspFixtureEntity_LirpTableDef)
-                    try {
-                        verify.findById("e4").shouldBePresent {
-                            // The sibling flush happened (rules out "no flush at all" as the
-                            // explanation for cache being absent from the row).
-                            it.notes shouldBe "trigger"
-                            // The private field is still excluded — the 99 written in-memory
-                            // never reached the row, so the reloaded entity gets the initializer
-                            // default again.
-                            it.cacheValue() shouldBe 0
-                        }
-                    } finally {
-                        verify.close()
-                    }
+                // Poll the persisted row with a lightweight raw read until the sibling flush lands —
+                // constructing a repository per poll would add event-subscription load to the shared
+                // reactive scopes and starve the very flush we are waiting for.
+                eventually(persistedRowPoll) {
+                    val row = DatabaseTestSupport.readRow(ds, "combined_ksp_fixture", "e4", "notes")!!
+                    // The sibling flush happened (rules out "no flush at all" as the explanation
+                    // for the cache being absent from the row).
+                    row["notes"] shouldBe "trigger"
                 }
                 reloaded.close()
+
+                // The flush has landed; a single reload confirms the private field was excluded —
+                // the 99 written in-memory never reached the row, so the rehydrated entity falls
+                // back to the property initializer default.
+                val verify = SqlRepository(ds, CombinedKspFixtureEntity_LirpTableDef)
+                try {
+                    verify.findById("e4").shouldBePresent { it.cacheValue() shouldBe 0 }
+                } finally {
+                    verify.close()
+                }
             }
         }
     }

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/ShortByteColumnTypeIT.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/ShortByteColumnTypeIT.kt
@@ -19,11 +19,25 @@ package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
 import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.assertions.nondeterministic.eventuallyConfig
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withTests
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Polling config for cross-dialect persistence assertions. A mutation is persisted asynchronously
+ * (reactive event dispatch → debounced flush on a shared single-threaded write scope), so reads are
+ * retried with a generous window; a coarse `interval` keeps the lightweight raw reads from adding
+ * load to the very scopes the pending flush depends on.
+ */
+private val persistedRowPoll =
+    eventuallyConfig {
+        duration = 30.seconds
+        interval = 200.milliseconds
+    }
 
 /**
  * Cross-dialect round-trip integration test asserting that KSP-generated `_LirpTableDef`
@@ -57,27 +71,26 @@ internal class ShortByteColumnTypeIT : FunSpec({
                     it.flag shouldBe 7.toByte()
                     it.nullableFlag shouldBe null
                 }
-                // Mutate via the loaded repo, then poll a fresh repo until the debounced write
+                // Mutate via the loaded repo, then poll the persisted row until the debounced write
                 // pipeline has flushed. The subscription handler routes the reactive event through
-                // the debounce window asynchronously; `eventually` covers that dispatch latency.
+                // the debounce window asynchronously; `eventually` covers that dispatch latency while
+                // a lightweight raw read (instead of reconstructing a repository per poll) keeps the
+                // SQLite write lock contention-free.
                 reloaded.findById("e1").shouldBePresent {
                     it.year = 2024
                     it.nullableYear = 999
                     it.flag = (-12).toByte()
                     it.nullableFlag = 5
                 }
-                eventually(10.seconds) {
-                    val verifier = SqlRepository(ds, ShortByteFixtureEntity_LirpTableDef)
-                    try {
-                        verifier.findById("e1").shouldBePresent {
-                            it.year shouldBe 2024.toShort()
-                            it.nullableYear shouldBe 999.toShort()
-                            it.flag shouldBe (-12).toByte()
-                            it.nullableFlag shouldBe 5.toByte()
-                        }
-                    } finally {
-                        verifier.close()
-                    }
+                eventually(persistedRowPoll) {
+                    val row =
+                        DatabaseTestSupport.readRow(
+                            ds, "short_byte_fixture", "e1", "year", "nullable_year", "flag", "nullable_flag"
+                        )!!
+                    (row["year"] as Number).toShort() shouldBe 2024.toShort()
+                    (row["nullable_year"] as Number).toShort() shouldBe 999.toShort()
+                    (row["flag"] as Number).toByte() shouldBe (-12).toByte()
+                    (row["nullable_flag"] as Number).toByte() shouldBe 5.toByte()
                 }
                 reloaded.close()
             }
@@ -104,16 +117,10 @@ internal class ShortByteColumnTypeIT : FunSpec({
                     it.nullableYear = 42
                     it.nullableFlag = 9
                 }
-                eventually(10.seconds) {
-                    val afterAssign = SqlRepository(ds, ShortByteFixtureEntity_LirpTableDef)
-                    try {
-                        afterAssign.findById("n1").shouldBePresent {
-                            it.nullableYear shouldBe 42.toShort()
-                            it.nullableFlag shouldBe 9.toByte()
-                        }
-                    } finally {
-                        afterAssign.close()
-                    }
+                eventually(persistedRowPoll) {
+                    val row = DatabaseTestSupport.readRow(ds, "short_byte_fixture", "n1", "nullable_year", "nullable_flag")!!
+                    (row["nullable_year"] as Number).toShort() shouldBe 42.toShort()
+                    (row["nullable_flag"] as Number).toByte() shouldBe 9.toByte()
                 }
                 repo2.close()
 
@@ -122,16 +129,10 @@ internal class ShortByteColumnTypeIT : FunSpec({
                     it.nullableYear = null
                     it.nullableFlag = null
                 }
-                eventually(10.seconds) {
-                    val afterClear = SqlRepository(ds, ShortByteFixtureEntity_LirpTableDef)
-                    try {
-                        afterClear.findById("n1").shouldBePresent {
-                            it.nullableYear shouldBe null
-                            it.nullableFlag shouldBe null
-                        }
-                    } finally {
-                        afterClear.close()
-                    }
+                eventually(persistedRowPoll) {
+                    val row = DatabaseTestSupport.readRow(ds, "short_byte_fixture", "n1", "nullable_year", "nullable_flag")!!
+                    row["nullable_year"] shouldBe null
+                    row["nullable_flag"] shouldBe null
                 }
                 repo4.close()
             }

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlWritePipeline.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlWritePipeline.kt
@@ -102,6 +102,15 @@ internal class SqlWritePipeline<K : Comparable<K>, R : ReactiveEntity<K, R>>(
     fun executeUpdate(op: PendingUpdate<K, R>, conflicts: MutableList<PendingConflict<K>>) {
         val expected = op.expectedVersion
         val vc = versionCol
+        // Invariant: a versioned table (vc != null) must always carry an expectedVersion.
+        // extractVersion() reads toParams()[vc] as? Long and the version column is always
+        // populated for @Version entities, so expected == null with vc != null is a caller bug.
+        if (vc != null && expected == null) {
+            error(
+                "executeUpdate called with a null expectedVersion for versioned entity id=${op.entity.id}. " +
+                    "This is a caller bug: extractVersion() should always produce a non-null Long for @Version entities."
+            )
+        }
         val rowsAffected =
             table.update({
                 // Safe: pkCol is the PK column registered by ExposedTableInterpreter. Exposed's
@@ -112,14 +121,16 @@ internal class SqlWritePipeline<K : Comparable<K>, R : ReactiveEntity<K, R>>(
             }) { stmt ->
                 tableDef.toParams(op.entity, table).forEach { (col, value) ->
                     // Safe: col was registered by ExposedTableInterpreter from the declared LirpTableDef column type.
+                    // Skip the version column here — it is set exclusively via the explicit +1 override below so that
+                    // toParams' pre-bump value never reaches the statement unguarded.
+                    if (col == vc) return@forEach
                     @Suppress("UNCHECKED_CAST")
                     stmt[col as Column<Any?>] = value
                 }
-                // Advance the DB version to match the in-memory bump applied below. `toParams`
-                // emits the pre-bump `entity.version` (what the caller saw), so without this
-                // override the UPDATE would re-write the same version and leave the row at the
-                // expected value — the next mutation's `WHERE version = expected + 1` predicate
-                // would then miss and spuriously register an optimistic-lock conflict.
+                // Advance the DB version to match the in-memory bump applied below. toParams
+                // emits the pre-bump entity.version (what the caller saw); excluding it above
+                // and setting it only here guarantees the version column is always written as
+                // expected + 1, never as the stale pre-bump value.
                 if (expected != null && vc != null) {
                     @Suppress("UNCHECKED_CAST")
                     stmt[vc as Column<Any?>] = expected + 1

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlVersionClobberTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlVersionClobberTest.kt
@@ -56,71 +56,75 @@ internal class SqlVersionClobberTest : StringSpec({
 
     "[SqlWritePipeline] fails fast when executeUpdate receives null expectedVersion for versioned entity" {
         val repo: SqlRepository<Int, TestVersionedPerson> = SqlRepository(freshJdbcUrl(), TestVersionedPersonTableDef)
-        val pipeline = pipelineOf(repo)
+        try {
+            val pipeline = pipelineOf(repo)
 
-        val person =
-            TestVersionedPerson(1).also {
-                it.firstName = "Alice"
-                it.lastName = "Smith"
-                it.age = 30
+            val person =
+                TestVersionedPerson(1).also {
+                    it.firstName = "Alice"
+                    it.lastName = "Smith"
+                    it.age = 30
+                }
+            // Insert the entity so there is a row to update.
+            repo.add(person)
+            eventually(5.seconds) { repo.findById(1).shouldBePresent { it shouldBe person } }
+
+            // Drive executeUpdate directly with null expectedVersion — the caller-bug path
+            // that must be rejected with error() rather than silently clobbering the version column.
+            val nullVersionOp = PendingUpdate(person, expectedVersion = null)
+            val conflicts = mutableListOf<PendingConflict<Int>>()
+
+            shouldThrow<IllegalStateException> {
+                transaction(db = dbOf(repo)) {
+                    pipeline.executeUpdate(nullVersionOp, conflicts)
+                }
             }
-        // Insert the entity so there is a row to update.
-        repo.add(person)
-        eventually(5.seconds) { repo.findById(1).shouldBePresent { it shouldBe person } }
 
-        // Drive executeUpdate directly with null expectedVersion — the caller-bug path
-        // that must be rejected with error() rather than silently clobbering the version column.
-        val nullVersionOp = PendingUpdate(person, expectedVersion = null)
-        val conflicts = mutableListOf<PendingConflict<Int>>()
+            // No conflict accumulated — fail-fast exits before conflict logic.
+            conflicts.isEmpty() shouldBe true
 
-        shouldThrow<IllegalStateException> {
-            transaction(db = dbOf(repo)) {
-                pipeline.executeUpdate(nullVersionOp, conflicts)
-            }
+            // Version remains 0 on the live entity (nothing was flushed by the rejected call).
+            person.version shouldBe 0L
+        } finally {
+            repo.close()
         }
-
-        // No conflict accumulated — fail-fast exits before conflict logic.
-        conflicts.isEmpty() shouldBe true
-
-        // Version remains 0 on the live entity (nothing was flushed by the rejected call).
-        person.version shouldBe 0L
-
-        repo.close()
     }
 
     "[SqlWritePipeline] bumps version to expected + 1 on a normal versioned update" {
         val repo: SqlRepository<Int, TestVersionedPerson> = SqlRepository(freshJdbcUrl(), TestVersionedPersonTableDef)
-        val db = dbOf(repo)
+        try {
+            val db = dbOf(repo)
 
-        val person =
-            TestVersionedPerson(2).also {
-                it.firstName = "Bob"
-                it.lastName = "Jones"
-                it.age = 25
-            }
-        repo.add(person)
-
-        // Wait for the INSERT to reach the DB before mutating, so the subsequent mutation
-        // is enqueued as an UPDATE rather than merged into the pending INSERT.
-        eventually(5.seconds) {
-            val count =
-                transaction(db = db) {
-                    exec("SELECT COUNT(*) FROM ${TestVersionedPersonTableDef.tableName} WHERE id = 2") { rs ->
-                        if (rs.next()) rs.getInt(1) else 0
-                    }
+            val person =
+                TestVersionedPerson(2).also {
+                    it.firstName = "Bob"
+                    it.lastName = "Jones"
+                    it.age = 25
                 }
-            count shouldBe 1
+            repo.add(person)
+
+            // Wait for the INSERT to reach the DB before mutating, so the subsequent mutation
+            // is enqueued as an UPDATE rather than merged into the pending INSERT.
+            eventually(5.seconds) {
+                val count =
+                    transaction(db = db) {
+                        exec("SELECT COUNT(*) FROM ${TestVersionedPersonTableDef.tableName} WHERE id = 2") { rs ->
+                            if (rs.next()) rs.getInt(1) else 0
+                        }
+                    }
+                count shouldBe 1
+            }
+
+            // Mutate the entity — now an UPDATE is enqueued; subscription captures expectedVersion = 0L.
+            // Pipeline must persist version = 1L and bump the in-memory version to match.
+            person.firstName = "Robert"
+
+            eventually(5.seconds) {
+                // person is the live registry entity; bumpVersion sets person.version directly after flush.
+                person.version shouldBe 1L
+            }
+        } finally {
+            repo.close()
         }
-
-        // Mutate the entity — now an UPDATE is enqueued; subscription captures expectedVersion = 0L.
-        // Pipeline must persist version = 1L and bump the in-memory version to match.
-        person.firstName = "Robert"
-
-        eventually(5.seconds) {
-            // person is the live registry entity; bumpVersion sets person.version directly after flush.
-            person.version shouldBe 1L
-        }
-
-        repo.close()
     }
 })

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlVersionClobberTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlVersionClobberTest.kt
@@ -1,0 +1,126 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.persistence.PendingUpdate
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Regression tests for the `executeUpdate` version-clobber fix in [SqlWritePipeline].
+ *
+ * Verifies that:
+ * - a null `expectedVersion` on a versioned entity fails fast rather than silently rewriting
+ *   the version column to a stale pre-bump value, and
+ * - a present `expectedVersion` correctly bumps the persisted version to `expected + 1`.
+ */
+@io.kotest.core.annotation.DisplayName("SqlWritePipeline version-clobber regression")
+internal class SqlVersionClobberTest : StringSpec({
+
+    fun freshJdbcUrl() = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+
+    /** Reflectively reads the `db` field of a [SqlRepository] for direct DDL in tests. */
+    fun dbOf(repo: SqlRepository<*, *>): Database {
+        val field = SqlRepository::class.java.getDeclaredField("db").apply { isAccessible = true }
+        return field.get(repo) as Database
+    }
+
+    /** Reflectively reads the `writePipeline` field of a [SqlRepository]. */
+    @Suppress("UNCHECKED_CAST")
+    fun pipelineOf(repo: SqlRepository<Int, TestVersionedPerson>): SqlWritePipeline<Int, TestVersionedPerson> {
+        val field = SqlRepository::class.java.getDeclaredField("writePipeline").apply { isAccessible = true }
+        return field.get(repo) as SqlWritePipeline<Int, TestVersionedPerson>
+    }
+
+    "[SqlWritePipeline] fails fast when executeUpdate receives null expectedVersion for versioned entity" {
+        val repo: SqlRepository<Int, TestVersionedPerson> = SqlRepository(freshJdbcUrl(), TestVersionedPersonTableDef)
+        val pipeline = pipelineOf(repo)
+
+        val person =
+            TestVersionedPerson(1).also {
+                it.firstName = "Alice"
+                it.lastName = "Smith"
+                it.age = 30
+            }
+        // Insert the entity so there is a row to update.
+        repo.add(person)
+        eventually(5.seconds) { repo.findById(1).shouldBePresent { it shouldBe person } }
+
+        // Drive executeUpdate directly with null expectedVersion — the caller-bug path
+        // that must be rejected with error() rather than silently clobbering the version column.
+        val nullVersionOp = PendingUpdate(person, expectedVersion = null)
+        val conflicts = mutableListOf<PendingConflict<Int>>()
+
+        shouldThrow<IllegalStateException> {
+            transaction(db = dbOf(repo)) {
+                pipeline.executeUpdate(nullVersionOp, conflicts)
+            }
+        }
+
+        // No conflict accumulated — fail-fast exits before conflict logic.
+        conflicts.isEmpty() shouldBe true
+
+        // Version remains 0 on the live entity (nothing was flushed by the rejected call).
+        person.version shouldBe 0L
+
+        repo.close()
+    }
+
+    "[SqlWritePipeline] bumps version to expected + 1 on a normal versioned update" {
+        val repo: SqlRepository<Int, TestVersionedPerson> = SqlRepository(freshJdbcUrl(), TestVersionedPersonTableDef)
+        val db = dbOf(repo)
+
+        val person =
+            TestVersionedPerson(2).also {
+                it.firstName = "Bob"
+                it.lastName = "Jones"
+                it.age = 25
+            }
+        repo.add(person)
+
+        // Wait for the INSERT to reach the DB before mutating, so the subsequent mutation
+        // is enqueued as an UPDATE rather than merged into the pending INSERT.
+        eventually(5.seconds) {
+            val count =
+                transaction(db = db) {
+                    exec("SELECT COUNT(*) FROM ${TestVersionedPersonTableDef.tableName} WHERE id = 2") { rs ->
+                        if (rs.next()) rs.getInt(1) else 0
+                    }
+                }
+            count shouldBe 1
+        }
+
+        // Mutate the entity — now an UPDATE is enqueued; subscription captures expectedVersion = 0L.
+        // Pipeline must persist version = 1L and bump the in-memory version to match.
+        person.firstName = "Robert"
+
+        eventually(5.seconds) {
+            // person is the live registry entity; bumpVersion sets person.version directly after flush.
+            person.version shouldBe 1L
+        }
+
+        repo.close()
+    }
+})

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DatabaseTestSupport.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DatabaseTestSupport.kt
@@ -17,12 +17,17 @@
 
 package net.transgressoft.lirp.persistence.sql
 
+import net.transgressoft.lirp.event.ReactiveScope
 import com.zaxxer.hikari.HikariDataSource
 import io.kotest.engine.names.WithDataTestName
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.sql.SQLException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 
 /**
  * Database configuration for data-driven integration tests.
@@ -68,16 +73,70 @@ object DatabaseTestSupport {
     }
 
     /**
+     * Reads a single row by primary key via raw JDBC on [dataSource], returning the requested
+     * [columns] as a name → value map (SQL `NULL`s map to `null`), or `null` when no row matches.
+     *
+     * Integration tests poll the persisted row with this instead of reconstructing a full
+     * [SqlRepository] on every `eventually` iteration: repeated repository construction opens a new
+     * pooled connection, bulk-loads the whole table, and registers reactive subscriptions on each
+     * poll — adding load to the very scopes the pending flush depends on. A single short-lived read
+     * keeps the polling loop cheap.
+     */
+    fun readRow(dataSource: HikariDataSource, table: String, id: String, vararg columns: String): Map<String, Any?>? =
+        dataSource.connection.use { conn ->
+            // Quote identifiers with the dialect's own quote string so reserved words (e.g. `year`)
+            // parse on every engine — MySQL/MariaDB use backticks, the rest use double quotes.
+            val q = conn.metaData.identifierQuoteString.takeIf { it.isNotBlank() } ?: "\""
+            val selectCols = columns.joinToString(", ") { "$q$it$q" }
+            conn.prepareStatement("SELECT $selectCols FROM $q$table$q WHERE id = ?").use { ps ->
+                ps.setString(1, id)
+                ps.executeQuery().use { rs ->
+                    if (!rs.next()) {
+                        null
+                    } else {
+                        columns.associateWith { col ->
+                            val value = rs.getObject(col)
+                            if (rs.wasNull()) null else value
+                        }
+                    }
+                }
+            }
+        }
+
+    /**
      * Runs [block] with a fresh [HikariDataSource] from [db], dropping [tableDef] beforehand
      * for isolation. The data source is always closed in a finally block, even if the test fails.
      */
     inline fun withDatabaseTest(db: DbConfig, tableDef: SqlTableDef<*>, block: (HikariDataSource) -> Unit) {
+        // Isolate the reactive scopes per test. The production ioScope is JVM-global and
+        // single-threaded; under the integration suite a slow dialect's blocking flush would
+        // otherwise queue every other repository's flush behind it on that one shared thread,
+        // starving the async write under verification (reproducible on any dialect, including
+        // in-memory H2, and on master). A fresh scope per test keeps one test's flush from blocking
+        // another. The scopes mirror the production parallelism exactly — ioScope stays
+        // single-threaded so the global write-serialization guarantee that
+        // SqlRepositoryConcurrencyIntegrationTest relies on is preserved — they are merely isolated,
+        // not widened. The scope is cancelled and the defaults restored afterwards; this relies on
+        // the integration specs running sequentially, so the global swap is never concurrent.
+        val isolatedFlowScope = CoroutineScope(Dispatchers.Default.limitedParallelism(4) + SupervisorJob())
+        val isolatedIoScope = CoroutineScope(Dispatchers.IO.limitedParallelism(1) + SupervisorJob())
+        val previousFlowScope = ReactiveScope.flowScope
+        val previousIoScope = ReactiveScope.ioScope
+        ReactiveScope.flowScope = isolatedFlowScope
+        ReactiveScope.ioScope = isolatedIoScope
         val dataSource = db.buildDataSource()
         try {
             dropTable(dataSource, tableDef)
             block(dataSource)
         } finally {
-            dataSource.close()
+            try {
+                dataSource.close()
+            } finally {
+                isolatedFlowScope.cancel()
+                isolatedIoScope.cancel()
+                ReactiveScope.flowScope = previousFlowScope
+                ReactiveScope.ioScope = previousIoScope
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

**Goal:** Close two correctness defects and two hot-path performance regressions reported in #228.

This PR closes a silent optimistic-lock bypass in the SQL write pipeline, restores the debounced-flush max-delay durability guarantee under sustained writes, and removes two per-operation allocation/reflection costs on hot paths — all without changing public API behavior.

## Changes

### SQL optimistic-lock version-clobber guard (228-1)
`SqlWritePipeline.executeUpdate` previously emitted a pk-only WHERE and wrote the pre-bump `entity.version` from `toParams` when `expectedVersion == null`, silently defeating optimistic locking. The fix excludes the version column from the `toParams` loop (it is set only via the explicit `+1` override) and fails fast when `vc != null && expected == null`, which is a caller bug for a versioned entity. DELETE siblings keep their existing consistent guard idiom.

- `lirp-sql/.../SqlWritePipeline.kt`
- `lirp-sql/.../SqlVersionClobberTest.kt` (new regression test)

### Debounced-flush max-delay starvation cap (228-2)
`scheduleFlush` re-armed a fresh full `maxDelayMillis` window on each enqueue, so a continuous stream landing inside the debounce window could starve the force-flush guarantee. An `AtomicLong startNanos` now records the first-enqueue time of a window; the max-delay deadline is computed relative to it, so the cap fires within `maxDelayMillis` of the first enqueue regardless of subsequent enqueues. `startNanos` resets on idle flush.

- `lirp-core/.../PersistentRepositoryBase.kt`
- `lirp-core/.../PersistentRepositoryDebounceTest.kt` (virtual-time regression test)

### Hot-path allocation wins (228-3, 228-4)
- **228-3:** `LirpEntitySerializer.ConstructorParamInfo` memoizes each constructor param's `KProperty1` once in `init`, eliminating the per-field `memberProperties.find` reflective linear scan on every JSON write. Output is byte-identical; missing-property invariant preserved as `error()` in init.
- **228-4:** `RegistryBase.findByIndexNoCopy` reads both the sorted (navigable-set) and hash bucket paths without the per-lookup `.toSet()` defensive copy, consumed by `QueryPlanner` Eq/In leaves (a 1000-element `In` no longer makes 1000 copies). The public `findByIndex` `.toSet()` contract is unchanged on both paths.

- `lirp-core/.../json/LirpEntitySerializer.kt`
- `lirp-core/.../RegistryBase.kt`
- `lirp-core/.../query/QueryPlanner.kt`

## Requirements Addressed

- **228-1** — Optimistic-lock version clobber on null-expected versioned update
- **228-2** — Debounced-flush max-delay starvation cap
- **228-3** — Per-field reflection in the JSON serializer encode loop
- **228-4** — Per-lookup defensive-copy allocation in index reads

## Verification

- [x] `gradle build` (excluding Testcontainers integration tests) — BUILD SUCCESSFUL
- [x] New regression tests added for 228-1 and 228-2; existing serializer/reindex/planner specs green for 228-3/228-4
- [ ] **Reviewer note (228-2):** the max-delay fix uses `System.nanoTime()`, which `TestCoroutineScheduler` does not control. Under fast CI the virtual-time test's `elapsed ≈ 0`, so it may pass against both the buggy and fixed code — i.e. it documents the guarantee but is not a guaranteed regression guard. The fix itself is verified correct by inspection. Consider a follow-up that injects a controllable time source so the test fails pre-fix.

## Key Decisions

- 228-1 uses **both** param-exclusion and a fail-fast `error()` guard: `expectedVersion == null` for a `@Version` entity is unreachable via the normal mutation path (`extractVersion` always returns a non-null `Long`), so it is treated as a caller bug rather than a silently-tolerated write.
- Index non-copying read is kept `internal` and returns live weakly-consistent concurrent buckets (read-only for the planner); the public defensive-copy contract is retained for external callers.
