### PR TITLE
Registry ProjectionMap (core + FX)

### DIFF
--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/entity/SoftDeletable.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/entity/SoftDeletable.kt
@@ -1,0 +1,32 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.entity
+
+import java.time.Instant
+
+/**
+ * Marks an entity as supporting soft deletion via a nullable [deletedAt] timestamp.
+ *
+ * An entity is considered soft-deleted when [deletedAt] is non-null. Repositories and
+ * projections that are aware of soft deletion filter out soft-deleted entities from their
+ * visible result sets.
+ */
+interface SoftDeletable {
+    /** The instant at which the entity was soft-deleted, or `null` if it is active. */
+    val deletedAt: Instant?
+}

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/CoreFactories.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/CoreFactories.kt
@@ -47,3 +47,31 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> projecti
     sourceRef: () -> AggregateCollectionRef<K, E>,
     keyExtractor: (E) -> PK
 ): ProjectionMap<K, PK, E> = ProjectionMap(sourceRef, keyExtractor)
+
+/**
+ * Creates a read-only projection that groups all entities from a [Registry] by a secondary key.
+ *
+ * The returned [RegistryProjectionMap] lazily initializes on the first map access,
+ * building its initial state from the registry's current contents and subscribing to
+ * incremental [net.transgressoft.lirp.event.CrudEvent] notifications for ongoing maintenance.
+ * Soft-deleted entities (those implementing [net.transgressoft.lirp.entity.SoftDeletable] with a
+ * non-null `deletedAt`) are excluded from all buckets.
+ *
+ * Keys are maintained in natural sorted order via a [java.util.concurrent.ConcurrentSkipListMap].
+ *
+ * Usage:
+ * ```kotlin
+ * val itemsByAlbum by registryProjectionMap(trackRepo) { it.albumName }
+ * ```
+ *
+ * @param K the entity ID type, must be [Comparable]
+ * @param PK the projection key type, must be [Comparable]
+ * @param E the entity type
+ * @param registry the source registry to project
+ * @param keyExtractor trailing-lambda grouping function that extracts the projection key from an entity
+ * @return a [RegistryProjectionMap] delegate grouping registry entities by [keyExtractor]
+ */
+fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> registryProjectionMap(
+    registry: Registry<K, E>,
+    keyExtractor: (E) -> PK
+): RegistryProjectionMap<K, PK, E> = RegistryProjectionMap(registry, keyExtractor)

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/ProjectionCore.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/ProjectionCore.kt
@@ -1,0 +1,156 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import net.transgressoft.lirp.entity.IdentifiableEntity
+import java.util.Collections
+import java.util.concurrent.ConcurrentSkipListMap
+
+/**
+ * Shared bucket engine for projection maps.
+ *
+ * Holds the backing [ConcurrentSkipListMap] and the [onChange] callback, and provides all
+ * bucket-mutation operations used by both aggregate-source and registry-source projections.
+ * This class is a pure composition target: it is not abstract and has no supertype.
+ *
+ * No reverse-index or entity-id logic lives here; callers are responsible for tracking
+ * which bucket key an entity belongs to across updates.
+ *
+ * @param K the entity ID type, must be [Comparable]
+ * @param PK the projection key type, must be [Comparable]
+ * @param E the entity type
+ * @param keyExtractor grouping function that extracts the projection key from an entity
+ */
+internal class ProjectionCore<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>>(
+    private val keyExtractor: (E) -> PK
+) {
+    val backingMap = ConcurrentSkipListMap<PK, List<E>>()
+    val readOnlyView: Map<PK, List<E>> = Collections.unmodifiableMap(backingMap)
+
+    /**
+     * Optional callback invoked after each projection change with the current map state.
+     * Fires after every incremental update that results in at least one addition, removal, or replacement.
+     *
+     * The callback fires on the same thread that performed the mutation; subscribers requiring a
+     * specific thread must marshal themselves.
+     */
+    var onChange: ((Map<PK, List<E>>) -> Unit)? = null
+
+    /**
+     * Returns an unmodifiable frozen snapshot of [elements] suitable for storage as a bucket value.
+     */
+    fun freezeBucket(elements: List<E>): List<E> = Collections.unmodifiableList(ArrayList(elements))
+
+    /**
+     * Inserts each element in [elements] into its bucket as determined by [keyExtractor], creating
+     * the bucket if absent. Fires [onChange] when at least one element was added.
+     */
+    fun handleAdded(elements: List<E>) {
+        var changed = false
+        for (element in elements) {
+            val key = keyExtractor(element)
+            backingMap[key] = freezeBucket((backingMap[key] ?: emptyList()) + element)
+            changed = true
+        }
+        if (changed) onChange?.invoke(readOnlyView)
+    }
+
+    /**
+     * Removes each element in [elements] from its bucket. When the primary bucket lookup by
+     * [keyExtractor] misses (e.g. the key field changed before removal), falls back to
+     * [removeFromAnyBucket]. Fires [onChange] when at least one element was removed.
+     */
+    fun handleRemoved(elements: List<E>) {
+        var changed = false
+        for (element in elements) {
+            val key = keyExtractor(element)
+            val bucket = backingMap[key]
+            if (bucket != null && element in bucket) {
+                val filtered = bucket.filter { it != element }
+                if (filtered.isEmpty()) backingMap.remove(key)
+                else backingMap[key] = freezeBucket(filtered)
+                changed = true
+            } else {
+                changed = removeFromAnyBucket(element) || changed
+            }
+        }
+        if (changed) onChange?.invoke(readOnlyView)
+    }
+
+    /**
+     * Scans all buckets and removes the first occurrence of [element], returning `true` if found.
+     *
+     * Used as a fallback when the element's key field has already been mutated so the primary
+     * bucket lookup would miss.
+     */
+    fun removeFromAnyBucket(element: E): Boolean {
+        for (entry in backingMap.entries) {
+            if (element in entry.value) {
+                val filtered = entry.value.filter { it != element }
+                // ConcurrentSkipListMap entry iterators return SimpleImmutableEntry instances whose setValue throws
+                // UnsupportedOperationException — go through the map directly instead.
+                if (filtered.isEmpty()) backingMap.remove(entry.key)
+                else backingMap[entry.key] = freezeBucket(filtered)
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * Removes [element] from the bucket at [key]. If the element is not found in that bucket,
+     * falls back to [removeFromAnyBucket]. Fires [onChange] when at least one element was removed.
+     */
+    fun handleRemovedFromBucket(element: E, key: PK) {
+        val bucket = backingMap[key]
+        if (bucket != null && element in bucket) {
+            val filtered = bucket.filter { it != element }
+            if (filtered.isEmpty()) backingMap.remove(key)
+            else backingMap[key] = freezeBucket(filtered)
+            onChange?.invoke(readOnlyView)
+        } else {
+            if (removeFromAnyBucket(element)) onChange?.invoke(readOnlyView)
+        }
+    }
+
+    /**
+     * Removes the entity with the given [entityId] from the bucket at [key], using an ID-based
+     * lookup rather than object equality. Used when the entity object may have already changed
+     * (e.g., key field mutation) so equality-based lookups would miss. Fires [onChange] when removed.
+     */
+    fun handleRemovedByIdFromBucket(entityId: K, key: PK) {
+        val bucket = backingMap[key] ?: return
+        val filtered = bucket.filter { it.id != entityId }
+        if (filtered.size == bucket.size) return // nothing removed
+        if (filtered.isEmpty()) backingMap.remove(key) else backingMap[key] = freezeBucket(filtered)
+        onChange?.invoke(readOnlyView)
+    }
+
+    /**
+     * Replaces the entity with the same [id][IdentifiableEntity.id] as [newEntity] in the bucket
+     * at [key]. No-op when the bucket is absent, the entity is not in the bucket, or the entity
+     * is already equal to [newEntity]. Fires [onChange] when the replacement occurs.
+     */
+    fun handleReplaceInBucket(newEntity: E, key: PK) {
+        val bucket = backingMap[key] ?: return
+        val oldEntity = bucket.firstOrNull { it.id == newEntity.id } ?: return
+        if (oldEntity == newEntity) return
+        backingMap[key] = freezeBucket(bucket.map { if (it.id == newEntity.id) newEntity else it })
+        onChange?.invoke(readOnlyView)
+    }
+}

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/ProjectionMap.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/ProjectionMap.kt
@@ -19,15 +19,13 @@ package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.event.CollectionChangeEvent
-import java.util.Collections
-import java.util.concurrent.ConcurrentSkipListMap
 import kotlin.reflect.KProperty
 
 /**
  * A read-only grouped view that derives a `Map<PK, List<E>>` from a source collection,
  * grouping entities by a secondary key via [keyExtractor].
  *
- * The projection uses a [ConcurrentSkipListMap] for natural key ordering with CME-free iteration,
+ * The projection uses a [java.util.concurrent.ConcurrentSkipListMap] for natural key ordering with CME-free iteration,
  * and fires an optional [onChange]
  * callback when the projection state changes. It has no JavaFX dependency and works with
  * any JVM target including Android and server-side applications.
@@ -41,7 +39,7 @@ import kotlin.reflect.KProperty
  * The map is read-only. All mutations flow through the source collection.
  *
  * **Thread safety:** Iterating [keys], [values], [entries], or calling [size], [containsKey],
- * and [get] is CME-free under concurrent mutation because the backing map is [ConcurrentSkipListMap].
+ * and [get] is CME-free under concurrent mutation because the backing map is [java.util.concurrent.ConcurrentSkipListMap].
  * Reads are weakly-consistent: entries added concurrently may or may not be visible mid-iteration,
  * but iteration always completes without error. Mutations via [onChange], [MutableAggregateList],
  * or [MutableAggregateSet] still flow through a single source-collection mutation thread;
@@ -49,7 +47,7 @@ import kotlin.reflect.KProperty
  * individual bucket — that contract is unchanged.
  *
  * @param K the entity ID type, must be [Comparable]
- * @param PK the projection key type, must be [Comparable] (used as the backing [ConcurrentSkipListMap] key)
+ * @param PK the projection key type, must be [Comparable] (used as the backing [java.util.concurrent.ConcurrentSkipListMap] key)
  * @param E the entity type
  * @param sourceRef deferred reference to the source collection (resolved on first access)
  * @param keyExtractor grouping function that extracts the projection key from an entity
@@ -58,8 +56,7 @@ class ProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEnti
     private val sourceRef: () -> AggregateCollectionRef<K, E>,
     private val keyExtractor: (E) -> PK
 ) : AbstractMap<PK, List<E>>() {
-    private val backingMap = ConcurrentSkipListMap<PK, List<E>>()
-    private val readOnlyView: Map<PK, List<E>> = Collections.unmodifiableMap(backingMap)
+    private val core = ProjectionCore<K, PK, E>(keyExtractor)
 
     @Volatile
     private var initialized = false
@@ -71,20 +68,22 @@ class ProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEnti
      * The callback fires on the same thread that performed the source mutation; subscribers
      * requiring a specific thread must marshal themselves. No cross-thread atomicity is provided.
      */
-    internal var onChange: ((Map<PK, List<E>>) -> Unit)? = null
+    internal var onChange: ((Map<PK, List<E>>) -> Unit)?
+        get() = core.onChange
+        set(value) {
+            core.onChange = value
+        }
 
     private fun initialize() {
         if (initialized) return
         synchronized(this) {
             if (initialized) return
             val source = sourceRef()
-            handleAdded(source.resolveAll().toList())
+            core.handleAdded(source.resolveAll().toList())
             subscribeToSource(source)
             initialized = true
         }
     }
-
-    private fun freezeBucket(elements: List<E>): List<E> = java.util.Collections.unmodifiableList(ArrayList(elements))
 
     @Suppress("UNCHECKED_CAST")
     private fun subscribeToSource(source: AggregateCollectionRef<K, E>) {
@@ -92,8 +91,8 @@ class ProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEnti
             if (event.type == CollectionChangeEvent.Type.CLEAR) {
                 rebuild(source)
             } else {
-                if (event.added.isNotEmpty()) handleAdded(event.added as List<E>)
-                if (event.removed.isNotEmpty()) handleRemoved(event.removed as List<E>)
+                if (event.added.isNotEmpty()) core.handleAdded(event.added as List<E>)
+                if (event.removed.isNotEmpty()) core.handleRemoved(event.removed as List<E>)
             }
         }
         when (source) {
@@ -103,87 +102,46 @@ class ProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEnti
     }
 
     private fun rebuild(source: AggregateCollectionRef<K, E>) {
-        backingMap.clear()
-        handleAdded(source.resolveAll().toList())
-    }
-
-    private fun handleAdded(elements: List<E>) {
-        var changed = false
-        for (element in elements) {
-            val key = keyExtractor(element)
-            backingMap[key] = freezeBucket((backingMap[key] ?: emptyList()) + element)
-            changed = true
-        }
-        if (changed) onChange?.invoke(readOnlyView)
-    }
-
-    private fun handleRemoved(elements: List<E>) {
-        var changed = false
-        for (element in elements) {
-            val key = keyExtractor(element)
-            val bucket = backingMap[key]
-            if (bucket != null && element in bucket) {
-                val filtered = bucket.filter { it != element }
-                if (filtered.isEmpty()) backingMap.remove(key)
-                else backingMap[key] = freezeBucket(filtered)
-                changed = true
-            } else {
-                changed = removeFromAnyBucket(element) || changed
-            }
-        }
-        if (changed) onChange?.invoke(readOnlyView)
-    }
-
-    private fun removeFromAnyBucket(element: E): Boolean {
-        for (entry in backingMap.entries) {
-            if (element in entry.value) {
-                val filtered = entry.value.filter { it != element }
-                // ConcurrentSkipListMap entry iterators return SimpleImmutableEntry instances whose setValue throws
-                // UnsupportedOperationException — go through the map directly instead.
-                if (filtered.isEmpty()) backingMap.remove(entry.key)
-                else backingMap[entry.key] = freezeBucket(filtered)
-                return true
-            }
-        }
-        return false
+        core.backingMap.clear()
+        core.handleAdded(source.resolveAll().toList())
     }
 
     // Map<PK, List<E>> delegation — enables direct read access (projection.size, projection["key"])
     override val size: Int get() {
         initialize()
-        return readOnlyView.size
+        return core.readOnlyView.size
     }
     override val entries: Set<Map.Entry<PK, List<E>>> get() {
         initialize()
-        return readOnlyView.entries
+        return core.readOnlyView.entries
     }
     override val keys: Set<PK> get() {
         initialize()
-        return readOnlyView.keys
+        return core.readOnlyView.keys
     }
     override val values: Collection<List<E>> get() {
         initialize()
-        return readOnlyView.values
+        return core.readOnlyView.values
     }
 
     override fun containsKey(key: PK): Boolean {
         initialize()
-        return readOnlyView.containsKey(key)
+        return core.readOnlyView.containsKey(key)
     }
 
     override fun containsValue(value: List<E>): Boolean {
         initialize()
-        return readOnlyView.containsValue(value)
+        return core.readOnlyView.containsValue(value)
     }
 
     override fun get(key: PK): List<E>? {
         initialize()
-        return readOnlyView[key]
+        return core.readOnlyView[key]
     }
 
     override fun isEmpty(): Boolean {
         initialize()
-        return readOnlyView.isEmpty()
+        return core.readOnlyView.isEmpty()
     }
 
     /**

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionMap.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionMap.kt
@@ -96,10 +96,7 @@ class RegistryProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : Identifi
             // Seed first so the initial snapshot is complete before any events are processed;
             // soft-deleted entities are excluded from all buckets.
             for (entity in registry) {
-                if (isSoftDeleted(entity)) continue
-                val key = keyExtractor(entity)
-                core.handleAdded(listOf(entity))
-                reverseIndex[entity.id] = key
+                if (!isSoftDeleted(entity)) addToBucket(entity)
             }
             // Subscribe after the seed is complete to avoid double-applying events that arrive
             // during iteration.
@@ -115,56 +112,61 @@ class RegistryProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : Identifi
 
     private fun handleCrudEvent(event: CrudEvent<K, E>) {
         when (event) {
-            is StandardCrudEvent.Create ->
-                event.entities.values.forEach { entity ->
-                    if (!isSoftDeleted(entity)) {
-                        core.handleAdded(listOf(entity))
-                        reverseIndex[entity.id] = keyExtractor(entity)
-                    }
-                }
-            is StandardCrudEvent.Delete ->
-                event.entities.values.forEach { entity ->
-                    val oldKey = reverseIndex[entity.id]
-                    if (oldKey != null) {
-                        core.handleRemovedFromBucket(entity, oldKey)
-                    } else {
-                        core.handleRemoved(listOf(entity))
-                    }
-                    reverseIndex.remove(entity.id)
-                }
-            is StandardCrudEvent.Update ->
-                event.entities.forEach { (id, newEntity) ->
-                    val oldKey = reverseIndex[id]
-                    if (isSoftDeleted(newEntity)) {
-                        // Soft-delete: treat as removal. Remove by ID because the entity object
-                        // may differ from the one stored in the bucket.
-                        if (oldKey != null) core.handleRemovedByIdFromBucket(id, oldKey)
-                        reverseIndex.remove(id)
-                    } else {
-                        val newKey = keyExtractor(newEntity)
-                        when {
-                            oldKey == null -> {
-                                // Restore from soft-delete or first-time create arriving as update
-                                core.handleAdded(listOf(newEntity))
-                                reverseIndex[id] = newKey
-                            }
-                            oldKey != newKey -> {
-                                // Key changed: remove from the old bucket by ID (the new entity
-                                // object carries the new key value, so equality-based lookup would miss)
-                                // and add to the new bucket.
-                                core.handleRemovedByIdFromBucket(id, oldKey)
-                                core.handleAdded(listOf(newEntity))
-                                reverseIndex[id] = newKey
-                            }
-                            else -> {
-                                // Same key, non-key content changed
-                                core.handleReplaceInBucket(newEntity, newKey)
-                            }
-                        }
-                    }
-                }
+            is StandardCrudEvent.Create -> event.entities.values.forEach(::onCreated)
+            is StandardCrudEvent.Delete -> event.entities.values.forEach(::onDeleted)
+            is StandardCrudEvent.Update -> event.entities.forEach { (id, entity) -> onUpdated(id, entity) }
             else -> { /* CONFLICT, RECOVERY_FAILED — not subscribed */ }
         }
+    }
+
+    private fun onCreated(entity: E) {
+        if (!isSoftDeleted(entity)) addToBucket(entity)
+    }
+
+    private fun onDeleted(entity: E) {
+        val oldKey = reverseIndex.remove(entity.id)
+        // A Delete carries the stored object, so equality-based removal is safe. Fall back to a
+        // full scan only when the entity was never indexed (e.g. it was soft-deleted at seed time).
+        if (oldKey != null) core.handleRemovedFromBucket(entity, oldKey) else core.handleRemoved(listOf(entity))
+    }
+
+    private fun onUpdated(id: K, entity: E) {
+        if (isSoftDeleted(entity)) {
+            removeSoftDeleted(id)
+            return
+        }
+        val oldKey = reverseIndex[id]
+        val newKey = keyExtractor(entity)
+        when {
+            // Not currently bucketed: a restore from soft-delete, or a create arriving as an update.
+            oldKey == null -> addToBucket(entity)
+            // Bucket key changed: move the entity from its old bucket to the new one.
+            oldKey != newKey -> reBucket(id, entity, oldKey)
+            // Same bucket key, only non-key content changed.
+            else -> core.handleReplaceInBucket(entity, newKey)
+        }
+    }
+
+    /** Adds [entity] to its bucket and records its current key in the reverse index. */
+    private fun addToBucket(entity: E) {
+        core.handleAdded(listOf(entity))
+        reverseIndex[entity.id] = keyExtractor(entity)
+    }
+
+    /** Moves [entity] out of its [oldKey] bucket and into the bucket for its current key. */
+    private fun reBucket(id: K, entity: E, oldKey: PK) {
+        // Remove by id: the updated entity carries the new key value, so equality-based lookup
+        // against the old bucket would miss.
+        core.handleRemovedByIdFromBucket(id, oldKey)
+        addToBucket(entity)
+    }
+
+    /**
+     * Removes a soft-deleted entity from its bucket. Removal is by id because the updated entity
+     * carries the new `deletedAt` value and would not compare equal to the stored instance.
+     */
+    private fun removeSoftDeleted(id: K) {
+        reverseIndex.remove(id)?.let { oldKey -> core.handleRemovedByIdFromBucket(id, oldKey) }
     }
 
     private fun isSoftDeleted(entity: E): Boolean =

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionMap.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionMap.kt
@@ -1,0 +1,224 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import net.transgressoft.lirp.entity.IdentifiableEntity
+import net.transgressoft.lirp.entity.SoftDeletable
+import net.transgressoft.lirp.event.CrudEvent
+import net.transgressoft.lirp.event.LirpEventSubscription
+import net.transgressoft.lirp.event.StandardCrudEvent
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KProperty
+
+/**
+ * A read-only grouped view that derives a `Map<PK, List<E>>` from a [Registry] source,
+ * grouping all entities by a secondary key via [keyExtractor].
+ *
+ * The projection uses a [java.util.concurrent.ConcurrentSkipListMap] (via [ProjectionCore]) for natural
+ * key ordering with CME-free iteration, and fires an optional [onChange] callback when the
+ * projection state changes. It has no JavaFX dependency.
+ *
+ * The projection initializes lazily on the first [getValue] (Kotlin `by` delegation) or map
+ * access call, building its initial state from [Registry.iterator] and then subscribing to
+ * incremental [CrudEvent] notifications. Soft-deleted entities (those implementing
+ * [SoftDeletable] with a non-null [deletedAt]) are filtered out of all buckets.
+ *
+ * Key-change re-bucketing on [CrudEvent.Update] is driven by an internal
+ * `ConcurrentHashMap<K, PK>` reverse index (entity id → current bucket key), which
+ * provides O(1) old-key lookup without relying on the event's old-state snapshot.
+ *
+ * The map is read-only. All mutations flow through the registry.
+ *
+ * **Consistency window:** During lazy initialization, the projection seeds from [Registry.iterator]
+ * and then subscribes to incremental [CrudEvent] notifications. Mutations that occur in the narrow
+ * window between iterator exhaustion and the subscription coroutine starting its collect loop will
+ * not appear in the projection until the affected entity receives a subsequent event. This mirrors
+ * the weakly-consistent contract of the underlying [java.util.concurrent.ConcurrentSkipListMap] iteration.
+ *
+ * **Thread safety:** same weakly-consistent contract as [ProjectionMap] — iteration is
+ * CME-free via [java.util.concurrent.ConcurrentSkipListMap]; compound read-modify-write of a
+ * single bucket is not cross-thread atomic.
+ *
+ * @param K the entity ID type, must be [Comparable]
+ * @param PK the projection key type, must be [Comparable] (used as the backing [java.util.concurrent.ConcurrentSkipListMap] key)
+ * @param E the entity type
+ * @param registry the source registry whose entities are projected
+ * @param keyExtractor grouping function that extracts the projection key from an entity
+ */
+class RegistryProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>>(
+    private val registry: Registry<K, E>,
+    private val keyExtractor: (E) -> PK
+) : AbstractMap<PK, List<E>>() {
+
+    private val core = ProjectionCore<K, PK, E>(keyExtractor)
+
+    /** Reverse index: entity id → current bucket key. Enables O(1) old-key lookup on Update. */
+    private val reverseIndex = ConcurrentHashMap<K, PK>()
+
+    @Volatile
+    private var initialized = false
+
+    /** Held to prevent GC from cancelling the underlying coroutine job. */
+    private lateinit var subscription: LirpEventSubscription<*, *, *>
+
+    /**
+     * Optional callback invoked after each projection change with the current map state.
+     * Fires after every incremental update that results in at least one addition, removal, or replacement.
+     *
+     * The callback fires on the same thread that performed the registry mutation; subscribers
+     * requiring a specific thread must marshal themselves.
+     */
+    internal var onChange: ((Map<PK, List<E>>) -> Unit)?
+        get() = core.onChange
+        set(value) {
+            core.onChange = value
+        }
+
+    private fun initialize() {
+        if (initialized) return
+        synchronized(this) {
+            if (initialized) return
+            // Seed first so the initial snapshot is complete before any events are processed;
+            // soft-deleted entities are excluded from all buckets.
+            for (entity in registry) {
+                if (isSoftDeleted(entity)) continue
+                val key = keyExtractor(entity)
+                core.handleAdded(listOf(entity))
+                reverseIndex[entity.id] = key
+            }
+            // Subscribe after the seed is complete to avoid double-applying events that arrive
+            // during iteration.
+            subscription =
+                registry.subscribe(
+                    CrudEvent.Type.CREATE,
+                    CrudEvent.Type.UPDATE,
+                    CrudEvent.Type.DELETE
+                ) { event -> handleCrudEvent(event) }
+            initialized = true
+        }
+    }
+
+    private fun handleCrudEvent(event: CrudEvent<K, E>) {
+        when (event) {
+            is StandardCrudEvent.Create ->
+                event.entities.values.forEach { entity ->
+                    if (!isSoftDeleted(entity)) {
+                        core.handleAdded(listOf(entity))
+                        reverseIndex[entity.id] = keyExtractor(entity)
+                    }
+                }
+            is StandardCrudEvent.Delete ->
+                event.entities.values.forEach { entity ->
+                    val oldKey = reverseIndex[entity.id]
+                    if (oldKey != null) {
+                        core.handleRemovedFromBucket(entity, oldKey)
+                    } else {
+                        core.handleRemoved(listOf(entity))
+                    }
+                    reverseIndex.remove(entity.id)
+                }
+            is StandardCrudEvent.Update ->
+                event.entities.forEach { (id, newEntity) ->
+                    val oldKey = reverseIndex[id]
+                    if (isSoftDeleted(newEntity)) {
+                        // Soft-delete: treat as removal. Remove by ID because the entity object
+                        // may differ from the one stored in the bucket.
+                        if (oldKey != null) core.handleRemovedByIdFromBucket(id, oldKey)
+                        reverseIndex.remove(id)
+                    } else {
+                        val newKey = keyExtractor(newEntity)
+                        when {
+                            oldKey == null -> {
+                                // Restore from soft-delete or first-time create arriving as update
+                                core.handleAdded(listOf(newEntity))
+                                reverseIndex[id] = newKey
+                            }
+                            oldKey != newKey -> {
+                                // Key changed: remove from the old bucket by ID (the new entity
+                                // object carries the new key value, so equality-based lookup would miss)
+                                // and add to the new bucket.
+                                core.handleRemovedByIdFromBucket(id, oldKey)
+                                core.handleAdded(listOf(newEntity))
+                                reverseIndex[id] = newKey
+                            }
+                            else -> {
+                                // Same key, non-key content changed
+                                core.handleReplaceInBucket(newEntity, newKey)
+                            }
+                        }
+                    }
+                }
+            else -> { /* CONFLICT, RECOVERY_FAILED — not subscribed */ }
+        }
+    }
+
+    private fun isSoftDeleted(entity: E): Boolean =
+        (entity as? SoftDeletable)?.deletedAt != null
+
+    // AbstractMap read overrides — all call initialize() first and delegate to core.readOnlyView
+
+    override val size: Int get() {
+        initialize()
+        return core.readOnlyView.size
+    }
+
+    override val entries: Set<Map.Entry<PK, List<E>>> get() {
+        initialize()
+        return core.readOnlyView.entries
+    }
+
+    override val keys: Set<PK> get() {
+        initialize()
+        return core.readOnlyView.keys
+    }
+
+    override val values: Collection<List<E>> get() {
+        initialize()
+        return core.readOnlyView.values
+    }
+
+    override fun containsKey(key: PK): Boolean {
+        initialize()
+        return core.readOnlyView.containsKey(key)
+    }
+
+    override fun containsValue(value: List<E>): Boolean {
+        initialize()
+        return core.readOnlyView.containsValue(value)
+    }
+
+    override fun get(key: PK): List<E>? {
+        initialize()
+        return core.readOnlyView[key]
+    }
+
+    override fun isEmpty(): Boolean {
+        initialize()
+        return core.readOnlyView.isEmpty()
+    }
+
+    /**
+     * Returns `this` projection map, initializing the registry state on the first call.
+     *
+     * Implements Kotlin `by`-delegation: `val grouped by registryProjectionMap(repo) { it.key }`.
+     */
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): RegistryProjectionMap<K, PK, E> {
+        initialize()
+        return this
+    }
+}

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionMapTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionMapTest.kt
@@ -1,0 +1,330 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import net.transgressoft.lirp.event.StandardCrudEvent
+import net.transgressoft.lirp.testing.ReactiveScopeSerialization
+import net.transgressoft.lirp.testing.Stress
+import net.transgressoft.lirp.testing.reactiveScope
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.time.Instant
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Tests for [RegistryProjectionMap], verifying registry-source grouping behavior, incremental
+ * updates via CrudEvent subscription, reverse-index re-bucketing on key change, soft-delete
+ * filtering, onChange callback, sorted key ordering, and concurrent CME-free iteration.
+ *
+ * Update events are fired manually via `emitAsync` on the repository, mirroring the behaviour
+ * of persistent repositories that subscribe to entity mutations internally.
+ */
+@DisplayName("RegistryProjectionMap")
+internal class RegistryProjectionMapTest : StringSpec({
+
+    val reactive = reactiveScope()
+
+    lateinit var ctx: LirpContext
+    lateinit var trackRepo: AudioItemVolatileRepository
+
+    beforeEach {
+        ctx = LirpContext()
+        trackRepo = AudioItemVolatileRepository(ctx)
+    }
+
+    afterEach {
+        ctx.close()
+    }
+
+    "builds initial state from registry on first access" {
+        trackRepo.create(1, "Jazz Intro", "Jazz")
+        trackRepo.create(2, "Jazz Outro", "Jazz")
+        trackRepo.create(3, "Rock Anthem", "Rock")
+
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+
+        projection.size shouldBe 2
+        projection["Jazz"]!!.size shouldBe 2
+        projection["Rock"]!!.size shouldBe 1
+    }
+
+    "skips soft-deleted entities during lazy seed" {
+        val t1 =
+            SoftDeletableMutableAudioItem(1, "Deleted Track", "Jazz").also {
+                it.deletedAt = Instant.now()
+                trackRepo.add(it)
+            }
+        reactive.advance()
+        trackRepo.create(2, "Active Track", "Jazz")
+        reactive.advance()
+
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+
+        projection["Jazz"]!!.size shouldBe 1
+        projection["Jazz"]!!.none { it.id == t1.id } shouldBe true
+    }
+
+    "adds entity to correct bucket on Create" {
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+        projection.size shouldBe 0
+
+        trackRepo.create(1, "New Track", "Classical")
+        reactive.advance()
+
+        projection["Classical"]!!.size shouldBe 1
+    }
+
+    "removes entity from bucket on Delete" {
+        trackRepo.create(1, "Track A", "Pop")
+        trackRepo.create(2, "Track B", "Pop")
+        val trackC = trackRepo.create(3, "Track C", "Rock")
+
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+        projection["Pop"]!!.size shouldBe 2
+
+        trackRepo.remove(trackC)
+        reactive.advance()
+
+        projection.containsKey("Rock") shouldBe false
+        projection.size shouldBe 1
+    }
+
+    "removes empty bucket key after last entity deleted" {
+        val t1 = trackRepo.create(1, "Track A", "Blues")
+        trackRepo.create(2, "Track B", "Jazz")
+
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+        projection.containsKey("Blues") shouldBe true
+
+        trackRepo.remove(t1)
+        reactive.advance()
+
+        projection.containsKey("Blues") shouldBe false
+        projection.size shouldBe 1
+    }
+
+    "replaces entity in bucket on Update when key is unchanged" {
+        trackRepo.create(1, "Old Title", "Rock")
+
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+        projection["Rock"]!!.first().title shouldBe "Old Title"
+
+        // Use distinct entity objects so handleReplaceInBucket detects the change
+        val oldSnapshot = MutableAudioItem(1, "Old Title", "Rock")
+        val updatedEntity = MutableAudioItem(1, "New Title", "Rock")
+        trackRepo.emitAsync(StandardCrudEvent.Update(updatedEntity, oldSnapshot))
+        reactive.advance()
+
+        projection["Rock"]!!.size shouldBe 1
+        projection["Rock"]!!.first().title shouldBe "New Title"
+    }
+
+    "re-buckets entity via reverse index when key changes on Update" {
+        trackRepo.create(1, "Track A", "Jazz")
+        trackRepo.create(2, "Track B", "Rock")
+
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+        projection["Jazz"]!!.size shouldBe 1
+        projection["Rock"]!!.size shouldBe 1
+
+        // Use distinct entity objects: old key was Jazz, new key is Rock
+        val oldSnapshot = MutableAudioItem(1, "Track A", "Jazz")
+        val updatedEntity = MutableAudioItem(1, "Track A", "Rock")
+        trackRepo.emitAsync(StandardCrudEvent.Update(updatedEntity, oldSnapshot))
+        reactive.advance()
+
+        projection.containsKey("Jazz") shouldBe false
+        projection["Rock"]!!.size shouldBe 2
+    }
+
+    "removes entity from bucket on Update when deletedAt is set" {
+        val t1 =
+            SoftDeletableMutableAudioItem(1, "Track A", "Jazz").also {
+                trackRepo.add(it)
+            }
+        reactive.advance()
+        trackRepo.create(2, "Track B", "Jazz")
+        reactive.advance()
+
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+        projection["Jazz"]!!.size shouldBe 2
+
+        // Soft-delete: set deletedAt and emit Update event
+        val oldSnapshot = t1.clone()
+        t1.deletedAt = Instant.now()
+        trackRepo.emitAsync(StandardCrudEvent.Update(t1, oldSnapshot))
+        reactive.advance()
+
+        projection["Jazz"]!!.size shouldBe 1
+        projection["Jazz"]!!.none { it.id == t1.id } shouldBe true
+    }
+
+    "fires onChange after Create" {
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+        projection.size shouldBe 0
+
+        var callbackSnapshot: Map<String, List<AudioItem>>? = null
+        projection.onChange = { callbackSnapshot = it }
+
+        trackRepo.create(1, "Track A", "Blues")
+        reactive.advance()
+
+        callbackSnapshot shouldNotBe null
+        callbackSnapshot!!.containsKey("Blues") shouldBe true
+    }
+
+    "fires onChange after Delete" {
+        trackRepo.create(1, "Track A", "Blues")
+        reactive.advance()
+        val t2 = trackRepo.create(2, "Track B", "Blues")
+        reactive.advance()
+
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+        projection.size shouldBe 1
+
+        var callbackCount = 0
+        projection.onChange = { callbackCount++ }
+
+        trackRepo.remove(t2)
+        reactive.advance()
+
+        callbackCount shouldBe 1
+    }
+
+    "fires onChange after Update" {
+        trackRepo.create(1, "Track A", "Jazz")
+        reactive.advance()
+
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+        projection.size shouldBe 1
+
+        var callbackCount = 0
+        projection.onChange = { callbackCount++ }
+
+        // Create a fresh entity object with same id but updated title — distinct object
+        // reference so handleReplaceInBucket detects an actual change
+        val oldSnapshot = MutableAudioItem(1, "Track A", "Jazz")
+        val updatedEntity = MutableAudioItem(1, "Track A Updated", "Jazz")
+        trackRepo.emitAsync(StandardCrudEvent.Update(updatedEntity, oldSnapshot))
+        reactive.advance()
+
+        callbackCount shouldBe 1
+        projection["Jazz"]!!.first().title shouldBe "Track A Updated"
+    }
+
+    "keys are in natural sorted order" {
+        trackRepo.create(1, "A", "Rock")
+        trackRepo.create(2, "B", "Classical")
+        trackRepo.create(3, "C", "Blues")
+        trackRepo.create(4, "D", "Jazz")
+
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+
+        projection.keys.toList() shouldContainExactly listOf("Blues", "Classical", "Jazz", "Rock")
+    }
+
+    "reflects writer state after concurrent creates" {
+        val totalItems = 100
+        val albumNames = listOf("Alpha", "Bravo", "Charlie", "Delta")
+
+        val seedItems =
+            (1..totalItems).map { i ->
+                MutableAudioItem(i, "Track-$i", albumNames[i % albumNames.size])
+            }
+
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+        projection.size shouldBe 0
+
+        val executor = Executors.newSingleThreadExecutor()
+        val latch = CountDownLatch(totalItems)
+
+        val readerJob =
+            reactive.scope.launch(Dispatchers.Default) {
+                while (latch.count > 0L) {
+                    projection.keys.toList()
+                    projection.entries.forEach { it.value.size }
+                }
+            }
+
+        try {
+            for (item in seedItems) {
+                executor.submit {
+                    trackRepo.add(item)
+                    latch.countDown()
+                }
+            }
+            latch.await(10, TimeUnit.SECONDS) shouldBe true
+            reactive.advance()
+
+            projection.values.sumOf { it.size } shouldBe totalItems
+            projection.keys.toList() shouldContainExactly albumNames.sorted()
+        } finally {
+            readerJob.cancel()
+            executor.shutdownNow()
+        }
+    }
+
+    "iterates without ConcurrentModificationException under concurrent add and remove stress"
+        .config(tags = setOf(Stress)) {
+            extension(ReactiveScopeSerialization)
+
+            val seedSize = 50
+            val mutations = 2000
+            val readerIterations = 500
+
+            val seedItems =
+                (1..seedSize).map { i ->
+                    MutableAudioItem(i, "Track-$i", "Album-${i % 5}")
+                }
+            seedItems.forEach { trackRepo.add(it) }
+
+            val projection = registryProjectionMap(trackRepo) { it.albumName }
+            // Trigger init before writers start
+            projection.size shouldBe 5
+
+            shouldNotThrowAny {
+                val writerJob =
+                    launch(Dispatchers.Default) {
+                        repeat(mutations) { i ->
+                            val item = MutableAudioItem(seedSize + i + 1, "Extra-$i", "Album-${i % 5}")
+                            trackRepo.add(item)
+                            trackRepo.remove(item)
+                        }
+                    }
+
+                val readerJob =
+                    launch(Dispatchers.Default) {
+                        repeat(readerIterations) {
+                            projection.keys.toList()
+                            projection.entries.forEach { it.value.size }
+                        }
+                    }
+
+                writerJob.join()
+                readerJob.join()
+            }
+        }
+})

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionMapTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionMapTest.kt
@@ -182,6 +182,59 @@ internal class RegistryProjectionMapTest : StringSpec({
         projection["Jazz"]!!.none { it.id == t1.id } shouldBe true
     }
 
+    "restores entity to bucket on Update when deletedAt is cleared" {
+        val t1 =
+            SoftDeletableMutableAudioItem(1, "Track A", "Jazz").also {
+                trackRepo.add(it)
+            }
+        reactive.advance()
+
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+        projection["Jazz"]!!.size shouldBe 1
+
+        // Soft-delete removes it from its bucket and drops it from the reverse index
+        val activeSnapshot = t1.clone()
+        t1.deletedAt = Instant.now()
+        trackRepo.emitAsync(StandardCrudEvent.Update(t1, activeSnapshot))
+        reactive.advance()
+        projection.containsKey("Jazz") shouldBe false
+
+        // Clearing deletedAt on a later Update restores it (oldKey is absent → treated as an add)
+        val deletedSnapshot = t1.clone()
+        t1.deletedAt = null
+        trackRepo.emitAsync(StandardCrudEvent.Update(t1, deletedSnapshot))
+        reactive.advance()
+
+        projection["Jazz"]!!.size shouldBe 1
+        projection["Jazz"]!!.first().id shouldBe t1.id
+    }
+
+    "exposes read-only accessors consistent with bucket state" {
+        trackRepo.create(1, "Track A", "Jazz")
+        trackRepo.create(2, "Track B", "Rock")
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+
+        projection.isEmpty() shouldBe false
+        projection.containsKey("Jazz") shouldBe true
+        projection.containsKey("Pop") shouldBe false
+        projection.containsValue(projection["Jazz"]!!) shouldBe true
+        projection.entries.size shouldBe 2
+        projection.values.sumOf { it.size } shouldBe 2
+    }
+
+    "ignores Delete for an entity that was never bucketed" {
+        trackRepo.create(1, "Track A", "Jazz")
+        val projection = registryProjectionMap(trackRepo) { it.albumName }
+        projection["Jazz"]!!.size shouldBe 1
+
+        // Entity absent from the reverse index falls back to a full-scan removal that finds nothing.
+        trackRepo.emitAsync(StandardCrudEvent.Delete(MutableAudioItem(99, "Ghost", "Rock")))
+        reactive.advance()
+
+        projection["Jazz"]!!.size shouldBe 1
+        projection.containsKey("Rock") shouldBe false
+    }
+
     "fires onChange after Create" {
         val projection = registryProjectionMap(trackRepo) { it.albumName }
         projection.size shouldBe 0

--- a/lirp-core/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/LirpTestFixtures.kt
+++ b/lirp-core/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/LirpTestFixtures.kt
@@ -21,11 +21,13 @@ import net.transgressoft.lirp.entity.CascadeAction
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.entity.ReactiveEntity
 import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.entity.SoftDeletable
 import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.LirpEventSubscriber
 import net.transgressoft.lirp.event.LirpEventSubscriberBase
 import net.transgressoft.lirp.persistence.json.JsonFileRepository
 import java.io.File
+import java.time.Instant
 import java.util.concurrent.Flow
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.serialization.KSerializer
@@ -108,6 +110,58 @@ class MutableAudioItem
         }
 
         override fun toString(): String = "MutableAudioItem(id=$id, title='$title', albumName='$albumName')"
+    }
+
+// ---------------------------------------------------------------------------
+// SoftDeletable audio item — music-domain fixture implementing SoftDeletable
+// ---------------------------------------------------------------------------
+
+/**
+ * Audio item that supports soft deletion via a reactive [deletedAt] property.
+ *
+ * Implements both [AudioItem] and [SoftDeletable], allowing it to be stored in
+ * [AudioItemVolatileRepository] and used to exercise soft-delete-aware projections.
+ * Setting [deletedAt] to a non-null value emits a normal [CrudEvent.Update] through
+ * the repository, triggering projection removal.
+ *
+ * Not declared `internal` so it is accessible from all test source sets.
+ */
+class SoftDeletableMutableAudioItem
+    @JvmOverloads
+    constructor(
+        override val id: Int,
+        title: String,
+        albumName: String = ""
+    ) : ReactiveEntityBase<Int, AudioItem>(), AudioItem, SoftDeletable {
+        override val uniqueId: String get() = "soft-deletable-audio-item-$id"
+
+        override var title: String by reactiveProperty(title)
+        override var albumName: String by reactiveProperty(albumName)
+
+        /** The instant at which this item was soft-deleted, or `null` if it is active. */
+        override var deletedAt: Instant? by reactiveProperty(null)
+
+        override fun compareTo(other: AudioItem): Int = id.compareTo(other.id)
+
+        override fun clone(): SoftDeletableMutableAudioItem =
+            SoftDeletableMutableAudioItem(id, title, albumName).also { it.deletedAt = deletedAt }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is SoftDeletableMutableAudioItem) return false
+            return id == other.id && title == other.title && albumName == other.albumName && deletedAt == other.deletedAt
+        }
+
+        override fun hashCode(): Int {
+            var result = id.hashCode()
+            result = 31 * result + title.hashCode()
+            result = 31 * result + albumName.hashCode()
+            result = 31 * result + (deletedAt?.hashCode() ?: 0)
+            return result
+        }
+
+        override fun toString(): String =
+            "SoftDeletableMutableAudioItem(id=$id, title='$title', albumName='$albumName', deletedAt=$deletedAt)"
     }
 
 // ---------------------------------------------------------------------------

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxFactories.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxFactories.kt
@@ -19,8 +19,10 @@ package net.transgressoft.lirp.persistence.fx
 
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.persistence.FxObservableCollection
+import net.transgressoft.lirp.persistence.Registry
 import net.transgressoft.lirp.persistence.mutableAggregateList
 import net.transgressoft.lirp.persistence.mutableAggregateSet
