### PR TITLE
Fix dropped-update seed-window race in registry projections

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/MultiKeyRegistryProjection.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/MultiKeyRegistryProjection.kt
@@ -123,15 +123,23 @@ class MultiKeyRegistryProjection<K : Comparable<K>, PK : Comparable<PK>, E : Ide
         if (initialized) return
         synchronized(initLock) {
             if (initialized) return
-            for (entity in registry) {
-                if (!isSoftDeleted(entity)) addToBucket(entity)
-            }
+            // Subscribe BEFORE seeding so events emitted concurrently during the seed iteration are
+            // not dropped (the publisher short-circuits emissions while there are no subscribers, and
+            // the registry iterator is only weakly consistent). Events arriving while seeding are
+            // buffered and replayed in arrival order after the seed completes, so the seed thread
+            // stays the sole writer during seeding. Entities captured by both the seed iterator and a
+            // buffered create are de-duplicated by the reverse-index guard in onCreated.
+            val seedBuffer = SeedEventBuffer<K, E>()
             subscription =
                 registry.subscribeAsync(
                     CrudEvent.Type.CREATE,
                     CrudEvent.Type.UPDATE,
                     CrudEvent.Type.DELETE
-                ) { event -> handleCrudEvent(event) }
+                ) { event -> if (!seedBuffer.deferIfSeeding(event)) handleCrudEvent(event) }
+            for (entity in registry) {
+                if (!isSoftDeleted(entity)) addToBucket(entity)
+            }
+            seedBuffer.completeSeed { handleCrudEvent(it) }
             initialized = true
         }
     }
@@ -146,7 +154,11 @@ class MultiKeyRegistryProjection<K : Comparable<K>, PK : Comparable<PK>, E : Ide
     }
 
     private fun onCreated(entity: E) {
-        if (!isSoftDeleted(entity)) addToBucket(entity)
+        if (isSoftDeleted(entity)) return
+        // Skip entities already bucketed — e.g. one both captured by the seed iterator and replayed
+        // as a buffered create from the seed window — so it is not added to its buckets twice.
+        if (reverseIndex.containsKey(entity.id)) return
+        addToBucket(entity)
     }
 
     private fun onDeleted(entity: E) {

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/RegistryProjection.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/RegistryProjection.kt
@@ -110,19 +110,24 @@ class RegistryProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identifiabl
         if (initialized) return
         synchronized(initLock) {
             if (initialized) return
-            // Seed first so the initial snapshot is complete before any events are processed;
-            // soft-deleted entities are excluded from all buckets.
-            for (entity in registry) {
-                if (!isSoftDeleted(entity)) addToBucket(entity)
-            }
-            // Subscribe after the seed is complete to avoid double-applying events that arrive
-            // during iteration.
+            // Subscribe BEFORE seeding so events emitted concurrently during the seed iteration are
+            // not dropped (the publisher short-circuits emissions while there are no subscribers, and
+            // the registry iterator is only weakly consistent). Events arriving while seeding are
+            // buffered and replayed in arrival order after the seed completes, so the seed thread
+            // stays the sole writer during seeding. Entities captured by both the seed iterator and a
+            // buffered create are de-duplicated by the reverse-index guard in onCreated.
+            val seedBuffer = SeedEventBuffer<K, E>()
             subscription =
                 registry.subscribeAsync(
                     CrudEvent.Type.CREATE,
                     CrudEvent.Type.UPDATE,
                     CrudEvent.Type.DELETE
-                ) { event -> handleCrudEvent(event) }
+                ) { event -> if (!seedBuffer.deferIfSeeding(event)) handleCrudEvent(event) }
+            // Soft-deleted entities are excluded from all buckets.
+            for (entity in registry) {
+                if (!isSoftDeleted(entity)) addToBucket(entity)
+            }
+            seedBuffer.completeSeed { handleCrudEvent(it) }
             initialized = true
         }
     }
