### PR TITLE
Direct subscriber transport: synchronous in-process callbacks (v3.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,60 @@ These are **breaking changes**; see [Migration from 2.x to 3.0.0](#migration-fro
 
 ## Migration from 2.x to 3.0
 
+### `subscribe` is now synchronous by default
+
+The unqualified `subscribe` overload now delivers callbacks **synchronously on the emitting thread**.
+All former async `subscribe` call sites must be renamed to `subscribeAsync`:
+
+```kotlin
+// 2.x — subscribe was asynchronous (coroutine-based)
+entity.subscribe { event: MutationEvent<K, R> ->
+    searchService.reindex(event.entity)   // ran on a coroutine
+}
+
+// 3.0.0 — rename to subscribeAsync to keep coroutine delivery
+entity.subscribeAsync { event: MutationEvent<K, R> ->
+    searchService.reindex(event.entity)   // still runs on a coroutine
+}
+
+// 3.0.0 — use subscribe for fast in-process work that must be synchronous
+entity.subscribe { event: MutationEvent<K, R> ->
+    localCache.invalidate(event.entity.id)   // runs inline, no coroutine overhead
+}
+```
+
+**Migration steps:**
+1. Rename all former `subscribe { suspend lambda }` call sites to `subscribeAsync`.
+2. Leave any callback that is fast and must run synchronously (cache updates, index maintenance,
+   audit appends) as `subscribe`.
+3. Use `subscribeAsync` for slow, blocking, or remote work that must not delay the emitting thread.
+
+The `subscribeAsync(Consumer<E>)` Java overload replaces the former `subscribe(Consumer<E>)`.
+
+The filtered `subscribeAsync(vararg eventTypes, Consumer<E>)` overload on reactive entities now
+honors its event-type filter: a subscriber receives only the requested types. Previously the filter
+argument was ignored and every event type was delivered. Java callers relying on the old
+deliver-everything behavior must subscribe without a type filter to keep receiving all events.
+
+### `changes` access arms the replay buffer (lazy bridge init)
+
+In 2.x, the async bridge (Channel + SharedFlow) was created when the publisher was constructed.
+In 3.0.0, it is created lazily on the first call to `subscribeAsync`, `changes`, or
+`subscribe(Flow.Subscriber)`. Events emitted before the bridge is armed are **not** buffered.
+
+```kotlin
+// 2.x — replay worked without any boot step
+val publisher = FlowEventPublisher<...>("id", PublisherConfig.withReplay(5))
+publisher.emitAsync(event1)   // buffered automatically
+
+// 3.0.0 — arm the bridge before emitting to enable replay buffering
+val publisher = FlowEventPublisher<...>("id", PublisherConfig.withReplay(5))
+publisher.changes   // arms the bridge; subsequent emits are buffered
+publisher.emitAsync(event1)   // now buffered for replay
+```
+
+If replay buffering from startup is required, access `publisher.changes` once during initialization.
+
 ### Core projection imports
 
 | 2.x | 3.0.0 |

--- a/README.md
+++ b/README.md
@@ -156,27 +156,59 @@ class AlbumRepository : VolatileRepository<Int, Album>("Albums") {
 
 val repo = AlbumRepository()
 
-// Repository-level: track all structural changes
+// Repository-level: track all structural changes (synchronous — runs inline on the calling thread)
 repo.subscribe { event ->
     when (event) {
-        is StandardCrudEvent.Create -> println("Added: ${event.entity.title}")
-        is StandardCrudEvent.Update -> println("Updated album ${event.entityId}")
-        is StandardCrudEvent.Delete -> println("Removed album ${event.entityId}")
+        is StandardCrudEvent.Create -> println("Added: ${event.entities.values.first().title}")
+        is StandardCrudEvent.Update -> println("Updated album")
+        is StandardCrudEvent.Delete -> println("Removed album")
         else -> {}
     }
 }
 
 val nevermind = repo.create(1, "Nevermind", "rock", 42)
 
-// Entity-level: fine-grained property change tracking
+// Entity-level: fine-grained property change tracking (synchronous)
 nevermind.subscribe { event ->
-    println("Rating changed: ${event.oldEntity.rating} -> ${event.newEntity.rating}")
+    if (event is PropertyChanged<*, *, *>)
+        println("${event.property.name}: ${event.oldValue} -> ${event.newValue}")
 }
 
 nevermind.rating = 9.5  // fires both entity subscriber and repository Update event
+
+// For slow or remote work, use subscribeAsync — delivers on a coroutine, does not block the emitting thread
+repo.subscribeAsync { event ->
+    if (event is StandardCrudEvent.Create) {
+        // e.g. update a remote search index, send a notification — safe here because we're on a coroutine
+        println("Async: album added to search index: ${event.entities.values.first().title}")
+    }
+}
 ```
 
 See [Core Concepts](https://github.com/octaviospain/lirp/wiki/Core-Concepts) for the reactive-property model, subscription patterns, and entity lifecycle.
+
+### Synchronous vs asynchronous subscriptions
+
+LIRP offers two subscription transports:
+
+| Transport | Method | Delivery | Use when |
+|-----------|--------|----------|----------|
+| **Synchronous** | `subscribe { }` | Inline on the emitting thread, before `emitAsync` returns | Fast in-process work: cache updates, audit appends, in-memory index maintenance — anything that must be visible by the time the mutation returns |
+| **Asynchronous** | `subscribeAsync { }` | On a coroutine dispatcher, after `emitAsync` returns | Slow, blocking, or remote work (database writes, HTTP calls, fan-out); anything that must not block the mutation path |
+
+```kotlin
+// Sync — runs immediately on the thread that mutates the entity
+entity.subscribe { event ->
+    localIndex.update(event)   // fast, must be consistent before the next read
+}
+
+// Async — runs on a coroutine after the mutation returns
+entity.subscribeAsync { event ->
+    searchService.reindex(event.entity)   // slow — safe to defer
+}
+```
+
+If a sync callback is slow or blocks, it delays the emitting thread for every mutation. Use `subscribeAsync` for any work that takes more than a few microseconds or that calls I/O.
 
 ## SQL Persistence
 
@@ -312,6 +344,15 @@ Benchmarks run with JMH 1.37 on OpenJDK 21.0.10, 13th Gen Intel Core i7-13700, 6
 | `JsonFileRepository` | 97,720 ops/s | 27 ns |
 
 `findById()` at 27 ns is against the in-memory `ConcurrentHashMap` — the SQL and JSON repositories skip the round-trip entirely. For operation-level persistence timing details and full benchmark methodology, see [Performance Benchmarks](https://github.com/octaviospain/lirp/wiki/Performance-Benchmarks).
+
+## Upgrading to v3.0.0
+
+Version 3.0.0 contains breaking changes to the subscription API and the mutation event model. See **[CHANGELOG.md](CHANGELOG.md)** for the full migration guide, including:
+
+- `subscribe` is now **synchronous** by default — rename all former async `subscribe` call sites to `subscribeAsync`
+- `changes` access arms the replay buffer lazily — touch `publisher.changes` at boot if replay buffering from startup is needed
+- `PropertyChanged` / `BatchChanged` replace `oldEntity` / `newEntity` on mutation events
+- Core and FX projection map imports moved to `…persistence.projection` subpackages
 
 ## Documentation
 

--- a/lirp-api/api/lirp-api.api
+++ b/lirp-api/api/lirp-api.api
@@ -35,14 +35,16 @@ public abstract interface class net/transgressoft/lirp/entity/ReactiveEntity : j
 	public abstract fun getChanges ()Lkotlinx/coroutines/flow/SharedFlow;
 	public abstract fun getLastDateModified ()Ljava/time/LocalDateTime;
 	public abstract fun isClosed ()Z
-	public fun subscribe (Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
-	public abstract fun subscribe (Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
-	public abstract fun subscribe ([Lnet/transgressoft/lirp/event/MutationEvent$Type;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public abstract fun subscribe (Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public abstract fun subscribe ([Lnet/transgressoft/lirp/event/MutationEvent$Type;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync (Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public abstract fun subscribeAsync (Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public abstract fun subscribeAsync ([Lnet/transgressoft/lirp/event/MutationEvent$Type;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 	public abstract fun withEventsDisabled (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public final class net/transgressoft/lirp/entity/ReactiveEntity$DefaultImpls {
-	public static fun subscribe (Lnet/transgressoft/lirp/entity/ReactiveEntity;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public static fun subscribeAsync (Lnet/transgressoft/lirp/entity/ReactiveEntity;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 }
 
 public abstract interface class net/transgressoft/lirp/entity/SoftDeletable {
@@ -119,13 +121,15 @@ public abstract interface class net/transgressoft/lirp/event/LirpEventPublisher 
 	public abstract fun getSubscriberCount ()I
 	public abstract fun isClosed ()Z
 	public abstract fun isEventActive (Lnet/transgressoft/lirp/event/EventType;)Z
-	public fun subscribe (Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
-	public abstract fun subscribe (Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
-	public abstract fun subscribe ([Lnet/transgressoft/lirp/event/EventType;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public abstract fun subscribe (Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public abstract fun subscribe ([Lnet/transgressoft/lirp/event/EventType;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync (Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public abstract fun subscribeAsync (Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public abstract fun subscribeAsync ([Lnet/transgressoft/lirp/event/EventType;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 }
 
 public final class net/transgressoft/lirp/event/LirpEventPublisher$DefaultImpls {
-	public static fun subscribe (Lnet/transgressoft/lirp/event/LirpEventPublisher;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public static fun subscribeAsync (Lnet/transgressoft/lirp/event/LirpEventPublisher;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 }
 
 public abstract interface class net/transgressoft/lirp/event/LirpEventSubscriber : java/util/concurrent/Flow$Subscriber {
@@ -373,7 +377,7 @@ public abstract interface class net/transgressoft/lirp/persistence/PersistentRep
 public final class net/transgressoft/lirp/persistence/PersistentRepository$DefaultImpls {
 	public static fun minus (Lnet/transgressoft/lirp/persistence/PersistentRepository;Ljava/util/Collection;)Z
 	public static fun minus (Lnet/transgressoft/lirp/persistence/PersistentRepository;Lnet/transgressoft/lirp/entity/ReactiveEntity;)Z
-	public static fun subscribe (Lnet/transgressoft/lirp/persistence/PersistentRepository;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public static fun subscribeAsync (Lnet/transgressoft/lirp/persistence/PersistentRepository;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 }
 
 public final class net/transgressoft/lirp/persistence/RawInitEntry {
@@ -400,7 +404,7 @@ public abstract interface class net/transgressoft/lirp/persistence/ReactivePrimi
 }
 
 public final class net/transgressoft/lirp/persistence/ReactivePrimitive$DefaultImpls {
-	public static fun subscribe (Lnet/transgressoft/lirp/persistence/ReactivePrimitive;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public static fun subscribeAsync (Lnet/transgressoft/lirp/persistence/ReactivePrimitive;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 }
 
 public abstract interface class net/transgressoft/lirp/persistence/Registry : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker, net/transgressoft/lirp/event/LirpEventPublisher {
@@ -420,7 +424,7 @@ public abstract interface class net/transgressoft/lirp/persistence/Registry : ja
 }
 
 public final class net/transgressoft/lirp/persistence/Registry$DefaultImpls {
-	public static fun subscribe (Lnet/transgressoft/lirp/persistence/Registry;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public static fun subscribeAsync (Lnet/transgressoft/lirp/persistence/Registry;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 }
 
 public abstract interface class net/transgressoft/lirp/persistence/Repository : net/transgressoft/lirp/persistence/Registry {
@@ -435,7 +439,7 @@ public abstract interface class net/transgressoft/lirp/persistence/Repository : 
 public final class net/transgressoft/lirp/persistence/Repository$DefaultImpls {
 	public static fun minus (Lnet/transgressoft/lirp/persistence/Repository;Ljava/util/Collection;)Z
 	public static fun minus (Lnet/transgressoft/lirp/persistence/Repository;Lnet/transgressoft/lirp/entity/IdentifiableEntity;)Z
-	public static fun subscribe (Lnet/transgressoft/lirp/persistence/Repository;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public static fun subscribeAsync (Lnet/transgressoft/lirp/persistence/Repository;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 }
 
 public abstract interface annotation class net/transgressoft/lirp/persistence/Version : java/lang/annotation/Annotation {
@@ -449,6 +453,6 @@ public abstract interface class net/transgressoft/lirp/persistence/json/JsonRepo
 public final class net/transgressoft/lirp/persistence/json/JsonRepository$DefaultImpls {
 	public static fun minus (Lnet/transgressoft/lirp/persistence/json/JsonRepository;Ljava/util/Collection;)Z
 	public static fun minus (Lnet/transgressoft/lirp/persistence/json/JsonRepository;Lnet/transgressoft/lirp/entity/ReactiveEntity;)Z
-	public static fun subscribe (Lnet/transgressoft/lirp/persistence/json/JsonRepository;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public static fun subscribeAsync (Lnet/transgressoft/lirp/persistence/json/JsonRepository;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 }
 

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntity.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntity.kt
@@ -34,6 +34,12 @@ import kotlinx.coroutines.flow.SharedFlow
  * - **Dormant**: All subscribers cancelled; publisher shut down and nullified. Reactivates lazily on next subscription.
  * - **Closed**: Terminal state. All operations that mutate or subscribe throw [IllegalStateException].
  *
+ * Subscription transports:
+ * - **Synchronous** (`subscribe`): the callback is invoked inline on the emitting thread, before
+ *   any async delivery. Ideal for fast in-process work that must be visible immediately after the mutation.
+ * - **Asynchronous** (`subscribeAsync`): the action runs in a coroutine on a background dispatcher.
+ *   Suitable for slow, blocking, or fan-out work that must not block the emitting thread.
+ *
  * @param K the type of the entity's id.
  * @param R the type of the entity.
  */
@@ -53,7 +59,7 @@ interface ReactiveEntity<K, R : ReactiveEntity<K, R>> :
     val isClosed: Boolean
 
     /**
-     * A flow of entity change events that can be observed by collectors.
+     * A flow of entity change events that can be observed by collectors asynchronously.
      */
     val changes: SharedFlow<MutationEvent<K, R>>
 
@@ -63,30 +69,56 @@ interface ReactiveEntity<K, R : ReactiveEntity<K, R>> :
     fun emitAsync(event: MutationEvent<K, R>)
 
     /**
-     * Subscribes to all mutation events on this entity.
+     * Subscribes synchronously to all mutation events on this entity.
+     *
+     * The callback is invoked inline on the emitting thread before any async delivery.
+     *
+     * @param callback The function invoked for each mutation event on the emitting thread
+     * @return A subscription handle that can be cancelled to stop receiving events
+     */
+    fun subscribe(callback: (MutationEvent<K, R>) -> Unit): LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>>
+
+    /**
+     * Subscribes synchronously to mutation events of the specified types only.
+     *
+     * The callback is invoked inline on the emitting thread for matching events only.
+     *
+     * @param eventTypes The mutation event types to filter on
+     * @param callback The function invoked for each matching event on the emitting thread
+     * @return A subscription handle that can be cancelled to stop receiving events
+     */
+    fun subscribe(vararg eventTypes: MutationEvent.Type, callback: (MutationEvent<K, R>) -> Unit):
+        LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>>
+
+    /**
+     * Subscribes asynchronously to all mutation events on this entity.
+     *
+     * Events are delivered on a coroutine; the action does not run on the emitting thread.
      *
      * @param action The suspend function invoked for each mutation event
      * @return A subscription handle that can be cancelled to stop receiving events
      */
-    fun subscribe(action: suspend (MutationEvent<K, R>) -> Unit): LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>>
+    fun subscribeAsync(action: suspend (MutationEvent<K, R>) -> Unit): LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>>
 
     /**
-     * Subscribes to all mutation events on this entity using a Java [Consumer].
+     * Java-interop async subscription via [Consumer]; delegates to [subscribeAsync].
      *
-     * @param action The consumer invoked for each mutation event
+     * @param action The consumer invoked for each mutation event in a coroutine
      * @return A subscription handle that can be cancelled to stop receiving events
      */
-    fun subscribe(action: Consumer<in MutationEvent<K, R>>): LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>> =
-        subscribe(action::accept)
+    fun subscribeAsync(action: Consumer<in MutationEvent<K, R>>): LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>> =
+        subscribeAsync(action::accept)
 
     /**
-     * Subscribes to mutation events of the specified types, using a Java [Consumer].
+     * Subscribes asynchronously to mutation events of the specified types, using a Java [Consumer].
+     *
+     * Events are delivered on a coroutine for the matching types only.
      *
      * @param eventTypes The mutation event types to filter on
-     * @param action The consumer invoked for each matching event
+     * @param action The consumer invoked for each matching event in a coroutine
      * @return A subscription handle that can be cancelled to stop receiving events
      */
-    fun subscribe(vararg eventTypes: MutationEvent.Type, action: Consumer<in MutationEvent<K, R>>):
+    fun subscribeAsync(vararg eventTypes: MutationEvent.Type, action: Consumer<in MutationEvent<K, R>>):
         LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>>
 
     /**
@@ -117,7 +149,7 @@ interface ReactiveEntity<K, R : ReactiveEntity<K, R>> :
     /**
      * Permanently closes this entity and releases its publisher resources.
      *
-     * After closing [subscribe] throw [IllegalStateException]. Idempotent: subsequent calls are safe no-ops.
+     * After closing [subscribe] and [subscribeAsync] throw [IllegalStateException]. Idempotent: subsequent calls are safe no-ops.
      */
     override fun close()
 

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/event/LirpEventPublisher.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/event/LirpEventPublisher.kt
@@ -30,8 +30,16 @@ import kotlinx.coroutines.flow.SharedFlow
  * events to interested subscribers. It serves as a bridge between the standard
  * Java Flow API and lirp event system.
  *
+ * Subscription transports:
+ * - **Synchronous** (`subscribe`): the callback is invoked inline on the emitting thread, before
+ *   any async delivery. Zero coroutine overhead; ideal for fast in-process work (cache updates,
+ *   audit appends) that must be visible by the time the mutation returns.
+ * - **Asynchronous** (`subscribeAsync`): the action runs in a coroutine on a background dispatcher.
+ *   Suitable for slow, blocking, or fan-out work that must not block the emitting thread.
+ *
  * A publisher can be permanently closed via [close]. Once closed, it rejects new subscriptions
- * and event emissions. The [subscriberCount] property allows observing the number of active subscribers.
+ * and event emissions. The [subscriberCount] property allows observing the number of active subscribers,
+ * counting both sync and async registrations.
  *
  * @param ET The specific type of [EventType] associated with this publisher
  * @param E The specific type of [LirpEvent] published by this publisher
@@ -39,7 +47,9 @@ import kotlinx.coroutines.flow.SharedFlow
 interface LirpEventPublisher<ET : EventType, out E : LirpEvent<ET>> : Flow.Publisher<@UnsafeVariance E>, AutoCloseable {
 
     /**
-     * A flow of entity change events that collectors can observe.
+     * A flow of entity change events that collectors can observe asynchronously.
+     *
+     * Accessing this property arms the internal async bridge if it has not been armed yet.
      */
     val changes: SharedFlow<E>
 
@@ -51,7 +61,7 @@ interface LirpEventPublisher<ET : EventType, out E : LirpEvent<ET>> : Flow.Publi
     val isClosed: Boolean
 
     /**
-     * The current number of active subscribers.
+     * The current number of active subscribers, counting both synchronous and asynchronous registrations.
      */
     val subscriberCount: Int
 
@@ -61,27 +71,54 @@ interface LirpEventPublisher<ET : EventType, out E : LirpEvent<ET>> : Flow.Publi
     fun emitAsync(event: @UnsafeVariance E)
 
     /**
-     * Subscribes to all events emitted by this publisher.
+     * Subscribes synchronously to all events emitted by this publisher.
+     *
+     * The callback is invoked inline on the emitting thread before any async delivery.
+     *
+     * @param callback The function invoked for each emitted event on the emitting thread
+     * @return A subscription handle that can be cancelled to stop receiving events
+     */
+    fun subscribe(callback: (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, @UnsafeVariance E>
+
+    /**
+     * Subscribes synchronously to events of the specified types only.
+     *
+     * The callback is invoked inline on the emitting thread for matching events only.
+     *
+     * @param eventTypes The event types to filter on; events of other types are ignored
+     * @param callback The function invoked for each matching event on the emitting thread
+     * @return A subscription handle that can be cancelled to stop receiving events
+     */
+    fun subscribe(vararg eventTypes: ET, callback: (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, @UnsafeVariance E>
+
+    /**
+     * Subscribes asynchronously to all events emitted by this publisher.
+     *
+     * Events are delivered on a coroutine; the action does not run on the emitting thread.
      *
      * @param action The suspend function invoked for each emitted event
      * @return A subscription handle that can be cancelled to stop receiving events
      */
-    fun subscribe(action: suspend (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, @UnsafeVariance E>
+    fun subscribeAsync(action: suspend (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, @UnsafeVariance E>
 
     /**
-     * Legacy compatibility method for Java-style Consumer subscriptions.
-     * Consider migrating to the Kotlin Flow-based subscription method instead.
+     * Java-interop async subscription via [Consumer]; delegates to [subscribeAsync].
+     *
+     * @param action The consumer invoked for each emitted event in a coroutine
+     * @return A subscription handle that can be cancelled to stop receiving events
      */
-    fun subscribe(action: Consumer<in E>): LirpEventSubscription<in LirpEntity, ET, @UnsafeVariance E> = subscribe(action::accept)
+    fun subscribeAsync(action: Consumer<in E>): LirpEventSubscription<in LirpEntity, ET, @UnsafeVariance E> = subscribeAsync(action::accept)
 
     /**
-     * Subscribes to events of the specified types only.
+     * Subscribes asynchronously to events of the specified types only.
+     *
+     * Events are delivered on a coroutine; the action does not run on the emitting thread.
      *
      * @param eventTypes The event types to filter on; events of other types are ignored
      * @param action The suspend function invoked for each matching event
      * @return A subscription handle that can be cancelled to stop receiving events
      */
-    fun subscribe(vararg eventTypes: ET, action: suspend (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, @UnsafeVariance E>
+    fun subscribeAsync(vararg eventTypes: ET, action: suspend (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, @UnsafeVariance E>
 
     /**
      * Activates emission for the given event types. Events of non-activated types are silently dropped.
@@ -107,7 +144,7 @@ interface LirpEventPublisher<ET : EventType, out E : LirpEvent<ET>> : Flow.Publi
     /**
      * Permanently closes this publisher.
      *
-     * After closing, [emitAsync] and all [subscribe] overloads throw [IllegalStateException].
+     * After closing, [emitAsync] and all [subscribe]/[subscribeAsync] overloads throw [IllegalStateException].
      * Idempotent: subsequent calls are safe no-ops.
      */
     override fun close()

--- a/lirp-core/api/lirp-core.api
+++ b/lirp-core/api/lirp-core.api
@@ -31,9 +31,11 @@ public abstract class net/transgressoft/lirp/entity/ReactiveEntityBase : net/tra
 	public final fun setEventsDisabled (Z)V
 	public fun setLastDateModified (Ljava/time/LocalDateTime;)V
 	public fun subscribe (Ljava/util/concurrent/Flow$Subscriber;)V
-	public fun subscribe (Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
-	public fun subscribe (Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
-	public fun subscribe ([Lnet/transgressoft/lirp/event/MutationEvent$Type;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribe (Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribe ([Lnet/transgressoft/lirp/event/MutationEvent$Type;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync (Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync (Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync ([Lnet/transgressoft/lirp/event/MutationEvent$Type;Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 	public fun withEventsDisabled (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public final fun withEventsDisabledForClone (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
@@ -90,14 +92,23 @@ public final class net/transgressoft/lirp/event/FlowEventPublisher : net/transgr
 	public fun isEventActive (Lnet/transgressoft/lirp/event/EventType;)Z
 	public final fun onCloseOnEmpty (Lkotlin/jvm/functions/Function0;)V
 	public fun subscribe (Ljava/util/concurrent/Flow$Subscriber;)V
-	public fun subscribe (Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
-	public fun subscribe (Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
-	public fun subscribe ([Lnet/transgressoft/lirp/event/EventType;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribe (Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribe ([Lnet/transgressoft/lirp/event/EventType;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync (Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync (Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync ([Lnet/transgressoft/lirp/event/EventType;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class net/transgressoft/lirp/event/FlowEventPublisher$ReactiveSubscription : net/transgressoft/lirp/event/LirpEventSubscription {
 	public fun <init> (Lnet/transgressoft/lirp/event/FlowEventPublisher;Lnet/transgressoft/lirp/event/LirpEventPublisher;Lkotlinx/coroutines/Job;)V
+	public fun cancel ()V
+	public fun getSource ()Lnet/transgressoft/lirp/event/LirpEventPublisher;
+	public fun request (J)V
+}
+
+public final class net/transgressoft/lirp/event/FlowEventPublisher$SyncSubscription : net/transgressoft/lirp/event/LirpEventSubscription {
+	public fun <init> (Lnet/transgressoft/lirp/event/FlowEventPublisher;Lnet/transgressoft/lirp/event/LirpEventPublisher;Lkotlin/jvm/functions/Function1;)V
 	public fun cancel ()V
 	public fun getSource ()Lnet/transgressoft/lirp/event/LirpEventPublisher;
 	public fun request (J)V
@@ -825,10 +836,13 @@ public abstract class net/transgressoft/lirp/persistence/RegistryBase : net/tran
 	public fun searchStream (Ljava/util/function/Predicate;)Ljava/util/stream/Stream;
 	public fun size ()I
 	public fun subscribe (Ljava/util/concurrent/Flow$Subscriber;)V
-	public fun subscribe (Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
-	public fun subscribe (Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
-	public fun subscribe ([Lnet/transgressoft/lirp/event/CrudEvent$Type;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
-	public synthetic fun subscribe ([Lnet/transgressoft/lirp/event/EventType;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribe (Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribe ([Lnet/transgressoft/lirp/event/CrudEvent$Type;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public synthetic fun subscribe ([Lnet/transgressoft/lirp/event/EventType;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync (Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync (Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync ([Lnet/transgressoft/lirp/event/CrudEvent$Type;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public synthetic fun subscribeAsync ([Lnet/transgressoft/lirp/event/EventType;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 	public static final fun viaAccessorFor$net_transgressoft_lirp_core (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpViaAccessor;
 	protected final fun wireRefBubbleUp (Lnet/transgressoft/lirp/entity/IdentifiableEntity;)V
 }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/CollectionChangeEventExtensions.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/CollectionChangeEventExtensions.kt
@@ -58,7 +58,7 @@ fun <K : Comparable<K>, R : ReactiveEntity<K, R>, E : Any> ReactiveEntity<K, R>.
     refName: String? = null,
     action: suspend (CollectionChangeEvent<E>) -> Unit
 ): LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>> =
-    subscribe { event ->
+    subscribeAsync { event ->
         if (event is AggregateMutationEvent<*, *> &&
             event.childEvent is CollectionChangeEvent<*> &&
             (refName == null || event.refName == refName)
@@ -109,11 +109,10 @@ fun <K : Comparable<K>, R : ReactiveEntity<K, R>, E : Any> ReactiveEntity<K, R>.
 fun <K : Comparable<K>, R : ReactiveEntity<K, R>> ReactiveEntity<K, R>.subscribeToMutations(
     action: suspend (MutationEvent<K, R>) -> Unit
 ): LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>> =
-    subscribe { event ->
+    subscribeAsync { event ->
         if (event !is AggregateMutationEvent<*, *>) {
             // Safe: AggregateMutationEvent is excluded above; K and R are bound by the receiver.
-            @Suppress("UNCHECKED_CAST")
-            action(event as MutationEvent<K, R>)
+            action(event)
         }
     }
 

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/PropertySubscriptionExtensions.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/PropertySubscriptionExtensions.kt
@@ -68,7 +68,7 @@ fun <K : Comparable<K>, R : ReactiveEntity<K, R>, V> ReactiveEntity<K, R>.subscr
     property: KProperty1<R, V>,
     action: suspend (old: V, new: V) -> Unit
 ): LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>> =
-    subscribe { event ->
+    subscribeAsync { event ->
         if (event is PropertyChanged<*, *, *> && event.property.name == property.name) {
             @Suppress("UNCHECKED_CAST") // Safe: name check ensures only events for this property reach the cast
             action(event.oldValue as V, event.newValue as V)
@@ -104,7 +104,7 @@ fun <K : Comparable<K>, R : ReactiveEntity<K, R>, V> ReactiveEntity<K, R>.subscr
     property: KProperty1<R, V>,
     action: suspend (PropertyChanged<K, R, V>) -> Unit
 ): LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>> =
-    subscribe { event ->
+    subscribeAsync { event ->
         if (event is PropertyChanged<*, *, *> && event.property.name == property.name) {
             @Suppress("UNCHECKED_CAST") // Safe: name check ensures only events for this property reach the cast
             action(event as PropertyChanged<K, R, V>)

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -433,9 +433,20 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
         publisher.emitAsync(event)
     }
 
-    override fun subscribe(action: suspend (MutationEvent<K, R>) -> Unit): LirpEventSubscription<in LirpEntity, MutationEvent.Type, MutationEvent<K, R>> {
+    override fun subscribe(callback: (MutationEvent<K, R>) -> Unit): LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>> {
         check(!isClosed) { "Entity '${this::class.java.simpleName}' is closed" }
-        return publisher.subscribe(action)
+        return publisher.subscribe(callback)
+    }
+
+    override fun subscribe(vararg eventTypes: MutationEvent.Type, callback: (MutationEvent<K, R>) -> Unit):
+        LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>> {
+        check(!isClosed) { "Entity '${this::class.java.simpleName}' is closed" }
+        return publisher.subscribe(*eventTypes, callback = callback)
+    }
+
+    override fun subscribeAsync(action: suspend (MutationEvent<K, R>) -> Unit): LirpEventSubscription<in LirpEntity, MutationEvent.Type, MutationEvent<K, R>> {
+        check(!isClosed) { "Entity '${this::class.java.simpleName}' is closed" }
+        return publisher.subscribeAsync(action)
     }
 
     override fun subscribe(subscriber: Flow.Subscriber<in MutationEvent<K, R>>?) {
@@ -443,13 +454,10 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
         publisher.subscribe(subscriber)
     }
 
-    override fun subscribe(vararg eventTypes: MutationEvent.Type, action: Consumer<in MutationEvent<K, R>>):
+    override fun subscribeAsync(vararg eventTypes: MutationEvent.Type, action: Consumer<in MutationEvent<K, R>>):
         LirpEventSubscription<in R, MutationEvent.Type, MutationEvent<K, R>> {
         check(!isClosed) { "Entity '${this::class.java.simpleName}' is closed" }
-        require(MUTATE in eventTypes) {
-            throw IllegalArgumentException("Only UPDATE event is supported for reactive entities")
-        }
-        return subscribe(action::accept)
+        return publisher.subscribeAsync(*eventTypes, action = action::accept)
     }
 
     /**

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/event/FlowEventPublisher.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/event/FlowEventPublisher.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.event
 
 import net.transgressoft.lirp.entity.LirpEntity
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Flow
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -38,6 +39,10 @@ import kotlinx.coroutines.launch
  *
  * @property replay Number of events to replay to new subscribers. Default 0 means
  *   new subscribers only see events after they subscribe.
+ *   Note: replay buffering begins only after the async bridge is first armed (by accessing
+ *   [FlowEventPublisher.changes] or calling [FlowEventPublisher.subscribeAsync]). Events emitted
+ *   before the bridge is armed are not buffered. To buffer from startup: access `publisher.changes`
+ *   once at initialization.
  * @property extraBufferCapacity Buffer size for events when subscribers are slow.
  *   Larger values use more memory but handle burst traffic better.
  * @property onBufferOverflow What happens when buffer is full:
@@ -102,37 +107,32 @@ data class PublisherConfig(
 }
 
 /**
- * Class that provides reactive event publishing capabilities using Kotlin coroutine flows.
+ * Class that provides reactive event publishing with both synchronous callbacks and
+ * Kotlin coroutine flows.
  *
- * `FlowEventPublisher` implements the core functionality needed for reactive programming by:
- * 1. Managing a [MutableSharedFlow] to broadcast events to multiple subscribers
- * 2. Providing compatibility with both Java's [Flow.Subscriber] API and Kotlin's flow-based approach
- * 3. Supporting suspending functions for asynchronous event handling
- * 4. Implementing [AutoCloseable] for deterministic resource cleanup
- * 5. Tracking the number of active subscribers via atomic operations
+ * `FlowEventPublisher` supports two subscription transports:
+ * - **Synchronous** (`subscribe`): callbacks are stored in a [CopyOnWriteArrayList] and invoked
+ *   inline on the emitting thread before any async delivery. Zero coroutine overhead. Ideal for
+ *   fast in-process work (cache updates, index maintenance) that must be complete by the time
+ *   [emitAsync] returns. Reentrancy on the same publisher from the same thread is handled via a
+ *   per-publisher `ThreadLocal` trampoline that defers reentrant events breadth-first.
+ * - **Asynchronous** (`subscribeAsync`): actions run in coroutines on a background dispatcher via a
+ *   lazily constructed `Channel`/`MutableSharedFlow` bridge. The bridge is initialized on the first
+ *   call to [subscribeAsync], [changes], or [subscribe] with a [Flow.Subscriber]; a publisher with
+ *   only sync subscribers allocates no coroutine machinery.
  *
- * This class serves as a foundational layer for both entity-level reactivity (property changes)
- * and collection-level reactivity (CRUD operations) within the reactive architecture.
- *
- * Key features:
- * - Thread-safe event publication with backpressure handling
- * - Support for both traditional subscribers and modern flow collectors
- * - Coroutine-based asynchronous event processing
- * - Selective event publishing based on event type activation
- * - Lifecycle management via [close]/[isClosed] — a closed publisher rejects new operations
- * - Subscriber count visibility via [subscriberCount]
- * - Optional self-close when all subscribers cancel via [closeOnEmpty]
+ * [closeOnEmpty] fires only when both the sync callback list and the async subscriber count
+ * reach zero simultaneously.
  *
  * @param E The specific type of [LirpEvent] this publisher will emit
  *
  * @see [LirpEventPublisher]
  * @see [SharedFlow]
  */
-class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
+class FlowEventPublisher<ET : EventType, E : LirpEvent<ET>>
     @JvmOverloads
     constructor(
         private val id: String,
-        // SharedFlow for entity change events with sufficient buffer and SUSPEND policy to ensure no events are lost
         private val config: PublisherConfig = PublisherConfig.DEFAULT,
         /**
          * When true, the publisher closes itself when the last subscriber cancels and no subscribe
@@ -148,22 +148,53 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
          * registered via [onCloseOnEmpty] is invoked so observers can react to the imminent shutdown.
          */
         private val closeOnEmpty: Boolean = false
-    ): LirpEventPublisher<ET, E> {
+    ) : LirpEventPublisher<ET, E> {
 
         private val log = KotlinLogging.logger {}
 
         /**
-         * Channel for processing events with configurable buffer capacity.
-         *
-         * The capacity is determined by [PublisherConfig.channelCapacity], defaulting to
-         * [Channel.UNLIMITED]. Use a bounded capacity to cap
-         * memory usage under sustained high-frequency mutations with slow subscribers.
+         * Lazily initialized async bridge holding the Channel, MutableSharedFlow, and drain coroutine.
+         * Armed only on the first async entry point; never armed by sync subscribe overloads.
          */
-        private val eventChannel = Channel<E>(config.channelCapacity)
+        private inner class Bridge {
+            val channel: Channel<E> = Channel(config.channelCapacity)
 
-        private val changesFlow = MutableSharedFlow<E>(config.replay, config.extraBufferCapacity, config.onBufferOverflow)
+            @Suppress("kotlin:S6305") // Exposing mutable flow is ok here for a private class
+            val flow: MutableSharedFlow<E> = MutableSharedFlow(config.replay, config.extraBufferCapacity, config.onBufferOverflow)
+            val changes: SharedFlow<E> = flow.asSharedFlow()
 
-        override val changes: SharedFlow<E> = changesFlow.asSharedFlow()
+            init {
+                flowScope.launch {
+                    for (event in channel) {
+                        try {
+                            flow.emit(event)
+                        } catch (exception: Exception) {
+                            log.error(exception) { "Unexpected error during event emission: $event" }
+                        }
+                    }
+                }
+            }
+        }
+
+        private val _bridgeHolder: Lazy<Bridge> = lazy(LazyThreadSafetyMode.SYNCHRONIZED) { Bridge() }
+
+        private fun armBridge(): Bridge = _bridgeHolder.value
+
+        // Returns null (non-blocking) if the bridge is not yet initialized — safe for the emitAsync fast path
+        private val bridge: Bridge? get() = if (_bridgeHolder.isInitialized()) _bridgeHolder.value else null
+
+        /**
+         * Diagnostic read-only flag for testing: `true` only after the async bridge has been armed
+         * (on first call to [subscribeAsync], [changes], or [subscribe] with a [Flow.Subscriber]).
+         * A publisher with only sync [subscribe] callbacks must keep this `false`.
+         */
+        internal val isBridgeInitialized: Boolean get() = _bridgeHolder.isInitialized()
+
+        override val changes: SharedFlow<E>
+            get() {
+                check(!isClosed) { "Publisher '$id' is closed" }
+                return armBridge().changes
+            }
 
         /**
          * The coroutine scope used for emitting change events.
@@ -178,15 +209,16 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
 
         override val isClosed: Boolean get() = closedFlag.get()
 
-        private val _subscriberCount = AtomicInteger(0)
+        private val _syncSubscriberCount = AtomicInteger(0)
+        private val _asyncSubscriberCount = AtomicInteger(0)
 
-        override val subscriberCount: Int get() = _subscriberCount.get()
+        override val subscriberCount: Int get() = _syncSubscriberCount.get() + _asyncSubscriberCount.get()
 
         /**
-         * Tracks subscribe() calls that have incremented [_subscriberCount] but whose coroutine
-         * job has not yet been registered with [invokeOnCompletion]. While this counter is
-         * non-zero, [closeOnEmpty] must not trigger close() even if [_subscriberCount] reaches
-         * zero, because a concurrent subscriber is still being set up.
+         * Tracks subscribeAsync() calls that have incremented [_asyncSubscriberCount] but whose coroutine
+         * job has not yet been registered with [invokeOnCompletion]. While this counter is non-zero,
+         * [closeOnEmpty] must not trigger [close] even if [subscriberCount] reaches zero, because a
+         * concurrent subscriber is still being set up.
          */
         private val _inFlightSubscribes = AtomicInteger(0)
 
@@ -194,53 +226,104 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
         @Volatile
         private var onCloseOnEmptyCallback: (() -> Unit)? = null
 
+        /**
+         * Holds sync callbacks registered via [subscribe]. [CopyOnWriteArrayList] provides
+         * snapshot-safe iteration: concurrent subscribe/cancel during dispatch affects the
+         * next iteration only, never the current one.
+         */
+        private val directCallbacks = CopyOnWriteArrayList<(E) -> Unit>()
+
+        // Per-publisher reentrancy trampoline (modeled on Guava EventBus PerThreadQueuedDispatcher)
+        private val _isDispatching: ThreadLocal<Boolean> = ThreadLocal.withInitial { false }
+        private val _pendingEvents: ThreadLocal<ArrayDeque<E>> = ThreadLocal.withInitial { ArrayDeque() }
+
         init {
             log.trace { "FlowEventPublisher created: $id" }
-
-            // Create a single persistent coroutine to handle all emissions for a fire and forget approach
-            flowScope.launch {
-                for (event in eventChannel) {
-                    try {
-                        changesFlow.emit(event) // This suspends if needed
-                    } catch (exception: Exception) {
-                        log.error(exception) { "Unexpected error during event emission: $event" }
-                    }
-                }
-            }
         }
 
         /**
          * Permanently closes this publisher.
          *
          * Uses [AtomicBoolean.compareAndSet] to ensure the close logic runs exactly once even
-         * under concurrent calls. After closing, [emitAsync] and all [subscribe] overloads throw
-         * [IllegalStateException]. Idempotent: subsequent calls are safe no-ops.
+         * under concurrent calls. After closing, [emitAsync] and all [subscribe]/[subscribeAsync]
+         * overloads throw [IllegalStateException]. Idempotent: subsequent calls are safe no-ops.
          */
         override fun close() {
             if (closedFlag.compareAndSet(false, true)) {
-                eventChannel.close()
+                bridge?.channel?.close()
+                directCallbacks.clear()
                 log.trace { "$this closed" }
             }
         }
 
         override fun emitAsync(event: E) {
             check(!isClosed) { "Publisher '$id' is closed" }
-            // Short-circuit when nobody is listening and no replay is configured: the event would
-            // be funneled through eventChannel → changesFlow and dropped on the floor anyway.
-            // Skipping here avoids the trySend allocation, the activeTypes lookup, and the
-            // persistent-coroutine wakeup. Safe because replay == 0 means no late subscriber can
-            // observe events emitted before they subscribed.
-            if (_subscriberCount.get() == 0 && config.replay == 0) return
-            // Read the volatile reference once to get a consistent snapshot; a concurrent disableEvents()
-            // replacing the reference after this read will not affect the check or the send
+            // Short-circuit when nobody is listening and no replay is configured.
+            if (subscriberCount == 0 && config.replay == 0) return
+
+            // Read activatedEventTypes once; both dispatch paths share this snapshot.
             val activeTypes = activatedEventTypes
-            if (event.type in activeTypes) {
-                // Use trySend so we don't block the caller
-                // If the channel is full, this will return the closed/failed result
-                val result = eventChannel.trySend(event)
+
+            // [1] Sync dispatch: when callbacks are registered and the event type is active
+            if (directCallbacks.isNotEmpty() && event.type in activeTypes) {
+                dispatchSync(event)
+            }
+
+            // [2] Async bridge dispatch: only if the bridge has been armed
+            val b = bridge
+            if (b != null && event.type in activeTypes) {
+                val result = b.channel.trySend(event)
                 if (!result.isSuccess) {
                     log.warn { "Failed to send event to channel (capacity=${config.channelCapacity}): $event" }
                 }
+            }
+        }
+
+        /**
+         * Dispatches [event] to all sync callbacks using a per-publisher trampoline to handle
+         * reentrancy. When a sync callback triggers another [emitAsync] on the same publisher from
+         * the same thread, the reentrant event is queued and drained breadth-first after the current
+         * dispatch completes. Each callback is wrapped in try/catch(Exception) so a throwing callback
+         * does not prevent delivery to remaining callbacks. Error propagates as a bug detector.
+         */
+        private fun dispatchSync(event: E) {
+            if (_isDispatching.get()) {
+                _pendingEvents.get().addLast(event)
+                return
+            }
+            _isDispatching.set(true)
+            try {
+                var current: E? = event
+                while (current != null) {
+                    for (callback in directCallbacks) {
+                        try {
+                            callback(current)
+                        } catch (e: Exception) {
+                            log.error(e) { "Exception in sync callback for publisher '$id'" }
+                        }
+                    }
+                    current = _pendingEvents.get().removeFirstOrNull()
+                }
+            } finally {
+                _isDispatching.set(false)
+                // If a callback propagated a Throwable out of the drain loop, queued reentrant events
+                // remain; clear them so they are not silently replayed on the next dispatch on this thread.
+                _pendingEvents.get().clear()
+            }
+        }
+
+        /**
+         * Fires [closeOnEmpty] if both sync and async subscriber counts are zero and no async
+         * subscribe call is currently in-flight.
+         */
+        private fun maybeCloseOnEmpty() {
+            if (closeOnEmpty &&
+                _syncSubscriberCount.get() == 0 &&
+                _asyncSubscriberCount.get() == 0 &&
+                _inFlightSubscribes.get() == 0
+            ) {
+                onCloseOnEmptyCallback?.invoke()
+                close()
             }
         }
 
@@ -256,20 +339,50 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
         }
 
         /**
-         * Shared [invokeOnCompletion] handler used by all three subscribe() overloads.
-         *
-         * Decrements [_subscriberCount]. If both [_subscriberCount] and [_inFlightSubscribes]
-         * reach zero and [closeOnEmpty] is enabled, fires the [onCloseOnEmptyCallback] and
-         * then closes this publisher. The double-zero check prevents premature close during
-         * concurrent subscribe/cancel cycles where a new subscriber is still being registered.
+         * Shared [invokeOnCompletion] handler used by async subscribe overloads. Decrements
+         * [_asyncSubscriberCount] and delegates to [maybeCloseOnEmpty].
          */
         private fun Job.registerCompletionHandler() {
             invokeOnCompletion {
-                _subscriberCount.decrementAndGet()
-                if (closeOnEmpty && _subscriberCount.get() == 0 && _inFlightSubscribes.get() == 0) {
-                    onCloseOnEmptyCallback?.invoke()
-                    close()
+                _asyncSubscriberCount.decrementAndGet()
+                maybeCloseOnEmpty()
+            }
+        }
+
+        override fun subscribe(callback: (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, E> {
+            // Bracket registration with the in-flight counter so a concurrent last-subscriber cancel
+            // cannot closeOnEmpty between the isClosed check and the directCallbacks add — that would
+            // leave a live handle on a closed publisher and corrupt the subscriber count.
+            _inFlightSubscribes.incrementAndGet()
+            try {
+                if (isClosed) {
+                    if (closeOnEmpty) return cancelledSyncSubscription()
+                    error("Publisher '$id' is closed")
                 }
+                directCallbacks.add(callback)
+                _syncSubscriberCount.incrementAndGet()
+                log.trace { "Sync subscription registered to $id" }
+                return SyncSubscription(this, callback)
+            } finally {
+                _inFlightSubscribes.decrementAndGet()
+            }
+        }
+
+        override fun subscribe(vararg eventTypes: ET, callback: (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, E> {
+            _inFlightSubscribes.incrementAndGet()
+            try {
+                if (isClosed) {
+                    if (closeOnEmpty) return cancelledSyncSubscription()
+                    error("Publisher '$id' is closed")
+                }
+                // Store the wrapper lambda (not the original callback) so cancel() can remove it by identity
+                val wrapper: (E) -> Unit = { event -> if (event.type in eventTypes) callback(event) }
+                directCallbacks.add(wrapper)
+                _syncSubscriberCount.incrementAndGet()
+                log.trace { "Filtered sync subscription registered to $id for event types: ${eventTypes.joinToString()}" }
+                return SyncSubscription(this, wrapper)
+            } finally {
+                _inFlightSubscribes.decrementAndGet()
             }
         }
 
@@ -287,11 +400,25 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
             }
             log.trace { "Subscription registered to $subscriber" }
 
-            _subscriberCount.incrementAndGet()
+            _asyncSubscriberCount.incrementAndGet()
 
+            // Arm the bridge synchronously, before launching the collect coroutine. Otherwise an
+            // emitAsync between this call returning and the coroutine being scheduled would see a
+            // null bridge and silently drop the event; the channel must exist to buffer it.
+            val armed = armBridge()
+            // A concurrent external close() may have fired after the isClosed check above but before
+            // arming; arming would otherwise leak a Channel + drain coroutine that is never closed.
+            // Tear the freshly-armed bridge down on that race.
+            if (isClosed) {
+                armed.channel.close()
+                _asyncSubscriberCount.decrementAndGet()
+                _inFlightSubscribes.decrementAndGet()
+                if (closeOnEmpty) return
+                error("Publisher '$id' is closed")
+            }
             val job =
                 flowScope.launch {
-                    changesFlow.collect { event ->
+                    armed.flow.collect { event ->
                         subscriber.onNext(event)
                     }
                 }
@@ -303,12 +430,12 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
         }
 
         /**
-         * Subscribes to entity change events by providing an action to execute when changes occur.
+         * Subscribes asynchronously to entity change events by providing a suspending action.
          *
-         * @param action The action to execute when the entity changes
+         * @param action The suspend action to execute when events are emitted
          * @return A subscription that can be used to unsubscribe
          */
-        override fun subscribe(action: suspend (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, E> {
+        override fun subscribeAsync(action: suspend (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, E> {
             _inFlightSubscribes.incrementAndGet()
             if (isClosed) {
                 _inFlightSubscribes.decrementAndGet()
@@ -316,16 +443,29 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
                     return cancelledSubscription()
                 error("Publisher '$id' is closed")
             }
-            log.trace { "Anonymous subscription registered to $id" }
+            log.trace { "Async subscription registered to $id" }
 
-            _subscriberCount.incrementAndGet()
+            _asyncSubscriberCount.incrementAndGet()
+
+            // Arm the bridge synchronously, before launching the collect coroutine, so an emitAsync
+            // racing this subscription is buffered by the channel rather than dropped against a null bridge.
+            val armed = armBridge()
+            // Tear down the freshly-armed bridge if an external close() raced in after the isClosed
+            // check above, otherwise the Channel + drain coroutine would leak on the process-lived scope.
+            if (isClosed) {
+                armed.channel.close()
+                _asyncSubscriberCount.decrementAndGet()
+                _inFlightSubscribes.decrementAndGet()
+                if (closeOnEmpty) return cancelledSubscription()
+                error("Publisher '$id' is closed")
+            }
 
             // Each subscription requires its own collection coroutine to handle events independently
             // This is a deliberate design pattern for reactive subscriptions
             @Suppress("kotlin:S6311")
             val job =
                 flowScope.launch {
-                    changesFlow.collect { event ->
+                    armed.flow.collect { event ->
                         action(event)
                     }
                 }
@@ -336,23 +476,36 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
             return ReactiveSubscription(this, job)
         }
 
-        override fun subscribe(vararg eventTypes: ET, action: suspend (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, E> {
+        override fun subscribeAsync(vararg eventTypes: ET, action: suspend (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, E> {
             _inFlightSubscribes.incrementAndGet()
             if (isClosed) {
                 _inFlightSubscribes.decrementAndGet()
                 if (closeOnEmpty) return cancelledSubscription()
                 error("Publisher '$id' is closed")
             }
-            log.trace { "Subscription registered to $id for event types: ${eventTypes.joinToString()}" }
+            log.trace { "Async filtered subscription registered to $id for event types: ${eventTypes.joinToString()}" }
 
-            _subscriberCount.incrementAndGet()
+            _asyncSubscriberCount.incrementAndGet()
+
+            // Arm the bridge synchronously, before launching the collect coroutine, so an emitAsync
+            // racing this subscription is buffered by the channel rather than dropped against a null bridge.
+            val armed = armBridge()
+            // Tear down the freshly-armed bridge if an external close() raced in after the isClosed
+            // check above, otherwise the Channel + drain coroutine would leak on the process-lived scope.
+            if (isClosed) {
+                armed.channel.close()
+                _asyncSubscriberCount.decrementAndGet()
+                _inFlightSubscribes.decrementAndGet()
+                if (closeOnEmpty) return cancelledSubscription()
+                error("Publisher '$id' is closed")
+            }
 
             // Each subscription requires its own collection coroutine to handle events independently
             // This is a deliberate design pattern for reactive subscriptions
             @Suppress("kotlin:S6311")
             val job =
                 flowScope.launch {
-                    changesFlow.collect { event ->
+                    armed.flow.collect { event ->
                         if (event.type in eventTypes) {
                             action(event)
                         }
@@ -382,7 +535,10 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
         private fun cancelledSubscription(): LirpEventSubscription<in LirpEntity, ET, E> =
             ReactiveSubscription(this, Job().apply { cancel() })
 
-        inner class ReactiveSubscription<T: LirpEntity>(override val source: LirpEventPublisher<ET, E>, private val job: Job)
+        private fun cancelledSyncSubscription(): LirpEventSubscription<in LirpEntity, ET, E> =
+            SyncSubscription(this, {})
+
+        inner class ReactiveSubscription<T : LirpEntity>(override val source: LirpEventPublisher<ET, E>, private val job: Job)
         : LirpEventSubscription<T, ET, E> {
 
             override fun request(n: Long) {
@@ -391,6 +547,28 @@ class FlowEventPublisher<ET : EventType, E: LirpEvent<ET>>
 
             override fun cancel() {
                 job.cancel()
+            }
+        }
+
+        /**
+         * Subscription handle for synchronous callbacks registered via [subscribe].
+         *
+         * Cancellation removes the stored callback from [directCallbacks] and decrements the sync
+         * subscriber count. For filtered subscriptions, the stored callback is the wrapper lambda
+         * that performs the type check, not the original user-provided callback.
+         */
+        inner class SyncSubscription<T : LirpEntity>(override val source: LirpEventPublisher<ET, E>, private val storedCallback: (E) -> Unit)
+        : LirpEventSubscription<T, ET, E> {
+
+            override fun request(n: Long) {
+                error("Events cannot be requested on demand")
+            }
+
+            override fun cancel() {
+                if (directCallbacks.remove(storedCallback)) {
+                    _syncSubscriberCount.decrementAndGet()
+                    maybeCloseOnEmpty()
+                }
             }
         }
     }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/AggregateRefDelegate.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/AggregateRefDelegate.kt
@@ -375,7 +375,7 @@ class AggregateRefDelegate<K : Comparable<K>, E : IdentifiableEntity<K>>(
         // the cast is safe because subscribe() only reads from the entity's publisher,
         // which is internally consistent regardless of the type parameter.
         val rawChild = referencedEntity as ReactiveEntity<Comparable<Any>, *>
-        return rawChild.subscribe { childEvent ->
+        return rawChild.subscribeAsync { childEvent ->
             // Type parameters are erased at runtime; the self-referential bound R : ReactiveEntity<K, R>
             // cannot be verified at the wildcard call site. ReactiveEntityBase.emitBubbleUpEvent() is used
             // here because it is defined on the entity class itself (which has the correctly-typed R),

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/FxScalarPropertyDelegate.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/FxScalarPropertyDelegate.kt
@@ -31,6 +31,7 @@ package net.transgressoft.lirp.persistence
  * The callback receives the old value captured by the FxScalar delegate before invoking
  * `super.set()`, the new value, and a mutation block wrapping the `super.set()` call.
  */
+@Suppress("kotlin:S6517") // Nominal capability marker, its single method is incidental
 interface FxScalarPropertyDelegate {
     /**
      * Binds a mutation callback injected by [RegistryBase] that emits a typed mutation event for

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
@@ -562,61 +562,70 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
          */
         protected fun subscribeEntity(entity: R) {
             val subscription =
-                entity.subscribe { mutationEvent ->
+                entity.subscribeAsync { mutationEvent ->
                     pendingLock.read {
                         if (closed) return@read
-                        // Extract the pre-mutation version and index keys from the captured carrier.
-                        // PropertyChanged and BatchChanged carry immutable scalars frozen at assignment
-                        // time, so they are safe to read here even under deferred coroutine dispatch.
-                        val versionAtMutation: Long? =
-                            when (mutationEvent) {
-                                is PropertyChanged<*, *, *> ->
-                                    @Suppress("UNCHECKED_CAST")
-                                    (mutationEvent as PropertyChanged<K, R, *>).versionAtMutation
-                                        ?: extractVersion(mutationEvent.entity)
-                                is BatchChanged<*, *> ->
-                                    @Suppress("UNCHECKED_CAST")
-                                    (mutationEvent as BatchChanged<K, R>).versionAtMutation
-                                        ?: extractVersion(mutationEvent.entity)
-                                else -> extractVersion(mutationEvent.entity)
-                            }
-                        enqueueUpdate(mutationEvent.entity, versionAtMutation)
-
-                        // Keep secondary indexes in sync before invoking the subclass hook so a
-                        // throwing override of onEntityMutated cannot leave findByIndex / range
-                        // queries returning stale results.
-                        //
-                        // Scope each old-key removal to the property that actually changed. A single
-                        // batch can touch several @Indexed properties of different runtime types, and
-                        // applying one property's key to a differently-typed sorted index would throw
-                        // ClassCastException in the comparator. PropertyChanged carries one
-                        // (property, key) pair; BatchChanged is fanned out per indexed field change.
-                        when (mutationEvent) {
-                            is PropertyChanged<*, *, *> -> {
-                                @Suppress("UNCHECKED_CAST")
-                                val propertyChanged = mutationEvent as PropertyChanged<K, R, *>
-                                reindexEntity(
-                                    propertyChanged.entity,
-                                    propertyChanged.oldIndexKey,
-                                    propertyChanged.newIndexKey,
-                                    propertyChanged.property.name
-                                )
-                            }
-                            is BatchChanged<*, *> -> {
-                                @Suppress("UNCHECKED_CAST")
-                                val batchChanged = mutationEvent as BatchChanged<K, R>
-                                for (change in batchChanged.changes) {
-                                    if (isPropertyIndexed(change.property)) {
-                                        reindexEntity(batchChanged.entity, change.oldValue, change.newValue, change.property.name)
-                                    }
-                                }
-                            }
-                            else -> { /* ReactiveMutationEvent / AggregateMutationEvent — no index keys to apply */ }
-                        }
+                        enqueueUpdate(mutationEvent.entity, versionAtMutation(mutationEvent))
+                        // Reindex before the subclass hook so a throwing onEntityMutated override
+                        // cannot leave findByIndex / range queries returning stale results.
+                        reindexMutation(mutationEvent)
                         onEntityMutated(mutationEvent)
                     }
                 }
             subscriptionsMap[entity.id] = subscription
+        }
+
+        /**
+         * Resolves the entity version to pin into the pending update cell for `@Version`-aware subclasses.
+         *
+         * [PropertyChanged] and [BatchChanged] carry an immutable `versionAtMutation` scalar frozen at
+         * assignment time, safe to read under deferred coroutine dispatch. Falling back to [extractVersion]
+         * on the live entity is safe because version bumps run inside the debounced write pipeline, not at
+         * mutation time, so the live entity still holds the pre-flush value when the subscriber drains.
+         */
+        private fun versionAtMutation(mutationEvent: MutationEvent<K, R>): Long? =
+            when (mutationEvent) {
+                is PropertyChanged<*, *, *> ->
+                    @Suppress("UNCHECKED_CAST")
+                    (mutationEvent as PropertyChanged<K, R, *>).versionAtMutation ?: extractVersion(mutationEvent.entity)
+                is BatchChanged<*, *> ->
+                    @Suppress("UNCHECKED_CAST")
+                    (mutationEvent as BatchChanged<K, R>).versionAtMutation ?: extractVersion(mutationEvent.entity)
+                else -> extractVersion(mutationEvent.entity)
+            }
+
+        /**
+         * Applies the mutation's index-key delta to the secondary indexes.
+         *
+         * Each old-key removal is scoped to the property that actually changed: a single batch can touch
+         * several `@Indexed` properties of different runtime types, and applying one property's key to a
+         * differently-typed sorted index would throw [ClassCastException] in the comparator. [PropertyChanged]
+         * carries one (property, key) pair; [BatchChanged] is fanned out per indexed field change.
+         * [ReactiveMutationEvent]/[AggregateMutationEvent] carry no index keys and are skipped.
+         */
+        private fun reindexMutation(mutationEvent: MutationEvent<K, R>) {
+            when (mutationEvent) {
+                is PropertyChanged<*, *, *> -> {
+                    @Suppress("UNCHECKED_CAST")
+                    val propertyChanged = mutationEvent as PropertyChanged<K, R, *>
+                    reindexEntity(
+                        propertyChanged.entity,
+                        propertyChanged.oldIndexKey,
+                        propertyChanged.newIndexKey,
+                        propertyChanged.property.name
+                    )
+                }
+                is BatchChanged<*, *> -> {
+                    @Suppress("UNCHECKED_CAST")
+                    val batchChanged = mutationEvent as BatchChanged<K, R>
+                    for (change in batchChanged.changes) {
+                        if (isPropertyIndexed(change.property)) {
+                            reindexEntity(batchChanged.entity, change.oldValue, change.newValue, change.property.name)
+                        }
+                    }
+                }
+                else -> { /* ReactiveMutationEvent / AggregateMutationEvent — no index keys to apply */ }
+            }
         }
 
         /**

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/MultiKeyRegistryProjectionMap.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/MultiKeyRegistryProjectionMap.kt
@@ -127,7 +127,7 @@ class MultiKeyRegistryProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : 
                 if (!isSoftDeleted(entity)) addToBucket(entity)
             }
             subscription =
-                registry.subscribe(
+                registry.subscribeAsync(
                     CrudEvent.Type.CREATE,
                     CrudEvent.Type.UPDATE,
                     CrudEvent.Type.DELETE

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/RegistryProjectionMap.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/RegistryProjectionMap.kt
@@ -118,7 +118,7 @@ class RegistryProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : Identifi
             // Subscribe after the seed is complete to avoid double-applying events that arrive
             // during iteration.
             subscription =
-                registry.subscribe(
+                registry.subscribeAsync(
                     CrudEvent.Type.CREATE,
                     CrudEvent.Type.UPDATE,
                     CrudEvent.Type.DELETE

--- a/lirp-core/src/test/java/net/transgressoft/lirp/JavaInteroperabilityTest.java
+++ b/lirp-core/src/test/java/net/transgressoft/lirp/JavaInteroperabilityTest.java
@@ -96,7 +96,7 @@ class JavaInteroperabilityTest {
                 String[] oldValueHolder = new String[1];
                 String[] newValueHolder = new String[1];
 
-                var subscription = appName.subscribe(event -> {
+                var subscription = appName.subscribeAsync(event -> {
                     var pc = (PropertyChanged<?, ?, ?>) event;
                     oldValueHolder[0] = (String) pc.getOldValue();
                     newValueHolder[0] = (String) pc.getNewValue();
@@ -167,7 +167,7 @@ class JavaInteroperabilityTest {
             var oldTitle = new String[1];
             var newTitle = new String[1];
 
-            var subscription = audioItem.subscribe(event -> {
+            var subscription = audioItem.subscribeAsync(event -> {
                 var pc = (PropertyChanged<?, ?, ?>) event;
                 oldTitle[0] = (String) pc.getOldValue();
                 newTitle[0] = (String) pc.getNewValue();
@@ -314,7 +314,7 @@ class JavaInteroperabilityTest {
             audioItem.close();
 
             assertTrue(audioItem.isClosed());
-            assertThrows(IllegalStateException.class, () -> audioItem.subscribe(event -> {}));
+            assertThrows(IllegalStateException.class, () -> audioItem.subscribeAsync(event -> {}));
         }
 
         @Test
@@ -324,7 +324,7 @@ class JavaInteroperabilityTest {
             repository.close();
 
             assertTrue(repository.isClosed());
-            assertThrows(IllegalStateException.class, () -> repository.subscribe(event -> {}));
+            assertThrows(IllegalStateException.class, () -> repository.subscribeAsync(event -> {}));
         }
     }
 
@@ -339,14 +339,14 @@ class JavaInteroperabilityTest {
 
             try (var audioItem = new MutableAudioItem(1, "Track Alpha")) {
                 audioItemRef[0] = audioItem;
-                var subscription = audioItem.subscribe(event -> {});
+                var subscription = audioItem.subscribeAsync(event -> {});
                 audioItem.setTitle("Track Beta");
                 scheduler.advanceUntilIdle();
                 subscription.cancel();
             }
 
             assertTrue(audioItemRef[0].isClosed());
-            assertThrows(IllegalStateException.class, () -> audioItemRef[0].subscribe(event -> {}));
+            assertThrows(IllegalStateException.class, () -> audioItemRef[0].subscribeAsync(event -> {}));
         }
 
         @Test
@@ -361,7 +361,7 @@ class JavaInteroperabilityTest {
             }
 
             assertTrue(repoRef[0].isClosed());
-            assertThrows(IllegalStateException.class, () -> repoRef[0].subscribe(event -> {}));
+            assertThrows(IllegalStateException.class, () -> repoRef[0].subscribeAsync(event -> {}));
         }
     }
 
@@ -467,10 +467,10 @@ class JavaInteroperabilityTest {
             var audioItem = new MutableAudioItem(1, "Track Alpha");
 
             // Throwing Consumer — unconditional exception on every event
-            audioItem.subscribe(event -> { throw new RuntimeException("intentional Java exception"); });
+            audioItem.subscribeAsync(event -> { throw new RuntimeException("intentional Java exception"); });
 
             var healthyCounter = new AtomicInteger(0);
-            audioItem.subscribe(event -> healthyCounter.incrementAndGet());
+            audioItem.subscribeAsync(event -> healthyCounter.incrementAndGet());
 
             audioItem.setTitle("Track Beta");
             audioItem.setTitle("Track Charlie");
@@ -541,7 +541,7 @@ class JavaInteroperabilityTest {
             var latch = new CountDownLatch(1);
             var receivedAggregateEvent = new AtomicReference<MutationEvent<?, ?>>(null);
 
-            bubbleUp.subscribe(event -> {
+            bubbleUp.subscribeAsync(event -> {
                 if (event instanceof AggregateMutationEvent) {
                     receivedAggregateEvent.set(event);
                     latch.countDown();
@@ -685,7 +685,7 @@ class JavaInteroperabilityTest {
             var repository = new AudioItemVolatileRepository();
             var eventEntities = new ArrayList<AudioItem>();
 
-            var subscription = repository.subscribe(
+            var subscription = repository.subscribeAsync(
                 event -> eventEntities.addAll(event.getEntities().values()));
 
             repository.create(1, "Track Alpha", "");
@@ -706,7 +706,7 @@ class JavaInteroperabilityTest {
             repository.create(1, "Track Alpha", "");
 
             List<CrudEvent<Integer, ? extends AudioItem>> receivedEvents = new ArrayList<>();
-            var subscription = repository.subscribe(event -> receivedEvents.add(event));
+            var subscription = repository.subscribeAsync(event -> receivedEvents.add(event));
 
             repository.remove(alpha);
             scheduler.advanceUntilIdle();
@@ -745,7 +745,7 @@ class JavaInteroperabilityTest {
             repository.create(3, "Track Charlie", "");
 
             List<CrudEvent<Integer, ? extends AudioItem>> receivedEvents = new ArrayList<>();
-            var subscription = repository.subscribe(event -> receivedEvents.add(event));
+            var subscription = repository.subscribeAsync(event -> receivedEvents.add(event));
 
             repository.clear();
             scheduler.advanceUntilIdle();

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/IntegrationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/IntegrationTest.kt
@@ -67,7 +67,7 @@ class IntegrationTest : DescribeSpec({
                     (1..subscriberCount).map {
                         reactive.scope.launch {
                             val events = Collections.synchronizedList(mutableListOf<CrudEvent<String, TestEntity>>())
-                            val subscription = publisher.subscribe { event -> events.add(event) }
+                            val subscription = publisher.subscribeAsync { event -> events.add(event) }
                             reactive.advance()
                             collectedCounts.add(events.size)
                             subscription.cancel()
@@ -191,7 +191,7 @@ class IntegrationTest : DescribeSpec({
             val subscriptions =
                 (1..subscriberCount).map {
                     val events = Collections.synchronizedList(mutableListOf<CrudEvent<String, TestEntity>>())
-                    val sub = publisher.subscribe { event -> events.add(event) }
+                    val sub = publisher.subscribeAsync { event -> events.add(event) }
                     sub to events
                 }
 
@@ -223,14 +223,14 @@ class IntegrationTest : DescribeSpec({
             val subscribersPerEntity = 3
 
             val repoEvents = Collections.synchronizedList(mutableListOf<CrudEvent<Int, PolymorphicCustomer>>())
-            val repoSubscription = repository.subscribe { repoEvents.add(it) }
+            val repoSubscription = repository.subscribeAsync { repoEvents.add(it) }
 
             val customers = (1..entityCount).map { id -> repository.create(id, "Customer-$id", null) }
 
             val entitySubscriptions =
                 customers.flatMap { customer ->
                     (1..subscribersPerEntity).map {
-                        customer.subscribe { }
+                        customer.subscribeAsync { }
                     }
                 }
             reactive.advance()
@@ -255,7 +255,7 @@ class IntegrationTest : DescribeSpec({
 
             val entity = LazyTestEntity("concurrent-test")
             val receivedEvents = Collections.synchronizedList(mutableListOf<MutationEvent<String, LazyTestEntity>>())
-            val subscription = entity.subscribe { event -> receivedEvents.add(event) }
+            val subscription = entity.subscribeAsync { event -> receivedEvents.add(event) }
 
             val jobs =
                 (1..mutationCount).map { coroutineId ->
@@ -298,7 +298,7 @@ class IntegrationTest : DescribeSpec({
 
                 val subscriptions =
                     (1..3).map {
-                        entity.subscribe { event -> cycleEvents.add(event) }
+                        entity.subscribeAsync { event -> cycleEvents.add(event) }
                     }
 
                 repeat(mutationsPerCycle) { i ->
@@ -316,7 +316,7 @@ class IntegrationTest : DescribeSpec({
             creationCounter.get() shouldBeGreaterThanOrEqual cycleCount
 
             val finalEvents = Collections.synchronizedList(mutableListOf<MutationEvent<String, LazyTestEntity>>())
-            val finalSubscription = entity.subscribe { event -> finalEvents.add(event) }
+            val finalSubscription = entity.subscribeAsync { event -> finalEvents.add(event) }
             entity.value = "final-check"
             reactive.advance()
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/ReactiveEntityLazyInitTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/ReactiveEntityLazyInitTest.kt
@@ -45,11 +45,11 @@ class ReactiveEntityLazyInitTest : StringSpec({
         publisherCreationCounter.get() shouldBe 0
 
         // Subscribe - should trigger publisher creation
-        val subscription = entity.subscribe { }
+        val subscription = entity.subscribeAsync { }
         publisherCreationCounter.get() shouldBe 1
 
         // Subsequent subscriptions should not create new publishers
-        val subscription2 = entity.subscribe { }
+        val subscription2 = entity.subscribeAsync { }
         publisherCreationCounter.get() shouldBe 1
 
         subscription.cancel()
@@ -80,7 +80,7 @@ class ReactiveEntityLazyInitTest : StringSpec({
         // Subscribe
         val receivedEvents = mutableListOf<MutationEvent<String, LazyTestEntity>>()
         val subscription =
-            entity.subscribe { event ->
+            entity.subscribeAsync { event ->
                 receivedEvents.add(event)
             }
 
@@ -133,7 +133,7 @@ class ReactiveEntityLazyInitTest : StringSpec({
         // Subscribe to only the first 10
         val subscriptions =
             entities.take(10).map { entity ->
-                entity.subscribe { }
+                entity.subscribeAsync { }
             }
 
         // Only the first 10 should have publishers
@@ -164,7 +164,7 @@ class ReactiveEntityLazyInitTest : StringSpec({
         customFactoryCalled.get() shouldBe 0
 
         // Subscribe - factory should be called
-        val subscription = entity.subscribe { }
+        val subscription = entity.subscribeAsync { }
         customFactoryCalled.get() shouldBe 1
 
         subscription.cancel()
@@ -182,7 +182,7 @@ class ReactiveEntityLazyInitTest : StringSpec({
             (1..threadCount).map {
                 executor.submit<Unit> {
                     latch.await()
-                    entity.subscribe { }
+                    entity.subscribeAsync { }
                 }
             }
 
@@ -199,7 +199,7 @@ class ReactiveEntityLazyInitTest : StringSpec({
         entity.close()
 
         shouldThrow<IllegalStateException> {
-            entity.subscribe { }
+            entity.subscribeAsync { }
         }
     }
 
@@ -207,14 +207,14 @@ class ReactiveEntityLazyInitTest : StringSpec({
         val publisherCreationCounter = AtomicInteger(0)
         val entity = LazyTestEntity("close-with-publisher", publisherCreationCounter)
 
-        val subscription = entity.subscribe { }
+        val subscription = entity.subscribeAsync { }
         publisherCreationCounter.get() shouldBe 1
 
         entity.close()
         entity.isClosed shouldBe true
 
         shouldThrow<IllegalStateException> {
-            entity.subscribe { }
+            entity.subscribeAsync { }
         }
 
         subscription.cancel()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/ReactiveEntityLifecycleTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/ReactiveEntityLifecycleTest.kt
@@ -18,7 +18,8 @@
 package net.transgressoft.lirp.entity
 
 import net.transgressoft.lirp.event.MutationEvent
-import net.transgressoft.lirp.event.MutationEvent.Type.MUTATE
+import net.transgressoft.lirp.event.MutationEvent.Type.BATCH_CHANGED
+import net.transgressoft.lirp.event.MutationEvent.Type.PROPERTY_CHANGED
 import net.transgressoft.lirp.event.PropertyChanged
 import net.transgressoft.lirp.event.ReactiveMutationEvent
 import net.transgressoft.lirp.persistence.AudioItem
@@ -64,12 +65,12 @@ class ReactiveEntityLifecycleTest : StringSpec({
     "ReactiveEntity close() closes its publisher when publisher is initialized" {
         val entity = LazyTestEntity("lifecycle-4")
 
-        val subscription = entity.subscribe { }
+        val subscription = entity.subscribeAsync { }
         entity.close()
 
         entity.isClosed shouldBe true
         shouldThrow<IllegalStateException> {
-            entity.subscribe { }
+            entity.subscribeAsync { }
         }
 
         subscription.cancel()
@@ -92,7 +93,7 @@ class ReactiveEntityLifecycleTest : StringSpec({
 
         val exception =
             shouldThrow<IllegalStateException> {
-                entity.subscribe { }
+                entity.subscribeAsync { }
             }
         exception.message shouldContain "LazyTestEntity"
     }
@@ -119,7 +120,7 @@ class ReactiveEntityLifecycleTest : StringSpec({
     "Closed ReactiveEntity throws IllegalStateException on emitAsync" {
         val entity = LazyTestEntity("lifecycle-8")
         // Subscribe first to initialize the publisher
-        val subscription = entity.subscribe { }
+        val subscription = entity.subscribeAsync { }
         entity.close()
 
         shouldThrow<IllegalStateException> {
@@ -134,14 +135,14 @@ class ReactiveEntityLifecycleTest : StringSpec({
         val entity = LazyTestEntity("lifecycle-9", creationCounter)
 
         // First subscription creates the publisher (counter = 1)
-        val subscription = entity.subscribe { }
+        val subscription = entity.subscribeAsync { }
         creationCounter.get() shouldBe 1
 
         subscription.cancel()
         reactive.advance()
 
         // Entity is dormant: next subscription must create a fresh publisher (counter = 2)
-        val subscription2 = entity.subscribe { }
+        val subscription2 = entity.subscribeAsync { }
         creationCounter.get() shouldBe 2
 
         subscription2.cancel()
@@ -151,14 +152,14 @@ class ReactiveEntityLifecycleTest : StringSpec({
         val creationCounter = AtomicInteger(0)
         val entity = LazyTestEntity("lifecycle-10", creationCounter)
 
-        val subscriptions = List(3) { entity.subscribe { } }
+        val subscriptions = List(3) { entity.subscribeAsync { } }
         creationCounter.get() shouldBe 1
 
         subscriptions.forEach { it.cancel() }
         reactive.advance()
 
         // Entity is dormant: next subscription recreates the publisher
-        val subscription = entity.subscribe { }
+        val subscription = entity.subscribeAsync { }
         creationCounter.get() shouldBe 2
 
         subscription.cancel()
@@ -169,13 +170,13 @@ class ReactiveEntityLifecycleTest : StringSpec({
         val entity = LazyTestEntity("lifecycle-11", creationCounter)
 
         // Go dormant
-        val sub1 = entity.subscribe { }
+        val sub1 = entity.subscribeAsync { }
         sub1.cancel()
         reactive.advance()
 
         // Reactivate: subscribe again — must not throw
         val receivedEvents = mutableListOf<MutationEvent<String, LazyTestEntity>>()
-        val sub2 = entity.subscribe { event -> receivedEvents.add(event) }
+        val sub2 = entity.subscribeAsync { event -> receivedEvents.add(event) }
 
         entity.value = "reactivated"
         reactive.advance()
@@ -191,20 +192,20 @@ class ReactiveEntityLifecycleTest : StringSpec({
         val entity = LazyTestEntity("lifecycle-12", creationCounter)
 
         // Cycle 1: subscribe -> cancel -> dormant
-        val sub1 = entity.subscribe { }
+        val sub1 = entity.subscribeAsync { }
         creationCounter.get() shouldBe 1
         sub1.cancel()
         reactive.advance()
 
         // Cycle 2: subscribe -> cancel -> dormant
-        val sub2 = entity.subscribe { }
+        val sub2 = entity.subscribeAsync { }
         creationCounter.get() shouldBe 2
         sub2.cancel()
         reactive.advance()
 
         // Cycle 3: subscribe (active), receive events
         val receivedEvents = mutableListOf<MutationEvent<String, LazyTestEntity>>()
-        val sub3 = entity.subscribe { event -> receivedEvents.add(event) }
+        val sub3 = entity.subscribeAsync { event -> receivedEvents.add(event) }
         creationCounter.get() shouldBe 3
 
         entity.value = "after-cycles"
@@ -224,7 +225,7 @@ class ReactiveEntityLifecycleTest : StringSpec({
         creationCounter.get() shouldBe 0
 
         // Active: publisher created on first subscribe
-        val sub1 = entity.subscribe { }
+        val sub1 = entity.subscribeAsync { }
         creationCounter.get() shouldBe 1
 
         // Dormant: all subscribers cancelled
@@ -232,7 +233,7 @@ class ReactiveEntityLifecycleTest : StringSpec({
         reactive.advance()
 
         // Active again: new subscription reactivates
-        val sub2 = entity.subscribe { }
+        val sub2 = entity.subscribeAsync { }
         creationCounter.get() shouldBe 2
 
         // Closed: permanent terminal state
@@ -241,13 +242,13 @@ class ReactiveEntityLifecycleTest : StringSpec({
         entity.isClosed shouldBe true
 
         shouldThrow<IllegalStateException> {
-            entity.subscribe { }
+            entity.subscribeAsync { }
         }
     }
 
     "ReactiveEntityBase emitAsync throws IllegalStateException when entity is closed" {
         val audioItem = MutableAudioItem(1, "Track Alpha")
-        val sub = audioItem.subscribe { }
+        val sub = audioItem.subscribeAsync { }
         audioItem.close()
 
         shouldThrow<IllegalStateException> {
@@ -257,21 +258,26 @@ class ReactiveEntityLifecycleTest : StringSpec({
         sub.cancel()
     }
 
-    "ReactiveEntityBase subscribe with vararg eventTypes throws IllegalArgumentException when MUTATE is absent" {
-        val audioItem = MutableAudioItem(1, "Track Alpha")
-
-        shouldThrow<IllegalArgumentException> {
-            audioItem.subscribe(*emptyArray<MutationEvent.Type>(), action = Consumer { _ -> })
-        }
-
-        audioItem.close()
-    }
-
-    "ReactiveEntityBase subscribe with MUTATE type succeeds and delivers events" {
+    "ReactiveEntityBase subscribeAsync with vararg eventTypes excludes non-matching event types" {
         val audioItem = MutableAudioItem(1, "Track Alpha")
         val received = mutableListOf<MutationEvent<Int, AudioItem>>()
 
-        val subscription = audioItem.subscribe(MUTATE) { event -> received.add(event) }
+        // A single-property assignment emits PROPERTY_CHANGED; a BATCH_CHANGED-only filter must exclude it.
+        val subscription = audioItem.subscribeAsync(BATCH_CHANGED, action = Consumer { event -> received.add(event) })
+        audioItem.title = "Track Beta"
+        reactive.advance()
+
+        received.size shouldBe 0
+        subscription.cancel()
+        audioItem.close()
+    }
+
+    "ReactiveEntityBase subscribeAsync with matching event type delivers events" {
+        val audioItem = MutableAudioItem(1, "Track Alpha")
+        val received = mutableListOf<MutationEvent<Int, AudioItem>>()
+
+        // A property assignment emits PROPERTY_CHANGED, so a PROPERTY_CHANGED filter receives it.
+        val subscription = audioItem.subscribeAsync(PROPERTY_CHANGED) { event -> received.add(event) }
 
         audioItem.title = "Track Beta"
         reactive.advance()
@@ -284,7 +290,7 @@ class ReactiveEntityLifecycleTest : StringSpec({
     "disableEvents suppresses mutation events from reactiveProperty setters" {
         val audioItem = MutableAudioItem(1, "Track Alpha")
         val received = mutableListOf<MutationEvent<Int, AudioItem>>()
-        val subscription = audioItem.subscribe { event -> received.add(event) }
+        val subscription = audioItem.subscribeAsync { event -> received.add(event) }
 
         audioItem.suppressEvents()
         audioItem.title = "Track Beta"
@@ -307,7 +313,7 @@ class ReactiveEntityLifecycleTest : StringSpec({
     "withEventsDisabled suppresses events and restores emission afterward" {
         val audioItem = MutableAudioItem(1, "Track Alpha")
         val received = mutableListOf<MutationEvent<Int, AudioItem>>()
-        val subscription = audioItem.subscribe { event -> received.add(event) }
+        val subscription = audioItem.subscribeAsync { event -> received.add(event) }
 
         audioItem.silently {
             audioItem.title = "Silent Track"
@@ -327,7 +333,7 @@ class ReactiveEntityLifecycleTest : StringSpec({
     "withEventsDisabled restores state even if action throws" {
         val audioItem = MutableAudioItem(1, "Track Alpha")
         val received = mutableListOf<MutationEvent<Int, AudioItem>>()
-        val subscription = audioItem.subscribe { event -> received.add(event) }
+        val subscription = audioItem.subscribeAsync { event -> received.add(event) }
 
         shouldThrow<RuntimeException> {
             audioItem.silently {
@@ -347,7 +353,7 @@ class ReactiveEntityLifecycleTest : StringSpec({
     "disableEvents suppresses mutateAndPublish block emission" {
         val audioItem = MutableAudioItem(1, "Track Alpha")
         val received = mutableListOf<MutationEvent<Int, AudioItem>>()
-        val subscription = audioItem.subscribe { event -> received.add(event) }
+        val subscription = audioItem.subscribeAsync { event -> received.add(event) }
 
         audioItem.suppressEvents()
         audioItem.bulkUpdate("Silent Track")

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/SubscriptionExtensionsTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/SubscriptionExtensionsTest.kt
@@ -192,7 +192,7 @@ class SubscriptionExtensionsTest : StringSpec({
         val receivedEvents = mutableListOf<Any>()
         val latch = CountDownLatch(2)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             receivedEvents.add(event)
             latch.countDown()
         }
@@ -291,7 +291,7 @@ class SubscriptionExtensionsTest : StringSpec({
         val receivedBatch = AtomicReference<Any?>(null)
         val latch = CountDownLatch(1)
 
-        item.subscribe { event ->
+        item.subscribeAsync { event ->
             if (event is BatchChanged<*, *>) {
                 receivedBatch.set(event)
                 latch.countDown()
@@ -316,7 +316,7 @@ class SubscriptionExtensionsTest : StringSpec({
         val receivedBatch = AtomicReference<Any?>(null)
         val latch = CountDownLatch(1)
 
-        item.subscribe { event ->
+        item.subscribeAsync { event ->
             if (event is BatchChanged<*, *>) {
                 receivedBatch.set(event)
                 latch.countDown()
@@ -339,7 +339,7 @@ class SubscriptionExtensionsTest : StringSpec({
         val receivedAggEvent = AtomicReference<Any?>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedAggEvent.set(event)
                 latch.countDown()
@@ -364,7 +364,7 @@ class SubscriptionExtensionsTest : StringSpec({
         val receivedAggEvent = AtomicReference<Any?>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedAggEvent.set(event)
                 latch.countDown()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/AggregateBubbleUpTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/AggregateBubbleUpTest.kt
@@ -73,7 +73,7 @@ internal class AggregateBubbleUpTest : FunSpec({
         val receivedEvent = AtomicReference<MutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             receivedEvent.set(event)
             latch.countDown()
         }
@@ -94,7 +94,7 @@ internal class AggregateBubbleUpTest : FunSpec({
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedEvent.set(event)
                 latch.countDown()
@@ -117,7 +117,7 @@ internal class AggregateBubbleUpTest : FunSpec({
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedEvent.set(event)
                 latch.countDown()
@@ -144,7 +144,7 @@ internal class AggregateBubbleUpTest : FunSpec({
 
         val receivedEventCount = java.util.concurrent.atomic.AtomicInteger(0)
 
-        playlist.subscribe { receivedEventCount.incrementAndGet() }
+        playlist.subscribeAsync { receivedEventCount.incrementAndGet() }
 
         audioItem.title = "Track A Updated"
 
@@ -163,7 +163,7 @@ internal class AggregateBubbleUpTest : FunSpec({
         val latch1 = CountDownLatch(1)
         val receivedCount = java.util.concurrent.atomic.AtomicInteger(0)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedCount.incrementAndGet()
                 latch1.countDown()
@@ -180,7 +180,7 @@ internal class AggregateBubbleUpTest : FunSpec({
         playlist.audioItem.resolve()
 
         val latch2 = CountDownLatch(1)
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 latch2.countDown()
             }
@@ -207,7 +207,7 @@ internal class AggregateBubbleUpTest : FunSpec({
         val eventCount = java.util.concurrent.atomic.AtomicInteger(0)
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 eventCount.incrementAndGet()
                 latch.countDown()
@@ -248,7 +248,7 @@ internal class AggregateBubbleUpTest : FunSpec({
         val eventCount = java.util.concurrent.atomic.AtomicInteger(0)
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 eventCount.incrementAndGet()
                 latch.countDown()
@@ -274,14 +274,14 @@ internal class AggregateBubbleUpTest : FunSpec({
         val cReceivedCount = java.util.concurrent.atomic.AtomicInteger(0)
 
         // BubbleAudioPlaylist should receive bubble-up from BubbleAudioTrack
-        audioPlaylist.subscribe { event ->
+        audioPlaylist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 bReceivedLatch.countDown()
             }
         }
 
         // BubbleAudioLibrary should NOT receive any events — bubble-up is single-level
-        audioLibrary.subscribe { cReceivedCount.incrementAndGet() }
+        audioLibrary.subscribeAsync { cReceivedCount.incrementAndGet() }
 
         track.updateTrackName("mutated")
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/ConcurrencyStressTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/ConcurrencyStressTest.kt
@@ -70,17 +70,17 @@ class ConcurrencyStressTest : DescribeSpec({
 
             // Subscribers registered before writers start
             val sub1 =
-                repository.subscribe { event ->
+                repository.subscribeAsync { event ->
                     queue1.add(event)
                     latch1.countDown()
                 }
             val sub2 =
-                repository.subscribe { event ->
+                repository.subscribeAsync { event ->
                     queue2.add(event)
                     latch2.countDown()
                 }
             val sub3 =
-                repository.subscribe { event ->
+                repository.subscribeAsync { event ->
                     queue3.add(event)
                     latch3.countDown()
                 }
@@ -140,17 +140,17 @@ class ConcurrencyStressTest : DescribeSpec({
 
             // Subscribers registered before writers start
             val sub1 =
-                publisher.subscribe { event ->
+                publisher.subscribeAsync { event ->
                     queue1.add(event)
                     latch1.countDown()
                 }
             val sub2 =
-                publisher.subscribe { event ->
+                publisher.subscribeAsync { event ->
                     queue2.add(event)
                     latch2.countDown()
                 }
             val sub3 =
-                publisher.subscribe { event ->
+                publisher.subscribeAsync { event ->
                     queue3.add(event)
                     latch3.countDown()
                 }
@@ -214,22 +214,22 @@ class ConcurrencyStressTest : DescribeSpec({
 
             // Subscribers registered before writers start
             val crudSub1 =
-                repository.subscribe { event ->
+                repository.subscribeAsync { event ->
                     crudQueue1.add(event)
                     crudLatch1.countDown()
                 }
             val crudSub2 =
-                repository.subscribe { event ->
+                repository.subscribeAsync { event ->
                     crudQueue2.add(event)
                     crudLatch2.countDown()
                 }
             val mutSub1 =
-                mutationPublisher.subscribe { event ->
+                mutationPublisher.subscribeAsync { event ->
                     mutQueue1.add(event)
                     mutLatch1.countDown()
                 }
             val mutSub2 =
-                mutationPublisher.subscribe { event ->
+                mutationPublisher.subscribeAsync { event ->
                     mutQueue2.add(event)
                     mutLatch2.countDown()
                 }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/ExceptionIsolationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/ExceptionIsolationTest.kt
@@ -44,7 +44,7 @@ class ExceptionIsolationTest : DescribeSpec({
             publisher.activateEvents(CREATE)
 
             // Throwing subscriber — unconditional exception on every event
-            publisher.subscribe { throw RuntimeException("intentional subscriber exception") }
+            publisher.subscribeAsync { throw RuntimeException("intentional subscriber exception") }
 
             val healthy1 = publisher.record()
             val healthy2 = publisher.record()
@@ -63,8 +63,8 @@ class ExceptionIsolationTest : DescribeSpec({
             publisher.activateEvents(CREATE)
 
             // Two throwing subscribers
-            publisher.subscribe { throw RuntimeException("thrower-1 exception") }
-            publisher.subscribe { throw RuntimeException("thrower-2 exception") }
+            publisher.subscribeAsync { throw RuntimeException("thrower-1 exception") }
+            publisher.subscribeAsync { throw RuntimeException("thrower-2 exception") }
 
             val healthy = publisher.record()
 
@@ -81,7 +81,7 @@ class ExceptionIsolationTest : DescribeSpec({
             publisher.activateEvents(CREATE)
 
             // Throwing subscriber registered via the plain subscribe() overload
-            publisher.subscribe { throw RuntimeException("intentional exception from plain subscribe") }
+            publisher.subscribeAsync { throw RuntimeException("intentional exception from plain subscribe") }
 
             // Healthy subscriber registered via the filtered record(eventType) overload
             val healthy = publisher.record(CREATE)

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/FlowEventPublisherTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/FlowEventPublisherTest.kt
@@ -30,7 +30,6 @@ import net.transgressoft.lirp.testing.reactiveScope
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -68,8 +67,6 @@ class FlowEventPublisherTest : DescribeSpec({
             val newName = "Updated Name"
             entity.name = newName
 
-            reactive.advance()
-
             receivedEvents.size shouldBe 1
             val event = receivedEvents[0]
             event.shouldBeInstanceOf<PropertyChanged<String, TestEntity, String>>()
@@ -90,8 +87,6 @@ class FlowEventPublisherTest : DescribeSpec({
 
             entity.addFriendAddress("John", "Apple avenue")
 
-            reactive.advance()
-
             receivedEvents.size shouldBe 1
             val event = receivedEvents[0]
             // mutateAndPublish emits BatchChanged; assert the typed payload, not only live entity state
@@ -111,8 +106,6 @@ class FlowEventPublisherTest : DescribeSpec({
 
             entity.addUnmanagedProperty("John", "Apple avenue")
 
-            reactive.advance()
-
             receivedEvents.size shouldBe 0
         }
 
@@ -127,8 +120,6 @@ class FlowEventPublisherTest : DescribeSpec({
 
             val oldName = entity.name
             entity.name = oldName // Same value
-
-            reactive.advance()
 
             receivedEvents.size shouldBe 0
 
@@ -158,8 +149,6 @@ class FlowEventPublisherTest : DescribeSpec({
 
             val originalName = entity.name
             entity.name = "New Name"
-
-            reactive.advance()
 
             receivedEvents.size shouldBe 1
             val event = receivedEvents[0] as PropertyChanged<String, TestEntity, String>
@@ -195,7 +184,7 @@ class FlowEventPublisherTest : DescribeSpec({
             val receivedEvents = mutableListOf<CrudEvent<String, TestEntity>>()
 
             val subscription =
-                publisher.subscribe { event ->
+                publisher.subscribeAsync { event ->
                     if (event.isCreate()) {
                         receivedEvents.add(event)
                     }
@@ -221,7 +210,7 @@ class FlowEventPublisherTest : DescribeSpec({
             val receivedEvents = mutableListOf<CrudEvent<String, TestEntity>>()
 
             val subscription =
-                publisher.subscribe { event ->
+                publisher.subscribeAsync { event ->
                     if (event.isUpdate()) {
                         receivedEvents.add(event)
                     }
@@ -252,7 +241,7 @@ class FlowEventPublisherTest : DescribeSpec({
             val receivedEvents = mutableListOf<CrudEvent<String, TestEntity>>()
 
             val subscription =
-                publisher.subscribe { event ->
+                publisher.subscribeAsync { event ->
                     if (event.isDelete()) {
                         receivedEvents.add(event)
                     }
@@ -276,9 +265,9 @@ class FlowEventPublisherTest : DescribeSpec({
             val updateCounter = AtomicInteger(0)
             val deleteCounter = AtomicInteger(0)
 
-            val createSubscription = publisher.subscribe(CREATE) { createCounter.incrementAndGet() }
-            val updateSubscription = publisher.subscribe(UPDATE) { updateCounter.incrementAndGet() }
-            val deleteSubscription = publisher.subscribe(DELETE) { deleteCounter.incrementAndGet() }
+            val createSubscription = publisher.subscribeAsync(CREATE) { createCounter.incrementAndGet() }
+            val updateSubscription = publisher.subscribeAsync(UPDATE) { updateCounter.incrementAndGet() }
+            val deleteSubscription = publisher.subscribeAsync(DELETE) { deleteCounter.incrementAndGet() }
 
             val entity = TestEntity(UUID.randomUUID().toString())
             publisher.emitAsync(Create(entity))
@@ -331,8 +320,8 @@ class FlowEventPublisherTest : DescribeSpec({
             val counter1 = AtomicInteger(0)
             val counter2 = AtomicInteger(0)
 
-            val subscription1 = entity.subscribe { counter1.incrementAndGet() }
-            val subscription2 = entity.subscribe { counter2.incrementAndGet() }
+            val subscription1 = entity.subscribeAsync { counter1.incrementAndGet() }
+            val subscription2 = entity.subscribeAsync { counter2.incrementAndGet() }
 
             entity.name = "First update"
             entity.name = "Second update"
@@ -357,7 +346,7 @@ class FlowEventPublisherTest : DescribeSpec({
             val entity = TestEntity(UUID.randomUUID().toString())
             val counter = AtomicInteger(0)
 
-            val subscription = entity.subscribe(Consumer { counter.incrementAndGet() })
+            val subscription = entity.subscribeAsync(Consumer { counter.incrementAndGet() })
 
             entity.name = "Updated via Consumer"
 
@@ -401,7 +390,7 @@ class FlowEventPublisherTest : DescribeSpec({
             publisher.activateEvents(CREATE)
 
             val receivedEvents = mutableListOf<CrudEvent<String, TestEntity>>()
-            val subscription = publisher.subscribe { receivedEvents.add(it) }
+            val subscription = publisher.subscribeAsync { receivedEvents.add(it) }
 
             publisher.emitAsync(Create(TestEntity("before-cancel")))
             reactive.advance()
@@ -424,7 +413,7 @@ class FlowEventPublisherTest : DescribeSpec({
 
             val receivedEvents = mutableListOf<CrudEvent<String, TestEntity>>()
             val subscription =
-                publisher.subscribe { event ->
+                publisher.subscribeAsync { event ->
                     receivedEvents.add(event)
                 }
 
@@ -452,9 +441,9 @@ class FlowEventPublisherTest : DescribeSpec({
             val subscriber2Events = mutableListOf<CrudEvent<String, TestEntity>>()
             val subscriber3Events = mutableListOf<CrudEvent<String, TestEntity>>()
 
-            val sub1 = publisher.subscribe { subscriber1Events.add(it) }
-            val sub2 = publisher.subscribe { subscriber2Events.add(it) }
-            val sub3 = publisher.subscribe { subscriber3Events.add(it) }
+            val sub1 = publisher.subscribeAsync { subscriber1Events.add(it) }
+            val sub2 = publisher.subscribeAsync { subscriber2Events.add(it) }
+            val sub3 = publisher.subscribeAsync { subscriber3Events.add(it) }
 
             repeat(50) { i ->
                 publisher.emitAsync(Create(TestEntity("entity-$i")))
@@ -483,7 +472,7 @@ class FlowEventPublisherTest : DescribeSpec({
             val processedCount = AtomicInteger(0)
 
             val subscription =
-                publisher.subscribe { event ->
+                publisher.subscribeAsync { event ->
                     allEvents.add(event)
                     processedCount.incrementAndGet()
 
@@ -515,7 +504,7 @@ class FlowEventPublisherTest : DescribeSpec({
             val receivedEvents = mutableListOf<CrudEvent<String, TestEntity>>()
 
             val subscription =
-                publisher.subscribe { event ->
+                publisher.subscribeAsync { event ->
                     receivedEvents.add(event)
                     // Simulate slow subscriber
                     delay(1.milliseconds)
@@ -548,30 +537,32 @@ class FlowEventPublisherTest : DescribeSpec({
                 val received = CopyOnWriteArrayList<CrudEvent<String, TestEntity>>()
 
                 val subscription =
-                    publisher.subscribe { event ->
+                    publisher.subscribeAsync { event ->
                         delay(50.milliseconds)
                         received.add(event)
                     }
 
                 try {
                     // The SharedFlow has replay=0 and subscribe() starts its collecting coroutine
-                    // asynchronously, so events emitted before that coroutine is actually collecting
-                    // are dropped. Warm up first and wait until the subscriber observes an event:
-                    // that guarantees the collector is live before emitting the events under test,
-                    // making delivery deterministic rather than dependent on scheduler timing.
-                    publisher.emitAsync(Create(TestEntity("warmup")))
+                    // asynchronously, so events emitted before that coroutine is collecting are dropped.
+                    // Re-emit a warm-up event on every poll until the subscriber observes one: a single
+                    // warm-up emit can itself race ahead of the collector and be dropped, which would
+                    // leave `received` empty until the timeout. Once a warm-up is seen the collector is
+                    // live, so the events under test that follow cannot be dropped.
                     eventually(5.seconds) {
-                        received.shouldNotBeEmpty()
+                        publisher.emitAsync(Create(TestEntity("warmup")))
+                        received.any { it.entities.values.first().id == "warmup" } shouldBe true
                     }
-                    received.clear()
 
                     repeat(5) { i ->
                         publisher.emitAsync(Create(TestEntity("entity-$i")))
                         delay(10.milliseconds)
                     }
 
+                    // Count only the events under test; warm-up events still draining through the slow
+                    // subscriber must not affect the result, so filter by prefix rather than clearing.
                     eventually(10.seconds) {
-                        received.size shouldBe 5
+                        received.count { it.entities.values.first().id.startsWith("entity-") } shouldBe 5
                     }
                     received.any { it.entities.values.first().id == "entity-0" } shouldBe true
                     received.any { it.entities.values.first().id == "entity-4" } shouldBe true
@@ -596,7 +587,7 @@ class FlowEventPublisherTest : DescribeSpec({
             reactive.advance()
 
             val lateSubscriberEvents = mutableListOf<CrudEvent<String, TestEntity>>()
-            val lateSubscription = publisher.subscribe { lateSubscriberEvents.add(it) }
+            val lateSubscription = publisher.subscribeAsync { lateSubscriberEvents.add(it) }
 
             reactive.advance()
 
@@ -625,7 +616,7 @@ class FlowEventPublisherTest : DescribeSpec({
                 }
 
             val receivedEvents = mutableListOf<CrudEvent<String, TestEntity>>()
-            val subscription = publisher.subscribe { receivedEvents.add(it) }
+            val subscription = publisher.subscribeAsync { receivedEvents.add(it) }
 
             val entity = TestEntity(UUID.randomUUID().toString())
             publisher.emitAsync(Create(entity))
@@ -648,7 +639,7 @@ class FlowEventPublisherTest : DescribeSpec({
                 }
 
             val receivedEvents = mutableListOf<CrudEvent<String, TestEntity>>()
-            val subscription = publisher.subscribe { receivedEvents.add(it) }
+            val subscription = publisher.subscribeAsync { receivedEvents.add(it) }
 
             val entity = TestEntity(UUID.randomUUID().toString())
             publisher.emitAsync(Create(entity))
@@ -661,7 +652,7 @@ class FlowEventPublisherTest : DescribeSpec({
             subscription.cancel()
         }
 
-        it("with replay config delivers historical events to late subscribers") {
+        it("with replay config delivers historical events to late subscribers when bridge is armed at startup") {
             val replayCount = 3
             val publisher =
                 FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>(
@@ -671,7 +662,12 @@ class FlowEventPublisherTest : DescribeSpec({
                     activateEvents(CREATE)
                 }
 
-            // Emit events before any subscriber exists
+            // Arm the bridge before emitting so replay buffering starts from the first event.
+            // Without this, events emitted before the first subscribeAsync call are not buffered.
+            @Suppress("UNUSED_VARIABLE")
+            val bridge = publisher.changes
+
+            // Emit 5 events; with replay=3, only the last 3 are buffered
             val earlyEntities = List(5) { i -> TestEntity("early-entity-$i") }
             earlyEntities.forEach { entity ->
                 publisher.emitAsync(Create(entity))
@@ -681,7 +677,7 @@ class FlowEventPublisherTest : DescribeSpec({
 
             // Late subscriber should receive the last 3 events (replay count)
             val lateSubscriberEvents = mutableListOf<CrudEvent<String, TestEntity>>()
-            val lateSubscription = publisher.subscribe { lateSubscriberEvents.add(it) }
+            val lateSubscription = publisher.subscribeAsync { lateSubscriberEvents.add(it) }
 
             reactive.advance()
 
@@ -731,7 +727,7 @@ class FlowEventPublisherTest : DescribeSpec({
                 }
 
             val receivedEvents = mutableListOf<CrudEvent<String, TestEntity>>()
-            val subscription = publisher.subscribe { receivedEvents.add(it) }
+            val subscription = publisher.subscribeAsync { receivedEvents.add(it) }
 
             repeat(4) { i ->
                 publisher.emitAsync(Create(TestEntity("entity-$i")))
@@ -787,7 +783,7 @@ class FlowEventPublisherTest : DescribeSpec({
 
             val exception =
                 shouldThrow<IllegalStateException> {
-                    publisher.subscribe { }
+                    publisher.subscribeAsync { }
                 }
             exception.message shouldContain "test-publisher"
         }
@@ -798,7 +794,7 @@ class FlowEventPublisherTest : DescribeSpec({
 
             val exception =
                 shouldThrow<IllegalStateException> {
-                    publisher.subscribe(Consumer { })
+                    publisher.subscribeAsync(Consumer { })
                 }
             exception.message shouldContain "test-publisher"
         }
@@ -809,7 +805,7 @@ class FlowEventPublisherTest : DescribeSpec({
 
             val exception =
                 shouldThrow<IllegalStateException> {
-                    publisher.subscribe(CREATE) { }
+                    publisher.subscribeAsync(CREATE) { }
                 }
             exception.message shouldContain "test-publisher"
         }
@@ -842,7 +838,7 @@ class FlowEventPublisherTest : DescribeSpec({
                     activateEvents(CREATE)
                 }
             val receivedEvents = mutableListOf<CrudEvent<String, TestEntity>>()
-            publisher.subscribe { receivedEvents.add(it) }
+            publisher.subscribeAsync { receivedEvents.add(it) }
 
             publisher.emitAsync(Create(TestEntity("before-close")))
             reactive.advance()
@@ -871,7 +867,7 @@ class FlowEventPublisherTest : DescribeSpec({
                     ).apply {
                         activateEvents(CREATE)
                     }
-                publisher.subscribe { }
+                publisher.subscribeAsync { }
 
                 val iterations = 1000
                 val toggleJob =
@@ -901,7 +897,7 @@ class FlowEventPublisherTest : DescribeSpec({
                     activateEvents(UPDATE)
                 }
             val receivedEvents = mutableListOf<CrudEvent<String, TestEntity>>()
-            val subscription = publisher.subscribe { receivedEvents.add(it) }
+            val subscription = publisher.subscribeAsync { receivedEvents.add(it) }
 
             publisher.emitAsync(Create(TestEntity("entity-1")))
             reactive.advance()
@@ -924,7 +920,7 @@ class FlowEventPublisherTest : DescribeSpec({
                     val jobs =
                         (1..50).map {
                             launch {
-                                val sub = publisher.subscribe { }
+                                val sub = publisher.subscribeAsync { }
                                 // Tiny yield to increase interleaving probability
                                 delay(1.milliseconds)
                                 sub.cancel()
@@ -948,7 +944,7 @@ class FlowEventPublisherTest : DescribeSpec({
             val onEmptyCallCount = AtomicInteger(0)
             publisher.onCloseOnEmpty { onEmptyCallCount.incrementAndGet() }
 
-            val sub = publisher.subscribe { }
+            val sub = publisher.subscribeAsync { }
             sub.cancel()
             reactive.advance()
 
@@ -959,8 +955,8 @@ class FlowEventPublisherTest : DescribeSpec({
             val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("CloseAfterEmptyPublisher", closeOnEmpty = true)
             publisher.activateEvents(CREATE)
 
-            val sub1 = publisher.subscribe { }
-            val sub2 = publisher.subscribe { }
+            val sub1 = publisher.subscribeAsync { }
+            val sub2 = publisher.subscribeAsync { }
 
             publisher.isClosed shouldBe false
 
@@ -977,12 +973,12 @@ class FlowEventPublisherTest : DescribeSpec({
             val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("ClosedOnEmptyPublisher", closeOnEmpty = true)
             publisher.activateEvents(CREATE)
 
-            val sub = publisher.subscribe { }
+            val sub = publisher.subscribeAsync { }
             sub.cancel()
             reactive.advance()
 
             // closeOnEmpty close is automatic — subscribe returns a no-op instead of throwing
-            val noOpSub = publisher.subscribe { }
+            val noOpSub = publisher.subscribeAsync { }
             noOpSub.cancel() // should not throw
         }
 
@@ -990,13 +986,206 @@ class FlowEventPublisherTest : DescribeSpec({
             val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("EmitAfterEmptyPublisher", closeOnEmpty = true)
             publisher.activateEvents(CREATE)
 
-            val sub = publisher.subscribe { }
+            val sub = publisher.subscribeAsync { }
             sub.cancel()
             reactive.advance()
 
             shouldThrow<IllegalStateException> {
                 publisher.emitAsync(Create(TestEntity("entity-1")))
             }
+        }
+    }
+
+    describe("sync transport") {
+
+        it("sync-only publisher never arms the async bridge") {
+            val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("sync-only-bridge-test")
+            publisher.activateEvents(CREATE)
+            val received = mutableListOf<CrudEvent<String, TestEntity>>()
+
+            val sub = publisher.subscribe { received.add(it) }
+
+            repeat(5) { i -> publisher.emitAsync(Create(TestEntity("e-$i"))) }
+
+            publisher.isBridgeInitialized shouldBe false
+            received.size shouldBe 5
+
+            sub.cancel()
+        }
+
+        it("sync callback runs on the emitting thread before emitAsync returns") {
+            val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("sync-thread-test")
+            publisher.activateEvents(CREATE)
+            var callbackThread: Thread? = null
+
+            val sub = publisher.subscribe { callbackThread = Thread.currentThread() }
+
+            val emittingThread = Thread.currentThread()
+            publisher.emitAsync(Create(TestEntity("e-1")))
+
+            // Callback ran synchronously — observable without any reactive.advance()
+            callbackThread shouldBe emittingThread
+
+            sub.cancel()
+        }
+
+        it("exception in middle sync callback is isolated; other callbacks and async still receive the event") {
+            val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("exception-isolation-test")
+            publisher.activateEvents(CREATE)
+            val firstReceived = mutableListOf<CrudEvent<String, TestEntity>>()
+            val thirdReceived = mutableListOf<CrudEvent<String, TestEntity>>()
+            val asyncReceived = mutableListOf<CrudEvent<String, TestEntity>>()
+
+            publisher.subscribe { firstReceived.add(it) }
+            publisher.subscribe { throw RuntimeException("deliberate failure") }
+            publisher.subscribe { thirdReceived.add(it) }
+            publisher.subscribeAsync { asyncReceived.add(it) }
+
+            publisher.emitAsync(Create(TestEntity("e-1")))
+            reactive.advance()
+
+            firstReceived.size shouldBe 1
+            thirdReceived.size shouldBe 1
+            asyncReceived.size shouldBe 1
+        }
+
+        it("Error from sync callback propagates out of emitAsync and trampoline flag is reset after") {
+            val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("error-propagation-test")
+            publisher.activateEvents(CREATE)
+            var secondEventDelivered = false
+
+            publisher.subscribe { throw AssertionError("intentional error") }
+            publisher.subscribe { secondEventDelivered = true }
+
+            shouldThrow<AssertionError> {
+                publisher.emitAsync(Create(TestEntity("e-1")))
+            }
+
+            // Trampoline flag was reset in finally — subsequent emit still dispatches
+            shouldThrow<AssertionError> {
+                publisher.emitAsync(Create(TestEntity("e-2")))
+            }
+            secondEventDelivered shouldBe false
+        }
+
+        it("subscriberCount increments on sync subscribe and sync-only emitAsync still delivers") {
+            val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("sync-count-test")
+            publisher.activateEvents(CREATE)
+            val received = mutableListOf<CrudEvent<String, TestEntity>>()
+
+            publisher.subscriberCount shouldBe 0
+            val sub = publisher.subscribe { received.add(it) }
+            publisher.subscriberCount shouldBe 1
+
+            publisher.emitAsync(Create(TestEntity("e-1")))
+
+            received.size shouldBe 1
+
+            sub.cancel()
+            publisher.subscriberCount shouldBe 0
+        }
+
+        it("filtered sync subscribe delivers only matching event types and cancel removes the wrapper") {
+            val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("filtered-sync-test")
+            publisher.activateEvents(CREATE, UPDATE)
+            val createReceived = mutableListOf<CrudEvent<String, TestEntity>>()
+
+            val sub = publisher.subscribe(CREATE) { createReceived.add(it) }
+            publisher.subscriberCount shouldBe 1
+
+            publisher.emitAsync(Create(TestEntity("e-1")))
+            publisher.emitAsync(Update(TestEntity("e-1"), TestEntity("e-1")))
+
+            // Only CREATE was matched
+            createReceived.size shouldBe 1
+            createReceived[0].isCreate() shouldBe true
+
+            // Cancel removes the wrapper — count drops
+            sub.cancel()
+            publisher.subscriberCount shouldBe 0
+        }
+
+        it("reentrant emitAsync on same thread is drained breadth-first without stack overflow") {
+            val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("reentrancy-test")
+            publisher.activateEvents(CREATE, UPDATE)
+            val deliveryOrder = mutableListOf<String>()
+            val entity1 = TestEntity("e-1")
+            val entity2 = TestEntity("e-2")
+            val event1 = Create(entity1)
+            val event2 = Create(entity2)
+            var reentryFired = false
+
+            // First callback: on the first event, enqueues a second event from the same thread
+            publisher.subscribe { event ->
+                deliveryOrder.add("cb1:${event.entities.values.first().id}")
+                if (!reentryFired && event === event1) {
+                    reentryFired = true
+                    publisher.emitAsync(event2) // reentrant call from same thread
+                }
+            }
+            // Second callback: records receipt of both events
+            publisher.subscribe { event ->
+                deliveryOrder.add("cb2:${event.entities.values.first().id}")
+            }
+
+            publisher.emitAsync(event1)
+
+            // Breadth-first ordering: all callbacks see event1, then all callbacks see event2
+            deliveryOrder shouldBe listOf("cb1:e-1", "cb2:e-1", "cb1:e-2", "cb2:e-2")
+        }
+
+        it("closeOnEmpty publisher with sync-only subscriber closes after the subscriber cancels") {
+            val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("close-sync-only", closeOnEmpty = true)
+            publisher.activateEvents(CREATE)
+            val received = mutableListOf<CrudEvent<String, TestEntity>>()
+
+            val sub = publisher.subscribe { received.add(it) }
+            publisher.isClosed shouldBe false
+
+            sub.cancel()
+
+            publisher.isClosed shouldBe true
+        }
+
+        it("closeOnEmpty publisher with mixed subscribers closes only when both sync and async leave") {
+            val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("close-mixed", closeOnEmpty = true)
+            publisher.activateEvents(CREATE)
+
+            val syncSub = publisher.subscribe { }
+            val asyncSub = publisher.subscribeAsync { }
+
+            publisher.isClosed shouldBe false
+
+            syncSub.cancel()
+            publisher.isClosed shouldBe false // async still present
+
+            asyncSub.cancel()
+            reactive.advance()
+
+            publisher.isClosed shouldBe true
+        }
+
+        it("mixed sync and async subscribers both receive the same event") {
+            val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("mixed-test")
+            publisher.activateEvents(CREATE)
+            val syncReceived = mutableListOf<CrudEvent<String, TestEntity>>()
+            val asyncReceived = mutableListOf<CrudEvent<String, TestEntity>>()
+
+            val syncSub = publisher.subscribe { syncReceived.add(it) }
+            val asyncSub = publisher.subscribeAsync { asyncReceived.add(it) }
+
+            publisher.emitAsync(Create(TestEntity("e-1")))
+
+            // Sync delivered inline, no advance needed
+            syncReceived.size shouldBe 1
+
+            // Async delivered after advance
+            reactive.advance()
+            asyncReceived.size shouldBe 1
+            asyncReceived[0].entities.values.first().id shouldBe syncReceived[0].entities.values.first().id
+
+            syncSub.cancel()
+            asyncSub.cancel()
         }
     }
 
@@ -1010,7 +1199,7 @@ class FlowEventPublisherTest : DescribeSpec({
         it("subscriberCount increments on subscribe") {
             val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("test-publisher")
 
-            val subscription = publisher.subscribe { }
+            val subscription = publisher.subscribeAsync { }
 
             publisher.subscriberCount shouldBe 1
 
@@ -1020,7 +1209,7 @@ class FlowEventPublisherTest : DescribeSpec({
         it("subscriberCount decrements on cancel") {
             val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("test-publisher")
 
-            val subscription = publisher.subscribe { }
+            val subscription = publisher.subscribeAsync { }
             publisher.subscriberCount shouldBe 1
 
             subscription.cancel()
@@ -1032,10 +1221,10 @@ class FlowEventPublisherTest : DescribeSpec({
         it("subscriberCount tracks multiple subscribers correctly") {
             val publisher = FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("test-publisher")
 
-            val sub1 = publisher.subscribe { }
+            val sub1 = publisher.subscribeAsync { }
             publisher.subscriberCount shouldBe 1
 
-            val sub2 = publisher.subscribe { }
+            val sub2 = publisher.subscribeAsync { }
             publisher.subscriberCount shouldBe 2
 
             sub1.cancel()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/HighConcurrencyStressTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/HighConcurrencyStressTest.kt
@@ -65,7 +65,7 @@ class HighConcurrencyStressTest : DescribeSpec({
             // Register all 250 subscribers before writers start
             val subscriptions =
                 subscribers.map { (queue, latch) ->
-                    repository.subscribe { event ->
+                    repository.subscribeAsync { event ->
                         queue.add(event)
                         latch.countDown()
                     }
@@ -116,7 +116,7 @@ class HighConcurrencyStressTest : DescribeSpec({
             // Register all 250 subscribers before writers start
             val subscriptions =
                 subscribers.map { (queue, latch) ->
-                    publisher.subscribe { event ->
+                    publisher.subscribeAsync { event ->
                         queue.add(event)
                         latch.countDown()
                     }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/PublisherResilienceTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/PublisherResilienceTest.kt
@@ -45,7 +45,7 @@ class PublisherResilienceTest : DescribeSpec({
             publisher.activateEvents(CREATE)
 
             // Throwing subscriber — its coroutine will crash on every received event
-            publisher.subscribe { throw RuntimeException("intentional exception") }
+            publisher.subscribeAsync { throw RuntimeException("intentional exception") }
 
             // First emission phase: throwing subscriber crashes
             repeat(5) { i ->
@@ -71,7 +71,7 @@ class PublisherResilienceTest : DescribeSpec({
             publisher.activateEvents(CREATE)
 
             // Register both a throwing subscriber and a healthy one simultaneously
-            publisher.subscribe { throw RuntimeException("intentional exception") }
+            publisher.subscribeAsync { throw RuntimeException("intentional exception") }
             val healthy = publisher.record()
 
             // First emission phase: both subscribers active, throwing one crashes
@@ -97,9 +97,9 @@ class PublisherResilienceTest : DescribeSpec({
             publisher.activateEvents(CREATE)
 
             // Register one throwing and two healthy subscribers
-            publisher.subscribe { throw RuntimeException("intentional exception") }
-            publisher.subscribe { /* healthy subscriber 1 */ }
-            publisher.subscribe { /* healthy subscriber 2 */ }
+            publisher.subscribeAsync { throw RuntimeException("intentional exception") }
+            publisher.subscribeAsync { /* healthy subscriber 1 */ }
+            publisher.subscribeAsync { /* healthy subscriber 2 */ }
 
             // Emit events to trigger the throwing subscriber's crash and let its coroutine terminate
             repeat(5) { i ->

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/SlowSubscriberTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/SlowSubscriberTest.kt
@@ -82,10 +82,10 @@ class SlowSubscriberTest : DescribeSpec({
             publisher.activateEvents(CrudEvent.Type.CREATE)
 
             // Fast subscriber: instant handler, no delay
-            val fastSub = publisher.subscribe { fastCounter.incrementAndGet() }
+            val fastSub = publisher.subscribeAsync { fastCounter.incrementAndGet() }
             // Slow subscriber: deliberate delay simulating expensive processing
             val slowSub =
-                publisher.subscribe { event ->
+                publisher.subscribeAsync { event ->
                     delay(SLOW_DELAY_MS.milliseconds)
                     slowCounter.incrementAndGet()
                 }
@@ -123,12 +123,12 @@ class SlowSubscriberTest : DescribeSpec({
             publisher.activateEvents(CrudEvent.Type.CREATE)
 
             val fastSub =
-                publisher.subscribe {
+                publisher.subscribeAsync {
                     fastCounter.incrementAndGet()
                     fastLatch.countDown()
                 }
             val slowSub =
-                publisher.subscribe { event ->
+                publisher.subscribeAsync { event ->
                     delay(SLOW_DELAY_MS.milliseconds)
                     slowCounter.incrementAndGet()
                     slowLatch.countDown()
@@ -175,12 +175,12 @@ class SlowSubscriberTest : DescribeSpec({
             publisher.activateEvents(CrudEvent.Type.CREATE)
 
             val fastSub =
-                publisher.subscribe {
+                publisher.subscribeAsync {
                     fastLatch.countDown()
                     if (fastLatch.count == 0L) fastCompletedMs.set(System.currentTimeMillis())
                 }
             val slowSub =
-                publisher.subscribe { event ->
+                publisher.subscribeAsync { event ->
                     delay(SLOW_DELAY_MS.milliseconds)
                     slowLatch.countDown()
                     if (slowLatch.count == 0L) slowCompletedMs.set(System.currentTimeMillis())
@@ -216,9 +216,9 @@ class SlowSubscriberTest : DescribeSpec({
 
             val repository = AudioItemVolatileRepository()
 
-            val fastSub = repository.subscribe { fastCounter.incrementAndGet() }
+            val fastSub = repository.subscribeAsync { fastCounter.incrementAndGet() }
             val slowSub =
-                repository.subscribe { event ->
+                repository.subscribeAsync { event ->
                     delay(SLOW_DELAY_MS.milliseconds)
                     slowCounter.incrementAndGet()
                 }
@@ -250,9 +250,9 @@ class SlowSubscriberTest : DescribeSpec({
 
             val repository = AudioItemVolatileRepository()
 
-            val fastSub = repository.subscribe { fastLatch.countDown() }
+            val fastSub = repository.subscribeAsync { fastLatch.countDown() }
             val slowSub =
-                repository.subscribe { event ->
+                repository.subscribeAsync { event ->
                     delay(SLOW_DELAY_MS.milliseconds)
                     slowLatch.countDown()
                 }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateCascadeTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/AggregateCascadeTest.kt
@@ -104,7 +104,7 @@ internal class AggregateCascadeTest : FunSpec({
         val eventCountBefore = AtomicInteger(0)
         val beforeLatch = CountDownLatch(1)
         val subscription =
-            playlist.subscribe { event ->
+            playlist.subscribeAsync { event ->
                 if (event is AggregateMutationEvent<*, *>) {
                     eventCountBefore.incrementAndGet()
                     beforeLatch.countDown()
@@ -234,7 +234,7 @@ internal class AggregateCascadeTest : FunSpec({
 
         // After final cancel, no events should be forwarded
         val eventCount = AtomicInteger(0)
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 eventCount.incrementAndGet()
             }
@@ -255,7 +255,7 @@ internal class AggregateCascadeTest : FunSpec({
         val eventCount = AtomicInteger(0)
         val initialLatch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 eventCount.incrementAndGet()
                 initialLatch.countDown()
@@ -283,7 +283,7 @@ internal class AggregateCascadeTest : FunSpec({
         val playlist = mutableRefPlaylistRepo.create(id = 100, audioItemId = 1)
 
         val received = mutableListOf<MutationEvent<Int, MutableRefPlaylist>>()
-        playlist.subscribe { received.add(it) }
+        playlist.subscribeAsync { received.add(it) }
 
         audioItem.title = "Track B"
         reactive.advance()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/CollectionChangeEventTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/CollectionChangeEventTest.kt
@@ -62,7 +62,7 @@ internal class CollectionChangeEventTest : StringSpec({
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedEvent.set(event)
                 latch.countDown()
@@ -89,7 +89,7 @@ internal class CollectionChangeEventTest : StringSpec({
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedEvent.set(event)
                 latch.countDown()
@@ -117,7 +117,7 @@ internal class CollectionChangeEventTest : StringSpec({
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedEvent.set(event)
                 latch.countDown()
@@ -145,7 +145,7 @@ internal class CollectionChangeEventTest : StringSpec({
         val receivedEvents = mutableListOf<AggregateMutationEvent<*, *>>()
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedEvents.add(event)
                 latch.countDown()
@@ -173,7 +173,7 @@ internal class CollectionChangeEventTest : StringSpec({
         val receivedEvents = mutableListOf<AggregateMutationEvent<*, *>>()
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedEvents.add(event)
                 latch.countDown()
@@ -201,7 +201,7 @@ internal class CollectionChangeEventTest : StringSpec({
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedEvent.set(event)
                 latch.countDown()
@@ -225,7 +225,7 @@ internal class CollectionChangeEventTest : StringSpec({
         val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
         var eventCount = 0
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 eventCount++
             }
@@ -243,7 +243,7 @@ internal class CollectionChangeEventTest : StringSpec({
         val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
         var reactiveMutationCount = 0
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is ReactiveMutationEvent<*, *>) {
                 reactiveMutationCount++
             }
@@ -264,7 +264,7 @@ internal class CollectionChangeEventTest : StringSpec({
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
 
-        group.subscribe { event ->
+        group.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedEvent.set(event)
                 latch.countDown()
@@ -291,7 +291,7 @@ internal class CollectionChangeEventTest : StringSpec({
         val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
         val latch = CountDownLatch(1)
 
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) {
                 receivedEvent.set(event)
                 latch.countDown()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/MutableAggregateCollectionRefTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/MutableAggregateCollectionRefTest.kt
@@ -156,7 +156,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
 
-        playlist.subscribe { events.add(it) }
+        playlist.subscribeAsync { events.add(it) }
         val beforeModified = playlist.lastDateModified
 
         // Bounded spin-wait until system clock advances past the captured timestamp.
@@ -215,7 +215,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
             DefaultAudioPlaylist(1, "Test", listOf(1))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
-        playlist.subscribe { events.add(it) }
+        playlist.subscribeAsync { events.add(it) }
 
         playlist.audioItems[0] = t2
 
@@ -234,7 +234,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
             DefaultAudioPlaylist(1, "Test", listOf(1, 3))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
-        playlist.subscribe { events.add(it) }
+        playlist.subscribeAsync { events.add(it) }
 
         playlist.audioItems.add(1, t2)
 
@@ -252,7 +252,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
             DefaultAudioPlaylist(1, "Test", listOf(1, 2, 3))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
-        playlist.subscribe { events.add(it) }
+        playlist.subscribeAsync { events.add(it) }
 
         val removed = playlist.audioItems.removeAt(1)
 
@@ -272,7 +272,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
             DefaultAudioPlaylist(1, "Test", listOf(1, 2, 3))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
-        playlist.subscribe { events.add(it) }
+        playlist.subscribeAsync { events.add(it) }
 
         val sub = playlist.audioItems.subList(1, 3)
         sub.add(tNew)
@@ -291,7 +291,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
             DefaultAudioPlaylist(1, "Test", listOf(1, 2))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
-        playlist.subscribe { events.add(it) }
+        playlist.subscribeAsync { events.add(it) }
 
         val iter = playlist.audioItems.listIterator()
         iter.next()
@@ -310,7 +310,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
             DefaultAudioPlaylist(100, "Group", initialPlaylistIds = setOf(1, 2))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
-        group.subscribe { events.add(it) }
+        group.subscribeAsync { events.add(it) }
 
         val iter = group.playlists.iterator()
         iter.next()
@@ -379,7 +379,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
             DefaultAudioPlaylist(100, "Group", initialPlaylistIds = setOf(1, 2, 3))
                 .also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
-        group.subscribe { events.add(it) }
+        group.subscribeAsync { events.add(it) }
 
         val result = group.playlists.removeAll(listOf(p1, p2))
         reactive.advance()
@@ -393,7 +393,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         val unrelated = DefaultAudioPlaylist(99, "Unrelated").also(playlistRepo::add)
         val group = DefaultAudioPlaylist(100, "Group", initialPlaylistIds = setOf(1)).also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
-        group.subscribe { events.add(it) }
+        group.subscribeAsync { events.add(it) }
 
         val result = group.playlists.removeAll(listOf(unrelated))
         reactive.advance()
@@ -405,7 +405,7 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
     "addAll on mutable aggregate set returns false and emits no event when collection is empty" {
         val group = DefaultAudioPlaylist(100, "Group").also(playlistRepo::add)
         val events = Collections.synchronizedList(mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>())
-        group.subscribe { events.add(it) }
+        group.subscribeAsync { events.add(it) }
 
         val result = group.playlists.addAll(emptyList())
         reactive.advance()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ReactivePropertyDelegateTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ReactivePropertyDelegateTest.kt
@@ -33,10 +33,8 @@ class ReactivePropertyDelegateTest : StringSpec({
         val entity = DelegateProbeEntity("probe-1", "initial")
         val received = CopyOnWriteArrayList<MutationEvent<String, DelegateProbeEntity>>()
         val subscription = entity.subscribe { received.add(it) }
-        reactive.advance()
 
         writeReactivePropertyBackingField<String>(entity, "name", "silently-rewritten")
-        reactive.advance()
 
         entity.name shouldBe "silently-rewritten"
         received.shouldBeEmpty()
@@ -58,13 +56,11 @@ class ReactivePropertyDelegateTest : StringSpec({
         val entity = DelegateProbeEntity("probe-3", "initial")
         val received = CopyOnWriteArrayList<MutationEvent<String, DelegateProbeEntity>>()
         val subscription = entity.subscribe { received.add(it) }
-        reactive.advance()
 
         val timestampBefore = entity.lastDateModified
         // Ensure clock tick so timestamps can differ
         Thread.sleep(2)
         entity.name = "loudly-changed"
-        reactive.advance()
 
         entity.name shouldBe "loudly-changed"
         received.size shouldBe 1

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ReflectionFreeVerificationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ReflectionFreeVerificationTest.kt
@@ -93,7 +93,7 @@ internal class ReflectionFreeVerificationTest : FunSpec({
         val playlist = playlistRepo.create(id = 200, audioItemId = 2)
 
         var received = false
-        playlist.subscribe { received = true }
+        playlist.subscribeAsync { received = true }
         audioItem.title = "Track B Updated"
 
         received shouldBe true
@@ -119,7 +119,7 @@ internal class ReflectionFreeVerificationTest : FunSpec({
         val playlist = mutableRefRepo.create(id = 400, audioItemId = 4)
 
         var receivedAfterClose = false
-        playlist.subscribe { receivedAfterClose = true }
+        playlist.subscribeAsync { receivedAfterClose = true }
 
         // close() uses loadRefAccessor + cancelAllBubbleUp — not the old declaredFields scan
         playlist.close()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegisterRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegisterRepositoryTest.kt
@@ -210,7 +210,7 @@ internal class RegisterRepositoryTest : StringSpec({
         // Bubble-up must fire: a mutation on the audio item should reach the playlist's subscribers
         // as an AggregateMutationEvent.
         val bubbleUpReceived = AtomicBoolean(false)
-        loadedPlaylist.subscribe { event ->
+        loadedPlaylist.subscribeAsync { event ->
             if (event is AggregateMutationEvent<*, *>) bubbleUpReceived.set(true)
         }
         audioItem.title = "Track Alpha Updated"

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/SearchPerformanceTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/SearchPerformanceTest.kt
@@ -128,8 +128,6 @@ internal class SearchPerformanceTest : StringSpec({
 
         repository.lazySearch { true }.toSet()
 
-        reactive.advance()
-
         readEventEmitted.get() shouldBe false
     }
 
@@ -161,8 +159,6 @@ internal class SearchPerformanceTest : StringSpec({
         repository.subscribe(READ) { readEventEmitted.set(true) }
 
         repository.searchStream { true }.collect(Collectors.toSet())
-
-        reactive.advance()
 
         readEventEmitted.get() shouldBe false
     }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/VolatileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/VolatileRepositoryTest.kt
@@ -227,13 +227,13 @@ internal class VolatileRepositoryTest : FunSpec({
         val receivedAudioItemIds = mutableSetOf<Int>()
 
         val createSubscription =
-            repository.subscribe(CREATE) { event ->
+            repository.subscribeAsync(CREATE) { event ->
                 createEventsReceived.incrementAndGet()
                 event.entities.keys.forEach { receivedAudioItemIds.add(it) }
             }
 
         val updateSubscription =
-            repository.subscribe(UPDATE) { event ->
+            repository.subscribeAsync(UPDATE) { event ->
                 updateEventsReceived.incrementAndGet()
             }
 
@@ -401,7 +401,7 @@ internal class VolatileRepositoryTest : FunSpec({
             val t3 = trackRepo.create(3, "T3")
             val playlist = DefaultAudioPlaylist(1, "Bulk Add").also(playlistRepo::add)
 
-            playlist.subscribe { events.add(it) }
+            playlist.subscribeAsync { events.add(it) }
 
             playlist.audioItems.addAll(listOf(t1, t2, t3))
             reactive.advance()
@@ -424,7 +424,7 @@ internal class VolatileRepositoryTest : FunSpec({
                 DefaultAudioPlaylist(1, "Bulk Remove", listOf(1, 2, 3))
                     .also(playlistRepo::add)
 
-            playlist.subscribe { events.add(it) }
+            playlist.subscribeAsync { events.add(it) }
 
             playlist.audioItems.removeAll(listOf(t1, t3))
             reactive.advance()
@@ -441,7 +441,7 @@ internal class VolatileRepositoryTest : FunSpec({
 
             val playlist = DefaultAudioPlaylist(1, "Empty Add").also(playlistRepo::add)
 
-            playlist.subscribe { events.add(it) }
+            playlist.subscribeAsync { events.add(it) }
 
             val result = playlist.audioItems.addAll(emptyList())
             reactive.advance()
@@ -461,7 +461,7 @@ internal class VolatileRepositoryTest : FunSpec({
             val unrelated = trackRepo.create(99, "Unrelated")
             val playlist = DefaultAudioPlaylist(1, "No Match Remove").also(playlistRepo::add)
 
-            playlist.subscribe { events.add(it) }
+            playlist.subscribeAsync { events.add(it) }
 
             val result = playlist.audioItems.removeAll(listOf(unrelated))
             reactive.advance()
@@ -482,7 +482,7 @@ internal class VolatileRepositoryTest : FunSpec({
             val p3 = DefaultAudioPlaylist(3, "P3").also(sharedRepo::add)
             val group = DefaultAudioPlaylist(100, "Group").also(sharedRepo::add)
 
-            group.subscribe { events.add(it) }
+            group.subscribeAsync { events.add(it) }
 
             group.playlists.addAll(listOf(p1, p2, p3))
             reactive.advance()
@@ -501,7 +501,7 @@ internal class VolatileRepositoryTest : FunSpec({
             val t1 = trackRepo.create(1, "Track")
             val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
-            playlist.subscribe { events.add(it) }
+            playlist.subscribeAsync { events.add(it) }
 
             playlist.audioItems.add(t1)
             reactive.advance()
@@ -522,7 +522,7 @@ internal class VolatileRepositoryTest : FunSpec({
                 DefaultAudioPlaylist(1, "Test", listOf(1))
                     .also(playlistRepo::add)
 
-            playlist.subscribe { events.add(it) }
+            playlist.subscribeAsync { events.add(it) }
 
             playlist.audioItems.remove(t1)
             reactive.advance()
@@ -543,7 +543,7 @@ internal class VolatileRepositoryTest : FunSpec({
                 DefaultAudioPlaylist(1, "Test", listOf(1))
                     .also(playlistRepo::add)
 
-            playlist.subscribe { events.add(it) }
+            playlist.subscribeAsync { events.add(it) }
 
             playlist.audioItems.clear()
             reactive.advance()
@@ -599,7 +599,7 @@ internal class VolatileRepositoryTest : FunSpec({
                 DefaultAudioPlaylist(1, "Retain", listOf(1, 2, 3))
                     .also(playlistRepo::add)
 
-            playlist.subscribe { events.add(it) }
+            playlist.subscribeAsync { events.add(it) }
 
             playlist.audioItems.retainAll(listOf(t2))
             reactive.advance()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/AggregateJsonPersistenceTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/AggregateJsonPersistenceTest.kt
@@ -118,7 +118,7 @@ class AggregateJsonPersistenceTest : FunSpec({
         val bubbleUpReceived = AtomicBoolean(false)
 
         // Subscribe to the playlist to detect that a bubble-up event was emitted
-        playlist.subscribe { event ->
+        playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent) {
                 bubbleUpReceived.set(true)
                 persistenceLatch.countDown()
@@ -168,7 +168,7 @@ class AggregateJsonPersistenceTest : FunSpec({
         val reloadedPlaylist = playlistRepo2.findById(10).get()
         val bubbleUpLatch = CountDownLatch(1)
 
-        reloadedPlaylist.subscribe { event ->
+        reloadedPlaylist.subscribeAsync { event ->
             if (event is AggregateMutationEvent) bubbleUpLatch.countDown()
         }
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryRawInitLoadTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryRawInitLoadTest.kt
@@ -101,7 +101,7 @@ class JsonFileRepositoryRawInitLoadTest : StringSpec({
         // Attach a per-entity subscriber AFTER load completes; any retroactive event would surface here.
         val events = CopyOnWriteArrayList<String>()
         for (entity in repo) {
-            entity.subscribe { event -> events += event.toString() }
+            entity.subscribeAsync { event -> events += event.toString() }
         }
         // Bulk-load itself is a no-op for subscriber notifications. Sanity-check the first mutation
         // emits exactly one event so we know the subscription is wired.

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
@@ -266,7 +266,7 @@ class JsonFileRepositoryTest : DescribeSpec({
         it("publishes create events under concurrency").config(tags = setOf(Stress)) {
             val events = Collections.synchronizedList(mutableListOf<CrudEvent<Int, PolymorphicCustomer>>())
             val subscription: LirpEventSubscription<in PolymorphicCustomer, CrudEvent.Type, CrudEvent<Int, PolymorphicCustomer>> =
-                repository.subscribe(CREATE) { events.add(it) }
+                repository.subscribeAsync(CREATE) { events.add(it) }
             val testCustomers = (1..5_000).map { arbitraryStandardCustomer(it).next() }.distinct()
             testCustomers.chunked(500).map { chunk ->
                 reactive.scope.launch { chunk.forEach { c -> repository.create(c.id, c.name, c.email) } }
@@ -350,7 +350,7 @@ class JsonFileRepositoryTest : DescribeSpec({
         it("subscribers receive all create and delete events in order despite rapid changes") {
             val receivedEvents = mutableListOf<String>()
             val subscription =
-                repository.subscribe { event ->
+                repository.subscribeAsync { event ->
                     when {
                         event.isCreate() -> receivedEvents.add("CREATE-${event.entities.keys.first()}")
                         event.isUpdate() -> receivedEvents.add("UPDATE-${event.entities.keys.first()}")
@@ -793,7 +793,7 @@ class JsonFileRepositoryTest : DescribeSpec({
                 }
             val playlist = playlistRepo.create(1, "EventTest")
 
-            playlist.subscribe { received.set(true) }
+            playlist.subscribeAsync { received.set(true) }
 
             playlist.audioItems.add(t1)
 
@@ -903,7 +903,7 @@ class JsonFileRepositoryTest : DescribeSpec({
             val deferred = StandardCustomerJsonFileRepository(ctx, deferredFile, loadOnInit = false)
             try {
                 val receivedEvents = AtomicReference(mutableListOf<CrudEvent<Int, PolymorphicCustomer>>())
-                deferred.subscribe { event -> receivedEvents.get().add(event) }
+                deferred.subscribeAsync { event -> receivedEvents.get().add(event) }
                 deferred.load()
                 reactive.advance()
                 receivedEvents.get().filter { it.isCreate() || it.isUpdate() } shouldBe emptyList()

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/ReflectionFreeQueryDslTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/ReflectionFreeQueryDslTest.kt
@@ -102,8 +102,6 @@ internal class ReflectionFreeQueryDslTest : FunSpec({
 
         repo.query { where { Product::category eq "books" } }.toList()
 
-        reactive.advance()
-
         readEventEmitted.get().shouldBeFalse()
     }
 
@@ -148,8 +146,6 @@ internal class ReflectionFreeQueryDslTest : FunSpec({
         repo.subscribe(CrudEvent.Type.READ) { readEventEmitted.set(true) }
 
         repo.query { where { Product::category eq "toys" } }.toList()
-
-        reactive.advance()
 
         // Empty results still trigger the event wrapper, but the emitted set is empty
         readEventEmitted.get().shouldBeTrue()

--- a/lirp-core/src/testFixtures/kotlin/net/transgressoft/lirp/testing/EventRecorder.kt
+++ b/lirp-core/src/testFixtures/kotlin/net/transgressoft/lirp/testing/EventRecorder.kt
@@ -77,8 +77,8 @@ fun <ET : EventType, E : LirpEvent<ET>> LirpEventPublisher<ET, E>.record(
 ): EventRecorder<E> {
     val recorder = EventRecorder<E>()
     val subscription: LirpEventSubscription<in LirpEntity, ET, E> =
-        if (types.isEmpty()) subscribe(action = recorder::record)
-        else subscribe(*types, action = recorder::record)
+        if (types.isEmpty()) subscribe(callback = recorder::record)
+        else subscribe(*types, callback = recorder::record)
 
     // Subscription is kept alive by the publisher's internal bookkeeping; the explicit type
     // annotation above silences a compiler inference warning on the vararg branch.

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxMultiKeyProjectionMap.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxMultiKeyProjectionMap.kt
@@ -179,7 +179,7 @@ class FxMultiKeyProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E>(
      */
     private fun subscribeEntity(entity: E) {
         val subscription =
-            entity.subscribe { event ->
+            entity.subscribeAsync { event ->
                 // Delegate re-bucketing to reconcile, which computes the key delta from its own
                 // reverse-index (the tracked pre-mutation membership) and the current entity state.
                 core.reconcile(event.entity)

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionMap.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionMap.kt
@@ -149,7 +149,7 @@ class RegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : Identi
             // catches those cases by scheduling a force-flush (remove then re-insert) for the
             // entity's current projection key.
             updateSubscription =
-                registry.subscribe(CrudEvent.Type.UPDATE) { event ->
+                registry.subscribeAsync(CrudEvent.Type.UPDATE) { event ->
                     if (event is StandardCrudEvent.Update) {
                         val keysToFlush = event.entities.values.map(keyExtractor).toSet()
                         if (keysToFlush.isNotEmpty()) scheduleUpdateFlush(keysToFlush)

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedFxMultiKeyProjectionMap.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedFxMultiKeyProjectionMap.kt
@@ -189,7 +189,7 @@ class TransformedFxMultiKeyProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
      */
     private fun subscribeEntity(entity: E) {
         val subscription =
-            entity.subscribe { event ->
+            entity.subscribeAsync { event ->
                 // Delegate re-bucketing to reconcile, which computes the key delta from its own
                 // reverse-index (the tracked pre-mutation membership) and the current entity state.
                 core.reconcile(event.entity)

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjectionMap.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjectionMap.kt
@@ -147,7 +147,7 @@ class TransformedRegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
             // catches those cases: it precomputes the new V on the background thread and enqueues
             // a flush so FX listeners observe the updated transform result.
             updateSubscription =
-                registry.subscribe(CrudEvent.Type.UPDATE) { event ->
+                registry.subscribeAsync(CrudEvent.Type.UPDATE) { event ->
                     if (event is StandardCrudEvent.Update) {
                         val keysToFlush = event.entities.values.map(keyExtractor).toSet()
                         if (keysToFlush.isNotEmpty()) scheduleFlushForUpdates(keysToFlush)

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxScalarRegistryIntegrationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxScalarRegistryIntegrationTest.kt
@@ -25,10 +25,6 @@ import net.transgressoft.lirp.testing.reactiveScope
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Integration tests verifying that [net.transgressoft.lirp.persistence.RegistryBase] correctly
@@ -63,20 +59,14 @@ class FxScalarRegistryIntegrationTest : StringSpec({
     "RegistryBase binds fx string property and emits ReactiveMutationEvent on set" {
         val entity = fxPlaylistRepo.create(1, "playlist", tag = "initial")
 
-        val receivedEvent = AtomicReference<MutationEvent<Int, FxAudioPlaylistEntity>>(null)
-        val latch = CountDownLatch(1)
+        val received = mutableListOf<MutationEvent<Int, FxAudioPlaylistEntity>>()
 
-        entity.subscribe { event ->
-            receivedEvent.set(event)
-            latch.countDown()
-        }
+        entity.subscribe { event -> received.add(event) }
 
         entity.tagProperty.set("updated")
 
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        val event = receivedEvent.get()
-        event shouldNotBe null
-        val pc = event as PropertyChanged<Int, FxAudioPlaylistEntity, String>
+        received.size shouldBe 1
+        val pc = received[0] as PropertyChanged<Int, FxAudioPlaylistEntity, String>
         pc.oldValue shouldBe "initial"
         pc.newValue shouldBe "updated"
     }
@@ -100,20 +90,14 @@ class FxScalarRegistryIntegrationTest : StringSpec({
     "fx integer property emits ReactiveMutationEvent on set" {
         val entity = fxPlaylistRepo.create(2, "playlist", year = 0)
 
-        val receivedEvent = AtomicReference<MutationEvent<Int, FxAudioPlaylistEntity>>(null)
-        val latch = CountDownLatch(1)
+        val received = mutableListOf<MutationEvent<Int, FxAudioPlaylistEntity>>()
 
-        entity.subscribe { event ->
-            receivedEvent.set(event)
-            latch.countDown()
-        }
+        entity.subscribe { event -> received.add(event) }
 
         entity.yearProperty.set(2025)
 
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        val event = receivedEvent.get()
-        event shouldNotBe null
-        val pc = event as PropertyChanged<Int, FxAudioPlaylistEntity, Int>
+        received.size shouldBe 1
+        val pc = received[0] as PropertyChanged<Int, FxAudioPlaylistEntity, Int>
         pc.oldValue shouldBe 0
         pc.newValue shouldBe 2025
     }
@@ -121,20 +105,14 @@ class FxScalarRegistryIntegrationTest : StringSpec({
     "fx boolean property emits ReactiveMutationEvent on set" {
         val entity = fxPlaylistRepo.create(3, "playlist", active = false)
 
-        val receivedEvent = AtomicReference<MutationEvent<Int, FxAudioPlaylistEntity>>(null)
-        val latch = CountDownLatch(1)
+        val received = mutableListOf<MutationEvent<Int, FxAudioPlaylistEntity>>()
 
-        entity.subscribe { event ->
-            receivedEvent.set(event)
-            latch.countDown()
-        }
+        entity.subscribe { event -> received.add(event) }
 
         entity.activeProperty.set(true)
 
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        val event = receivedEvent.get()
-        event shouldNotBe null
-        val pc = event as PropertyChanged<Int, FxAudioPlaylistEntity, Boolean>
+        received.size shouldBe 1
+        val pc = received[0] as PropertyChanged<Int, FxAudioPlaylistEntity, Boolean>
         pc.oldValue shouldBe false
         pc.newValue shouldBe true
     }
@@ -142,20 +120,14 @@ class FxScalarRegistryIntegrationTest : StringSpec({
     "fx object property emits ReactiveMutationEvent on set" {
         val entity = fxPlaylistRepo.create(4, "playlist", description = null)
 
-        val receivedEvent = AtomicReference<MutationEvent<Int, FxAudioPlaylistEntity>>(null)
-        val latch = CountDownLatch(1)
+        val received = mutableListOf<MutationEvent<Int, FxAudioPlaylistEntity>>()
 
-        entity.subscribe { event ->
-            receivedEvent.set(event)
-            latch.countDown()
-        }
+        entity.subscribe { event -> received.add(event) }
 
         entity.descriptionProperty.set("vip")
 
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        val event = receivedEvent.get()
-        event shouldNotBe null
-        val pc = event as PropertyChanged<Int, FxAudioPlaylistEntity, String>
+        received.size shouldBe 1
+        val pc = received[0] as PropertyChanged<Int, FxAudioPlaylistEntity, String>
         pc.oldValue shouldBe null
         pc.newValue shouldBe "vip"
     }
@@ -163,36 +135,27 @@ class FxScalarRegistryIntegrationTest : StringSpec({
     "withEventsDisabled suppresses MutationEvent for fx scalar property" {
         val entity = fxPlaylistRepo.create(5, "playlist", tag = "before")
 
-        val receivedEvent = AtomicReference<MutationEvent<Int, FxAudioPlaylistEntity>>(null)
-        val latch = CountDownLatch(1)
+        val received = mutableListOf<MutationEvent<Int, FxAudioPlaylistEntity>>()
 
-        entity.subscribe { event ->
-            receivedEvent.set(event)
-            latch.countDown()
-        }
+        entity.subscribe { event -> received.add(event) }
 
         entity.silently { entity.tagProperty.set("silent") }
 
-        latch.await(500, TimeUnit.MILLISECONDS) shouldBe false
-        receivedEvent.get() shouldBe null
+        received.size shouldBe 0
         entity.tagProperty.get() shouldBe "silent"
     }
 
     "fx scalar property set before repository add does not emit event" {
         val entity = FxAudioPlaylistEntity(6, "standalone")
 
-        val receivedEvent = AtomicReference<MutationEvent<Int, FxAudioPlaylistEntity>>(null)
+        val received = mutableListOf<MutationEvent<Int, FxAudioPlaylistEntity>>()
 
-        entity.subscribe { event ->
-            receivedEvent.set(event)
-        }
+        entity.subscribe { event -> received.add(event) }
 
         entity.tagProperty.set("changed")
 
-        // Drain pending coroutines — entity is standalone (not in a repository), so no publisher
-        // is active. advanceUntilIdle() confirms no event delivery is pending.
-        reactive.advance()
+        // Entity is standalone (not in a repository), so no publisher is active — no event emitted.
         entity.tagProperty.get() shouldBe "changed"
-        receivedEvent.get() shouldBe null
+        received.size shouldBe 0
     }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
@@ -1508,7 +1508,7 @@ internal class TableDefProcessorTest : FunSpec({
         val mutationCount = java.util.concurrent.atomic.AtomicInteger(0)
         val subscribeMethod =
             playlistClass.methods.first {
-                it.name == "subscribe" &&
+                it.name == "subscribeAsync" &&
                     it.parameterCount == 1 &&
                     it.parameterTypes[0] == kotlin.jvm.functions.Function2::class.java
             }


### PR DESCRIPTION
## Summary

Adds a **synchronous subscription transport** to the reactive event system and makes it the unqualified default, while preserving the existing coroutine-based path under a new name. This is a breaking change targeting **v3.0.0**.

Previously every `subscribe { … }` delivered events asynchronously through a coroutine bridge. Many subscribers only do fast, in-process work (cache/index updates, counters) and paid coroutine overhead for it. `subscribe` is now synchronous and inline; callers who need background delivery opt in with `subscribeAsync`.

## What changed

- **`subscribe(callback: (E) -> Unit)` is now synchronous** — callbacks run inline on the emitting thread, before any async delivery, with zero coroutine overhead. The former coroutine `subscribe` is renamed **`subscribeAsync`** across `LirpEventPublisher`, `ReactiveEntity`, `Repository`, and `FlowEventPublisher` (including the Java `Consumer` overloads).
- **Lazy async bridge** — the `Channel`/`SharedFlow` machinery is constructed lazily and armed synchronously on the first async entry point. An entity with only synchronous subscribers allocates no coroutine machinery.
- **Dual subscriber counting** — `subscriberCount` and `closeOnEmpty` account for both transports; `closeOnEmpty` fires only once both reach zero.
- **Exception isolation & reentrancy** — a throwing synchronous callback is logged and isolated without blocking other callbacks or the async path (`Error` still propagates); reentrant synchronous emits are drained breadth-first via a per-publisher trampoline.
- **Symmetric filtered overloads** — a synchronous `subscribe(vararg eventTypes, callback)` mirrors the async filtered overload, and the filtered async `Consumer` overload now honors its event-type filter (it previously delivered every type).
- **Internal subscribers stay async** — repository persistence, aggregate bubble-up, and projection maps remain on `subscribeAsync` because they cross publishers, take locks, or require thread hops that must not run on the producer's hot path.

## Breaking changes & migration

- Rename former async `subscribe { … }` / `subscribe(Consumer)` call sites to `subscribeAsync`.
- Keep fast in-process callbacks on `subscribe`; use `subscribeAsync` for slow, blocking, or remote work.
- The async replay buffer is now armed lazily: access `publisher.changes` (or call `subscribeAsync`) at startup when replay-from-boot is required.
- The filtered async `Consumer` overload now filters; callers that relied on receiving all types must subscribe without a filter.

Full migration notes are in `CHANGELOG.md`; `README.md` has a sync-vs-async decision table, and the wiki documentation was updated accordingly.

## Testing

- Full build green including ABI compatibility checks (`apiCheck`) against regenerated baselines.
- Event-publisher test matrix covers sync-only, async-only, mixed, exception isolation, filtered, reentrancy, lazy-init, and `closeOnEmpty` behavior.
- SQL integration tests pass across PostgreSQL, MySQL, MariaDB, and SQLite (Testcontainers).
- Aggregate coverage maintained (line ~88.3%, branch ~73.1%).
- A long-standing timing-flaky slow-subscriber test was stabilized as part of this change.

Closes #195