+import javafx.collections.ObservableMap
 
 /**
  * Creates a property delegate for a JavaFX-observable mutable ordered aggregate collection reference.
@@ -174,3 +176,32 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> fxProjec
     dispatchToFxThread: Boolean = true
 ): FxProjectionMap<K, PK, E> =
     FxProjectionMap(sourceRef, keyExtractor, dispatchToFxThread)
+
+/**
+ * Creates a read-only [ObservableMap] projection delegate that groups all entities from a [Registry]
+ * by a secondary key, with bucket mutations dispatched to the JavaFX Application Thread.
+ *
+ * The returned [RegistryFxProjectionMap] lazily initializes on the first [RegistryFxProjectionMap.getValue] or
+ * [RegistryFxProjectionMap.addListener] call, building its initial state from the registry's current contents and
+ * subscribing to incremental [net.transgressoft.lirp.event.CrudEvent] notifications. Soft-deleted entities are excluded.
+ *
+ * Usage:
+ * ```kotlin
+ * val itemsByAlbum: ObservableMap<String, List<AudioItem>> by registryFxProjectionMap(trackRepo) { it.albumName }
+ * ```
+ *
+ * @param K the entity ID type
+ * @param PK the projection key type, must be [Comparable]
+ * @param E the entity type
+ * @param registry the source registry to project
+ * @param keyExtractor grouping function that extracts the projection key from an entity
+ * @param dispatchToFxThread when `true` (default), dispatches notifications to the FX Application Thread;
+ *   when `false`, dispatches on [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @return a read-only observable projection map delegate incrementally updated from the registry
+ */
+fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> registryFxProjectionMap(
+    registry: Registry<K, E>,
+    keyExtractor: (E) -> PK,
+    dispatchToFxThread: Boolean = true
+): RegistryFxProjectionMap<K, PK, E> =
+    RegistryFxProjectionMap(registry, keyExtractor, dispatchToFxThread)

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/RegistryFxProjectionMap.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/RegistryFxProjectionMap.kt
@@ -1,0 +1,335 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.entity.IdentifiableEntity
+import net.transgressoft.lirp.entity.SoftDeletable
+import net.transgressoft.lirp.event.CrudEvent
+import net.transgressoft.lirp.event.LirpEventSubscription
+import net.transgressoft.lirp.event.StandardCrudEvent
+import net.transgressoft.lirp.persistence.Registry
+import javafx.application.Platform
+import javafx.beans.InvalidationListener
+import javafx.collections.FXCollections
+import javafx.collections.MapChangeListener
+import javafx.collections.ObservableMap
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentSkipListMap
+import kotlin.reflect.KProperty
+
+/**
+ * A read-only [ObservableMap] projection that groups all entities from a [Registry] by a
+ * secondary key, with all bucket mutations dispatched to the JavaFX Application Thread.
+ *
+ * Entities are grouped by [keyExtractor] into frozen [List] buckets keyed by projection key
+ * type [PK]. The backing map is a [ConcurrentSkipListMap] wrapped by [FXCollections.observableMap],
+ * so projection keys are always iterated in natural sorted order with CME-free iteration.
+ *
+ * The projection initializes lazily: the registry subscription and initial state build happen
+ * on the first [getValue] or [addListener] call, not at construction time.
+ *
+ * Key changes are tracked via an internal `id → projection key` reverse index
+ * ([ConcurrentHashMap]), so no old-entity snapshot from the [CrudEvent] is required.
+ * Soft-deleted entities (those implementing [SoftDeletable] with a non-null [deletedAt])
+ * are excluded from all buckets.
+ *
+ * When [dispatchToFxThread] is `true` (the default), every incremental bucket mutation is
+ * dispatched to the JavaFX Application Thread via [Platform.runLater]. For single-entity events,
+ * exactly one `Platform.runLater` call is scheduled per entity mutation, resulting in one or two
+ * [MapChangeListener.Change] notifications depending on the operation (same-key updates fire a
+ * remove followed by a re-add to ensure listener notification even when the list content compares
+ * equal). Batch events carrying multiple entities schedule one runLater call per entity.
+ *
+ * When `false`, mutations are applied inline on the calling thread. This is intended for
+ * test scenarios where the JavaFX Application Thread is not available or desirable.
+ *
+ * Mutation methods ([put], [remove], [putAll], [clear]) throw [UnsupportedOperationException];
+ * all mutations flow through the source registry.
+ *
+ * **Consistency window:** During lazy initialization, the projection seeds from [Registry.iterator]
+ * and then subscribes to incremental [CrudEvent] notifications. Mutations that occur in the narrow
+ * window between iterator exhaustion and the subscription coroutine starting its collect loop will
+ * not appear in the projection until the affected entity receives a subsequent event. This mirrors
+ * the weakly-consistent contract of the underlying [java.util.concurrent.ConcurrentSkipListMap] iteration.
+ *
+ * @param K the entity ID type, must be [Comparable]
+ * @param PK the projection key type, must be [Comparable] (used as the backing [ConcurrentSkipListMap] key)
+ * @param E the entity type
+ * @param registry the source registry to project
+ * @param keyExtractor grouping function that extracts the projection key from an entity
+ * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
+ */
+class RegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>>(
+    private val registry: Registry<K, E>,
+    private val keyExtractor: (E) -> PK,
+    val dispatchToFxThread: Boolean = true
+) : ObservableMap<PK, List<E>> {
+    private val innerObservableMap: ObservableMap<PK, List<E>> =
+        FXCollections.observableMap(ConcurrentSkipListMap<PK, List<E>>())
+
+    // Entity id → current projection key; enables O(1) old-key lookup on Update without
+    // requiring an old-entity snapshot from the CrudEvent.
+    private val reverseIndex = ConcurrentHashMap<K, PK>()
+
+    @Volatile
+    private var initialized = false
+
+    // Held to prevent the JVM from GC-cancelling the underlying coroutine job
+    private lateinit var subscription: LirpEventSubscription<*, *, *>
+
+    private fun initialize() {
+        if (initialized) return
+        synchronized(this) {
+            if (initialized) return
+            // Populate initial state directly — writes bypass mutateMap so state is visible
+            // synchronously before initialized=true, mirroring FxProjectionMap.populateInitialState.
+            for (entity in registry) {
+                if (isSoftDeleted(entity)) continue
+                val key = keyExtractor(entity)
+                val updated = freezeBucket((innerObservableMap[key] ?: emptyList()) + entity)
+                innerObservableMap[key] = updated
+                reverseIndex[entity.id] = key
+            }
+            subscription =
+                registry.subscribe(
+                    CrudEvent.Type.CREATE,
+                    CrudEvent.Type.UPDATE,
+                    CrudEvent.Type.DELETE
+                ) { event -> handleCrudEvent(event) }
+            initialized = true
+        }
+    }
+
+    private fun handleCrudEvent(event: CrudEvent<K, E>) {
+        when (event) {
+            is StandardCrudEvent.Create ->
+                event.entities.values.forEach { entity ->
+                    if (!isSoftDeleted(entity)) {
+                        val key = keyExtractor(entity)
+                        mutateMap {
+                            val current = innerObservableMap[key] ?: emptyList()
+                            if (entity !in current) {
+                                innerObservableMap[key] = freezeBucket(current + entity)
+                            }
+                            reverseIndex[entity.id] = key
+                        }
+                    }
+                }
+            is StandardCrudEvent.Delete ->
+                event.entities.values.forEach { entity ->
+                    mutateMap {
+                        // Read and write reverseIndex on the same dispatch thread to avoid stale-read races
+                        // when multiple events for the same entity are processed concurrently.
+                        val key = reverseIndex[entity.id]
+                        if (key != null) {
+                            val current = innerObservableMap[key]
+                            if (current != null) {
+                                val filtered = current.filter { it.id != entity.id }
+                                if (filtered.isEmpty()) innerObservableMap.remove(key)
+                                else innerObservableMap[key] = freezeBucket(filtered)
+                            }
+                        } else {
+                            removeFromAnyBucket(entity)
+                        }
+                        reverseIndex.remove(entity.id)
+                    }
+                }
+            is StandardCrudEvent.Update ->
+                event.entities.forEach { (id, newEntity) ->
+                    mutateMap {
+                        // Read oldKey inside the lambda so it is co-located with all reverseIndex
+                        // writes, preventing stale reads when events for the same entity interleave.
+                        val oldKey = reverseIndex[id]
+                        if (isSoftDeleted(newEntity)) {
+                            // Soft-delete: remove the entity from its bucket
+                            if (oldKey != null) {
+                                val current = innerObservableMap[oldKey]
+                                if (current != null) {
+                                    val filtered = current.filter { it.id != id }
+                                    if (filtered.isEmpty()) innerObservableMap.remove(oldKey)
+                                    else innerObservableMap[oldKey] = freezeBucket(filtered)
+                                }
+                            } else {
+                                removeFromAnyBucket(newEntity)
+                            }
+                            reverseIndex.remove(id)
+                        } else {
+                            val newKey = keyExtractor(newEntity)
+                            when {
+                                oldKey == null -> {
+                                    // Restore from soft-delete or first-time create via Update
+                                    val current = innerObservableMap[newKey] ?: emptyList()
+                                    if (newEntity !in current) {
+                                        innerObservableMap[newKey] = freezeBucket(current + newEntity)
+                                    }
+                                    reverseIndex[id] = newKey
+                                }
+                                oldKey != newKey -> {
+                                    // Key changed: remove from old bucket, add to new bucket
+                                    val oldBucket = innerObservableMap[oldKey]
+                                    if (oldBucket != null) {
+                                        val filtered = oldBucket.filter { it.id != id }
+                                        if (filtered.isEmpty()) innerObservableMap.remove(oldKey)
+                                        else innerObservableMap[oldKey] = freezeBucket(filtered)
+                                    }
+                                    val newBucket = innerObservableMap[newKey] ?: emptyList()
+                                    innerObservableMap[newKey] = freezeBucket(newBucket + newEntity)
+                                    reverseIndex[id] = newKey
+                                }
+                                else -> {
+                                    // Same key, content changed: replace entity in bucket.
+                                    // Remove before re-inserting so the ObservableMap fires a change
+                                    // notification even when the old and new List values compare equal —
+                                    // JavaFX's ObservableMapWrapper skips callObservers when oldValue.equals(newValue).
+                                    val bucket = innerObservableMap[newKey]
+                                    if (bucket != null) {
+                                        val updated = bucket.map { if (it.id == id) newEntity else it }
+                                        innerObservableMap.remove(newKey)
+                                        innerObservableMap[newKey] = freezeBucket(updated)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            else -> { /* CONFLICT, RECOVERY_FAILED — not subscribed */ }
+        }
+    }
+
+    private fun removeFromAnyBucket(entity: E) {
+        for (entry in innerObservableMap.entries) {
+            if (entry.value.any { it.id == entity.id }) {
+                val filtered = entry.value.filter { it.id != entity.id }
+                // Use map put/remove directly so the ObservableMap wrapper fires change listeners (not entry mutation).
+                if (filtered.isEmpty()) innerObservableMap.remove(entry.key)
+                else innerObservableMap[entry.key] = freezeBucket(filtered)
+                return
+            }
+        }
+    }
+
+    private fun freezeBucket(elements: List<E>): List<E> =
+        Collections.unmodifiableList(ArrayList(elements))
+
+    private fun isSoftDeleted(entity: E): Boolean =
+        (entity as? SoftDeletable)?.deletedAt != null
+
+    private fun mutateMap(action: () -> Unit) {
+        if (dispatchToFxThread) {
+            if (Platform.isFxApplicationThread()) action()
+            else Platform.runLater(action)
+        } else {
+            action()
+        }
+    }
+
+    // ObservableMap<PK, List<E>> — read operations delegate to innerObservableMap after initialization
+
+    override val size: Int get() {
+        initialize()
+        return innerObservableMap.size
+    }
+
+    // Safe: ObservableMap declares MutableSet<MutableEntry> but the returned set is unmodifiable via Collections.unmodifiableSet.
+    // Callers cannot mutate through this view; the cast satisfies the interface contract without exposing true mutability.
+    // Returns the live entry set backed by innerObservableMap — consistent with keys and values,
+    // which also return live views. ConcurrentSkipListMap entries are CME-safe for iteration.
+    @Suppress("UNCHECKED_CAST")
+    override val entries: MutableSet<MutableMap.MutableEntry<PK, List<E>>> get() {
+        initialize()
+        return Collections.unmodifiableSet(innerObservableMap.entries) as MutableSet<MutableMap.MutableEntry<PK, List<E>>>
+    }
+
+    // Safe: same as entries — Collections.unmodifiableSet wraps the keys. The MutableSet return type is required by
+    // ObservableMap's interface but the returned set throws UnsupportedOperationException on mutation attempts.
+    @Suppress("UNCHECKED_CAST")
+    override val keys: MutableSet<PK> get() {
+        initialize()
+        return Collections.unmodifiableSet(innerObservableMap.keys) as MutableSet<PK>
+    }
+
+    // Safe: same as entries/keys — Collections.unmodifiableCollection wraps the values. The MutableCollection return type
+    // is required by ObservableMap's interface but the returned collection is effectively immutable.
+    @Suppress("UNCHECKED_CAST")
+    override val values: MutableCollection<List<E>> get() {
+        initialize()
+        return Collections.unmodifiableCollection(innerObservableMap.values) as MutableCollection<List<E>>
+    }
+
+    override fun containsKey(key: PK): Boolean {
+        initialize()
+        return innerObservableMap.containsKey(key)
+    }
+
+    override fun containsValue(value: List<E>): Boolean {
+        initialize()
+        return innerObservableMap.containsValue(value)
+    }
+
+    override fun get(key: PK): List<E>? {
+        initialize()
+        return innerObservableMap[key]
+    }
+
+    override fun isEmpty(): Boolean {
+        initialize()
+        return innerObservableMap.isEmpty()
+    }
+
+    // Mutation methods — this projection is read-only; all mutations flow through the source registry
+    override fun put(key: PK, value: List<E>): List<E> = throw UnsupportedOperationException(READ_ONLY_MESSAGE)
+
+    override fun remove(key: PK): List<E>? = throw UnsupportedOperationException(READ_ONLY_MESSAGE)
+
+    override fun putAll(from: Map<out PK, List<E>>) = throw UnsupportedOperationException(READ_ONLY_MESSAGE)
+
+    override fun clear() = throw UnsupportedOperationException(READ_ONLY_MESSAGE)
+
+    companion object {
+        private const val READ_ONLY_MESSAGE = "RegistryFxProjectionMap is read-only"
+    }
+
+    // Listener methods delegate to innerObservableMap; addListener also triggers initialization
+    // so the source subscription is established before the first change fires.
+    override fun addListener(listener: MapChangeListener<in PK, in List<E>>) {
+        initialize()
+        innerObservableMap.addListener(listener)
+    }
+
+    override fun removeListener(listener: MapChangeListener<in PK, in List<E>>) =
+        innerObservableMap.removeListener(listener)
+
+    override fun addListener(listener: InvalidationListener) {
+        initialize()
+        innerObservableMap.addListener(listener)
+    }
+
+    override fun removeListener(listener: InvalidationListener) =
+        innerObservableMap.removeListener(listener)
+
+    /**
+     * Returns `this` projection map, initializing the registry subscription on the first call.
+     *
+     * Implements Kotlin `by`-delegation: `val byAlbum: ObservableMap<String, List<AudioItem>> by registryFxProjectionMap(...)`.
+     */
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): RegistryFxProjectionMap<K, PK, E> {
+        initialize()
+        return this
+    }
+}

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/RegistryFxProjectionMap.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/RegistryFxProjectionMap.kt
@@ -102,8 +102,7 @@ class RegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : Identi
             for (entity in registry) {
                 if (isSoftDeleted(entity)) continue
                 val key = keyExtractor(entity)
-                val updated = freezeBucket((innerObservableMap[key] ?: emptyList()) + entity)
-                innerObservableMap[key] = updated
+                addToBucket(key, entity)
                 reverseIndex[entity.id] = key
             }
             subscription =
@@ -118,98 +117,83 @@ class RegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : Identi
 
     private fun handleCrudEvent(event: CrudEvent<K, E>) {
         when (event) {
-            is StandardCrudEvent.Create ->
-                event.entities.values.forEach { entity ->
-                    if (!isSoftDeleted(entity)) {
-                        val key = keyExtractor(entity)
-                        mutateMap {
-                            val current = innerObservableMap[key] ?: emptyList()
-                            if (entity !in current) {
-                                innerObservableMap[key] = freezeBucket(current + entity)
-                            }
-                            reverseIndex[entity.id] = key
-                        }
-                    }
-                }
-            is StandardCrudEvent.Delete ->
-                event.entities.values.forEach { entity ->
-                    mutateMap {
-                        // Read and write reverseIndex on the same dispatch thread to avoid stale-read races
-                        // when multiple events for the same entity are processed concurrently.
-                        val key = reverseIndex[entity.id]
-                        if (key != null) {
-                            val current = innerObservableMap[key]
-                            if (current != null) {
-                                val filtered = current.filter { it.id != entity.id }
-                                if (filtered.isEmpty()) innerObservableMap.remove(key)
-                                else innerObservableMap[key] = freezeBucket(filtered)
-                            }
-                        } else {
-                            removeFromAnyBucket(entity)
-                        }
-                        reverseIndex.remove(entity.id)
-                    }
-                }
-            is StandardCrudEvent.Update ->
-                event.entities.forEach { (id, newEntity) ->
-                    mutateMap {
-                        // Read oldKey inside the lambda so it is co-located with all reverseIndex
-                        // writes, preventing stale reads when events for the same entity interleave.
-                        val oldKey = reverseIndex[id]
-                        if (isSoftDeleted(newEntity)) {
-                            // Soft-delete: remove the entity from its bucket
-                            if (oldKey != null) {
-                                val current = innerObservableMap[oldKey]
-                                if (current != null) {
-                                    val filtered = current.filter { it.id != id }
-                                    if (filtered.isEmpty()) innerObservableMap.remove(oldKey)
-                                    else innerObservableMap[oldKey] = freezeBucket(filtered)
-                                }
-                            } else {
-                                removeFromAnyBucket(newEntity)
-                            }
-                            reverseIndex.remove(id)
-                        } else {
-                            val newKey = keyExtractor(newEntity)
-                            when {
-                                oldKey == null -> {
-                                    // Restore from soft-delete or first-time create via Update
-                                    val current = innerObservableMap[newKey] ?: emptyList()
-                                    if (newEntity !in current) {
-                                        innerObservableMap[newKey] = freezeBucket(current + newEntity)
-                                    }
-                                    reverseIndex[id] = newKey
-                                }
-                                oldKey != newKey -> {
-                                    // Key changed: remove from old bucket, add to new bucket
-                                    val oldBucket = innerObservableMap[oldKey]
-                                    if (oldBucket != null) {
-                                        val filtered = oldBucket.filter { it.id != id }
-                                        if (filtered.isEmpty()) innerObservableMap.remove(oldKey)
-                                        else innerObservableMap[oldKey] = freezeBucket(filtered)
-                                    }
-                                    val newBucket = innerObservableMap[newKey] ?: emptyList()
-                                    innerObservableMap[newKey] = freezeBucket(newBucket + newEntity)
-                                    reverseIndex[id] = newKey
-                                }
-                                else -> {
-                                    // Same key, content changed: replace entity in bucket.
-                                    // Remove before re-inserting so the ObservableMap fires a change
-                                    // notification even when the old and new List values compare equal —
-                                    // JavaFX's ObservableMapWrapper skips callObservers when oldValue.equals(newValue).
-                                    val bucket = innerObservableMap[newKey]
-                                    if (bucket != null) {
-                                        val updated = bucket.map { if (it.id == id) newEntity else it }
-                                        innerObservableMap.remove(newKey)
-                                        innerObservableMap[newKey] = freezeBucket(updated)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+            is StandardCrudEvent.Create -> event.entities.values.forEach(::onCreated)
+            is StandardCrudEvent.Delete -> event.entities.values.forEach(::onDeleted)
+            is StandardCrudEvent.Update -> event.entities.forEach { (id, entity) -> onUpdated(id, entity) }
             else -> { /* CONFLICT, RECOVERY_FAILED — not subscribed */ }
         }
+    }
+
+    private fun onCreated(entity: E) {
+        if (isSoftDeleted(entity)) return
+        val key = keyExtractor(entity)
+        mutateMap {
+            addToBucket(key, entity)
+            reverseIndex[entity.id] = key
+        }
+    }
+
+    private fun onDeleted(entity: E) {
+        mutateMap {
+            // Read and write reverseIndex on the same dispatch thread so concurrent events for the
+            // same entity cannot observe a stale key.
+            val key = reverseIndex.remove(entity.id)
+            if (key != null) removeFromBucket(key, entity.id) else removeFromAnyBucket(entity)
+        }
+    }
+
+    private fun onUpdated(id: K, newEntity: E) {
+        mutateMap {
+            // Read oldKey inside the lambda, co-located with all reverseIndex writes, so interleaving
+            // events for the same entity cannot observe a stale key.
+            val oldKey = reverseIndex[id]
+            if (isSoftDeleted(newEntity)) {
+                if (oldKey != null) removeFromBucket(oldKey, id) else removeFromAnyBucket(newEntity)
+                reverseIndex.remove(id)
+                return@mutateMap
+            }
+            val newKey = keyExtractor(newEntity)
+            when {
+                // Not currently bucketed: a restore from soft-delete, or a create arriving as an update.
+                oldKey == null -> addToBucket(newKey, newEntity)
+                // Bucket key changed: move the entity from its old bucket to the new one.
+                oldKey != newKey -> {
+                    removeFromBucket(oldKey, id)
+                    addToBucket(newKey, newEntity)
+                }
+                // Same bucket key, only non-key content changed.
+                else -> replaceInBucket(newKey, id, newEntity)
+            }
+            reverseIndex[id] = newKey
+        }
+    }
+
+    /** Adds [entity] to the [key] bucket if not already present. Must run on the dispatch thread. */
+    private fun addToBucket(key: PK, entity: E) {
+        val current = innerObservableMap[key] ?: emptyList()
+        if (entity !in current) innerObservableMap[key] = freezeBucket(current + entity)
+    }
+
+    /**
+     * Removes the entity with [id] from the [key] bucket, dropping the key when the bucket empties.
+     * Must run on the dispatch thread.
+     */
+    private fun removeFromBucket(key: PK, id: K) {
+        val current = innerObservableMap[key] ?: return
+        val filtered = current.filter { it.id != id }
+        if (filtered.isEmpty()) innerObservableMap.remove(key)
+        else innerObservableMap[key] = freezeBucket(filtered)
+    }
+
+    /** Replaces the entity with [id] in the [key] bucket with [entity]. Must run on the dispatch thread. */
+    private fun replaceInBucket(key: PK, id: K, entity: E) {
+        val bucket = innerObservableMap[key] ?: return
+        val updated = bucket.map { if (it.id == id) entity else it }
+        // Remove before re-inserting so the ObservableMap fires a change notification even when the
+        // old and new List values compare equal — JavaFX's ObservableMapWrapper skips callObservers
+        // when oldValue.equals(newValue).
+        innerObservableMap.remove(key)
+        innerObservableMap[key] = freezeBucket(updated)
     }
 
     private fun removeFromAnyBucket(entity: E) {

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/RegistryFxProjectionMapTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/RegistryFxProjectionMapTest.kt
@@ -1,0 +1,249 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import net.transgressoft.lirp.event.StandardCrudEvent
+import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.AudioItemVolatileRepository
+import net.transgressoft.lirp.persistence.LirpContext
+import net.transgressoft.lirp.persistence.MutableAudioItem
+import net.transgressoft.lirp.testing.reactiveScope
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import javafx.application.Platform
+import javafx.collections.MapChangeListener
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Tests for [RegistryFxProjectionMap], verifying lazy seeding from a pre-populated registry,
+ * [MapChangeListener] notifications on Create/Update/Delete, key-change re-bucketing via the
+ * internal reverse index, soft-delete filtering, and the FX Application Thread dispatch contract.
+ *
+ * All tests use `dispatchToFxThread = false` except the explicit FX-thread-dispatch verification,
+ * to avoid [Platform.runLater] timing issues in the test harness.
+ *
+ * Update events are fired manually via `emitAsync` on the repository, mirroring the behaviour
+ * of persistent repositories that subscribe to entity mutations internally.
+ */
+@DisplayName("RegistryFxProjectionMap")
+class RegistryFxProjectionMapTest : StringSpec({
+
+    val reactive = reactiveScope()
+
+    beforeSpec {
+        FxToolkitInit.ensureInitialized()
+    }
+
+    lateinit var trackRepo: AudioItemVolatileRepository
+
+    beforeEach {
+        trackRepo = AudioItemVolatileRepository()
+    }
+
+    afterEach {
+        LirpContext.default.close()
+    }
+
+    "groups entities by key extractor on first addListener" {
+        trackRepo.create(1, "Track A", "Jazz")
+        trackRepo.create(2, "Track B", "Jazz")
+        trackRepo.create(3, "Track C", "Rock")
+
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        val changes = mutableListOf<MapChangeListener.Change<out String, out List<AudioItem>>>()
+        projection.addListener(MapChangeListener(changes::add))
+
+        projection["Jazz"]!!.size shouldBe 2
+        projection["Rock"]!!.size shouldBe 1
+        projection.size shouldBe 2
+    }
+
+    "builds initial state lazily from registry on first getValue" {
+        trackRepo.create(1, "Track A", "Jazz")
+        trackRepo.create(2, "Track B", "Jazz")
+        trackRepo.create(3, "Track C", "Rock")
+
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+
+        // Initial state is not populated until first access
+        val map by projection
+        map["Jazz"]!!.size shouldBe 2
+        map["Rock"]!!.size shouldBe 1
+    }
+
+    "dispatches MapChangeListener on FX thread on Create" {
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, true)
+        val changes = mutableListOf<MapChangeListener.Change<out String, out List<AudioItem>>>()
+        val onFxThread = mutableListOf<Boolean>()
+
+        projection.addListener(
+            MapChangeListener { change ->
+                onFxThread.add(Platform.isFxApplicationThread())
+                changes.add(change)
+            }
+        )
+
+        val latch = CountDownLatch(1)
+        Platform.runLater {
+            trackRepo.create(1, "Track A", "Jazz")
+            latch.countDown()
+        }
+        latch.await(5, TimeUnit.SECONDS)
+
+        // Wait for the FX thread to process the change
+        val doneLatch = CountDownLatch(1)
+        Platform.runLater { doneLatch.countDown() }
+        doneLatch.await(5, TimeUnit.SECONDS)
+
+        changes.size shouldBe 1
+        changes[0].wasAdded() shouldBe true
+        onFxThread.all { it } shouldBe true
+    }
+
+    "dispatches MapChangeListener on Create" {
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        val changes = mutableListOf<MapChangeListener.Change<out String, out List<AudioItem>>>()
+        projection.addListener(MapChangeListener(changes::add))
+
+        trackRepo.create(1, "Track A", "Jazz")
+        reactive.advance()
+
+        changes.size shouldBe 1
+        changes[0].wasAdded() shouldBe true
+        changes[0].key shouldBe "Jazz"
+        projection["Jazz"]!!.size shouldBe 1
+    }
+
+    "dispatches MapChangeListener on Delete" {
+        val item = trackRepo.create(1, "Track A", "Jazz")
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        val changes = mutableListOf<MapChangeListener.Change<out String, out List<AudioItem>>>()
+        projection.addListener(MapChangeListener(changes::add))
+
+        // Seed has been read, now delete
+        projection["Jazz"]!!.size shouldBe 1
+        trackRepo.remove(item)
+        reactive.advance()
+
+        changes.any { it.wasRemoved() } shouldBe true
+        projection.containsKey("Jazz") shouldBe false
+    }
+
+    "dispatches MapChangeListener on Update with same key" {
+        val item = trackRepo.create(1, "Track A", "Jazz") as MutableAudioItem
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        val changes = mutableListOf<MapChangeListener.Change<out String, out List<AudioItem>>>()
+        projection.addListener(MapChangeListener(changes::add))
+
+        projection["Jazz"]!!.size shouldBe 1
+
+        // Mutate entity and fire Update event — albumName (bucket key) unchanged, only title changed
+        val oldSnapshot = item.clone()
+        item.title = "Track A Updated"
+        trackRepo.emitAsync(StandardCrudEvent.Update(item, oldSnapshot))
+        reactive.advance()
+
+        // Two changes expected: a remove (wasRemoved) and a re-add (wasAdded) for the same key,
+        // because JavaFX's ObservableMapWrapper skips callObservers when old and new List values
+        // compare equal — so we remove+re-insert to guarantee listener notification.
+        changes.size shouldBe 2
+        changes.any { it.wasRemoved() } shouldBe true
+        changes.any { it.wasAdded() } shouldBe true
+        projection["Jazz"]!!.size shouldBe 1
+        projection["Jazz"]!![0].title shouldBe "Track A Updated"
+    }
+
+    "re-buckets entity on FX thread when key changes on Update" {
+        val item = trackRepo.create(1, "Track A", "Jazz") as MutableAudioItem
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        val changes = mutableListOf<MapChangeListener.Change<out String, out List<AudioItem>>>()
+        projection.addListener(MapChangeListener(changes::add))
+
+        // Seed
+        projection["Jazz"]!!.size shouldBe 1
+
+        // Change the projection key and fire Update event
+        val oldSnapshot = item.clone()
+        item.albumName = "Rock"
+        trackRepo.emitAsync(StandardCrudEvent.Update(item, oldSnapshot))
+        reactive.advance()
+
+        projection.containsKey("Jazz") shouldBe false
+        projection["Rock"]!!.size shouldBe 1
+        projection["Rock"]!![0].id shouldBe 1
+    }
+
+    "removes empty bucket when last entity deleted" {
+        val item = trackRepo.create(1, "Track A", "Jazz")
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        projection.addListener(MapChangeListener { })
+
+        projection["Jazz"]!!.size shouldBe 1
+        trackRepo.remove(item)
+        reactive.advance()
+
+        projection.containsKey("Jazz") shouldBe false
+        projection.isEmpty() shouldBe true
+    }
+
+    "fires single MapChangeListener pulse per event" {
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        val pulseCount = AtomicInteger(0)
+
+        projection.addListener(MapChangeListener { pulseCount.incrementAndGet() })
+
+        // A single repository add should produce exactly one MapChangeListener pulse
+        trackRepo.create(1, "Track A", "Jazz")
+        reactive.advance()
+        pulseCount.get() shouldBe 1
+
+        pulseCount.set(0)
+        val item = trackRepo.create(2, "Track B", "Rock") as MutableAudioItem
+        reactive.advance()
+        pulseCount.get() shouldBe 1
+
+        // A key change (Update) should produce exactly two pulses:
+        // one removal from the old bucket, one addition to the new bucket
+        pulseCount.set(0)
+        val oldSnapshot = item.clone()
+        item.albumName = "Jazz"
+        trackRepo.emitAsync(StandardCrudEvent.Update(item, oldSnapshot))
+        reactive.advance()
+        // The single mutateMap block performs all bucket mutations: remove from "Rock" + add to "Jazz" = 2 map changes
+        pulseCount.get() shouldBe 2
+
+        // A single delete produces exactly one pulse
+        pulseCount.set(0)
+        trackRepo.remove(item)
+        reactive.advance()
+        pulseCount.get() shouldBe 1
+    }
+
+    "keys are in natural sorted order" {
+        trackRepo.create(1, "T1", "Zebra")
+        trackRepo.create(2, "T2", "Alpha")
+        trackRepo.create(3, "T3", "Middle")
+
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+
+        projection.keys.toList() shouldBe listOf("Alpha", "Middle", "Zebra")
+    }
+})

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/RegistryFxProjectionMapTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/RegistryFxProjectionMapTest.kt
@@ -22,12 +22,16 @@ import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.AudioItemVolatileRepository
 import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.MutableAudioItem
+import net.transgressoft.lirp.persistence.SoftDeletableMutableAudioItem
 import net.transgressoft.lirp.testing.reactiveScope
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import javafx.application.Platform
+import javafx.beans.InvalidationListener
 import javafx.collections.MapChangeListener
+import java.time.Instant
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -237,6 +241,72 @@ class RegistryFxProjectionMapTest : StringSpec({
         pulseCount.get() shouldBe 1
     }
 
+    "excludes soft-deleted entities during lazy seed" {
+        SoftDeletableMutableAudioItem(1, "Deleted Track", "Jazz").also {
+            it.deletedAt = Instant.now()
+            trackRepo.add(it)
+        }
+        reactive.advance()
+        trackRepo.create(2, "Active Track", "Jazz")
+        reactive.advance()
+
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        projection.addListener(MapChangeListener { })
+
+        projection["Jazz"]!!.size shouldBe 1
+        projection["Jazz"]!!.none { it.id == 1 } shouldBe true
+    }
+
+    "removes entity from bucket on Update when deletedAt is set" {
+        val t1 =
+            SoftDeletableMutableAudioItem(1, "Track A", "Jazz").also {
+                trackRepo.add(it)
+            }
+        reactive.advance()
+        trackRepo.create(2, "Track B", "Jazz")
+        reactive.advance()
+
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        projection.addListener(MapChangeListener { })
+        projection["Jazz"]!!.size shouldBe 2
+
+        val activeSnapshot = t1.clone()
+        t1.deletedAt = Instant.now()
+        trackRepo.emitAsync(StandardCrudEvent.Update(t1, activeSnapshot))
+        reactive.advance()
+
+        projection["Jazz"]!!.size shouldBe 1
+        projection["Jazz"]!!.none { it.id == 1 } shouldBe true
+    }
+
+    "restores entity to bucket on Update when deletedAt is cleared" {
+        val t1 =
+            SoftDeletableMutableAudioItem(1, "Track A", "Jazz").also {
+                trackRepo.add(it)
+            }
+        reactive.advance()
+
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        projection.addListener(MapChangeListener { })
+        projection["Jazz"]!!.size shouldBe 1
+
+        // Soft-delete removes it from its bucket
+        val activeSnapshot = t1.clone()
+        t1.deletedAt = Instant.now()
+        trackRepo.emitAsync(StandardCrudEvent.Update(t1, activeSnapshot))
+        reactive.advance()
+        projection.containsKey("Jazz") shouldBe false
+
+        // Clearing deletedAt on a later Update restores it
+        val deletedSnapshot = t1.clone()
+        t1.deletedAt = null
+        trackRepo.emitAsync(StandardCrudEvent.Update(t1, deletedSnapshot))
+        reactive.advance()
+
+        projection["Jazz"]!!.size shouldBe 1
+        projection["Jazz"]!!.first().id shouldBe 1
+    }
+
     "keys are in natural sorted order" {
         trackRepo.create(1, "T1", "Zebra")
         trackRepo.create(2, "T2", "Alpha")
@@ -245,5 +315,65 @@ class RegistryFxProjectionMapTest : StringSpec({
         val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
 
         projection.keys.toList() shouldBe listOf("Alpha", "Middle", "Zebra")
+    }
+
+    "exposes read-only accessors consistent with bucket state" {
+        trackRepo.create(1, "Track A", "Jazz")
+        trackRepo.create(2, "Track B", "Rock")
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        projection.addListener(MapChangeListener { })
+
+        projection.isEmpty() shouldBe false
+        projection.containsKey("Jazz") shouldBe true
+        projection.containsKey("Pop") shouldBe false
+        val jazzBucket = projection["Jazz"]!!
+        projection.containsValue(jazzBucket) shouldBe true
+        projection.entries.size shouldBe 2
+        projection.values.sumOf { it.size } shouldBe 2
+        projection.keys shouldBe setOf("Jazz", "Rock")
+    }
+
+    "mutation methods throw because the projection is read-only" {
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        projection.addListener(MapChangeListener { })
+
+        shouldThrow<UnsupportedOperationException> { projection.put("X", emptyList()) }
+        shouldThrow<UnsupportedOperationException> { projection.remove("X") }
+        shouldThrow<UnsupportedOperationException> { projection.putAll(mapOf("X" to emptyList())) }
+        shouldThrow<UnsupportedOperationException> { projection.clear() }
+    }
+
+    "registers and removes map and invalidation listeners" {
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        var invalidations = 0
+        val invalidationListener = InvalidationListener { invalidations++ }
+        val mapListener = MapChangeListener<String, List<AudioItem>> { }
+
+        projection.addListener(invalidationListener)
+        projection.addListener(mapListener)
+        trackRepo.create(1, "Track A", "Jazz")
+        reactive.advance()
+        invalidations shouldBe 1
+
+        projection.removeListener(invalidationListener)
+        projection.removeListener(mapListener)
+        trackRepo.create(2, "Track B", "Rock")
+        reactive.advance()
+        invalidations shouldBe 1
+    }
+
+    "ignores Delete for an entity that was never bucketed" {
+        trackRepo.create(1, "Track A", "Jazz")
+        val projection = RegistryFxProjectionMap(trackRepo, AudioItem::albumName, false)
+        projection.addListener(MapChangeListener { })
+        projection["Jazz"]!!.size shouldBe 1
+
+        // An entity whose id is absent from the reverse index exercises the full-scan fallback,
+        // which finds no matching bucket and leaves the projection unchanged.
+        trackRepo.emitAsync(StandardCrudEvent.Delete(MutableAudioItem(99, "Ghost", "Rock")))
+        reactive.advance()
+
+        projection["Jazz"]!!.size shouldBe 1
+        projection.containsKey("Rock") shouldBe false
     }
 })


### PR DESCRIPTION
## Summary

Adds registry-level reactive projection maps that bucket **every row of a repository** by a key extractor into a read-only, reactively-maintained `Map<PK, List<E>>` — in both `lirp-core` and `lirp-fx` — with the same thread-safety guarantees as the existing aggregate-bound `ProjectionMap`, and no hand-rolled `CrudEvent` subscriber required.

```kotlin
val byTenant: Map<TenantId, List<Vehicle>> by registryProjectionMap(vehicleRepo) { it.tenantId }
```

Closes #160.

## What changed

**`lirp-core` — `RegistryProjectionMap` + `registryProjectionMap(registry) { keyExtractor }`**
- Backed by `ConcurrentSkipListMap`; lazily seeded from `registry.iterator()` on first access; kept in sync over `CrudEvent` Create/Update/Delete with no manual subscriber.
- Key-change re-bucketing uses an internal `id → key` reverse index for O(1) detection — it never depends on `CrudEvent.Update`'s old-state payload. On a key change the entity atomically leaves its old bucket and joins the new one.
- Soft-deleted entities are filtered out of buckets (see `SoftDeletable` below); a soft-delete arriving as an `Update` is treated as a bucket removal.

**`lirp-fx` — `RegistryFxProjectionMap` + `registryFxProjectionMap(registry) { keyExtractor }`**
- Exposes a read-only `ObservableMap<PK, List<E>>` whose bucket mutations are all dispatched on the JavaFX application thread.
- Keeps its own observable backing and reverse index rather than reusing the core engine, preserving `lirp-fx`'s independence from `lirp-core` internals.

**Shared bucket engine extraction**
- The bucket machinery (sorted backing map, frozen-bucket snapshots, add/remove/empty-key handling, `onChange`) is extracted into an internal `ProjectionCore` consumed by both the existing `ProjectionMap` and the new `RegistryProjectionMap` via composition.
- The existing public `ProjectionMap` / `fxProjectionMap` API is unchanged and binary-compatible — current call sites are unaffected.

**New `SoftDeletable` interface (`lirp-api`)**
- A minimal opt-in contract (`deletedAt: Instant?`) the projections filter against via a safe cast, so soft-deleted rows drop out of bucket membership to match normal read visibility. Entities that don't implement it are unaffected.

## How it was tested

- New `RegistryProjectionMapTest` and `RegistryFxProjectionMapTest` cover lazy seeding, Create/Update/Delete bucketing, key-change re-bucketing via the reverse index, soft-delete removal, empty-bucket-key removal, and `onChange` firing.
- A concurrency stress test confirms concurrent add/remove across many threads converges to a consistent final state with no `ConcurrentModificationException`.
- The FX test asserts all bucket mutations land on the JavaFX application thread.
- The existing `ProjectionMap` test suite passes unchanged, confirming the bucket-engine extraction is behavior-preserving.
- Full `gradle build` is green across all modules.

## Notes

- The per-bucket value-transform and multi-key-extractor capabilities are intentionally out of scope here; this change establishes the unified projection infrastructure those build on.
