### PR TITLE
KSP: fix @ToOneAggregate delegate-val detection (source-window bleed + spacing variant)

### DIFF
--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ReactiveEntityRefProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ReactiveEntityRefProcessor.kt
@@ -43,6 +43,16 @@ private const val AGGREGATE_SET_REF_DELEGATE_FQN = "net.transgressoft.lirp.persi
 
 /** Separator between generated `RefEntry` / `CollectionRefEntry` entries inside a `listOf(...)` block. */
 private const val ENTRY_SEPARATOR = ",\n        "
+
+/**
+ * Matches the delegate-val form of a `@ToOneAggregate` property — `... by aggregate { ... }`,
+ * `by aggregate<...>`, `by optionalAggregate ...`, or `by mutableAggregate ...` (with or without a
+ * space before the lambda brace) — so it can be told apart from a scalar FK. Anchored on the `by`
+ * delegation keyword of the declaration itself, the pattern does not match a bare `aggregate(...)`
+ * factory call that merely appears on a neighbouring line.
+ */
+internal val TO_ONE_DELEGATE_VAL_REGEX =
+    Regex("""\bby\s+(?:aggregate|optionalAggregate|mutableAggregate)(?:\s*\{|<)""")
 private val STDLIB_COLLECTION_FQNS =
     setOf(
         "kotlin.collections.MutableList",
@@ -286,16 +296,12 @@ class ReactiveEntityRefProcessor(
         // at runtime via the existing delegate). Source-text scanning is required because KSP type
         // resolution resolves `val x by aggregate<K, X> { ... }` to AggregateRefDelegate, and we
         // cannot distinguish it from a scalar FK by type alone at this point.
-        val sourceText = readSourceLines(prop, linesBefore = 0, linesAfter = 2)
-        val isDelegateVal =
-            sourceText != null &&
-                (
-                    sourceText.contains("aggregate {") ||
-                        sourceText.contains("aggregate<") ||
-                        sourceText.contains("optionalAggregate") ||
-                        sourceText.contains("mutableAggregate{") ||
-                        sourceText.contains("mutableAggregate<")
-                )
+        // Read only the annotated declaration line — no trailing-line bleed. KSP locates a property at
+        // its `val`/`var` declaration, which carries the `by <factory>` delegation for the delegate-val
+        // form. Reading following lines would let a scalar FK immediately followed by a delegate-val
+        // aggregate property pick up that next line's `by aggregate { ... }` and be misclassified.
+        val sourceText = readSourceLines(prop, linesBefore = 0, linesAfter = 0)
+        val isDelegateVal = sourceText != null && TO_ONE_DELEGATE_VAL_REGEX.containsMatchIn(sourceText)
 
         // Extract target: KClass<*> annotation argument via the confirmed KSType cast pattern.
         val targetArg =

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ToOneAggregateRefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ToOneAggregateRefProcessorTest.kt
@@ -591,4 +591,87 @@ internal class ToOneAggregateRefProcessorTest : FunSpec({
         result.messages shouldContain "AudioItem"
         result.messages shouldContain "AudioTrack"
     }
+
+    test("ReactiveEntityRefProcessor keeps a scalar FK scalar when immediately followed by a delegate-val aggregate property") {
+        // Regression: detection previously scanned trailing lines, so a scalar FK whose declaration is
+        // immediately followed by `val x by aggregate<...> { ... }` had that next line pulled in and was
+        // misclassified as a delegate-val — generating delegate code (`it.companyId.referenceId`) against
+        // a plain scalar. The scalar must keep its scalar idGetter while the delegate-val keeps its own.
+        val result =
+            KspTestSupport.compile(
+                ReactiveEntityRefProcessorProvider(),
+                SourceFile.kotlin(
+                    "AdjacentRefsEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.ToOneAggregate
+                    import net.transgressoft.lirp.persistence.aggregate
+
+                    @PersistenceMapping
+                    class Company(override val id: Int) : ReactiveEntityBase<Int, Company>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = Company(id)
+                    }
+
+                    @PersistenceMapping
+                    class AudioTrack(override val id: Int) : ReactiveEntityBase<Int, AudioTrack>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = AudioTrack(id)
+                    }
+
+                    @PersistenceMapping
+                    class Vehicle(
+                        override val id: Int,
+                        companyId: Int,
+                        var audioTrackId: Int
+                    ) : ReactiveEntityBase<Int, Vehicle>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = Vehicle(id, companyId, audioTrackId)
+
+                        @ToOneAggregate(target = Company::class)
+                        var companyId: Int by reactiveProperty(companyId)
+                        @ToOneAggregate(target = AudioTrack::class)
+                        val audioTrack by aggregate<Int, AudioTrack> { audioTrackId }
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("Vehicle_LirpRefAccessor.kt")
+        // companyId stays a scalar FK: scalar cast idGetter, not the delegate's `referenceId` form
+        // (a misclassification would emit `idGetter = { it.companyId.referenceId }` instead).
+        content shouldContain "refName = \"company\""
+        content shouldContain "idGetter = { it.companyId as Comparable<Any> }"
+        // audioTrack is correctly the delegate-val.
+        content shouldContain "refName = \"audioTrack\""
+        content shouldContain "idGetter = { it.audioTrack.referenceId }"
+    }
+
+    test("delegate-val detection regex matches every by-delegation form, with or without a space before the brace") {
+        // mutableAggregate is a forward-looking guard (no single-ref factory exists yet), so its
+        // detection — including the spaced `mutableAggregate {` form missed by the old substring check
+        // — is verified directly against the regex rather than through a compilation that cannot exist.
+        val delegateForms =
+            listOf(
+                "val x by aggregate<Int, X> { xId }",
+                "val x by aggregate { xId }",
+                "val x by optionalAggregate<Int, X> { xId }",
+                "val x by optionalAggregate { xId }",
+                "val x by mutableAggregate<Int, X> { xId }",
+                "val x by mutableAggregate { xId }",
+                "val x by mutableAggregate{ xId }"
+            )
+        delegateForms.forEach { it to TO_ONE_DELEGATE_VAL_REGEX.containsMatchIn(it) shouldBe (it to true) }
+
+        val scalarForms =
+            listOf(
+                "var companyId: Int by reactiveProperty(companyId)",
+                "var companyId: Int? by reactiveProperty(companyId)",
+                "val items by aggregateList<Int, X>(itemIds)"
+            )
+        scalarForms.forEach { it to TO_ONE_DELEGATE_VAL_REGEX.containsMatchIn(it) shouldBe (it to false) }
+    }
 })


### PR DESCRIPTION
Closes #263.

`@ToOneAggregate` delegate-val detection in `ReactiveEntityRefProcessor` distinguishes the delegate-val form (`@ToOneAggregate(target = X::class) val x by aggregate<K, X> { ... }`) from a scalar FK (`@ToOneAggregate(target = X::class) var xId: K by reactiveProperty(...)`) by scanning source text, because KSP type resolution cannot tell them apart. The previous scan had two defects.

## Problems

1. **Window bleed.** The scan read the declaration line *plus the two following lines*. A scalar FK immediately followed by a delegate-val property (`val y by aggregate<...> { ... }`) had that following line pulled into the scanned text, so the substring check matched and the scalar was misclassified as a delegate-val — generating delegate code (`idGetter = { it.xId.referenceId }`) against a plain scalar that has no delegate.
2. **Missed spacing variant.** The check accepted `mutableAggregate{` but not `mutableAggregate {` (with a space).

## Fix

Detection now reads **only the annotated declaration line** — KSP locates a property at its `val`/`var` declaration, which is where the `by <factory>` delegation lives — and matches the `by` delegation form with a regex anchored on the `by` keyword:

```
\bby\s+(?:aggregate|optionalAggregate|mutableAggregate)(?:\s*\{|<)
```

This removes the trailing-line bleed and accepts both spaced and unspaced brace forms. `mutableAggregate` is kept as a forward-looking guard (no single-ref `mutableAggregate` factory exists yet), matching the existing intent in `TableDefProcessor`.

## Tests

- A scalar FK immediately followed by a delegate-val aggregate property now keeps its scalar `idGetter` while the delegate-val keeps its own — this case fails under the previous window (verified by temporarily reintroducing the bleed).
- A direct regex test covers every `by`-delegation form, including the spaced `mutableAggregate {` variant and the unspaced `mutableAggregate{`, plus negative cases (`by reactiveProperty(...)`, `by aggregateList<...>`).

All `lirp-ksp` tests pass (303), ktlint clean. Scope is limited to `lirp-ksp` and does not touch the projection work tracked elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)