### PR TITLE
FX value-transform projections: concurrency & seed-thread hardening

### DIFF
--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxSeedDispatch.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxSeedDispatch.kt
@@ -1,0 +1,48 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx.projection
+
+import javafx.application.Platform
+import java.util.concurrent.CountDownLatch
+
+/**
+ * Runs [block] on the JavaFX Application Thread, blocking the caller until it completes, when
+ * [dispatchToFxThread] is set and the current thread is not already the FX Application Thread.
+ * Otherwise runs [block] inline on the current thread.
+ *
+ * The value-transform projections invoke their `fxFactory` through this during the initial seed so
+ * the two-phase contract — `fxFactory` constructs FX values on the FX Application Thread — holds even
+ * when the first map access happens off that thread. The [Platform.isFxApplicationThread] guard is
+ * required: an unconditional dispatch-and-wait would deadlock when the first access is itself on the
+ * FX thread (the latch would never be counted down).
+ */
+internal fun runSeedOnFxThread(dispatchToFxThread: Boolean, block: () -> Unit) {
+    if (dispatchToFxThread && !Platform.isFxApplicationThread()) {
+        val latch = CountDownLatch(1)
+        Platform.runLater {
+            try {
+                block()
+            } finally {
+                latch.countDown()
+            }
+        }
+        latch.await()
+    } else {
+        block()
+    }
+}

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxSeedWindowBuffer.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxSeedWindowBuffer.kt
@@ -1,0 +1,66 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx.projection
+
+/**
+ * Closes the seed window of a registry-backed FX projection: the interval between the core
+ * subscribing to registry events and the projection finishing its direct seed.
+ *
+ * A registry-backed projection wires [onBucketsChanged] as the core's buckets-changed listener
+ * **before** triggering core initialization. The core fires that listener synchronously, on the
+ * constructing (init) thread, for its own seed — those callbacks are ignored because the projection
+ * applies the seed directly. Genuine mutations arriving during the window come from the registry
+ * event thread; they are buffered until [drainAndReconcile] hands them to [onWindowMutation] in one
+ * batch, after the direct seed, so no delta is lost between the seed snapshot and the listener wiring.
+ *
+ * Must be constructed on the init thread, before core initialization.
+ *
+ * @param PK the projection key type
+ * @param onWindowMutation invoked with the keys of genuine window mutations (and, on drain, with any
+ *   buffered keys) so the projection can schedule a flush for them
+ */
+internal class FxSeedWindowBuffer<PK : Comparable<PK>>(
+    private val onWindowMutation: (Set<PK>) -> Unit
+) {
+    private val initThread = Thread.currentThread()
+    private val buffer = sortedSetOf<PK>()
+    private var seeding = true
+
+    /** Core buckets-changed listener: ignores the core's synchronous seed, buffers window mutations. */
+    fun onBucketsChanged(changedKeys: Set<PK>) {
+        var dispatch = false
+        synchronized(buffer) {
+            when {
+                !seeding -> dispatch = true
+                Thread.currentThread() === initThread -> Unit // core's synchronous seed, applied directly
+                else -> buffer.addAll(changedKeys)
+            }
+        }
+        if (dispatch) onWindowMutation(changedKeys)
+    }
+
+    /** Ends the window and reconciles any keys mutated during it in a single batch. */
+    fun drainAndReconcile() {
+        val buffered =
+            synchronized(buffer) {
+                seeding = false
+                buffer.toSet().also { buffer.clear() }
+            }
+        if (buffered.isNotEmpty()) onWindowMutation(buffered)
+    }
+}

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedFxMultiKeyProjection.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedFxMultiKeyProjection.kt
@@ -77,8 +77,9 @@ import kotlinx.coroutines.launch
  *
  * Buckets that become empty remove their key from the map (neither transform phase is invoked for
  * absent buckets). The projection initializes lazily on the first [getValue] or [addListener] call.
