### PR TITLE
Two-phase FX projection transform: off-thread data extraction, on-FX-thread value construction (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,14 @@ These are **breaking changes**; see [Migration from 2.x to 3.0.0](#migration-fro
 
 ### Added
 
+- **Two-phase FX-safe value transform** — new `dataTransform` / `fxFactory` overloads on
+  `fxProjectionMap`, `registryFxProjectionMap`, `fxMultiKeyProjectionMap`, and
+  `registryFxMultiKeyProjectionMap` split bucket projection into an off-thread data-extraction
+  step (`dataTransform`) and an on-FX-thread construction step (`fxFactory`), making it safe
+  to build `SimpleSetProperty` / `ReadOnlyBooleanWrapper` values in the factory. A `fxFactory`
+  failure is logged with the bucket key and skipped so the remaining buckets in the same pulse
+  still flush. The existing single-`valueTransform` overloads are unaffected ([#256](https://github.com/octaviospain/lirp/issues/256)).
+
 - **`@ToOneAggregate`** — new annotation for FK scalar properties that replaces the hand-written
   companion `val` pattern. Place `@ToOneAggregate(target = TargetClass::class, onDelete = …)` on a
   scalar property whose name ends in `Id` (e.g. `var labelId: Int?`). KSP generates a

--- a/lirp-fx/api/lirp-fx.api
+++ b/lirp-fx/api/lirp-fx.api
@@ -252,20 +252,28 @@ public final class net/transgressoft/lirp/persistence/fx/projection/FxMultiKeyPr
 }
 
 public final class net/transgressoft/lirp/persistence/fx/projection/FxProjectionFactoriesKt {
+	public static final fun fxMultiKeyProjectionMap (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Z)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedFxMultiKeyProjectionMap;
 	public static final fun fxMultiKeyProjectionMap (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Z)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedFxMultiKeyProjectionMap;
 	public static final fun fxMultiKeyProjectionMap (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Z)Lnet/transgressoft/lirp/persistence/fx/projection/FxMultiKeyProjectionMap;
+	public static synthetic fun fxMultiKeyProjectionMap$default (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedFxMultiKeyProjectionMap;
 	public static synthetic fun fxMultiKeyProjectionMap$default (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedFxMultiKeyProjectionMap;
 	public static synthetic fun fxMultiKeyProjectionMap$default (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxMultiKeyProjectionMap;
+	public static final fun fxProjectionMap (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Z)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedFxProjectionMap;
 	public static final fun fxProjectionMap (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Z)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedFxProjectionMap;
 	public static final fun fxProjectionMap (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Z)Lnet/transgressoft/lirp/persistence/fx/projection/FxProjectionMap;
+	public static synthetic fun fxProjectionMap$default (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedFxProjectionMap;
 	public static synthetic fun fxProjectionMap$default (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedFxProjectionMap;
 	public static synthetic fun fxProjectionMap$default (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxProjectionMap;
+	public static final fun registryFxMultiKeyProjectionMap (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Z)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjectionMap;
 	public static final fun registryFxMultiKeyProjectionMap (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Z)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjectionMap;
 	public static final fun registryFxMultiKeyProjectionMap (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Z)Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjectionMap;
+	public static synthetic fun registryFxMultiKeyProjectionMap$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjectionMap;
 	public static synthetic fun registryFxMultiKeyProjectionMap$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjectionMap;
 	public static synthetic fun registryFxMultiKeyProjectionMap$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjectionMap;
+	public static final fun registryFxProjectionMap (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Z)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjectionMap;
 	public static final fun registryFxProjectionMap (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Z)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjectionMap;
 	public static final fun registryFxProjectionMap (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Z)Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionMap;
+	public static synthetic fun registryFxProjectionMap$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjectionMap;
 	public static synthetic fun registryFxProjectionMap$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjectionMap;
 	public static synthetic fun registryFxProjectionMap$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionMap;
 }
@@ -421,6 +429,8 @@ public final class net/transgressoft/lirp/persistence/fx/projection/RegistryFxPr
 
 public final class net/transgressoft/lirp/persistence/fx/projection/TransformedFxMultiKeyProjectionMap : java/lang/AutoCloseable, javafx/collections/ObservableMap {
 	public static final field Companion Lnet/transgressoft/lirp/persistence/fx/projection/TransformedFxMultiKeyProjectionMap$Companion;
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Z)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Z)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addListener (Ljavafx/beans/InvalidationListener;)V
@@ -460,6 +470,8 @@ public final class net/transgressoft/lirp/persistence/fx/projection/TransformedF
 
 public final class net/transgressoft/lirp/persistence/fx/projection/TransformedFxProjectionMap : javafx/collections/ObservableMap {
 	public static final field Companion Lnet/transgressoft/lirp/persistence/fx/projection/TransformedFxProjectionMap$Companion;
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Z)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Z)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addListener (Ljavafx/beans/InvalidationListener;)V
@@ -498,6 +510,8 @@ public final class net/transgressoft/lirp/persistence/fx/projection/TransformedF
 
 public final class net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjectionMap : java/lang/AutoCloseable, javafx/collections/ObservableMap {
 	public static final field Companion Lnet/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjectionMap$Companion;
+	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Z)V
+	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Z)V
 	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addListener (Ljavafx/beans/InvalidationListener;)V
@@ -537,6 +551,8 @@ public final class net/transgressoft/lirp/persistence/fx/projection/TransformedR
 
 public final class net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjectionMap : java/lang/AutoCloseable, javafx/collections/ObservableMap {
 	public static final field Companion Lnet/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjectionMap$Companion;
+	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Z)V
+	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Z)V
 	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addListener (Ljavafx/beans/InvalidationListener;)V

--- a/lirp-fx/build.gradle
+++ b/lirp-fx/build.gradle
@@ -27,6 +27,9 @@ def fxPlatform = osName.contains('mac') ? (isArm64 ? 'mac-aarch64' : 'mac') : os
 dependencies {
     api project(path: ':lirp-core')
 
+    implementation libs.kotlin.logging
+    implementation libs.slf4j.api
+
     compileOnly "org.openjfx:javafx-base:21:${fxPlatform}"
     compileOnly "org.openjfx:javafx-graphics:21:${fxPlatform}"
 

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionFactories.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionFactories.kt
@@ -121,6 +121,62 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V> fxPro
     TransformedFxProjectionMap(sourceRef, keyExtractor, valueTransform, dispatchToFxThread)
 
 /**
+ * Creates a two-phase value-transformed read-only [ObservableMap] projection that groups entities
+ * from an [FxObservableCollection] source by a secondary key.
+ *
+ * The transform is split into two phases:
+ * - [dataTransform] runs on the **background thread** that delivers source events. It extracts a
+ *   pure intermediate value `D` from the `(PK, List<E>)` bucket. **Must be thread-agnostic** — it
+ *   must not read or write any JavaFX property or node.
+ * - [fxFactory] runs on the **FX Application Thread** inside the flush pulse, once per changed
+ *   bucket. It receives the bucket key and the intermediate `D` produced by [dataTransform], and
+ *   constructs the final `V`. Safe to construct `SimpleSetProperty`, call `.bind(...)`, etc.
+ *
+ * If [fxFactory] throws for a bucket, the failure is logged (bucket key included) and that one
+ * bucket is skipped; the remaining buckets in the same pulse still flush.
+ *
+ * Usage:
+ * ```kotlin
+ * val albumViews by fxProjectionMap(
+ *     ::audioItems,
+ *     AudioItem::albumName,
+ *     dataTransform = { pk, items -> items.map { it.title } },
+ *     fxFactory = { pk, titles -> AlbumFxView(pk, titles) }
+ * )
+ * ```
+ *
+ * @param K the entity ID type
+ * @param PK the projection key type, must be [Comparable]
+ * @param E the entity type
+ * @param D the intermediate data type produced off-thread by [dataTransform]
+ * @param V the transform output type constructed on the FX Application Thread by [fxFactory]
+ * @param sourceRef lambda returning the source [FxObservableCollection]
+ * @param keyExtractor grouping function that extracts the projection key from an entity
+ * @param dataTransform pure off-thread function that extracts an intermediate value from a non-empty bucket;
+ *   must not access JavaFX observables
+ * @param fxFactory FX-thread function that constructs the final `V` from the bucket key and the
+ *   intermediate value produced by [dataTransform]; safe to build JavaFX property bindings here
+ * @param dispatchToFxThread when `true` (default), dispatches notifications to the FX Application Thread;
+ *   when `false`, dispatches on [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @return a read-only observable projection map delegate that emits values built on the FX Application Thread
+ */
+@Suppress("UNCHECKED_CAST")
+fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, D, V> fxProjectionMap(
+    sourceRef: () -> FxObservableCollection<K, E>,
+    keyExtractor: (E) -> PK,
+    dataTransform: (PK, List<E>) -> D,
+    fxFactory: (PK, D) -> V,
+    dispatchToFxThread: Boolean = true
+): TransformedFxProjectionMap<K, PK, E, V> =
+    TransformedFxProjectionMap(
+        sourceRef,
+        keyExtractor,
+        dataTransform as (PK, List<E>) -> Any?,
+        fxFactory as (PK, Any?) -> V,
+        dispatchToFxThread
+    )
+
+/**
  * Creates a value-transformed read-only [ObservableMap] projection that groups all entities from a
  * [Registry] by a secondary key, applying [valueTransform] to each bucket.
  *
@@ -153,6 +209,62 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V> regis
     dispatchToFxThread: Boolean = true
 ): TransformedRegistryFxProjectionMap<K, PK, E, V> =
     TransformedRegistryFxProjectionMap(registry, keyExtractor, valueTransform, dispatchToFxThread)
+
+/**
+ * Creates a two-phase value-transformed read-only [ObservableMap] projection that groups all entities
+ * from a [Registry] by a secondary key.
+ *
+ * The transform is split into two phases:
+ * - [dataTransform] runs on the **background thread** that delivers registry events. It extracts a
+ *   pure intermediate value `D` from the `(PK, List<E>)` bucket. **Must be thread-agnostic** — it
+ *   must not read or write any JavaFX property or node.
+ * - [fxFactory] runs on the **FX Application Thread** inside the flush pulse, once per changed
+ *   bucket. It receives the bucket key and the intermediate `D` produced by [dataTransform], and
+ *   constructs the final `V`. Safe to construct `SimpleSetProperty`, call `.bind(...)`, etc.
+ *
+ * If [fxFactory] throws for a bucket, the failure is logged (bucket key included) and that one
+ * bucket is skipped; the remaining buckets in the same pulse still flush.
+ *
+ * Usage:
+ * ```kotlin
+ * val albumViews: ObservableMap<String, AlbumFxView> by registryFxProjectionMap(
+ *     trackRepo,
+ *     { it.albumName },
+ *     dataTransform = { pk, items -> items.map { it.title } },
+ *     fxFactory = { pk, titles -> AlbumFxView(pk, titles) }
+ * )
+ * ```
+ *
+ * @param K the entity ID type
+ * @param PK the projection key type, must be [Comparable]
+ * @param E the entity type
+ * @param D the intermediate data type produced off-thread by [dataTransform]
+ * @param V the transform output type constructed on the FX Application Thread by [fxFactory]
+ * @param registry the source registry to project
+ * @param keyExtractor grouping function that extracts the projection key from an entity
+ * @param dataTransform pure off-thread function that extracts an intermediate value from a non-empty bucket;
+ *   must not access JavaFX observables
+ * @param fxFactory FX-thread function that constructs the final `V` from the bucket key and the
+ *   intermediate value produced by [dataTransform]; safe to build JavaFX property bindings here
+ * @param dispatchToFxThread when `true` (default), dispatches notifications to the FX Application Thread;
+ *   when `false`, dispatches on [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @return a read-only observable projection map delegate that emits values built on the FX Application Thread
+ */
+@Suppress("UNCHECKED_CAST")
+fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, D, V> registryFxProjectionMap(
+    registry: Registry<K, E>,
+    keyExtractor: (E) -> PK,
+    dataTransform: (PK, List<E>) -> D,
+    fxFactory: (PK, D) -> V,
+    dispatchToFxThread: Boolean = true
+): TransformedRegistryFxProjectionMap<K, PK, E, V> =
+    TransformedRegistryFxProjectionMap(
+        registry,
+        keyExtractor,
+        dataTransform as (PK, List<E>) -> Any?,
+        fxFactory as (PK, Any?) -> V,
+        dispatchToFxThread
+    )
 
 /**
  * Creates a read-only [ObservableMap] multi-key projection delegate that groups entities from an
@@ -221,6 +333,63 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E, V> fxMultiKeyProjectionMap(
     TransformedFxMultiKeyProjectionMap(sourceRef, keyExtractor, valueTransform, dispatchToFxThread)
 
 /**
+ * Creates a two-phase value-transformed read-only [ObservableMap] multi-key projection delegate that
+ * groups entities from an [FxObservableCollection] source by multiple secondary keys.
+ *
+ * Each entity is placed into every bucket named by a key returned from [keyExtractor]. The transform
+ * is split into two phases:
+ * - [dataTransform] runs on the **background thread** that delivers source events. It extracts a
+ *   pure intermediate value `D` from the `(PK, List<E>)` bucket. **Must be thread-agnostic** — it
+ *   must not read or write any JavaFX property or node.
+ * - [fxFactory] runs on the **FX Application Thread** inside the flush pulse, once per changed
+ *   bucket. It receives the bucket key and the intermediate `D` produced by [dataTransform], and
+ *   constructs the final `V`. Safe to construct `SimpleSetProperty`, call `.bind(...)`, etc.
+ *
+ * If [fxFactory] throws for a bucket, the failure is logged (bucket key included) and that one
+ * bucket is skipped; the remaining buckets in the same pulse still flush.
+ *
+ * Usage:
+ * ```kotlin
+ * val genreViews by fxMultiKeyProjectionMap(
+ *     ::audioItems,
+ *     { it.genres },
+ *     dataTransform = { pk, items -> items.map { it.title } },
+ *     fxFactory = { pk, titles -> GenreFxView(pk, titles) }
+ * )
+ * ```
+ *
+ * @param K the entity ID type
+ * @param PK the projection key type, must be [Comparable]
+ * @param E the entity type, must extend [ReactiveEntity]
+ * @param D the intermediate data type produced off-thread by [dataTransform]
+ * @param V the transform output type constructed on the FX Application Thread by [fxFactory]
+ * @param sourceRef lambda returning the source [FxObservableCollection]
+ * @param keyExtractor function that extracts the set of projection keys from an entity
+ * @param dataTransform pure off-thread function that extracts an intermediate value from a non-empty bucket;
+ *   must not access JavaFX observables
+ * @param fxFactory FX-thread function that constructs the final `V` from the bucket key and the
+ *   intermediate value produced by [dataTransform]; safe to build JavaFX property bindings here
+ * @param dispatchToFxThread when `true` (default), dispatches notifications to the FX Application Thread;
+ *   when `false`, dispatches on [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @return a read-only multi-key projection map delegate that emits values built on the FX Application Thread
+ */
+@Suppress("UNCHECKED_CAST")
+fun <K : Comparable<K>, PK : Comparable<PK>, E, D, V> fxMultiKeyProjectionMap(
+    sourceRef: () -> FxObservableCollection<K, E>,
+    keyExtractor: (E) -> Collection<PK>,
+    dataTransform: (PK, List<E>) -> D,
+    fxFactory: (PK, D) -> V,
+    dispatchToFxThread: Boolean = true
+): TransformedFxMultiKeyProjectionMap<K, PK, E, V> where E : IdentifiableEntity<K>, E : ReactiveEntity<K, E> =
+    TransformedFxMultiKeyProjectionMap(
+        sourceRef,
+        keyExtractor,
+        dataTransform as (PK, List<E>) -> Any?,
+        fxFactory as (PK, Any?) -> V,
+        dispatchToFxThread
+    )
+
+/**
  * Creates a read-only [ObservableMap] multi-key projection delegate that groups all entities from a
  * [Registry] by multiple secondary keys.
  *
@@ -285,3 +454,60 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V> regis
     dispatchToFxThread: Boolean = true
 ): TransformedRegistryFxMultiKeyProjectionMap<K, PK, E, V> =
     TransformedRegistryFxMultiKeyProjectionMap(registry, keyExtractor, valueTransform, dispatchToFxThread)
+
+/**
+ * Creates a two-phase value-transformed read-only [ObservableMap] multi-key projection delegate that
+ * groups all entities from a [Registry] by multiple secondary keys.
+ *
+ * Each entity is placed into every bucket named by a key returned from [keyExtractor]. The transform
+ * is split into two phases:
+ * - [dataTransform] runs on the **background thread** that delivers registry events. It extracts a
+ *   pure intermediate value `D` from the `(PK, List<E>)` bucket. **Must be thread-agnostic** — it
+ *   must not read or write any JavaFX property or node.
+ * - [fxFactory] runs on the **FX Application Thread** inside the flush pulse, once per changed
+ *   bucket. It receives the bucket key and the intermediate `D` produced by [dataTransform], and
+ *   constructs the final `V`. Safe to construct `SimpleSetProperty`, call `.bind(...)`, etc.
+ *
+ * If [fxFactory] throws for a bucket, the failure is logged (bucket key included) and that one
+ * bucket is skipped; the remaining buckets in the same pulse still flush.
+ *
+ * Usage:
+ * ```kotlin
+ * val genreViews: ObservableMap<String, GenreFxView> by registryFxMultiKeyProjectionMap(
+ *     trackRepo,
+ *     { it.genres },
+ *     dataTransform = { pk, items -> items.map { it.title } },
+ *     fxFactory = { pk, titles -> GenreFxView(pk, titles) }
+ * )
+ * ```
+ *
+ * @param K the entity ID type
+ * @param PK the projection key type, must be [Comparable]
+ * @param E the entity type
+ * @param D the intermediate data type produced off-thread by [dataTransform]
+ * @param V the transform output type constructed on the FX Application Thread by [fxFactory]
+ * @param registry the source registry whose entities are projected
+ * @param keyExtractor function that extracts the set of projection keys from an entity
+ * @param dataTransform pure off-thread function that extracts an intermediate value from a non-empty bucket;
+ *   must not access JavaFX observables
+ * @param fxFactory FX-thread function that constructs the final `V` from the bucket key and the
+ *   intermediate value produced by [dataTransform]; safe to build JavaFX property bindings here
+ * @param dispatchToFxThread when `true` (default), dispatches notifications to the FX Application Thread;
+ *   when `false`, dispatches on [net.transgressoft.lirp.event.ReactiveScope.flowScope]
+ * @return a read-only multi-key projection map delegate that emits values built on the FX Application Thread
+ */
+@Suppress("UNCHECKED_CAST")
+fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, D, V> registryFxMultiKeyProjectionMap(
+    registry: Registry<K, E>,
+    keyExtractor: (E) -> Collection<PK>,
+    dataTransform: (PK, List<E>) -> D,
+    fxFactory: (PK, D) -> V,
+    dispatchToFxThread: Boolean = true
+): TransformedRegistryFxMultiKeyProjectionMap<K, PK, E, V> =
+    TransformedRegistryFxMultiKeyProjectionMap(
+        registry,
+        keyExtractor,
+        dataTransform as (PK, List<E>) -> Any?,
+        fxFactory as (PK, Any?) -> V,
+        dispatchToFxThread
+    )

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedFxMultiKeyProjectionMap.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedFxMultiKeyProjectionMap.kt
@@ -26,6 +26,7 @@ import net.transgressoft.lirp.persistence.FxObservableCollection
 import net.transgressoft.lirp.persistence.fx.FxAggregateList
 import net.transgressoft.lirp.persistence.fx.FxAggregateSet
 import net.transgressoft.lirp.persistence.projection.MultiKeyProjectionMap
+import io.github.oshai.kotlinlogging.KotlinLogging
 import javafx.application.Platform
 import javafx.beans.InvalidationListener
 import javafx.collections.FXCollections
@@ -42,23 +43,27 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 
 /**
- * A read-only [ObservableMap] that derives a multi-key grouped and value-transformed view from an
- * [FxObservableCollection] source (either an [FxAggregateList] or [FxAggregateSet]).
+ * A read-only [ObservableMap] that derives a multi-key grouped and two-phase value-transformed view
+ * from an [FxObservableCollection] source (either an [FxAggregateList] or [FxAggregateSet]).
  *
  * Unlike [TransformedFxProjectionMap] (one entity per bucket), this map places each entity under
  * every bucket key that [keyExtractor] returns for it. A `MutableMultiKeyAudioItem` with genres
  * `{Rock, Jazz}` appears in both the `"Rock"` and `"Jazz"` buckets. Each non-empty bucket is then
- * passed to [valueTransform] to produce the observable value `V`.
+ * passed through two phases to produce the observable value `V`.
  *
- * The [valueTransform] is invoked on the **background thread** (the thread that delivers the
- * source collection's change event), not on the FX Application Thread. The computed `V` is then
- * staged and mirrored into the [ObservableMap] in a single FX pulse (one [Platform.runLater]
- * call in dispatch mode, one [ReactiveScope.flowScope] channel action otherwise). This separates
- * potentially expensive transform work from the UI-thread rendering step.
+ * 1. **Data extraction** (`dataTransform`, off-thread): runs on the background thread that delivers
+ *    the source collection's change event. Extracts a pure intermediate value from `(PK, List<E>)`.
+ *    Must not read or write any JavaFX property or node.
+ * 2. **FX construction** (`fxFactory`, FX Application Thread): receives the bucket key and the
+ *    intermediate value and constructs the final `V`. Safe to build `SimpleSetProperty`, call
+ *    `.bind(...)`, etc. Invoked exactly once per changed bucket per flush pulse.
  *
- * **Important:** [valueTransform] MUST be a pure, thread-agnostic function. It must not read
- * or write any JavaFX property or node, and must not block the calling thread. Transform output
- * is computed exactly once per affected bucket per source delta.
+ * If `fxFactory` throws for a bucket, the failure is logged (bucket key included) and that one
+ * bucket is skipped; the remaining buckets in the same pulse still flush.
+ *
+ * The computed `V` is staged and mirrored into the [ObservableMap] in a single FX pulse (one
+ * [Platform.runLater] call in dispatch mode, one [ReactiveScope.flowScope] channel action
+ * otherwise). This separates potentially expensive transform work from the UI-thread rendering step.
  *
  * Each entity added to a bucket is subscribed to its own mutation events. When a key-relevant
  * property changes (the key set returned by [keyExtractor] differs from the previous value), the
@@ -67,8 +72,10 @@ import kotlinx.coroutines.launch
  * The mutation subscription is cancelled when the entity is removed from all buckets, and all
  * remaining subscriptions are cancelled on [close].
  *
- * Buckets that become empty remove their key from the map (transform is not invoked for absent
- * buckets). The projection initializes lazily on the first [getValue] or [addListener] call.
+ * Buckets that become empty remove their key from the map (neither transform phase is invoked for
+ * absent buckets). The projection initializes lazily on the first [getValue] or [addListener] call.
+ * The seed loop runs on the first-access thread: both transform phases are invoked on that thread
+ * during seeding.
  *
  * Mutation methods ([put], [remove], [putAll], [clear]) throw [UnsupportedOperationException];
  * all mutations flow through the source collection.
@@ -80,15 +87,22 @@ import kotlinx.coroutines.launch
  * @param sourceRef deferred reference to the source [FxObservableCollection] (resolved on first access)
  * @param keyExtractor function that extracts the set of projection keys from an entity;
  *   each returned key names one bucket the entity belongs to
- * @param valueTransform pure function that maps a non-empty bucket to its display value
+ * @param dataTransform off-thread function that extracts a pure intermediate value from a non-empty
+ *   bucket; must not touch JavaFX observables
+ * @param fxFactory FX-thread function that constructs the final `V` from the bucket key and the
+ *   intermediate value produced by [dataTransform]; safe to build JavaFX property bindings here
  * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
  */
 class TransformedFxMultiKeyProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E, V>(
     private val sourceRef: () -> FxObservableCollection<K, E>,
     private val keyExtractor: (E) -> Collection<PK>,
-    private val valueTransform: (PK, List<E>) -> V,
+    private val dataTransform: (PK, List<E>) -> Any?,
+    @Suppress("UNCHECKED_CAST")
+    private val fxFactory: (PK, Any?) -> V,
     val dispatchToFxThread: Boolean = true
 ) : ObservableMap<PK, V>, AutoCloseable where E : IdentifiableEntity<K>, E : ReactiveEntity<K, E> {
+
+    private val log = KotlinLogging.logger {}
 
     private val innerObservableMap: ObservableMap<PK, V> =
         FXCollections.observableMap(ConcurrentSkipListMap<PK, V>())
@@ -104,11 +118,12 @@ class TransformedFxMultiKeyProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
     private val initBarrier: CompletableDeferred<Unit>? =
         if (!dispatchToFxThread) CompletableDeferred() else null
 
-    // Pending-flush coalescer — stores precomputed V values for non-empty buckets and tracks
-    // keys of removed (emptied) buckets separately, then flushes both into innerObservableMap
-    // in a single target-thread call per source event burst.
-    // ConcurrentHashMap does not allow null values, so removals are tracked in a separate set.
-    private val pendingUpdates = ConcurrentHashMap<PK, V>()
+    // Pending-flush coalescer — stores precomputed intermediate values (as Any?) for non-empty
+    // buckets and tracks keys of removed (emptied) buckets separately, then flushes both into
+    // innerObservableMap in a single target-thread call per source event burst.
+    // All accesses to pendingUpdates occur inside synchronized(this) blocks, allowing a plain
+    // HashMap that also tolerates null intermediate values from dataTransform.
+    private val pendingUpdates = HashMap<PK, Any?>()
     private val pendingRemovals = CopyOnWriteArraySet<PK>()
     private val flushScheduled = AtomicBoolean(false)
 
@@ -141,6 +156,30 @@ class TransformedFxMultiKeyProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
             keyExtractor
         )
 
+    /**
+     * Constructs a single-transform projection. [valueTransform] runs entirely off-thread; an
+     * identity [fxFactory] is supplied so the existing off-thread behavior is preserved exactly.
+     *
+     * @param sourceRef deferred reference to the source [FxObservableCollection]
+     * @param keyExtractor function that extracts the set of projection keys from an entity
+     * @param valueTransform pure off-thread function that maps a non-empty bucket to its display
+     *   value; must not touch JavaFX observables
+     * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
+     */
+    @Suppress("UNCHECKED_CAST")
+    constructor(
+        sourceRef: () -> FxObservableCollection<K, E>,
+        keyExtractor: (E) -> Collection<PK>,
+        valueTransform: (PK, List<E>) -> V,
+        dispatchToFxThread: Boolean = true
+    ) : this(
+        sourceRef = sourceRef,
+        keyExtractor = keyExtractor,
+        dataTransform = valueTransform,
+        fxFactory = { _, staged -> staged as V },
+        dispatchToFxThread = dispatchToFxThread
+    )
+
     init {
         mutationChannel?.let { channel ->
             ReactiveScope.flowScope.launch {
@@ -167,7 +206,12 @@ class TransformedFxMultiKeyProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
             // index, and subscribe each initially-bucketed entity to its mutation events.
             for (key in core.keys) {
                 val bucket = core.bucketSnapshot(key) ?: continue
-                innerObservableMap[key] = valueTransform(key, bucket)
+                val d = dataTransform(key, bucket)
+                try {
+                    innerObservableMap[key] = fxFactory(key, d)
+                } catch (t: Throwable) {
+                    log.error(t) { "fxFactory failed for bucket key=$key during seed; skipping this bucket" }
+                }
                 for (entity in bucket) {
                     entityBuckets.computeIfAbsent(entity.id) { Collections.newSetFromMap(ConcurrentHashMap()) }.add(key)
                     if (!entitySubscriptions.containsKey(entity.id)) {
@@ -202,13 +246,13 @@ class TransformedFxMultiKeyProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
     }
 
     /**
-     * Accumulates [changedKeys] into the pending-update map (precomputing the transform for each
-     * key on the background thread) and schedules a single flush if none is already pending.
+     * Accumulates [changedKeys] into the pending-update map (precomputing the intermediate data for
+     * each key on the background thread) and schedules a single flush if none is already pending.
      * After accumulating keys, checks whether any entities have entered or left all buckets
-     * so that subscriptions can be established or cancelled. The [valueTransform] runs here —
-     * on the calling (background) thread — never on the FX thread. The flush executes on the FX
-     * Application Thread ([Platform.runLater]) or on [ReactiveScope.flowScope] ([mutationChannel]),
-     * depending on [dispatchToFxThread].
+     * so that subscriptions can be established or cancelled. The [dataTransform] runs here —
+     * on the calling (background) thread — never on the FX thread. The [fxFactory] is called later
+     * inside [flush] on the FX Application Thread ([Platform.runLater]) or on
+     * [ReactiveScope.flowScope] ([mutationChannel]), depending on [dispatchToFxThread].
      */
     fun scheduleFlush(changedKeys: Set<PK>) {
         val (newUpdates, newRemovals) = computeTransforms(changedKeys)
@@ -216,12 +260,12 @@ class TransformedFxMultiKeyProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
         stageAndSchedule(newUpdates, newRemovals)
     }
 
-    private fun computeTransforms(changedKeys: Set<PK>): Pair<Map<PK, V>, Set<PK>> {
-        val updates = mutableMapOf<PK, V>()
+    private fun computeTransforms(changedKeys: Set<PK>): Pair<Map<PK, Any?>, Set<PK>> {
+        val updates = mutableMapOf<PK, Any?>()
         val removals = mutableSetOf<PK>()
         for (key in changedKeys) {
             val bucket = core.bucketSnapshot(key)
-            if (bucket == null) removals += key else updates[key] = valueTransform(key, bucket)
+            if (bucket == null) removals += key else updates[key] = dataTransform(key, bucket)
         }
         return Pair(updates, removals)
     }
@@ -256,7 +300,7 @@ class TransformedFxMultiKeyProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
         }
     }
 
-    private fun stageAndSchedule(newUpdates: Map<PK, V>, newRemovals: Set<PK>) {
+    private fun stageAndSchedule(newUpdates: Map<PK, Any?>, newRemovals: Set<PK>) {
         val shouldSchedule: Boolean
         // Stage the computed results into the shared pending structures atomically with respect to
         // flush(). Without this lock, a removal written to pendingRemovals after flush() clears
@@ -281,7 +325,7 @@ class TransformedFxMultiKeyProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
     }
 
     private fun flush() {
-        val updates: Map<PK, V>
+        val updates: Map<PK, Any?>
         val removals: Set<PK>
         // Drain both pending structures and reset the gate atomically with scheduleFlush's staging.
         synchronized(this) {
@@ -294,8 +338,12 @@ class TransformedFxMultiKeyProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
         for (key in removals) {
             innerObservableMap.remove(key)
         }
-        for ((key, value) in updates) {
-            innerObservableMap[key] = value
+        for ((key, d) in updates) {
+            try {
+                innerObservableMap[key] = fxFactory(key, d)
+            } catch (t: Throwable) {
+                log.error(t) { "fxFactory failed for bucket key=$key; skipping this bucket" }
+            }
         }
     }
 

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedFxProjectionMap.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedFxProjectionMap.kt
@@ -24,6 +24,7 @@ import net.transgressoft.lirp.persistence.FxObservableCollection
 import net.transgressoft.lirp.persistence.fx.FxAggregateList
 import net.transgressoft.lirp.persistence.fx.FxAggregateSet
 import net.transgressoft.lirp.persistence.projection.ProjectionMap
+import io.github.oshai.kotlinlogging.KotlinLogging
 import javafx.application.Platform
 import javafx.beans.InvalidationListener
 import javafx.collections.FXCollections
@@ -32,7 +33,6 @@ import javafx.collections.MapChangeListener
 import javafx.collections.ObservableMap
 import javafx.collections.SetChangeListener
 import java.util.Collections
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentSkipListMap
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.concurrent.atomic.AtomicBoolean
@@ -42,27 +42,32 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 
 /**
- * A read-only [ObservableMap] that derives a grouped and value-transformed view from an
+ * A read-only [ObservableMap] that derives a grouped and two-phase value-transformed view from an
  * [FxObservableCollection] source (either an [FxAggregateList] or [FxAggregateSet]).
  *
  * Entities from the source collection are grouped by [keyExtractor] into buckets of type
- * `List<E>`, then the [valueTransform] function maps each `(PK, List<E>)` pair to a value `V`.
+ * `List<E>`, then each non-empty bucket is passed through two phases to produce a value `V`.
  * The result is an `ObservableMap<PK, V>` whose entries stay in sync with the source.
  *
- * The [valueTransform] is invoked on the **background thread** (the thread that delivers the
- * source collection's change event), not on the FX Application Thread. The computed `V` is then
- * staged and mirrored into the [ObservableMap] in a single FX pulse (one [Platform.runLater]
- * call in dispatch mode, one [ReactiveScope.flowScope] channel action otherwise). This separates
- * potentially expensive transform work from the UI-thread rendering step.
+ * 1. **Data extraction** (`dataTransform`, off-thread): runs on the background thread that delivers
+ *    the source collection's change event. Extracts a pure intermediate value from `(PK, List<E>)`.
+ *    Must not read or write any JavaFX property or node.
+ * 2. **FX construction** (`fxFactory`, FX Application Thread): receives the bucket key and the
+ *    intermediate value and constructs the final `V`. Safe to build `SimpleSetProperty`, call
+ *    `.bind(...)`, etc. Invoked exactly once per changed bucket per flush pulse.
  *
- * **Important:** [valueTransform] MUST be a pure, thread-agnostic function. It must not read
- * or write any JavaFX property or node, and must not block the calling thread. Transform output
- * is computed exactly once per affected bucket per source delta.
+ * If `fxFactory` throws for a bucket, the failure is logged (bucket key included) and that one
+ * bucket is skipped; the remaining buckets in the same pulse still flush.
  *
- * Buckets that become empty remove their key from the map (transform is not invoked for absent
- * buckets).
+ * The computed `V` is staged and mirrored into the [ObservableMap] in a single FX pulse (one
+ * [Platform.runLater] call in dispatch mode, one [ReactiveScope.flowScope] channel action
+ * otherwise). This separates potentially expensive transform work from the UI-thread rendering step.
  *
- * The projection initializes lazily on the first [getValue] or [addListener] call.
+ * Buckets that become empty remove their key from the map (neither transform phase is invoked for
+ * absent buckets).
+ *
+ * The projection initializes lazily on the first [getValue] or [addListener] call. The seed loop
+ * runs on the first-access thread: both transform phases are invoked on that thread during seeding.
  *
  * Mutation methods ([put], [remove], [putAll], [clear]) throw [UnsupportedOperationException];
  * all mutations flow through the source collection.
@@ -73,15 +78,23 @@ import kotlinx.coroutines.launch
  * @param V the transform output type
  * @param sourceRef deferred reference to the source [FxObservableCollection]
  * @param keyExtractor grouping function that extracts the projection key from an entity
- * @param valueTransform pure function that maps a non-empty bucket to its display value
+ * @param dataTransform off-thread function that extracts a pure intermediate value from a non-empty
+ *   bucket; must not touch JavaFX observables
+ * @param fxFactory FX-thread function that constructs the final `V` from the bucket key and the
+ *   intermediate value produced by [dataTransform]; safe to build JavaFX property bindings here
  * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
  */
 class TransformedFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V>(
     private val sourceRef: () -> FxObservableCollection<K, E>,
     private val keyExtractor: (E) -> PK,
-    private val valueTransform: (PK, List<E>) -> V,
+    private val dataTransform: (PK, List<E>) -> Any?,
+    @Suppress("UNCHECKED_CAST")
+    private val fxFactory: (PK, Any?) -> V,
     val dispatchToFxThread: Boolean = true
 ) : ObservableMap<PK, V> {
+
+    private val log = KotlinLogging.logger {}
+
     private val innerObservableMap: ObservableMap<PK, V> =
         FXCollections.observableMap(ConcurrentSkipListMap<PK, V>())
 
@@ -100,11 +113,12 @@ class TransformedFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : Ide
     private val initBarrier: CompletableDeferred<Unit>? =
         if (!dispatchToFxThread) CompletableDeferred() else null
 
-    // Pending-flush coalescer — stores precomputed V values for non-empty buckets and tracks
-    // keys of removed (emptied) buckets separately, then flushes both into innerObservableMap
-    // in a single target-thread call per source event burst.
-    // ConcurrentHashMap does not allow null values, so removals are tracked in a separate set.
-    private val pendingUpdates = ConcurrentHashMap<PK, V>()
+    // Pending-flush coalescer — stores precomputed intermediate values (as Any?) for non-empty
+    // buckets and tracks keys of removed (emptied) buckets separately, then flushes both into
+    // innerObservableMap in a single target-thread call per source event burst.
+    // All accesses to pendingUpdates occur inside synchronized(this) blocks, allowing a plain
+    // HashMap that also tolerates null intermediate values from dataTransform.
+    private val pendingUpdates = HashMap<PK, Any?>()
     private val pendingRemovals = CopyOnWriteArraySet<PK>()
     private val flushScheduled = AtomicBoolean(false)
 
@@ -115,6 +129,30 @@ class TransformedFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : Ide
             { sourceRef() as AggregateCollectionRef<K, E> },
             keyExtractor
         )
+
+    /**
+     * Constructs a single-transform projection. [valueTransform] runs entirely off-thread; an
+     * identity [fxFactory] is supplied so the existing off-thread behavior is preserved exactly.
+     *
+     * @param sourceRef deferred reference to the source [FxObservableCollection]
+     * @param keyExtractor grouping function that extracts the projection key from an entity
+     * @param valueTransform pure off-thread function that maps a non-empty bucket to its display
+     *   value; must not touch JavaFX observables
+     * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
+     */
+    @Suppress("UNCHECKED_CAST")
+    constructor(
+        sourceRef: () -> FxObservableCollection<K, E>,
+        keyExtractor: (E) -> PK,
+        valueTransform: (PK, List<E>) -> V,
+        dispatchToFxThread: Boolean = true
+    ) : this(
+        sourceRef = sourceRef,
+        keyExtractor = keyExtractor,
+        dataTransform = valueTransform,
+        fxFactory = { _, staged -> staged as V },
+        dispatchToFxThread = dispatchToFxThread
+    )
 
     init {
         mutationChannel?.let { channel ->
@@ -185,7 +223,12 @@ class TransformedFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : Ide
             backingMap[key] = freezeBucket((backingMap[key] ?: emptyList()) + element)
         }
         for ((key, bucket) in backingMap) {
-            innerObservableMap[key] = valueTransform(key, bucket)
+            val d = dataTransform(key, bucket)
+            try {
+                innerObservableMap[key] = fxFactory(key, d)
+            } catch (t: Throwable) {
+                log.error(t) { "fxFactory failed for bucket key=$key during seed; skipping this bucket" }
+            }
         }
     }
 
@@ -234,20 +277,21 @@ class TransformedFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : Ide
     private fun freezeBucket(elements: List<E>): List<E> = Collections.unmodifiableList(ArrayList(elements))
 
     /**
-     * Precomputes the transformed value for each changed key on the background thread and schedules
+     * Precomputes the intermediate data for each changed key on the background thread and schedules
      * a single flush if none is already pending. Called by the [ProjectionMap] core via
      * `onBucketsChanged` and by the source-collection listeners.
      *
-     * The [valueTransform] runs here — on the calling (background) thread — never on the FX thread.
+     * The [dataTransform] runs here — on the calling (background) thread — never on the FX thread.
+     * The [fxFactory] is called later inside [flush] on the FX Application Thread.
      */
     fun scheduleFlush(changedKeys: Set<PK>) {
         // Compute transforms on the calling (background) thread before acquiring the lock,
-        // keeping potentially expensive valueTransform calls outside of any synchronized region.
-        val newUpdates = mutableMapOf<PK, V>()
+        // keeping potentially expensive dataTransform calls outside of any synchronized region.
+        val newUpdates = mutableMapOf<PK, Any?>()
         val newRemovals = mutableSetOf<PK>()
         for (key in changedKeys) {
             val bucket = backingMap[key]
-            if (bucket == null) newRemovals += key else newUpdates[key] = valueTransform(key, bucket)
+            if (bucket == null) newRemovals += key else newUpdates[key] = dataTransform(key, bucket)
         }
         val shouldSchedule: Boolean
         // Stage the computed results into the shared pending structures atomically with respect to
@@ -273,7 +317,7 @@ class TransformedFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : Ide
     }
 
     private fun flush() {
-        val updates: Map<PK, V>
+        val updates: Map<PK, Any?>
         val removals: Set<PK>
         // Drain both pending structures and reset the gate atomically with scheduleFlush's staging.
         synchronized(this) {
@@ -286,8 +330,12 @@ class TransformedFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : Ide
         for (key in removals) {
             innerObservableMap.remove(key)
         }
-        for ((key, value) in updates) {
-            innerObservableMap[key] = value
+        for ((key, d) in updates) {
+            try {
+                innerObservableMap[key] = fxFactory(key, d)
+            } catch (t: Throwable) {
+                log.error(t) { "fxFactory failed for bucket key=$key; skipping this bucket" }
+            }
         }
     }
 

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjectionMap.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjectionMap.kt
@@ -21,13 +21,13 @@ import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.persistence.Registry
 import net.transgressoft.lirp.persistence.projection.MultiKeyRegistryProjectionMap
+import io.github.oshai.kotlinlogging.KotlinLogging
 import javafx.application.Platform
 import javafx.beans.InvalidationListener
 import javafx.collections.FXCollections
 import javafx.collections.MapChangeListener
 import javafx.collections.ObservableMap
 import java.util.Collections
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentSkipListMap
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.concurrent.atomic.AtomicBoolean
@@ -38,28 +38,34 @@ import kotlinx.coroutines.launch
 
 /**
  * A read-only [ObservableMap] projection that groups all entities from a [Registry] by multiple
- * secondary keys and applies a [valueTransform] to each bucket, producing `ObservableMap<PK, V>`.
+ * secondary keys and applies a two-phase transform to each bucket, producing `ObservableMap<PK, V>`.
  *
  * Unlike [TransformedRegistryFxProjectionMap] (one entity per bucket), this map places each entity
  * under every bucket key that [keyExtractor] returns for it. A `MutableMultiKeyAudioItem` with
  * genres `{Rock, Jazz}` appears in both the `"Rock"` and `"Jazz"` buckets; each non-empty bucket
- * is then passed to [valueTransform] to produce the observable value `V`.
+ * is then passed through two phases to produce the observable value `V`.
  *
- * The [valueTransform] is invoked on the **background thread** (the thread delivering the
- * registry event), not on the FX Application Thread. The computed `V` is staged in a pending map
- * and applied to the [ObservableMap] in a single [Platform.runLater] call (dispatch mode) or one
- * [ReactiveScope.flowScope] channel action (non-dispatch mode), so all bucket changes from one
- * registry event land in exactly one FX pulse.
+ * 1. **Data extraction** (`dataTransform`, off-thread): runs on the background thread that delivers
+ *    the registry event. Extracts a pure intermediate value from `(PK, List<E>)`. Must not
+ *    read or write any JavaFX property or node.
+ * 2. **FX construction** (`fxFactory`, FX Application Thread): receives the bucket key and the
+ *    intermediate value and constructs the final `V`. Safe to build `SimpleSetProperty`, call
+ *    `.bind(...)`, etc. Invoked exactly once per changed bucket per flush pulse.
  *
- * **Important:** [valueTransform] MUST be a pure, thread-agnostic function. It must not read
- * or write any JavaFX property or node, and must not block the calling thread.
+ * If `fxFactory` throws for a bucket, the failure is logged (bucket key included) and that one
+ * bucket is skipped; the remaining buckets in the same pulse still flush.
+ *
+ * The computed `V` is staged in a pending map and applied to the [ObservableMap] in a single
+ * [Platform.runLater] call (dispatch mode) or one [ReactiveScope.flowScope] channel action
+ * (non-dispatch mode), so all bucket changes from one registry event land in exactly one FX pulse.
  *
  * In-place key-set changes (a registry Update that changes an entity's key set) are reflected
  * natively via the core's Update path with add-before-remove ordering — no per-entity mutation
  * subscriptions are needed. Buckets that become empty remove their key from the map. Soft-deleted
  * entities are excluded from all buckets by the core.
  *
- * The projection initializes lazily on the first [getValue] or [addListener] call.
+ * The projection initializes lazily on the first [getValue] or [addListener] call. The seed loop
+ * runs on the first-access thread: both transform phases are invoked on that thread during seeding.
  *
  * Mutation methods ([put], [remove], [putAll], [clear]) throw [UnsupportedOperationException];
  * all mutations flow through the source registry.
@@ -71,15 +77,22 @@ import kotlinx.coroutines.launch
  * @param registry the source registry whose entities are projected
  * @param keyExtractor function that extracts the set of projection keys from an entity;
  *   each returned key names one bucket the entity belongs to
- * @param valueTransform pure function that maps a non-empty bucket to its display value
+ * @param dataTransform off-thread function that extracts a pure intermediate value from a non-empty
+ *   bucket; must not touch JavaFX observables
+ * @param fxFactory FX-thread function that constructs the final `V` from the bucket key and the
+ *   intermediate value produced by [dataTransform]; safe to build JavaFX property bindings here
  * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
  */
 class TransformedRegistryFxMultiKeyProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V>(
     private val registry: Registry<K, E>,
     private val keyExtractor: (E) -> Collection<PK>,
-    private val valueTransform: (PK, List<E>) -> V,
+    private val dataTransform: (PK, List<E>) -> Any?,
+    @Suppress("UNCHECKED_CAST")
+    private val fxFactory: (PK, Any?) -> V,
     val dispatchToFxThread: Boolean = true
 ) : ObservableMap<PK, V>, AutoCloseable {
+
+    private val log = KotlinLogging.logger {}
 
     private val innerObservableMap: ObservableMap<PK, V> =
         FXCollections.observableMap(ConcurrentSkipListMap<PK, V>())
@@ -95,16 +108,41 @@ class TransformedRegistryFxMultiKeyProjectionMap<K : Comparable<K>, PK : Compara
     private val initBarrier: CompletableDeferred<Unit>? =
         if (!dispatchToFxThread) CompletableDeferred() else null
 
-    // Pending-flush coalescer — stores precomputed V values for non-empty buckets and tracks
-    // keys of removed (emptied) buckets separately, then flushes both into innerObservableMap
-    // in a single target-thread call per source event burst.
-    // ConcurrentHashMap does not allow null values, so removals are tracked in a separate set.
-    private val pendingUpdates = ConcurrentHashMap<PK, V>()
+    // Pending-flush coalescer — stores precomputed intermediate values (as Any?) for non-empty
+    // buckets and tracks keys of removed (emptied) buckets separately, then flushes both into
+    // innerObservableMap in a single target-thread call per source event burst.
+    // All accesses to pendingUpdates occur inside synchronized(this) blocks, allowing a plain
+    // HashMap that also tolerates null intermediate values from dataTransform.
+    private val pendingUpdates = HashMap<PK, Any?>()
     private val pendingRemovals = CopyOnWriteArraySet<PK>()
     private val flushScheduled = AtomicBoolean(false)
 
     private val core: MultiKeyRegistryProjectionMap<K, PK, E> =
         MultiKeyRegistryProjectionMap(registry, keyExtractor)
+
+    /**
+     * Constructs a single-transform projection. [valueTransform] runs entirely off-thread; an
+     * identity [fxFactory] is supplied so the existing off-thread behavior is preserved exactly.
+     *
+     * @param registry the source registry whose entities are projected
+     * @param keyExtractor function that extracts the set of projection keys from an entity
+     * @param valueTransform pure off-thread function that maps a non-empty bucket to its display
+     *   value; must not touch JavaFX observables
+     * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
+     */
+    @Suppress("UNCHECKED_CAST")
+    constructor(
+        registry: Registry<K, E>,
+        keyExtractor: (E) -> Collection<PK>,
+        valueTransform: (PK, List<E>) -> V,
+        dispatchToFxThread: Boolean = true
+    ) : this(
+        registry = registry,
+        keyExtractor = keyExtractor,
+        dataTransform = valueTransform,
+        fxFactory = { _, staged -> staged as V },
+        dispatchToFxThread = dispatchToFxThread
+    )
 
     init {
         mutationChannel?.let { channel ->
@@ -126,10 +164,15 @@ class TransformedRegistryFxMultiKeyProjectionMap<K : Comparable<K>, PK : Compara
             // schedule a flush — the seed is applied directly to innerObservableMap below.
             core.size
 
-            // Synchronously seed innerObservableMap by applying the transform to each initial bucket.
+            // Seed innerObservableMap by applying both transform phases to each initial bucket.
             for (key in core.keys) {
                 val bucket = core.bucketSnapshot(key) ?: continue
-                innerObservableMap[key] = valueTransform(key, bucket)
+                val d = dataTransform(key, bucket)
+                try {
+                    innerObservableMap[key] = fxFactory(key, d)
+                } catch (t: Throwable) {
+                    log.error(t) { "fxFactory failed for bucket key=$key during seed; skipping this bucket" }
+                }
             }
 
             // Wire the coalescer after the initial seed so that only incremental (post-init) changes
@@ -142,19 +185,20 @@ class TransformedRegistryFxMultiKeyProjectionMap<K : Comparable<K>, PK : Compara
     }
 
     /**
-     * Precomputes the transformed value for each changed key on the background thread and schedules
+     * Precomputes the intermediate data for each changed key on the background thread and schedules
      * a single flush if none is already pending. Called by the [MultiKeyRegistryProjectionMap] core
      * via `onBucketsChanged` for creates, deletes, and bucket key changes.
      *
-     * The [valueTransform] runs here — on the calling (background) thread — never on the FX thread.
+     * The [dataTransform] runs here — on the calling (background) thread — never on the FX thread.
+     * The [fxFactory] is called later inside [flush] on the FX Application Thread.
      */
     fun scheduleFlush(changedKeys: Set<PK>) {
         // Compute transforms on the calling (background) thread before acquiring the lock.
-        val newUpdates = mutableMapOf<PK, V>()
+        val newUpdates = mutableMapOf<PK, Any?>()
         val newRemovals = mutableSetOf<PK>()
         for (key in changedKeys) {
             val bucket = core.bucketSnapshot(key)
-            if (bucket == null) newRemovals += key else newUpdates[key] = valueTransform(key, bucket)
+            if (bucket == null) newRemovals += key else newUpdates[key] = dataTransform(key, bucket)
         }
         val shouldSchedule: Boolean
         // Stage the computed results into the shared pending structures atomically with respect to
@@ -180,7 +224,7 @@ class TransformedRegistryFxMultiKeyProjectionMap<K : Comparable<K>, PK : Compara
     }
 
     private fun flush() {
-        val updates: Map<PK, V>
+        val updates: Map<PK, Any?>
         val removals: Set<PK>
         // Drain both pending structures and reset the gate atomically with scheduleFlush's staging.
         synchronized(this) {
@@ -193,8 +237,12 @@ class TransformedRegistryFxMultiKeyProjectionMap<K : Comparable<K>, PK : Compara
         for (key in removals) {
             innerObservableMap.remove(key)
         }
-        for ((key, value) in updates) {
-            innerObservableMap[key] = value
+        for ((key, d) in updates) {
+            try {
+                innerObservableMap[key] = fxFactory(key, d)
+            } catch (t: Throwable) {
+                log.error(t) { "fxFactory failed for bucket key=$key; skipping this bucket" }
+            }
         }
     }
 

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjectionMap.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjectionMap.kt
@@ -24,12 +24,12 @@ import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.event.StandardCrudEvent
 import net.transgressoft.lirp.persistence.Registry
 import net.transgressoft.lirp.persistence.projection.RegistryProjectionMap
+import io.github.oshai.kotlinlogging.KotlinLogging
 import javafx.application.Platform
 import javafx.beans.InvalidationListener
 import javafx.collections.FXCollections
 import javafx.collections.MapChangeListener
 import javafx.collections.ObservableMap
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentSkipListMap
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.concurrent.atomic.AtomicBoolean
@@ -40,27 +40,34 @@ import kotlinx.coroutines.launch
 
 /**
  * A read-only [ObservableMap] projection that groups all entities from a [Registry] by a
- * secondary key and applies a [valueTransform] to each bucket, producing `ObservableMap<PK, V>`.
+ * secondary key and applies a two-phase transform to each bucket, producing `ObservableMap<PK, V>`.
  *
  * Entities are grouped by [keyExtractor] into frozen `List<E>` buckets, then each non-empty
- * bucket is passed to [valueTransform] to produce the observable value `V`. The projection
- * stays in sync with the registry: creates, deletes, and key-change Updates re-bucket entities;
- * same-key Updates recompute the transform for the affected bucket.
+ * bucket is passed through two phases to produce the observable value `V`:
  *
- * The [valueTransform] is invoked on the **background thread** (the thread delivering the
- * registry [CrudEvent]), not on the FX Application Thread. The computed `V` is staged in
- * a pending map and applied to the [ObservableMap] in a single [Platform.runLater] call
- * (dispatch mode) or one [ReactiveScope.flowScope] channel action (non-dispatch mode),
- * so all bucket changes from one registry event land in exactly one FX pulse.
+ * 1. **Data extraction** (`dataTransform`, off-thread): runs on the background thread that delivers
+ *    the registry event. Extracts a pure intermediate value from `(PK, List<E>)`. Must not
+ *    read or write any JavaFX property or node.
+ * 2. **FX construction** (`fxFactory`, FX Application Thread): receives the bucket key and the
+ *    intermediate value and constructs the final `V`. Safe to build `SimpleSetProperty`, call
+ *    `.bind(...)`, etc. Invoked exactly once per changed bucket per flush pulse.
  *
- * **Important:** [valueTransform] MUST be a pure, thread-agnostic function. It must not read
- * or write any JavaFX property or node, and must not block the calling thread.
+ * If `fxFactory` throws for a bucket, the failure is logged (bucket key included) and that one
+ * bucket is skipped; the remaining buckets in the same pulse still flush.
  *
- * Buckets that become empty remove their key from the map (transform is not invoked for
+ * The projection stays in sync with the registry: creates, deletes, and key-change Updates
+ * re-bucket entities; same-key Updates recompute the transform for the affected bucket.
+ *
+ * The computed `V` is staged in a pending map and applied to the [ObservableMap] in a single
+ * [Platform.runLater] call (dispatch mode) or one [ReactiveScope.flowScope] channel action
+ * (non-dispatch mode), so all bucket changes from one registry event land in exactly one FX pulse.
+ *
+ * Buckets that become empty remove their key from the map (neither transform phase is invoked for
  * absent buckets). Soft-deleted entities ([SoftDeletable] with non-null [deletedAt]) are
  * excluded from all buckets.
  *
- * The projection initializes lazily on the first [getValue] or [addListener] call.
+ * The projection initializes lazily on the first [getValue] or [addListener] call. The seed loop
+ * runs on the first-access thread: both transform phases are invoked on that thread during seeding.
  *
  * Mutation methods ([put], [remove], [putAll], [clear]) throw [UnsupportedOperationException];
  * all mutations flow through the source registry.
@@ -76,15 +83,23 @@ import kotlinx.coroutines.launch
  * @param V the transform output type
  * @param registry the source registry to project
  * @param keyExtractor grouping function that extracts the projection key from an entity
- * @param valueTransform pure function that maps a non-empty bucket to its display value
+ * @param dataTransform off-thread function that extracts a pure intermediate value from a non-empty
+ *   bucket; must not touch JavaFX observables
+ * @param fxFactory FX-thread function that constructs the final `V` from the bucket key and the
+ *   intermediate value produced by [dataTransform]; safe to build JavaFX property bindings here
  * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
  */
 class TransformedRegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V>(
     private val registry: Registry<K, E>,
     private val keyExtractor: (E) -> PK,
-    private val valueTransform: (PK, List<E>) -> V,
+    private val dataTransform: (PK, List<E>) -> Any?,
+    @Suppress("UNCHECKED_CAST")
+    private val fxFactory: (PK, Any?) -> V,
     val dispatchToFxThread: Boolean = true
 ) : ObservableMap<PK, V>, AutoCloseable {
+
+    private val log = KotlinLogging.logger {}
+
     private val innerObservableMap: ObservableMap<PK, V> =
         FXCollections.observableMap(ConcurrentSkipListMap<PK, V>())
 
@@ -99,11 +114,12 @@ class TransformedRegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
     private val initBarrier: CompletableDeferred<Unit>? =
         if (!dispatchToFxThread) CompletableDeferred() else null
 
-    // Pending-flush coalescer — stores precomputed V values for non-empty buckets and tracks
-    // keys of removed (emptied) buckets separately, then flushes both into innerObservableMap
-    // in a single target-thread call per source event burst.
-    // ConcurrentHashMap does not allow null values, so removals are tracked in a separate set.
-    private val pendingUpdates = ConcurrentHashMap<PK, V>()
+    // Pending-flush coalescer — stores precomputed intermediate values (as Any?) for non-empty
+    // buckets and tracks keys of removed (emptied) buckets separately, then flushes both into
+    // innerObservableMap in a single target-thread call per source event burst.
+    // All accesses to pendingUpdates occur inside synchronized(this) blocks, allowing a plain
+    // HashMap that also tolerates null intermediate values from dataTransform.
+    private val pendingUpdates = HashMap<PK, Any?>()
     private val pendingRemovals = CopyOnWriteArraySet<PK>()
     private val flushScheduled = AtomicBoolean(false)
 
@@ -113,6 +129,30 @@ class TransformedRegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
     // core's equality guard skips the bucket update (oldEntity === newEntity after in-place write).
     // Without this, a title-only field change would produce no flush and no MapChangeListener call.
     private var updateSubscription: LirpEventSubscription<*, *, *>? = null
+
+    /**
+     * Constructs a single-transform projection. [valueTransform] runs entirely off-thread; an
+     * identity [fxFactory] is supplied so the existing off-thread behavior is preserved exactly.
+     *
+     * @param registry the source registry to project
+     * @param keyExtractor grouping function that extracts the projection key from an entity
+     * @param valueTransform pure off-thread function that maps a non-empty bucket to its display
+     *   value; must not touch JavaFX observables
+     * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
+     */
+    @Suppress("UNCHECKED_CAST")
+    constructor(
+        registry: Registry<K, E>,
+        keyExtractor: (E) -> PK,
+        valueTransform: (PK, List<E>) -> V,
+        dispatchToFxThread: Boolean = true
+    ) : this(
+        registry = registry,
+        keyExtractor = keyExtractor,
+        dataTransform = valueTransform,
+        fxFactory = { _, staged -> staged as V },
+        dispatchToFxThread = dispatchToFxThread
+    )
 
     init {
         mutationChannel?.let { channel ->
@@ -132,27 +172,12 @@ class TransformedRegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
             // Trigger core initialization (seeds from registry, subscribes to CrudEvents).
             core.size
 
-            // Seed innerObservableMap by applying the transform to each initial bucket.
-            for (key in core.keys) {
-                val bucket = core.bucketSnapshot(key)
-                if (bucket != null) innerObservableMap[key] = valueTransform(key, bucket)
-            }
+            seedInitialBuckets()
 
             // Wire the coalescer after the initial seed.
             core.addOnBucketsChangedListener(::scheduleFlush)
 
-            // Guarantee MapChangeListener fires for in-place entity mutations. When a field is
-            // assigned on the live entity reference already stored in the bucket, the core skips
-            // the bucket update (equality guard), so onBucketsChanged never fires. This subscription
-            // catches those cases: it precomputes the new V on the background thread and enqueues
-            // a flush so FX listeners observe the updated transform result.
-            updateSubscription =
-                registry.subscribeAsync(CrudEvent.Type.UPDATE) { event ->
-                    if (event is StandardCrudEvent.Update) {
-                        val keysToFlush = event.entities.values.map(keyExtractor).toSet()
-                        if (keysToFlush.isNotEmpty()) scheduleFlushForUpdates(keysToFlush)
-                    }
-                }
+            subscribeToInPlaceUpdates()
 
             initBarrier?.complete(Unit)
             initialized = true
@@ -160,11 +185,46 @@ class TransformedRegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
     }
 
     /**
-     * Precomputes the transformed value for each changed key on the background thread and schedules
+     * Seeds [innerObservableMap] by applying both transform phases to each initial bucket on the
+     * first-access thread. A throwing [fxFactory] is logged with the bucket key and that one bucket
+     * is skipped, matching the per-bucket fault isolation of [flush].
+     */
+    private fun seedInitialBuckets() {
+        for (key in core.keys) {
+            val bucket = core.bucketSnapshot(key) ?: continue
+            val d = dataTransform(key, bucket)
+            try {
+                innerObservableMap[key] = fxFactory(key, d)
+            } catch (t: Throwable) {
+                log.error(t) { "fxFactory failed for bucket key=$key during seed; skipping this bucket" }
+            }
+        }
+    }
+
+    /**
+     * Guarantees a [MapChangeListener] fires for in-place entity mutations. When a field is assigned
+     * on the live entity reference already stored in the bucket, the core skips the bucket update
+     * (equality guard), so `onBucketsChanged` never fires. This subscription precomputes the new
+     * intermediate value on the background thread and enqueues a flush so FX listeners observe the
+     * updated transform result.
+     */
+    private fun subscribeToInPlaceUpdates() {
+        updateSubscription =
+            registry.subscribeAsync(CrudEvent.Type.UPDATE) { event ->
+                if (event is StandardCrudEvent.Update) {
+                    val keysToFlush = event.entities.values.map(keyExtractor).toSet()
+                    if (keysToFlush.isNotEmpty()) scheduleFlushForUpdates(keysToFlush)
+                }
+            }
+    }
+
+    /**
+     * Precomputes the intermediate data for each changed key on the background thread and schedules
      * a single flush if none is already pending. Called by the [RegistryProjectionMap] core via
      * `onBucketsChanged` for creates, deletes, and bucket key changes.
      *
-     * The [valueTransform] runs here — on the calling (background) thread — never on the FX thread.
+     * The [dataTransform] runs here — on the calling (background) thread — never on the FX thread.
+     * The [fxFactory] is called later inside [flush] on the FX Application Thread.
      */
     fun scheduleFlush(changedKeys: Set<PK>) {
         val (newUpdates, newRemovals) = computeTransforms(changedKeys)
@@ -172,7 +232,7 @@ class TransformedRegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
     }
 
     /**
-     * Precomputes the transformed value for in-place Update events where `onBucketsChanged` was
+     * Precomputes the intermediate data for in-place Update events where `onBucketsChanged` was
      * not called because the core's equality guard detected no structural bucket change.
      * Keys already staged by a concurrent `onBucketsChanged` call are skipped inside the lock
      * to avoid overwriting a newer bucket state with a stale in-place update.
@@ -183,20 +243,20 @@ class TransformedRegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
         if (newUpdates.isNotEmpty() || newRemovals.isNotEmpty()) stageAndSchedule(newUpdates, newRemovals)
     }
 
-    private fun computeTransforms(keys: Set<PK>): Pair<Map<PK, V>, Set<PK>> {
-        val updates = mutableMapOf<PK, V>()
+    private fun computeTransforms(keys: Set<PK>): Pair<Map<PK, Any?>, Set<PK>> {
+        val updates = mutableMapOf<PK, Any?>()
         val removals = mutableSetOf<PK>()
         for (key in keys) {
             val bucket = core.bucketSnapshot(key)
-            if (bucket == null) removals += key else updates[key] = valueTransform(key, bucket)
+            if (bucket == null) removals += key else updates[key] = dataTransform(key, bucket)
         }
         return Pair(updates, removals)
     }
 
     // Inside the lock, skip keys that onBucketsChanged has already staged to avoid
     // overwriting a structurally-different bucket update with a stale in-place snapshot.
-    private fun filterCandidates(candidateUpdates: Map<PK, V>, candidateRemovals: Set<PK>): Pair<Map<PK, V>, Set<PK>> {
-        val newUpdates = mutableMapOf<PK, V>()
+    private fun filterCandidates(candidateUpdates: Map<PK, Any?>, candidateRemovals: Set<PK>): Pair<Map<PK, Any?>, Set<PK>> {
+        val newUpdates = mutableMapOf<PK, Any?>()
         val newRemovals = mutableSetOf<PK>()
         synchronized(this) {
             for (key in candidateRemovals) {
@@ -209,7 +269,7 @@ class TransformedRegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
         return Pair(newUpdates, newRemovals)
     }
 
-    private fun stageAndSchedule(newUpdates: Map<PK, V>, newRemovals: Set<PK>) {
+    private fun stageAndSchedule(newUpdates: Map<PK, Any?>, newRemovals: Set<PK>) {
         val shouldSchedule: Boolean
         // Stage the computed results into the shared pending structures atomically with respect to
         // flush(). Without this lock, a removal written to pendingRemovals after flush() clears
@@ -234,7 +294,7 @@ class TransformedRegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
     }
 
     private fun flush() {
-        val updates: Map<PK, V>
+        val updates: Map<PK, Any?>
         val removals: Set<PK>
         // Drain both pending structures and reset the gate atomically so a concurrent scheduleFlush
         // arriving between the two clear() calls cannot be lost. Without this lock a removal
@@ -251,8 +311,12 @@ class TransformedRegistryFxProjectionMap<K : Comparable<K>, PK : Comparable<PK>,
         for (key in removals) {
             innerObservableMap.remove(key)
         }
-        for ((key, value) in updates) {
-            innerObservableMap[key] = value
+        for ((key, d) in updates) {
+            try {
+                innerObservableMap[key] = fxFactory(key, d)
+            } catch (t: Throwable) {
+                log.error(t) { "fxFactory failed for bucket key=$key; skipping this bucket" }
+            }
         }
     }
 

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/AlbumFxView.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/AlbumFxView.kt
@@ -1,0 +1,44 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx.projection
+
+import net.transgressoft.lirp.persistence.AudioItem
+import javafx.beans.property.ReadOnlyBooleanWrapper
+import javafx.beans.property.SimpleSetProperty
+import javafx.collections.FXCollections
+
+/**
+ * FX-backed projection value type used by two-phase transform tests.
+ *
+ * Wraps a [SimpleSetProperty] populated from [items] and a [ReadOnlyBooleanWrapper] bound
+ * to a non-empty condition via [bind]. Construction touches JavaFX observables, so it is only
+ * safe to call from the FX Application Thread.
+ *
+ * The [items] parameter accepts any entity list; single-key projection tests pass [AudioItem]
+ * instances while multi-key projection tests pass any entity type that the source produces.
+ */
+@Suppress("UNCHECKED_CAST")
+class AlbumFxView(val albumName: String, items: List<*>) {
+    val trackSet: SimpleSetProperty<Any> =
+        SimpleSetProperty(FXCollections.observableSet(items.toHashSet() as HashSet<Any>))
+    val hasTracksProperty: ReadOnlyBooleanWrapper =
+        ReadOnlyBooleanWrapper().also {
+            it.bind(trackSet.emptyProperty().not())
+        }
+    val hasTracks: Boolean get() = hasTracksProperty.get()
+}

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxMultiKeyProjectionMapTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxMultiKeyProjectionMapTest.kt
@@ -33,6 +33,7 @@ import io.kotest.matchers.shouldBe
 import javafx.application.Platform
 import javafx.beans.InvalidationListener
 import javafx.collections.MapChangeListener
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -387,6 +388,92 @@ class FxMultiKeyProjectionMapTest : StringSpec({
 
         projection.close()
         projection.entitySubscriptions.isEmpty() shouldBe true
+    }
+
+    "TransformedFxMultiKeyProjectionMap two-phase dataTransform runs off FX thread and fxFactory runs on FX thread building a real FX value" {
+        val source = fxAggregateList<Int, MutableMultiKeyAudioItem>(dispatchToFxThread = false)
+        val dataTransformThreadFlags = CopyOnWriteArrayList<Boolean>()
+        val fxFactoryThreadFlags = CopyOnWriteArrayList<Boolean>()
+
+        val pulseLatch = CountDownLatch(1)
+        val projection =
+            fxMultiKeyProjectionMap(
+                sourceRef = { source },
+                keyExtractor = { it.genres },
+                dataTransform = { _, items ->
+                    dataTransformThreadFlags.add(Platform.isFxApplicationThread())
+                    items.toList()
+                },
+                fxFactory = { genre, items ->
+                    fxFactoryThreadFlags.add(Platform.isFxApplicationThread())
+                    AlbumFxView(genre, items)
+                },
+                dispatchToFxThread = true
+            )
+        projection.addListener(
+            MapChangeListener {
+                pulseLatch.countDown()
+            }
+        )
+
+        // Add item from the test thread so dataTransform runs on the source-event thread (test
+        // thread, off FX thread), while fxFactory runs on the FX thread via Platform.runLater.
+        source.add(0, MutableMultiKeyAudioItem(1, "Track A", setOf("Rock")))
+        pulseLatch.await(5, TimeUnit.SECONDS) shouldBe true
+
+        dataTransformThreadFlags.isNotEmpty() shouldBe true
+        dataTransformThreadFlags.all { !it } shouldBe true
+        fxFactoryThreadFlags.isNotEmpty() shouldBe true
+        fxFactoryThreadFlags.all { it } shouldBe true
+        val view = projection["Rock"] as AlbumFxView
+        view.hasTracks shouldBe true
+    }
+
+    "TransformedFxMultiKeyProjectionMap fxFactory failure in one bucket does not prevent other buckets from flushing" {
+        val source = fxAggregateList<Int, MutableMultiKeyAudioItem>(dispatchToFxThread = false)
+        val projection =
+            fxMultiKeyProjectionMap(
+                sourceRef = { source },
+                keyExtractor = { it.genres },
+                dataTransform = { _, items -> items.toList() },
+                fxFactory = { genre, items ->
+                    if (genre == "Jazz") error("injected fxFactory failure")
+                    AlbumFxView(genre, items)
+                },
+                dispatchToFxThread = false
+            )
+        projection.addListener(MapChangeListener { })
+
+        source.add(0, MutableMultiKeyAudioItem(1, "Track A", setOf("Rock", "Jazz")))
+
+        projection.containsKey("Jazz") shouldBe false
+        projection.containsKey("Rock") shouldBe true
+        val view = projection["Rock"] as AlbumFxView
+        view.hasTracks shouldBe true
+    }
+
+    "TransformedFxMultiKeyProjectionMap single valueTransform overload runs off FX thread preserving backward compatibility" {
+        val source = fxAggregateList<Int, MutableMultiKeyAudioItem>(dispatchToFxThread = false)
+        val transformedOnFxThread = CopyOnWriteArrayList<Boolean>()
+        val projection =
+            TransformedFxMultiKeyProjectionMap(
+                { source },
+                { it.genres },
+                { pk, items ->
+                    transformedOnFxThread.add(Platform.isFxApplicationThread())
+                    "[$pk:${items.size}]"
+                },
+                false
+            )
+        projection.addListener(MapChangeListener { })
+
+        source.add(0, MutableMultiKeyAudioItem(1, "Track A", setOf("Rock", "Jazz")))
+        source.add(1, MutableMultiKeyAudioItem(2, "Track B", setOf("Rock")))
+
+        transformedOnFxThread.isNotEmpty() shouldBe true
+        transformedOnFxThread.all { !it } shouldBe true
+        projection["Rock"] shouldBe "[Rock:2]"
+        projection["Jazz"] shouldBe "[Jazz:1]"
     }
 
     "FxMultiKeyProjectionMap iterates without ConcurrentModificationException under concurrent multi-key churn"

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionMapTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionMapTest.kt
@@ -35,6 +35,7 @@ import javafx.application.Platform
 import javafx.beans.InvalidationListener
 import javafx.collections.MapChangeListener
 import javafx.collections.ObservableMap
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -616,6 +617,113 @@ class FxProjectionMapTest : StringSpec({
         transformOnFxThread.all { !it } shouldBe true
         listenerOnFxThread.isNotEmpty() shouldBe true
         listenerOnFxThread.all { it } shouldBe true
+    }
+
+    "TransformedFxProjectionMap two-phase dataTransform runs off FX thread and fxFactory runs on FX thread building a real FX value" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val dataTransformThreadFlags = CopyOnWriteArrayList<Boolean>()
+        val fxFactoryThreadFlags = CopyOnWriteArrayList<Boolean>()
+
+        val pulseLatch = CountDownLatch(1)
+        val projection =
+            fxProjectionMap(
+                sourceRef = { source },
+                keyExtractor = { it.albumName },
+                dataTransform = { _, items ->
+                    dataTransformThreadFlags.add(Platform.isFxApplicationThread())
+                    items.toList()
+                },
+                fxFactory = { albumName, items ->
+                    fxFactoryThreadFlags.add(Platform.isFxApplicationThread())
+                    AlbumFxView(albumName, items)
+                },
+                dispatchToFxThread = true
+            )
+        projection.addListener(
+            MapChangeListener {
+                pulseLatch.countDown()
+            }
+        )
+
+        source.add(0, FxAudioItem(1, "Track A", "Jazz"))
+        pulseLatch.await(5, TimeUnit.SECONDS) shouldBe true
+
+        dataTransformThreadFlags.isNotEmpty() shouldBe true
+        dataTransformThreadFlags.all { !it } shouldBe true
+        fxFactoryThreadFlags.isNotEmpty() shouldBe true
+        fxFactoryThreadFlags.all { it } shouldBe true
+        val view = projection["Jazz"] as AlbumFxView
+        view.hasTracks shouldBe true
+    }
+
+    "TransformedFxProjectionMap fxFactory failure in one bucket does not prevent other buckets from flushing" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val projection =
+            fxProjectionMap(
+                sourceRef = { source },
+                keyExtractor = { it.albumName },
+                dataTransform = { _, items -> items.toList() },
+                fxFactory = { albumName, items ->
+                    if (albumName == "Jazz") error("injected fxFactory failure")
+                    AlbumFxView(albumName, items)
+                },
+                dispatchToFxThread = false
+            )
+        projection.addListener(MapChangeListener { })
+
+        source.add(0, FxAudioItem(1, "Track A", "Jazz"))
+        source.add(1, FxAudioItem(2, "Track B", "Rock"))
+
+        projection.containsKey("Jazz") shouldBe false
+        projection.containsKey("Rock") shouldBe true
+        val view = projection["Rock"] as AlbumFxView
+        view.hasTracks shouldBe true
+    }
+
+    "TransformedFxProjectionMap fxFactory failure during initial seed skips only that bucket and leaves the projection usable" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        source.add(0, FxAudioItem(1, "Track A", "Jazz"))
+        source.add(1, FxAudioItem(2, "Track B", "Rock"))
+
+        val projection =
+            fxProjectionMap(
+                sourceRef = { source },
+                keyExtractor = { it.albumName },
+                dataTransform = { _, items -> items.toList() },
+                fxFactory = { albumName, items ->
+                    if (albumName == "Jazz") error("injected fxFactory failure during seed")
+                    AlbumFxView(albumName, items)
+                },
+                dispatchToFxThread = false
+            )
+
+        // First access triggers the lazy seed loop; a throwing fxFactory must not escape it.
+        projection.containsKey("Rock") shouldBe true
+        projection.containsKey("Jazz") shouldBe false
+        (projection["Rock"] as AlbumFxView).hasTracks shouldBe true
+    }
+
+    "TransformedFxProjectionMap single valueTransform overload runs off FX thread preserving backward compatibility" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val transformedOnFxThread = CopyOnWriteArrayList<Boolean>()
+        val projection =
+            TransformedFxProjectionMap(
+                { source },
+                { it.albumName },
+                { pk, items ->
+                    transformedOnFxThread.add(Platform.isFxApplicationThread())
+                    FxAlbumBucket(pk, items.map { it.title }.sorted())
+                },
+                false
+            )
+        projection.addListener(MapChangeListener { })
+
+        source.add(0, FxAudioItem(1, "Track A", "Jazz"))
+        source.add(1, FxAudioItem(2, "Track B", "Jazz"))
+
+        transformedOnFxThread.isNotEmpty() shouldBe true
+        transformedOnFxThread.all { !it } shouldBe true
+        projection["Jazz"] shouldBe FxAlbumBucket("Jazz", listOf("Track A", "Track B"))
     }
 
     "FxProjectionMap iterates without ConcurrentModificationException under concurrent reader and writer stress"

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjectionMapTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjectionMapTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.shouldBe
 import javafx.application.Platform
 import javafx.collections.MapChangeListener
 import java.time.Instant
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -340,5 +341,111 @@ class RegistryFxMultiKeyProjectionMapTest : StringSpec({
 
         projection.containsKey("Rock") shouldBe true
         projection.containsKey("Jazz") shouldBe false
+    }
+
+    "TransformedRegistryFxMultiKeyProjectionMap two-phase dataTransform runs off FX thread and fxFactory runs on FX thread building a real FX value" {
+        val dataTransformThreadFlags = CopyOnWriteArrayList<Boolean>()
+        val fxFactoryThreadFlags = CopyOnWriteArrayList<Boolean>()
+
+        val pulseLatch = CountDownLatch(1)
+        val projection =
+            registryFxMultiKeyProjectionMap(
+                trackRepo,
+                { it.genres },
+                dataTransform = { _, items ->
+                    dataTransformThreadFlags.add(Platform.isFxApplicationThread())
+                    items.toList()
+                },
+                fxFactory = { genre, items ->
+                    fxFactoryThreadFlags.add(Platform.isFxApplicationThread())
+                    AlbumFxView(genre, items)
+                },
+                dispatchToFxThread = true
+            )
+        projection.addListener(
+            MapChangeListener {
+                pulseLatch.countDown()
+            }
+        )
+
+        // Create the entity from the test thread so dataTransform runs on the background
+        // registry-event coroutine (off FX thread), and fxFactory runs on the FX thread via
+        // Platform.runLater inside flush().
+        trackRepo.create(1, "Track A", setOf("Rock"))
+        pulseLatch.await(5, TimeUnit.SECONDS) shouldBe true
+
+        dataTransformThreadFlags.isNotEmpty() shouldBe true
+        dataTransformThreadFlags.all { !it } shouldBe true
+        fxFactoryThreadFlags.isNotEmpty() shouldBe true
+        fxFactoryThreadFlags.all { it } shouldBe true
+        val view = projection["Rock"] as AlbumFxView
+        view.hasTracks shouldBe true
+    }
+
+    "TransformedRegistryFxMultiKeyProjectionMap fxFactory failure in one bucket does not prevent other buckets from flushing" {
+        val projection =
+            registryFxMultiKeyProjectionMap(
+                trackRepo,
+                { it.genres },
+                dataTransform = { _, items -> items.toList() },
+                fxFactory = { genre, items ->
+                    if (genre == "Jazz") error("injected fxFactory failure")
+                    AlbumFxView(genre, items)
+                },
+                dispatchToFxThread = false
+            )
+        projection.addListener(MapChangeListener { })
+
+        trackRepo.create(1, "Track A", setOf("Rock", "Jazz"))
+        reactive.advance()
+
+        projection.containsKey("Jazz") shouldBe false
+        projection.containsKey("Rock") shouldBe true
+        val view = projection["Rock"] as AlbumFxView
+        view.hasTracks shouldBe true
+    }
+
+    "TransformedRegistryFxMultiKeyProjectionMap fxFactory failure during initial seed skips only that bucket and leaves the projection usable" {
+        trackRepo.create(1, "Track A", setOf("Rock", "Jazz"))
+
+        val projection =
+            registryFxMultiKeyProjectionMap(
+                trackRepo,
+                { it.genres },
+                dataTransform = { _, items -> items.toList() },
+                fxFactory = { genre, items ->
+                    if (genre == "Jazz") error("injected fxFactory failure during seed")
+                    AlbumFxView(genre, items)
+                },
+                dispatchToFxThread = false
+            )
+
+        // First access triggers the lazy seed loop; a throwing fxFactory must not escape it.
+        projection.containsKey("Rock") shouldBe true
+        projection.containsKey("Jazz") shouldBe false
+        (projection["Rock"] as AlbumFxView).hasTracks shouldBe true
+    }
+
+    "TransformedRegistryFxMultiKeyProjectionMap single valueTransform overload runs off FX thread preserving backward compatibility" {
+        val transformedOnFxThread = CopyOnWriteArrayList<Boolean>()
+        trackRepo.create(1, "Track A", setOf("Rock"))
+        trackRepo.create(2, "Track B", setOf("Rock", "Jazz"))
+
+        val projection =
+            TransformedRegistryFxMultiKeyProjectionMap(
+                trackRepo,
+                { it.genres },
+                { pk, items ->
+                    transformedOnFxThread.add(Platform.isFxApplicationThread())
+                    "[$pk:${items.size}]"
+                },
+                false
+            )
+        projection.addListener(MapChangeListener { })
+
+        transformedOnFxThread.isNotEmpty() shouldBe true
+        transformedOnFxThread.all { !it } shouldBe true
+        projection["Rock"] shouldBe "[Rock:2]"
+        projection["Jazz"] shouldBe "[Jazz:1]"
     }
 })

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionMapTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionMapTest.kt
@@ -33,6 +33,7 @@ import javafx.application.Platform
 import javafx.beans.InvalidationListener
 import javafx.collections.MapChangeListener
 import java.time.Instant
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -575,5 +576,119 @@ class RegistryFxProjectionMapTest : StringSpec({
 
         projection.containsKey("Rock") shouldBe false
         projection.size shouldBe 1
+    }
+
+    "TransformedRegistryFxProjectionMap two-phase dataTransform runs off FX thread and fxFactory runs on FX thread building a real FX value" {
+        val dataTransformThreadFlags = CopyOnWriteArrayList<Boolean>()
+        val fxFactoryThreadFlags = CopyOnWriteArrayList<Boolean>()
+
+        val pulseLatch = CountDownLatch(1)
+        val projection =
+            registryFxProjectionMap(
+                trackRepo,
+                AudioItem::albumName,
+                dataTransform = { _, items ->
+                    dataTransformThreadFlags.add(Platform.isFxApplicationThread())
+                    items.toList()
+                },
+                fxFactory = { albumName, items ->
+                    fxFactoryThreadFlags.add(Platform.isFxApplicationThread())
+                    AlbumFxView(albumName, items)
+                },
+                dispatchToFxThread = true
+            )
+        projection.addListener(
+            MapChangeListener {
+                pulseLatch.countDown()
+            }
+        )
+
+        // Create the entity from the test thread (not the FX thread) so dataTransform runs
+        // on the background registry-event coroutine (off FX thread), and fxFactory runs on
+        // the FX thread via Platform.runLater inside flush().
+        trackRepo.create(1, "Track A", "Jazz")
+        pulseLatch.await(5, TimeUnit.SECONDS) shouldBe true
+
+        dataTransformThreadFlags.isNotEmpty() shouldBe true
+        dataTransformThreadFlags.all { !it } shouldBe true
+        fxFactoryThreadFlags.isNotEmpty() shouldBe true
+        fxFactoryThreadFlags.all { it } shouldBe true
+        val view = projection["Jazz"] as AlbumFxView
+        view.hasTracks shouldBe true
+    }
+
+    "TransformedRegistryFxProjectionMap fxFactory failure in one bucket does not prevent other buckets from flushing" {
+        val projection =
+            registryFxProjectionMap(
+                trackRepo,
+                AudioItem::albumName,
+                dataTransform = { _, items -> items.toList() },
+                fxFactory = { albumName, items ->
+                    if (albumName == "Jazz") error("injected fxFactory failure")
+                    AlbumFxView(albumName, items)
+                },
+                dispatchToFxThread = false
+            )
+        projection.addListener(MapChangeListener { })
+
+        trackRepo.create(1, "Track A", "Jazz")
+        trackRepo.create(2, "Track B", "Rock")
+        reactive.advance()
+
+        projection.containsKey("Jazz") shouldBe false
+        projection.containsKey("Rock") shouldBe true
+        val view = projection["Rock"] as AlbumFxView
+        view.hasTracks shouldBe true
+    }
+
+    "TransformedRegistryFxProjectionMap fxFactory failure during initial seed skips only that bucket and leaves the projection usable" {
+        trackRepo.create(1, "Track A", "Jazz")
+        trackRepo.create(2, "Track B", "Rock")
+
+        val projection =
+            registryFxProjectionMap(
+                trackRepo,
+                AudioItem::albumName,
+                dataTransform = { _, items -> items.toList() },
+                fxFactory = { albumName, items ->
+                    if (albumName == "Jazz") error("injected fxFactory failure during seed")
+                    AlbumFxView(albumName, items)
+                },
+                dispatchToFxThread = false
+            )
+
+        // First access triggers the lazy seed loop. A throwing fxFactory must not escape
+        // initialize() nor leave the projection half-wired with the core already subscribed.
+        projection.containsKey("Rock") shouldBe true
+        projection.containsKey("Jazz") shouldBe false
+        (projection["Rock"] as AlbumFxView).hasTracks shouldBe true
+
+        // The projection is fully initialized: a post-seed change still flushes normally.
+        trackRepo.create(3, "Track C", "Rock")
+        reactive.advance()
+        (projection["Rock"] as AlbumFxView).hasTracks shouldBe true
+    }
+
+    "TransformedRegistryFxProjectionMap single valueTransform overload runs off FX thread preserving backward compatibility" {
+        val transformedOnFxThread = CopyOnWriteArrayList<Boolean>()
+        val projection =
+            TransformedRegistryFxProjectionMap(
+                trackRepo,
+                AudioItem::albumName,
+                { pk, items ->
+                    transformedOnFxThread.add(Platform.isFxApplicationThread())
+                    RegistryAlbumBucket(pk, items.map { it.title }.sorted())
+                },
+                false
+            )
+        projection.addListener(MapChangeListener { })
+
+        trackRepo.create(1, "Track A", "Jazz")
+        trackRepo.create(2, "Track B", "Jazz")
+        reactive.advance()
+
+        transformedOnFxThread.isNotEmpty() shouldBe true
+        transformedOnFxThread.all { !it } shouldBe true
+        projection["Jazz"] shouldBe RegistryAlbumBucket("Jazz", listOf("Track A", "Track B"))
     }
 })


### PR DESCRIPTION
## Summary

Adds a two-phase value transform to the JavaFX projection maps so consumers can project source
entities into JavaFX-property-backed value types **safely on the FX Application Thread**.

Previously the projection maps offered a single `valueTransform(PK, List<E>) -> V` that runs on a
background thread. When the produced value `V` is built from JavaFX observables (e.g.
`SimpleSetProperty`, `ReadOnlyBooleanWrapper.bind(...)`), constructing it off-thread wires a
cross-thread dependency graph and forced a leaky data-only-then-rewrap workaround.

This change splits the transform into two phases:

- **`dataTransform(PK, List<E>) -> D`** — runs off the FX thread (the existing background dispatch),
  extracting a pure intermediate value. Must not touch JavaFX observables.
- **`fxFactory(PK, D) -> V`** — runs on the FX Application Thread inside the flush pulse, once per
  changed bucket, where it is safe to build `SimpleSetProperty` / call `.bind(...)`.

The off-thread compute model and one-pulse-per-event-burst cadence are unchanged. The change is
purely additive — the existing single-`valueTransform` overloads remain and behave identically
(internally wired to `dataTransform = valueTransform` plus an identity `fxFactory`).

## Changes

- **Backing classes** — `TransformedRegistryFxProjectionMap`, `TransformedFxProjectionMap`,
  `TransformedRegistryFxMultiKeyProjectionMap`, and `TransformedFxMultiKeyProjectionMap` are
  generalized to the two-phase model internally. The public class generic arity is unchanged
  (`<K, PK, E, V>`; the intermediate `D` is held internally as `Any?`), so there is no class-level
  ABI change.
- **Per-bucket fault isolation** — an `fxFactory` throw is logged with the bucket key and that one
  bucket is skipped; the remaining buckets in the same flush pulse still apply. This isolation holds
  in both the steady-state flush path **and** the lazy initial-seed path.
- **Factory overloads** — `fxProjectionMap`, `registryFxProjectionMap`, `fxMultiKeyProjectionMap`,
  and `registryFxMultiKeyProjectionMap` each gain an additive `dataTransform` + `fxFactory` overload
  with threading-contract KDoc and a usage example. The single-`valueTransform` overloads are
  untouched.

**Key files**
- `lirp-fx/.../projection/Transformed{Registry,}Fx{,MultiKey}ProjectionMap.kt`
- `lirp-fx/.../projection/FxProjectionFactories.kt`
- `lirp-fx/src/test/.../projection/AlbumFxView.kt` and the four projection-map test specs
- `lirp-fx/api/lirp-fx.api`, `CHANGELOG.md`, and the LIRP wiki projection-map page

## Testing

- New tests prove the threading contract both ways: `Platform.isFxApplicationThread()` is `false`
  inside `dataTransform` and `true` inside `fxFactory`, which constructs a real FX-backed value
  (`SimpleSetProperty` + bound `ReadOnlyBooleanWrapper`).
- Per-bucket fault isolation is covered for both the flush path and the initial-seed path.
- Backward compatibility is covered: the single-`valueTransform` overload still runs off the FX
  thread with unchanged map contents.
- ABI validation (`apiCheck`) is green with an additive-only `.api` diff.
- Full test suite passes; aggregate coverage is at or above the project baseline
  (line 87.86%, branch 73.66%).

## Breaking changes

None. The addition is backward compatible; no migration is required. A `CHANGELOG.md` "Added" entry
documents the new overloads.

Closes #256