@@ -137,7 +142,11 @@ class RegistryProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identifiabl
     }
 
     private fun onCreated(entity: E) {
-        if (!isSoftDeleted(entity)) addToBucket(entity)
+        if (isSoftDeleted(entity)) return
+        // Skip entities already bucketed — e.g. one both captured by the seed iterator and replayed
+        // as a buffered create from the seed window — so it is not added to its bucket twice.
+        if (reverseIndex.containsKey(entity.id)) return
+        addToBucket(entity)
     }
 
     private fun onDeleted(entity: E) {

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/SeedEventBuffer.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/SeedEventBuffer.kt
@@ -1,0 +1,67 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.projection
+
+import net.transgressoft.lirp.entity.IdentifiableEntity
+import net.transgressoft.lirp.event.CrudEvent
+
+/**
+ * Closes the seed window of a registry-backed projection: the interval between the projection
+ * subscribing to registry events and its seed iteration completing.
+ *
+ * A projection must subscribe to the registry **before** iterating it for the initial seed,
+ * otherwise events emitted concurrently during the seed are dropped — the publisher short-circuits
+ * emissions while there are no subscribers, and the registry iterator is only weakly consistent.
+ * Subscribing first, however, lets the event-delivery thread mutate buckets concurrently with the
+ * seed thread. This buffer serializes the two: while seeding, events are held; after the seed
+ * completes, [completeSeed] replays them in arrival order on the seed thread, keeping the seed
+ * thread the sole writer throughout and never losing a delta.
+ *
+ * @param K the entity ID type
+ * @param E the entity type
+ */
+internal class SeedEventBuffer<K : Comparable<K>, E : IdentifiableEntity<K>> {
+    private val pending = ArrayDeque<CrudEvent<K, E>>()
+    private var seeding = true
+
+    /**
+     * Buffers [event] when the seed is still in progress and returns `true`; returns `false` once the
+     * seed has completed, signalling the caller to apply the event directly.
+     */
+    fun deferIfSeeding(event: CrudEvent<K, E>): Boolean =
+        synchronized(pending) {
+            if (seeding) {
+                pending.addLast(event)
+                true
+            } else {
+                false
+            }
+        }
+
+    /**
+     * Ends the seed window and replays every buffered event, in arrival order, through [apply].
+     * Runs under the same monitor as [deferIfSeeding] so an event arriving mid-drain is either
+     * replayed here or applied directly by its caller afterwards — never lost and never applied twice.
+     */
+    fun completeSeed(apply: (CrudEvent<K, E>) -> Unit) {
+        synchronized(pending) {
+            seeding = false
+            while (pending.isNotEmpty()) apply(pending.removeFirst())
+        }
+    }
+}

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionTest.kt
@@ -239,6 +239,19 @@ internal class RegistryProjectionTest : StringSpec({
         projection.containsKey("Rock") shouldBe false
     }
 
+    "skips a redundant Create for an already-bucketed entity without duplicating it" {
+        trackRepo.create(1, "Track A", "Jazz")
+        val projection = registryProjection(trackRepo) { it.albumName }
+        projection["Jazz"]!!.size shouldBe 1
+
+        // A redundant Create for an id already held in a bucket (as happens when the seed iterator and
+        // a buffered seed-window create both reference the same entity) must not add it a second time.
+        trackRepo.emitAsync(StandardCrudEvent.Create(MutableAudioItem(1, "Track A", "Jazz")))
+        reactive.advance()
+
+        projection["Jazz"]!!.size shouldBe 1
+    }
+
     "fires onChange after Create" {
         val projection = registryProjection(trackRepo) { it.albumName }
         projection.size shouldBe 0
@@ -648,6 +661,21 @@ internal class RegistryProjectionTest : StringSpec({
         projection.containsKey("Jazz") shouldBe false
         projection["Rock"]!!.size shouldBe 2 // item and anotherItem still in Rock
         projection["Rock"]!!.any { it.id == item.id } shouldBe true
+    }
+
+    "MultiKeyRegistryProjection skips a redundant Create for an already-bucketed entity without duplicating it" {
+        val multiKeyRepo = MultiKeyAudioItemVolatileRepository(ctx)
+        multiKeyRepo.create(1, "Track A", setOf("Rock", "Jazz"))
+        val projection = registryMultiKeyProjection(multiKeyRepo) { it.genres }
+        projection["Rock"]!!.size shouldBe 1
+        projection["Jazz"]!!.size shouldBe 1
+
+        // A redundant Create for an id already held in its buckets must not add it a second time.
+        multiKeyRepo.emitAsync(StandardCrudEvent.Create(MutableMultiKeyAudioItem(1, "Track A", setOf("Rock", "Jazz"))))
+        reactive.advance()
+
+        projection["Rock"]!!.size shouldBe 1
+        projection["Jazz"]!!.size shouldBe 1
     }
 
     "MultiKeyRegistryProjection places entity in zero buckets when keyExtractor returns empty set" {

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/projection/SeedEventBufferTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/projection/SeedEventBufferTest.kt
@@ -1,0 +1,60 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.projection
+
+import net.transgressoft.lirp.event.CrudEvent
+import net.transgressoft.lirp.event.StandardCrudEvent
+import net.transgressoft.lirp.persistence.MutableAudioItem
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [SeedEventBuffer], verifying that events are buffered while the seed is in progress and
+ * replayed in arrival order on completion, and that events arriving after completion are passed
+ * through for direct application.
+ */
+@DisplayName("SeedEventBuffer")
+internal class SeedEventBufferTest : StringSpec({
+
+    "defers events while seeding and replays them in arrival order on completeSeed" {
+        val buffer = SeedEventBuffer<Int, MutableAudioItem>()
+        val create = StandardCrudEvent.Create(MutableAudioItem(1, "Track A", "Jazz"))
+        val delete = StandardCrudEvent.Delete(MutableAudioItem(2, "Track B", "Rock"))
+
+        buffer.deferIfSeeding(create) shouldBe true
+        buffer.deferIfSeeding(delete) shouldBe true
+
+        val replayed = mutableListOf<CrudEvent<Int, MutableAudioItem>>()
+        buffer.completeSeed { replayed.add(it) }
+
+        replayed shouldContainExactly listOf(create, delete)
+    }
+
+    "passes events through without deferring once the seed has completed" {
+        val buffer = SeedEventBuffer<Int, MutableAudioItem>()
+        val replayed = mutableListOf<CrudEvent<Int, MutableAudioItem>>()
+
+        // No events were buffered during the (empty) seed.
+        buffer.completeSeed { replayed.add(it) }
+        replayed shouldBe emptyList()
+
+        buffer.deferIfSeeding(StandardCrudEvent.Create(MutableAudioItem(1, "Track A", "Jazz"))) shouldBe false
+    }
+})

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjection.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjection.kt
@@ -111,9 +111,15 @@ class RegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable<PK>, E : I
         if (initialized) return
         synchronized(initLock) {
             if (initialized) return
+            // Wire the buckets-changed listener BEFORE triggering core initialization so a registry
+            // mutation landing in the seed window — the interval between the core subscribing and
+            // this projection finishing its direct seed — is buffered rather than lost. The core's
+            // own synchronous seed callbacks (fired on this thread) are ignored by the buffer; the
+            // seed is applied directly below.
+            val seedWindow = FxSeedWindowBuffer<PK>(::scheduleFlush)
+            core.addOnBucketsChangedListener(seedWindow::onBucketsChanged)
+
             // Trigger core initialization (seeds from registry, subscribes to CrudEvents).
-            // onBucketsChanged is left unset during this phase so the initial seed does not
-            // schedule a flush — the seed is applied directly to innerObservableMap below.
             core.size
 
             // Synchronously populate innerObservableMap from the core's freshly built buckets.
@@ -122,9 +128,9 @@ class RegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable<PK>, E : I
                 innerObservableMap[key] = freezeBucket(bucket)
             }
 
-            // Wire the coalescer after the initial seed so that only incremental (post-init) changes
-            // go through scheduleFlush.
-            core.addOnBucketsChangedListener(::scheduleFlush)
+            // End the window and reconcile any keys mutated during it in a single batch, so no
+            // delta is lost between the seed snapshot and the listener becoming live.
+            seedWindow.drainAndReconcile()
 
             initBarrier?.complete(Unit)
             initialized = true
@@ -186,12 +192,15 @@ class RegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable<PK>, E : I
         return innerObservableMap.size
     }
 
-    // Safe: ObservableMap declares MutableSet<MutableEntry> but the returned set is unmodifiable.
-    // Callers cannot mutate through this view; the cast satisfies the interface contract.
+    // Safe: ObservableMap declares MutableSet<MutableEntry> but the returned set is an unmodifiable
+    // point-in-time snapshot. Callers cannot mutate through this view; the cast satisfies the
+    // interface contract. The snapshot (rather than a live view of innerObservableMap.entries) gives
+    // every projection in the family the same read-only, stable-iteration entries semantics.
     @Suppress("UNCHECKED_CAST")
     override val entries: MutableSet<MutableMap.MutableEntry<PK, List<E>>> get() {
         initialize()
-        return Collections.unmodifiableSet(innerObservableMap.entries) as MutableSet<MutableMap.MutableEntry<PK, List<E>>>
+        val snapshot = innerObservableMap.entries.map { java.util.AbstractMap.SimpleImmutableEntry(it.key, it.value) }.toSet()
+        return Collections.unmodifiableSet(snapshot) as MutableSet<MutableMap.MutableEntry<PK, List<E>>>
     }
 
     // Safe: Collections.unmodifiableSet wraps the keys. The MutableSet return type is required

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjection.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjection.kt
@@ -127,9 +127,15 @@ class RegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identifia
         if (initialized) return
         synchronized(initLock) {
             if (initialized) return
+            // Wire the buckets-changed listener BEFORE triggering core initialization so a registry
+            // mutation landing in the seed window — the interval between the core subscribing and
+            // this projection finishing its direct seed — is buffered rather than lost. The core's
+            // own synchronous seed callbacks (fired on this thread) are ignored by the buffer; the
+            // seed is applied directly below.
+            val seedWindow = FxSeedWindowBuffer<PK>(::scheduleFlush)
+            core.addOnBucketsChangedListener(seedWindow::onBucketsChanged)
+
             // Trigger core initialization (seeds from registry, subscribes to CrudEvents).
-            // onBucketsChanged is left unset during this phase so the initial seed does not
-            // schedule a flush — the seed is applied directly to innerObservableMap below.
             core.size
 
             // Synchronously populate innerObservableMap from the core's freshly built buckets.
@@ -137,10 +143,6 @@ class RegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identifia
                 val bucket = core.bucketSnapshot(key)
                 if (bucket != null) innerObservableMap[key] = freezeBucket(bucket)
             }
-
-            // Wire the coalescer after the initial seed so that only incremental (post-init) changes
-            // go through scheduleFlush.
-            core.addOnBucketsChangedListener(::scheduleFlush)
 
             // Subscribe to Update events to guarantee MapChangeListener fires for in-place mutations.
             // When an entity is mutated via a field assignment on the same object reference already
@@ -155,6 +157,10 @@ class RegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identifia
                         if (keysToFlush.isNotEmpty()) scheduleUpdateFlush(keysToFlush)
                     }
                 }
+
+            // End the window and reconcile any keys mutated during it in a single batch, so no
+            // delta is lost between the seed snapshot and the listener becoming live.
+            seedWindow.drainAndReconcile()
 
             initBarrier?.complete(Unit)
             initialized = true
@@ -263,14 +269,16 @@ class RegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identifia
         return innerObservableMap.size
     }
 
-    // Safe: ObservableMap declares MutableSet<MutableEntry> but the returned set is unmodifiable via Collections.unmodifiableSet.
-    // Callers cannot mutate through this view; the cast satisfies the interface contract without exposing true mutability.
-    // Returns the live entry set backed by innerObservableMap — consistent with keys and values,
-    // which also return live views. ConcurrentSkipListMap entries are CME-safe for iteration.
+    // Safe: ObservableMap declares MutableSet<MutableEntry> but the returned set is an unmodifiable
+    // point-in-time snapshot. Callers cannot mutate through this view; the cast satisfies the
+    // interface contract without exposing true mutability. The snapshot (rather than a live view of
+    // innerObservableMap.entries) gives every projection in the family the same read-only,
+    // stable-iteration entries semantics.
     @Suppress("UNCHECKED_CAST")
     override val entries: MutableSet<MutableMap.MutableEntry<PK, List<E>>> get() {
         initialize()
-        return Collections.unmodifiableSet(innerObservableMap.entries) as MutableSet<MutableMap.MutableEntry<PK, List<E>>>
+        val snapshot = innerObservableMap.entries.map { java.util.AbstractMap.SimpleImmutableEntry(it.key, it.value) }.toSet()
+        return Collections.unmodifiableSet(snapshot) as MutableSet<MutableMap.MutableEntry<PK, List<E>>>
     }
 
     // Safe: same as entries — Collections.unmodifiableSet wraps the keys. The MutableSet return type is required by

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionConcurrencyStressTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionConcurrencyStressTest.kt
@@ -36,12 +36,17 @@ import java.util.concurrent.atomic.AtomicInteger
 /**
  * Concurrency regression tests for the registry-backed FX projections under a large async batch
  * import, using the production reactive dispatchers (via [ReactiveScopeSerialization]) so the real
- * background event coroutine and the FX Application Thread are both active.
+ * background event coroutine and the flush pipeline are both active.
  *
  * Guards against a seed-window dropped-update race: registry events arriving in the interval between
  * the core subscribing and the projection finishing its direct seed must not be lost, even when the
  * projection is first initialized in the middle of the import. With unique-per-entity keys, a dropped
  * event is permanent (no later event re-flushes the key), so full materialization is a strict probe.
+ *
+ * The projections run with `dispatchToFxThread = false` so flushes are serialized through the
+ * reactive flow scope rather than `Platform.runLater`, matching the rest of the projection test
+ * suite and keeping the probe independent of FX-thread scheduling. The seed-window fix is dispatch
+ * mode independent, so this still exercises it faithfully.
  */
 @DisplayName("Registry FX projection concurrency")
 class RegistryFxProjectionConcurrencyStressTest : StringSpec({
@@ -62,12 +67,14 @@ class RegistryFxProjectionConcurrencyStressTest : StringSpec({
         try {
             for (i in 1..itemCount) {
                 pool.submit {
+                    // Count starts, not completions, so the mid-import gate opens the seed window
+                    // while the import is still in full flight — a stronger probe of the race.
+                    started.incrementAndGet()
                     try {
                         repo.create(i, "Track-$i", setOf("artist-$i"))
                     } catch (t: Throwable) {
                         errors.add(t)
                     } finally {
-                        started.incrementAndGet()
                         completed.countDown()
                     }
                 }
@@ -95,7 +102,7 @@ class RegistryFxProjectionConcurrencyStressTest : StringSpec({
     "RegistryFxMultiKeyProjection materializes every entry when first initialized during a large concurrent import"
         .config(tags = setOf(Stress)) {
             val repo = MultiKeyAudioItemVolatileRepository()
-            val projection = RegistryFxMultiKeyProjection(repo, { it.genres }, true)
+            val projection = RegistryFxMultiKeyProjection(repo, { it.genres }, false)
 
             runConcurrentImport(repo) { projection.addListener(MapChangeListener { }) }
 
@@ -106,7 +113,7 @@ class RegistryFxProjectionConcurrencyStressTest : StringSpec({
     "RegistryFxProjection materializes every entry when first initialized during a large concurrent import"
         .config(tags = setOf(Stress)) {
             val repo = MultiKeyAudioItemVolatileRepository()
-            val projection = RegistryFxProjection(repo, { it.title }, true)
+            val projection = RegistryFxProjection(repo, { it.title }, false)
 
             runConcurrentImport(repo) { projection.addListener(MapChangeListener { }) }
 
@@ -117,7 +124,7 @@ class RegistryFxProjectionConcurrencyStressTest : StringSpec({
     "RegistryFxMultiKeyProjection iterates entries, keys, and values without exception under a concurrent import"
         .config(tags = setOf(Stress)) {
             val repo = MultiKeyAudioItemVolatileRepository()
-            val projection = RegistryFxMultiKeyProjection(repo, { it.genres }, true)
+            val projection = RegistryFxMultiKeyProjection(repo, { it.genres }, false)
             projection.addListener(MapChangeListener { })
 
             shouldNotThrowAny {
@@ -137,11 +144,18 @@ class RegistryFxProjectionConcurrencyStressTest : StringSpec({
                             }
                         }
                     }
-                runConcurrentImport(repo) { /* already initialized above */ }
-                stop.set(1)
-                readerTask.get(30, TimeUnit.SECONDS)
-                reader.shutdownNow()
-                readerError.isEmpty() shouldBe true
+                try {
+                    runConcurrentImport(repo) { /* already initialized above */ }
+                    stop.set(1)
+                    readerTask.get(30, TimeUnit.SECONDS)
+                    readerError.isEmpty() shouldBe true
+                } finally {
+                    // Stop the reader loop (it polls `stop`, not interruption) and reap the thread on
+                    // every path, so an assertion failure above cannot leak a spinning reader into
+                    // later tests.
+                    stop.set(1)
+                    reader.shutdownNow()
+                }
             }
         }
 })

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionConcurrencyStressTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionConcurrencyStressTest.kt
@@ -1,0 +1,147 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx.projection
+
+import net.transgressoft.lirp.persistence.LirpContext
+import net.transgressoft.lirp.persistence.MultiKeyAudioItemVolatileRepository
+import net.transgressoft.lirp.persistence.fx.FxToolkitInit
+import net.transgressoft.lirp.testing.ReactiveScopeSerialization
+import net.transgressoft.lirp.testing.Stress
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import javafx.collections.MapChangeListener
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Concurrency regression tests for the registry-backed FX projections under a large async batch
+ * import, using the production reactive dispatchers (via [ReactiveScopeSerialization]) so the real
+ * background event coroutine and the FX Application Thread are both active.
+ *
+ * Guards against a seed-window dropped-update race: registry events arriving in the interval between
+ * the core subscribing and the projection finishing its direct seed must not be lost, even when the
+ * projection is first initialized in the middle of the import. With unique-per-entity keys, a dropped
+ * event is permanent (no later event re-flushes the key), so full materialization is a strict probe.
+ */
+@DisplayName("Registry FX projection concurrency")
+class RegistryFxProjectionConcurrencyStressTest : StringSpec({
+    extension(ReactiveScopeSerialization)
+
+    beforeSpec { FxToolkitInit.ensureInitialized() }
+    afterEach { LirpContext.default.close() }
+
+    val itemCount = 1200
+    val importThreads = 8
+
+    /** Imports [itemCount] entities concurrently and runs [initDuringImport] once a third are in. */
+    fun runConcurrentImport(repo: MultiKeyAudioItemVolatileRepository, initDuringImport: () -> Unit) {
+        val errors = ConcurrentLinkedQueue<Throwable>()
+        val pool = Executors.newFixedThreadPool(importThreads)
+        val completed = CountDownLatch(itemCount)
+        val started = AtomicInteger(0)
+        try {
+            for (i in 1..itemCount) {
+                pool.submit {
+                    try {
+                        repo.create(i, "Track-$i", setOf("artist-$i"))
+                    } catch (t: Throwable) {
+                        errors.add(t)
+                    } finally {
+                        started.incrementAndGet()
+                        completed.countDown()
+                    }
+                }
+            }
+            // Open the seed window: initialize the projection mid-import.
+            while (started.get() < itemCount / 3) Thread.sleep(1)
+            initDuringImport()
+            completed.await(30, TimeUnit.SECONDS) shouldBe true
+        } finally {
+            pool.shutdownNow()
+        }
+        errors.isEmpty() shouldBe true
+    }
+
+    fun awaitMaterialized(currentCount: () -> Int): Int {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30)
+        var count = currentCount()
+        while (count < itemCount && System.nanoTime() < deadline) {
+            Thread.sleep(20)
+            count = currentCount()
+        }
+        return count
+    }
+
+    "RegistryFxMultiKeyProjection materializes every entry when first initialized during a large concurrent import"
+        .config(tags = setOf(Stress)) {
+            val repo = MultiKeyAudioItemVolatileRepository()
+            val projection = RegistryFxMultiKeyProjection(repo, { it.genres }, true)
+
+            runConcurrentImport(repo) { projection.addListener(MapChangeListener { }) }
+
+            val materialized = awaitMaterialized { projection.values.flatten().map { it.id }.toSet().size }
+            materialized shouldBe itemCount
+        }
+
+    "RegistryFxProjection materializes every entry when first initialized during a large concurrent import"
+        .config(tags = setOf(Stress)) {
+            val repo = MultiKeyAudioItemVolatileRepository()
+            val projection = RegistryFxProjection(repo, { it.title }, true)
+
+            runConcurrentImport(repo) { projection.addListener(MapChangeListener { }) }
+
+            val materialized = awaitMaterialized { projection.values.flatten().map { it.id }.toSet().size }
+            materialized shouldBe itemCount
+        }
+
+    "RegistryFxMultiKeyProjection iterates entries, keys, and values without exception under a concurrent import"
+        .config(tags = setOf(Stress)) {
+            val repo = MultiKeyAudioItemVolatileRepository()
+            val projection = RegistryFxMultiKeyProjection(repo, { it.genres }, true)
+            projection.addListener(MapChangeListener { })
+
+            shouldNotThrowAny {
+                val reader = Executors.newSingleThreadExecutor()
+                val stop = AtomicInteger(0)
+                val readerError = ConcurrentLinkedQueue<Throwable>()
+                val readerTask =
+                    reader.submit {
+                        while (stop.get() == 0) {
+                            try {
+                                projection.keys.toList()
+                                projection.entries.forEach { it.value.size }
+                                projection.values.flatten().size
+                            } catch (t: Throwable) {
+                                readerError.add(t)
+                                return@submit
+                            }
+                        }
+                    }
+                runConcurrentImport(repo) { /* already initialized above */ }
+                stop.set(1)
+                readerTask.get(30, TimeUnit.SECONDS)
+                reader.shutdownNow()
+                readerError.isEmpty() shouldBe true
+            }
+        }
+})


### PR DESCRIPTION
Closes #266.

## Problem

A large async batch import into a registry that backs an FX projection lost entries when the projection was first initialized in the middle of the import. With unique-ish bucket keys (e.g. an artist catalog keyed by artist), hundreds of entities never materialized in the projection.

A focused reproduction (production dispatchers, ~1200-entity concurrent import) made this precise:

| When the projection is initialized | Materialized |
|---|---|
| before the import | 1200 / 1200 |
| during the import | ~511–924 / 1200 |

## Root cause

The registry-backed projection cores (`RegistryProjection`, `MultiKeyRegistryProjection`) seeded their initial state by iterating the registry and **only then** subscribed to change events. Events emitted during that seed iteration were dropped: the event publisher short-circuits emissions while there are no subscribers, and the registry iterator is only weakly consistent. For a key with no later event, the loss was permanent.

The FX decorators (`RegistryFxProjection`, `RegistryFxMultiKeyProjection`) added a second, narrower window by wiring their flush listener after their own seed without a seed-window buffer — unlike the transformed variants, which already used one.

Note on the originally-reported symptom: the `ConcurrentModificationException` is not reproducible from the projection snapshot getters. `FXCollections.observableMap` wraps the backing map in `ObservableMapWrapper`, whose entry/key/value iterators delegate to the backing `ConcurrentSkipListMap`'s weakly-consistent iterator, so iteration is CME-free; concurrent-read stress over the projections threw nothing. The reproducible defect was the dropped-update race described above.

## Fix

- **Subscribe before seeding, and buffer.** Projections now subscribe first and route events that arrive during the seed through a new `SeedEventBuffer`, which holds them and replays them in arrival order once the seed completes. The seed thread stays the sole writer throughout, so no delta is lost. The FX decorators reuse the existing `FxSeedWindowBuffer` for their own seed window.
- **De-duplicate.** An entity captured by both the seed iterator and a replayed seed-window create is skipped via the reverse index in `onCreated`, so it is never added to its bucket twice.
- **Uniform `entries` semantics.** `RegistryFxProjection.entries` and `RegistryFxMultiKeyProjection.entries` now return the same defensive point-in-time snapshot as the other six projection variants, instead of a live view, giving the whole family consistent read-only iteration semantics.

The transformed registry FX projections also benefit, since they build on the fixed cores.

## Tests

- `SeedEventBufferTest` — deterministic buffer / replay-in-order / pass-through-after-completion coverage.
- `RegistryProjectionTest` — two deterministic reverse-index dedup cases (single- and multi-key).
- `RegistryFxProjectionConcurrencyStressTest` (`Stress`-tagged) — imports ~1200 entities concurrently while initializing the projection mid-import and asserts full materialization, plus a concurrent-read no-exception guard.

## Verification

- Reproduction goes from ~511–924 / 1200 to **1200 / 1200** after the fix.
- `gradle build` (all modules: unit tests + ktlint) passes.
- `Stress`-tagged suite for both modules passes (including the 250-subscriber and same-key contention tests).
- Aggregated coverage: line 88.3%, branch 73.6% (both above the project baseline); `SeedEventBuffer` is fully covered.

No public API or behavioral breaking changes for existing single-threaded callers, so no migration notes.