- * The seed loop runs on the first-access thread: both transform phases are invoked on that thread
- * during seeding.
+ * During seeding `dataTransform` runs on the first-access thread, while `fxFactory` runs on the FX
+ * Application Thread (marshalled there when dispatching and first access is off that thread),
+ * preserving the two-phase contract.
  *
  * In addition to the [ObservableMap] surface, this class implements [ObservableProjection]:
  * [addOnEntriesChangedListener] replays the current entries on registration (each with a null
@@ -120,6 +121,11 @@ class TransformedFxMultiKeyProjection<K : Comparable<K>, PK : Comparable<PK>, E,
 
     @Volatile
     private var initialized = false
+
+    // Lifecycle flag honored by stageAndSchedule, flush, and addOnEntriesChangedListener under the flush
+    // monitor. Once set by close(), staging stops, no pending flush delivers, and registration is refused.
+    @Volatile
+    private var closed = false
 
     private val initLock = Any()
 
@@ -213,26 +219,38 @@ class TransformedFxMultiKeyProjection<K : Comparable<K>, PK : Comparable<PK>, E,
             // subscribes to source collection changes, and populates the reverse index.
             core.size
 
-            // Seed innerObservableMap from the core's freshly built state, seed the reverse
-            // index, and subscribe each initially-bucketed entity to its mutation events.
-            for (key in core.keys) {
-                val bucket = core.bucketSnapshot(key) ?: continue
-                val d = dataTransform(key, bucket)
+            seedInitialBuckets()
+
+            initBarrier?.complete(Unit)
+            initialized = true
+        }
+    }
+
+    /**
+     * Seeds the reverse index, subscribes each initially-bucketed entity, and applies both transform
+     * phases to each initial bucket. [dataTransform] runs on the first-access thread; [fxFactory] and
+     * the map mutation are marshalled to the FX Application Thread when dispatching, so the two-phase
+     * contract holds even when first access happens off the FX thread. A throwing [fxFactory] is logged
+     * with the bucket key and that one bucket is skipped, matching the per-bucket fault isolation of [flush].
+     */
+    private fun seedInitialBuckets() {
+        val staged = LinkedHashMap<PK, Any?>()
+        for (key in core.keys) {
+            val bucket = core.bucketSnapshot(key) ?: continue
+            staged[key] = dataTransform(key, bucket)
+            for (entity in bucket) {
+                entityBuckets.computeIfAbsent(entity.id) { Collections.newSetFromMap(ConcurrentHashMap()) }.add(key)
+                if (!entitySubscriptions.containsKey(entity.id)) subscribeEntity(entity)
+            }
+        }
+        runSeedOnFxThread(dispatchToFxThread) {
+            for ((key, d) in staged) {
                 try {
                     innerObservableMap[key] = fxFactory(key, d)
                 } catch (t: Throwable) {
                     log.error(t) { "fxFactory failed for bucket key=$key during seed; skipping this bucket" }
                 }
-                for (entity in bucket) {
-                    entityBuckets.computeIfAbsent(entity.id) { Collections.newSetFromMap(ConcurrentHashMap()) }.add(key)
-                    if (!entitySubscriptions.containsKey(entity.id)) {
-                        subscribeEntity(entity)
-                    }
-                }
             }
-
-            initBarrier?.complete(Unit)
-            initialized = true
         }
     }
 
@@ -319,6 +337,7 @@ class TransformedFxMultiKeyProjection<K : Comparable<K>, PK : Comparable<PK>, E,
         // while flushScheduled is still true, so compareAndSet(false,true) fails and no new
         // runLater is scheduled — the removal is silently dropped until the next event.
         synchronized(this) {
+            if (closed) return
             for (key in newRemovals) {
                 pendingUpdates.remove(key)
                 pendingRemovals.add(key)
@@ -347,6 +366,7 @@ class TransformedFxMultiKeyProjection<K : Comparable<K>, PK : Comparable<PK>, E,
         val recipients: List<(List<ProjectionEntryChange<PK, V>>) -> Unit>
         val changes =
             synchronized(this) {
+                if (closed) return
                 val updates = HashMap(pendingUpdates)
                 pendingUpdates.clear()
                 val removals = HashSet(pendingRemovals)
@@ -428,8 +448,15 @@ class TransformedFxMultiKeyProjection<K : Comparable<K>, PK : Comparable<PK>, E,
      * entry-change batches are fired.
      */
     override fun close() {
-        synchronized(initLock) {
+        synchronized(this) {
+            if (closed) return
+            closed = true
+            pendingUpdates.clear()
+            pendingRemovals.clear()
+            flushScheduled.set(false)
             entriesChangedListeners.clear()
+        }
+        synchronized(initLock) {
             for (subscription in entitySubscriptions.values) {
                 subscription.cancel()
             }
@@ -454,6 +481,7 @@ class TransformedFxMultiKeyProjection<K : Comparable<K>, PK : Comparable<PK>, E,
         // after the lock is released so user code never runs while the monitor is held.
         val initial: List<ProjectionEntryChange<PK, V>> =
             synchronized(this) {
+                if (closed) return AutoCloseable { }
                 entriesChangedListeners.add(listener)
                 innerObservableMap.map { (k, v) -> ProjectionEntryChange(k, null, v) }
             }

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedFxProjection.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedFxProjection.kt
@@ -73,8 +73,9 @@ import kotlinx.coroutines.launch
  * subsequent [flush] pulse, with old values snapshotted from [innerObservableMap] before mutation.
  * The [close] method clears all entries-changed listeners.
  *
- * The projection initializes lazily on the first [getValue] or [addListener] call. The seed loop
- * runs on the first-access thread: both transform phases are invoked on that thread during seeding.
+ * The projection initializes lazily on the first [getValue] or [addListener] call. During seeding
+ * `dataTransform` runs on the first-access thread, while `fxFactory` runs on the FX Application Thread
+ * (marshalled there when dispatching and first access is off that thread), preserving the two-phase contract.
  *
  * Mutation methods ([put], [remove], [putAll], [clear]) throw [UnsupportedOperationException];
  * all mutations flow through the source collection.
@@ -113,6 +114,11 @@ class TransformedFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identi
 
     @Volatile
     private var initialized = false
+
+    // Lifecycle flag honored by scheduleFlush, flush, and addOnEntriesChangedListener under the flush
+    // monitor. Once set by close(), staging stops, no pending flush delivers, and registration is refused.
+    @Volatile
+    private var closed = false
 
     private val initLock = Any()
 
@@ -227,12 +233,18 @@ class TransformedFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identi
             val key = keyExtractor(element)
             backingMap[key] = freezeBucket((backingMap[key] ?: emptyList()) + element)
         }
-        for ((key, bucket) in backingMap) {
-            val d = dataTransform(key, bucket)
-            try {
-                innerObservableMap[key] = fxFactory(key, d)
-            } catch (t: Throwable) {
-                log.error(t) { "fxFactory failed for bucket key=$key during seed; skipping this bucket" }
+        // dataTransform runs off the FX thread (the first-access thread); fxFactory and the map
+        // mutation are marshalled to the FX Application Thread when dispatching, honoring the
+        // two-phase contract even when first access happens off the FX thread.
+        val staged = LinkedHashMap<PK, Any?>()
+        for ((key, bucket) in backingMap) staged[key] = dataTransform(key, bucket)
+        runSeedOnFxThread(dispatchToFxThread) {
+            for ((key, d) in staged) {
+                try {
+                    innerObservableMap[key] = fxFactory(key, d)
+                } catch (t: Throwable) {
+                    log.error(t) { "fxFactory failed for bucket key=$key during seed; skipping this bucket" }
+                }
             }
         }
     }
@@ -304,6 +316,7 @@ class TransformedFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identi
         // while flushScheduled is still true, so compareAndSet(false,true) fails and no new
         // runLater is scheduled — the removal is silently dropped until the next event.
         synchronized(this) {
+            if (closed) return
             for (key in newRemovals) {
                 pendingUpdates.remove(key)
                 pendingRemovals.add(key)
@@ -332,6 +345,7 @@ class TransformedFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identi
         val recipients: List<(List<ProjectionEntryChange<PK, V>>) -> Unit>
         val changes =
             synchronized(this) {
+                if (closed) return
                 val updates = HashMap(pendingUpdates)
                 pendingUpdates.clear()
                 val removals = HashSet(pendingRemovals)
@@ -455,12 +469,23 @@ class TransformedFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identi
     /**
      * Removes the change listener registered on the source collection and clears all entries-changed
      * listeners, so the source no longer retains or feeds this projection after close.
+     *
+     * Marking the projection closed, draining the pending-flush state, and clearing the listeners all
+     * happen atomically under the flush monitor, so a flush already in flight delivers nothing after
+     * close returns and a concurrent registration cannot survive. Idempotent.
      */
     override fun close() {
+        synchronized(this) {
+            if (closed) return
+            closed = true
+            pendingUpdates.clear()
+            pendingRemovals.clear()
+            flushScheduled.set(false)
+            entriesChangedListeners.clear()
+        }
         synchronized(initLock) {
             detachSourceListener?.invoke()
             detachSourceListener = null
-            entriesChangedListeners.clear()
         }
     }
 
@@ -480,6 +505,7 @@ class TransformedFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identi
         // after the lock is released so user code never runs while the monitor is held.
         val initial: List<ProjectionEntryChange<PK, V>> =
             synchronized(this) {
+                if (closed) return AutoCloseable { }
                 entriesChangedListeners.add(listener)
                 innerObservableMap.map { (k, v) -> ProjectionEntryChange(k, null, v) }
             }

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjection.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjection.kt
@@ -72,8 +72,9 @@ import kotlinx.coroutines.launch
  * [ProjectionEntryChange.oldValue]) and then emits a batched [ProjectionEntryChange] list on each
  * subsequent [flush] pulse, with old values snapshotted from [innerObservableMap] before mutation.
  *
- * The projection initializes lazily on the first [getValue] or [addListener] call. The seed loop
- * runs on the first-access thread: both transform phases are invoked on that thread during seeding.
+ * The projection initializes lazily on the first [getValue] or [addListener] call. During seeding
+ * `dataTransform` runs on the first-access thread, while `fxFactory` runs on the FX Application Thread
+ * (marshalled there when dispatching and first access is off that thread), preserving the two-phase contract.
  *
  * Mutation methods ([put], [remove], [putAll], [clear]) throw [UnsupportedOperationException];
  * all mutations flow through the source registry.
@@ -109,6 +110,11 @@ class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable
 
     @Volatile
     private var initialized = false
+
+    // Lifecycle flag honored by scheduleFlush, flush, and addOnEntriesChangedListener under the flush
+    // monitor. Once set by close(), staging stops, no pending flush delivers, and registration is refused.
+    @Volatile
+    private var closed = false
 
     private val initLock = Any()
 
@@ -169,28 +175,45 @@ class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable
         if (initialized) return
         synchronized(initLock) {
             if (initialized) return
+
+            // Wire the buckets-changed listener BEFORE triggering core initialization so a registry
+            // mutation landing in the seed window is not lost; the seed itself is applied directly below.
+            val seedWindow = FxSeedWindowBuffer<PK>(::scheduleFlush)
+            core.addOnBucketsChangedListener(seedWindow::onBucketsChanged)
+
             // Trigger core initialization (seeds from registry, subscribes to CrudEvents).
-            // onBucketsChanged is left unset during this phase so the initial seed does not
-            // schedule a flush — the seed is applied directly to innerObservableMap below.
             core.size
 
-            // Seed innerObservableMap by applying both transform phases to each initial bucket.
-            for (key in core.keys) {
-                val bucket = core.bucketSnapshot(key) ?: continue
-                val d = dataTransform(key, bucket)
+            seedInitialBuckets()
+
+            seedWindow.drainAndReconcile()
+
+            initBarrier?.complete(Unit)
+            initialized = true
+        }
+    }
+
+    /**
+     * Seeds [innerObservableMap] from the initial buckets. [dataTransform] runs on the first-access
+     * thread; [fxFactory] and the map mutation are marshalled to the FX Application Thread when
+     * dispatching, so the two-phase contract holds even when first access happens off the FX thread.
+     * A throwing [fxFactory] is logged with the bucket key and that one bucket is skipped, matching
+     * the per-bucket fault isolation of [flush].
+     */
+    private fun seedInitialBuckets() {
+        val staged = LinkedHashMap<PK, Any?>()
+        for (key in core.keys) {
+            val bucket = core.bucketSnapshot(key) ?: continue
+            staged[key] = dataTransform(key, bucket)
+        }
+        runSeedOnFxThread(dispatchToFxThread) {
+            for ((key, d) in staged) {
                 try {
                     innerObservableMap[key] = fxFactory(key, d)
                 } catch (t: Throwable) {
                     log.error(t) { "fxFactory failed for bucket key=$key during seed; skipping this bucket" }
                 }
             }
-
-            // Wire the coalescer after the initial seed so that only incremental (post-init) changes
-            // go through scheduleFlush.
-            core.addOnBucketsChangedListener(::scheduleFlush)
-
-            initBarrier?.complete(Unit)
-            initialized = true
         }
     }
 
@@ -217,6 +240,7 @@ class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable
         // while flushScheduled is still true, so compareAndSet(false,true) fails and no new
         // runLater is scheduled — the removal is silently dropped until the next event.
         synchronized(this) {
+            if (closed) return
             for (key in newRemovals) {
                 pendingUpdates.remove(key)
                 pendingRemovals.add(key)
@@ -245,6 +269,7 @@ class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable
         val recipients: List<(List<ProjectionEntryChange<PK, V>>) -> Unit>
         val changes =
             synchronized(this) {
+                if (closed) return
                 val updates = HashMap(pendingUpdates)
                 pendingUpdates.clear()
                 val removals = HashSet(pendingRemovals)
@@ -326,8 +351,15 @@ class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable
      * longer receives updates and no further entry-change batches are fired.
      */
     override fun close() {
-        synchronized(initLock) {
+        synchronized(this) {
+            if (closed) return
+            closed = true
+            pendingUpdates.clear()
+            pendingRemovals.clear()
+            flushScheduled.set(false)
             entriesChangedListeners.clear()
+        }
+        synchronized(initLock) {
             core.close()
         }
     }
@@ -348,6 +380,7 @@ class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable
         // after the lock is released so user code never runs while the monitor is held.
         val initial: List<ProjectionEntryChange<PK, V>> =
             synchronized(this) {
+                if (closed) return AutoCloseable { }
                 entriesChangedListeners.add(listener)
                 innerObservableMap.map { (k, v) -> ProjectionEntryChange(k, null, v) }
             }

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjection.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjection.kt
@@ -74,8 +74,9 @@ import kotlinx.coroutines.launch
  * absent buckets). Soft-deleted entities ([SoftDeletable] with non-null [deletedAt]) are
  * excluded from all buckets.
  *
- * The projection initializes lazily on the first [getValue] or [addListener] call. The seed loop
- * runs on the first-access thread: both transform phases are invoked on that thread during seeding.
+ * The projection initializes lazily on the first [getValue] or [addListener] call. During seeding
+ * `dataTransform` runs on the first-access thread, while `fxFactory` runs on the FX Application Thread
+ * (marshalled there when dispatching and first access is off that thread), preserving the two-phase contract.
  *
  * Mutation methods ([put], [remove], [putAll], [clear]) throw [UnsupportedOperationException];
  * all mutations flow through the source registry.
@@ -115,6 +116,11 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
 
     @Volatile
     private var initialized = false
+
+    // Lifecycle flag honored by stageAndSchedule, flush, and addOnEntriesChangedListener under the flush
+    // monitor. Once set by close(), staging stops, no pending flush delivers, and registration is refused.
+    @Volatile
+    private var closed = false
 
     private val initLock = Any()
 
@@ -179,15 +185,20 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
         if (initialized) return
         synchronized(initLock) {
             if (initialized) return
+
+            // Wire the buckets-changed listener BEFORE triggering core initialization so a registry
+            // mutation landing in the seed window is not lost; the seed itself is applied directly below.
+            val seedWindow = FxSeedWindowBuffer<PK>(::scheduleFlush)
+            core.addOnBucketsChangedListener(seedWindow::onBucketsChanged)
+
             // Trigger core initialization (seeds from registry, subscribes to CrudEvents).
             core.size
 
             seedInitialBuckets()
 
-            // Wire the coalescer after the initial seed.
-            core.addOnBucketsChangedListener(::scheduleFlush)
-
             subscribeToInPlaceUpdates()
+
+            seedWindow.drainAndReconcile()
 
             initBarrier?.complete(Unit)
             initialized = true
@@ -195,18 +206,25 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
     }
 
     /**
-     * Seeds [innerObservableMap] by applying both transform phases to each initial bucket on the
-     * first-access thread. A throwing [fxFactory] is logged with the bucket key and that one bucket
-     * is skipped, matching the per-bucket fault isolation of [flush].
+     * Seeds [innerObservableMap] from the initial buckets. [dataTransform] runs on the first-access
+     * thread; [fxFactory] and the map mutation are marshalled to the FX Application Thread when
+     * dispatching, so the two-phase contract holds even when first access happens off the FX thread.
+     * A throwing [fxFactory] is logged with the bucket key and that one bucket is skipped, matching
+     * the per-bucket fault isolation of [flush].
      */
     private fun seedInitialBuckets() {
+        val staged = LinkedHashMap<PK, Any?>()
         for (key in core.keys) {
             val bucket = core.bucketSnapshot(key) ?: continue
-            val d = dataTransform(key, bucket)
-            try {
-                innerObservableMap[key] = fxFactory(key, d)
-            } catch (t: Throwable) {
-                log.error(t) { "fxFactory failed for bucket key=$key during seed; skipping this bucket" }
+            staged[key] = dataTransform(key, bucket)
+        }
+        runSeedOnFxThread(dispatchToFxThread) {
+            for ((key, d) in staged) {
+                try {
+                    innerObservableMap[key] = fxFactory(key, d)
+                } catch (t: Throwable) {
+                    log.error(t) { "fxFactory failed for bucket key=$key during seed; skipping this bucket" }
+                }
             }
         }
     }
@@ -287,6 +305,7 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
         // while flushScheduled is still true, so compareAndSet(false,true) fails and no new
         // runLater is scheduled — the removal is silently dropped until the next event.
         synchronized(this) {
+            if (closed) return
             for (key in newRemovals) {
                 pendingUpdates.remove(key)
                 pendingRemovals.add(key)
@@ -317,6 +336,7 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
         val recipients: List<(List<ProjectionEntryChange<PK, V>>) -> Unit>
         val changes =
             synchronized(this) {
+                if (closed) return
                 val updates = HashMap(pendingUpdates)
                 pendingUpdates.clear()
                 val removals = HashSet(pendingRemovals)
@@ -398,8 +418,15 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
      * closing, the projection no longer receives updates and no further entry-change batches are fired.
      */
     override fun close() {
-        synchronized(initLock) {
+        synchronized(this) {
+            if (closed) return
+            closed = true
+            pendingUpdates.clear()
+            pendingRemovals.clear()
+            flushScheduled.set(false)
             entriesChangedListeners.clear()
+        }
+        synchronized(initLock) {
             core.close()
             updateSubscription?.cancel()
             updateSubscription = null
@@ -422,6 +449,7 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
         // after the lock is released so user code never runs while the monitor is held.
         val initial: List<ProjectionEntryChange<PK, V>> =
             synchronized(this) {
+                if (closed) return AutoCloseable { }
                 entriesChangedListeners.add(listener)
                 innerObservableMap.map { (k, v) -> ProjectionEntryChange(k, null, v) }
             }

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxMultiKeyProjectionTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxMultiKeyProjectionTest.kt
@@ -541,4 +541,21 @@ class FxMultiKeyProjectionTest : StringSpec({
                 allBucketedIds.contains(item.id) shouldBe true
             }
         }
+
+    "TransformedFxMultiKeyProjection close refuses new entries-changed registration and delivers nothing after" {
+        val source = fxAggregateList<Int, MutableMultiKeyAudioItem>(dispatchToFxThread = false)
+        val projection = fxMultiKeyProjection({ source }, { it.genres }, { pk, items -> "$pk:${items.size}" }, false)
+        projection.addListener(MapChangeListener { }) // first access wires the source callback
+        source.add(0, MutableMultiKeyAudioItem(1, "Track A", setOf("Rock")))
+        projection.containsKey("Rock") shouldBe true
+
+        projection.close()
+
+        val keys = mutableListOf<String>()
+        projection.addOnEntriesChangedListener { changes -> keys.addAll(changes.map { it.key }) }
+        keys shouldBe emptyList() // registration after close replays nothing
+
+        source.add(1, MutableMultiKeyAudioItem(2, "Track B", setOf("Jazz")))
+        keys shouldBe emptyList() // and delivers nothing after
+    }
 })

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionTest.kt
@@ -880,4 +880,62 @@ class FxProjectionTest : StringSpec({
         mkTransformMap.containsKey("Rock") shouldBe true
         mkTransformMap["Rock"] shouldBe FxAlbumBucket("Rock", listOf("Track A"))
     }
+
+    "TransformedFxProjection seed runs fxFactory on the FX thread when first access is off the FX thread" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        source.add(0, FxAudioItem(1, "Track A", "Jazz"))
+        source.add(1, FxAudioItem(2, "Track B", "Rock"))
+
+        val dataTransformOnFx = CopyOnWriteArrayList<Boolean>()
+        val fxFactoryOnFx = CopyOnWriteArrayList<Boolean>()
+        val projection =
+            fxProjection(
+                sourceRef = { source },
+                keyExtractor = { it.albumName },
+                dataTransform = { _, items ->
+                    dataTransformOnFx.add(Platform.isFxApplicationThread())
+                    items.toList()
+                },
+                fxFactory = { albumName, items ->
+                    fxFactoryOnFx.add(Platform.isFxApplicationThread())
+                    AlbumFxView(albumName, items)
+                },
+                dispatchToFxThread = true
+            )
+
+        // First access on a background (non-FX) thread must still seed fxFactory on the FX thread.
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            executor.submit { projection.size }.get(5, TimeUnit.SECONDS)
+        } finally {
+            executor.shutdownNow()
+        }
+
+        dataTransformOnFx.isNotEmpty() shouldBe true
+        dataTransformOnFx.all { !it } shouldBe true
+        fxFactoryOnFx.isNotEmpty() shouldBe true
+        fxFactoryOnFx.all { it } shouldBe true
+    }
+
+    "TransformedFxProjection close refuses new entries-changed registration and delivers nothing after" {
+        val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        source.add(0, FxAudioItem(1, "Track A", "Jazz"))
+        val projection =
+            fxProjection(sourceRef = { source }, keyExtractor = { it.albumName }, valueTransform = {
+                pk,
+                items
+                ->
+                "$pk:${items.size}"
+            }, dispatchToFxThread = false)
+        projection.containsKey("Jazz") shouldBe true
+
+        projection.close()
+
+        val keys = mutableListOf<String>()
+        projection.addOnEntriesChangedListener { changes -> keys.addAll(changes.map { it.key }) }
+        keys shouldBe emptyList() // registration after close replays nothing
+
+        source.add(1, FxAudioItem(2, "Track B", "Rock"))
+        keys shouldBe emptyList() // and delivers nothing after
+    }
 })

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjectionTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjectionTest.kt
@@ -35,6 +35,7 @@ import javafx.collections.ObservableMap
 import java.time.Instant
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -503,5 +504,57 @@ class RegistryFxMultiKeyProjectionTest : StringSpec({
         reactive.advance()
 
         changesLog shouldBe emptyList()
+    }
+
+    "TransformedRegistryFxMultiKeyProjection seed runs fxFactory on the FX thread when first access is off the FX thread" {
+        trackRepo.create(1, "Track A", setOf("Rock", "Jazz"))
+
+        val dataTransformOnFx = CopyOnWriteArrayList<Boolean>()
+        val fxFactoryOnFx = CopyOnWriteArrayList<Boolean>()
+        val projection =
+            registryFxMultiKeyProjection(
+                trackRepo,
+                { it.genres },
+                dataTransform = { _, items ->
+                    dataTransformOnFx.add(Platform.isFxApplicationThread())
+                    items.toList()
+                },
+                fxFactory = { genre, items ->
+                    fxFactoryOnFx.add(Platform.isFxApplicationThread())
+                    AlbumFxView(genre, items)
+                },
+                dispatchToFxThread = true
+            )
+
+        // First access on a background (non-FX) thread must still seed fxFactory on the FX thread.
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            executor.submit { (projection as ObservableMap<String, AlbumFxView>).size }.get(5, TimeUnit.SECONDS)
+        } finally {
+            executor.shutdownNow()
+        }
+
+        dataTransformOnFx.isNotEmpty() shouldBe true
+        dataTransformOnFx.all { !it } shouldBe true
+        fxFactoryOnFx.isNotEmpty() shouldBe true
+        fxFactoryOnFx.all { it } shouldBe true
+    }
+
+    "TransformedRegistryFxMultiKeyProjection close refuses new entries-changed registration and delivers nothing after" {
+        trackRepo.create(1, "Track A", setOf("Rock"))
+        reactive.advance()
+        val projection =
+            registryFxMultiKeyProjection(trackRepo, { it.genres }, { pk, items -> "$pk:${items.size}" }, false)
+        projection.containsKey("Rock") shouldBe true
+
+        projection.close()
+
+        val keys = mutableListOf<String>()
+        projection.addOnEntriesChangedListener { changes -> keys.addAll(changes.map { it.key }) }
+        keys shouldBe emptyList() // registration after close replays nothing
+
+        trackRepo.create(2, "Track B", setOf("Jazz"))
+        reactive.advance()
+        keys shouldBe emptyList() // and delivers nothing after
     }
 })

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionTest.kt
@@ -38,6 +38,7 @@ import javafx.collections.ObservableMap
 import java.time.Instant
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -868,5 +869,58 @@ class RegistryFxProjectionTest : StringSpec({
         reactive.advance()
 
         secondListenerKeys shouldBe listOf("Jazz")
+    }
+
+    "TransformedRegistryFxProjection seed runs fxFactory on the FX thread when first access is off the FX thread" {
+        trackRepo.create(1, "Track A", "Jazz")
+        trackRepo.create(2, "Track B", "Rock")
+
+        val dataTransformOnFx = CopyOnWriteArrayList<Boolean>()
+        val fxFactoryOnFx = CopyOnWriteArrayList<Boolean>()
+        val projection =
+            registryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                dataTransform = { _, items ->
+                    dataTransformOnFx.add(Platform.isFxApplicationThread())
+                    items.toList()
+                },
+                fxFactory = { albumName, items ->
+                    fxFactoryOnFx.add(Platform.isFxApplicationThread())
+                    AlbumFxView(albumName, items)
+                },
+                dispatchToFxThread = true
+            )
+
+        // First access on a background (non-FX) thread must still seed fxFactory on the FX thread.
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            executor.submit { (projection as ObservableMap<String, AlbumFxView>).size }.get(5, TimeUnit.SECONDS)
+        } finally {
+            executor.shutdownNow()
+        }
+
+        dataTransformOnFx.isNotEmpty() shouldBe true
+        dataTransformOnFx.all { !it } shouldBe true
+        fxFactoryOnFx.isNotEmpty() shouldBe true
+        fxFactoryOnFx.all { it } shouldBe true
+    }
+
+    "TransformedRegistryFxProjection close refuses new entries-changed registration and delivers nothing after" {
+        trackRepo.create(1, "Track A", "Rock")
+        reactive.advance()
+        val projection =
+            registryFxProjection(trackRepo, AudioItem::albumName, { pk, items -> "$pk:${items.size}" }, false)
+        projection.containsKey("Rock") shouldBe true
+
+        projection.close()
+
+        val keys = mutableListOf<String>()
+        projection.addOnEntriesChangedListener { changes -> keys.addAll(changes.map { it.key }) }
+        keys shouldBe emptyList() // registration after close replays nothing
+
+        trackRepo.create(2, "Track B", "Jazz")
+        reactive.advance()
+        keys shouldBe emptyList() // and delivers nothing after
     }
 })

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ReactiveEntityRefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ReactiveEntityRefProcessor.kt
@@ -701,17 +701,19 @@ class ReactiveEntityRefProcessor(
         val collectionEntriesCode = buildCollectionEntriesCode(collectionMetas)
 
         writeAccessorFile(
-            file = file,
-            packageName = packageName,
-            className = className,
-            kotlinClassName = kotlinClassName,
-            accessorName = accessorName,
-            visibility = visibility,
-            allReferencedFqns = allReferencedFqns,
-            entriesCode = entriesCode,
-            collectionEntriesCode = collectionEntriesCode,
-            collectionMetas = collectionMetas,
-            toOneEntries = toOneEntries
+            file,
+            AccessorFileSpec(
+                packageName = packageName,
+                className = className,
+                kotlinClassName = kotlinClassName,
+                accessorName = accessorName,
+                visibility = visibility,
+                allReferencedFqns = allReferencedFqns,
+                entriesCode = entriesCode,
+                collectionEntriesCode = collectionEntriesCode,
+                collectionMetas = collectionMetas,
+                toOneEntries = toOneEntries
+            )
         )
 
         logger.info("Generated $packageName.$accessorName for $className")
@@ -840,24 +842,40 @@ class ReactiveEntityRefProcessor(
         }
 
     /**
+     * Bundles the descriptive inputs for [writeAccessorFile]: the names of the accessor and its
+     * entity, the visibility, the imports to emit, and the pre-rendered entry code plus the metadata
+     * needed to generate `cancelAllBubbleUp`.
+     */
+    private data class AccessorFileSpec(
+        val packageName: String,
+        val className: String,
+        val kotlinClassName: String,
+        val accessorName: String,
+        val visibility: String,
+        val allReferencedFqns: List<String>,
+        val entriesCode: String,
+        val collectionEntriesCode: String,
+        val collectionMetas: List<CollectionRefPropertyMeta>,
+        val toOneEntries: List<ToOneRefPropertyMeta>
+    )
+
+    /**
      * Writes the `_LirpRefAccessor` source: package, imports, the generated KDoc header, the
      * `entries` and `collectionEntries` properties (each `emptyList()` when its section is blank),
-     * and the `cancelAllBubbleUp` override. The accessor-name set for [toOneEntries] scalar refs lets
-     * `cancelAllBubbleUp` avoid allocating a to-one delegate that was never created.
+     * and the `cancelAllBubbleUp` override. The accessor-name set for [AccessorFileSpec.toOneEntries]
+     * scalar refs lets `cancelAllBubbleUp` avoid allocating a to-one delegate that was never created.
      */
-    private fun writeAccessorFile(
-        file: OutputStream,
-        packageName: String,
-        className: String,
-        kotlinClassName: String,
-        accessorName: String,
-        visibility: String,
-        allReferencedFqns: List<String>,
-        entriesCode: String,
-        collectionEntriesCode: String,
-        collectionMetas: List<CollectionRefPropertyMeta>,
-        toOneEntries: List<ToOneRefPropertyMeta>
-    ) {
+    private fun writeAccessorFile(file: OutputStream, spec: AccessorFileSpec) {
+        val packageName = spec.packageName
+        val className = spec.className
+        val kotlinClassName = spec.kotlinClassName
+        val accessorName = spec.accessorName
+        val visibility = spec.visibility
+        val allReferencedFqns = spec.allReferencedFqns
+        val entriesCode = spec.entriesCode
+        val collectionEntriesCode = spec.collectionEntriesCode
+        val collectionMetas = spec.collectionMetas
+        val toOneEntries = spec.toOneEntries
         // Set of accessor names for scalar @ToOneAggregate entries — used in cancelAllBubbleUp to avoid
         // allocating a new delegate when none was created yet (e.g. entity closed before repo bind).
         // Delegate-val entries are excluded: their delegates are accessed directly without getOrComputeToOneRef.

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefProcessor.kt
@@ -213,7 +213,7 @@ class TableDefProcessor(
      * class has no resolved arms or no containing source file.
      */
     private fun emitResolvedPolymorphicSealedUnions(classDecl: KSClassDeclaration) {
-        val resolvedPolymorphicArms = polymorphicArmsByClass[classDecl]
+        val resolvedPolymorphicArms: Map<String, List<ArmTextMeta>>? = polymorphicArmsByClass[classDecl]
         if (resolvedPolymorphicArms.isNullOrEmpty()) return
         val packageName = classDecl.packageName.asString()
         val entitySimpleName = classDecl.simpleName.asString()


### PR DESCRIPTION
Closes #262.

Hardens the four FX value-transform projections (`TransformedFxProjection`, `TransformedFxMultiKeyProjection`, `TransformedRegistryFxProjection`, `TransformedRegistryFxMultiKeyProjection`) against three narrow concurrency / thread-of-execution gaps. Each manifests only under off-FX-thread first access of a preloaded source, concurrent registry mutation during lazy init, or a concurrent `close()`.

## What changed

### 1. Seed now runs `fxFactory` on the FX Application Thread
Previously the initial seed invoked `fxFactory` inline on whatever thread first touched the projection, violating the two-phase contract (`fxFactory` may build `SimpleSetProperty`, call `.bind(...)`, etc.). The seed now computes `dataTransform` off-thread and marshals only `fxFactory` and the map mutation to the FX thread via `Platform.runLater` + a latch — but only when dispatching and not already on the FX thread. The `isFxApplicationThread` guard prevents a self-deadlock when first access is itself on the FX thread. Shared helper: `runSeedOnFxThread`.

### 2. No lost registry delta in the seed window
The registry-backed projections wired their buckets-changed listener *after* the seed snapshot, so a registry mutation landing between the core subscribing and the listener being wired could be dropped. The listener is now wired *before* core initialization: the core's synchronous seed callbacks (same thread as init) are ignored, while genuine mutations arriving on the registry-event thread are buffered and reconciled in a single flush after the direct seed. Extracted into a reusable `FxSeedWindowBuffer`. The aggregate-backed projections already wired before core init and are unchanged.

### 3. `close()` serialized against registration and in-flight flush
`close()` previously cleared its listeners under a different monitor than `flush()`/registration used, so a concurrent registration could survive close and an in-flight flush could deliver after close returned. A `@Volatile closed` flag is now honored by the staging path, `flush()`, and `addOnEntriesChangedListener`; `close()` marks closed, drains pending state, and clears listeners atomically under the flush monitor before releasing the source listener / core subscription. It is idempotent and refuses post-close registration and delivery.

## Maintainability cleanups
Folded in a few SonarQube findings surfaced by the change:
- Reduced cognitive complexity of the multi-key projections' `initialize()` by extracting `seedInitialBuckets()` and `FxSeedWindowBuffer`.
- `ReactiveEntityRefProcessor.writeAccessorFile` now takes an `AccessorFileSpec` instead of 11 positional parameters.
- A read-only local in `TableDefProcessor` is typed as an immutable `Map`.

## Tests
- Off-FX-thread first access of a preloaded source seeds `fxFactory` on the FX thread (single-key aggregate, single-key registry, multi-key registry; the multi-key aggregate seeds via reference resolution that needs a repo-backed source, so the identical shared helper is covered by the other three).
- `close()` refuses post-close registration and delivers nothing afterward (all four).

286 `lirp-fx` tests pass, `lirp-ksp` tests pass, ktlint clean. Aggregate coverage LINE 88.25% / BRANCH 73.41% (above the recorded baseline).

## Notes
A deterministic test for the registry seed-window race (#2) is not feasible — the window is timing-dependent and can't be triggered reliably; correctness rests on the listener reorder plus thread-identity reasoning, with the full existing suite confirming unchanged behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)