### PR TITLE
#270 Add SQL construction SPI for non-public entities (LirpRawConstructor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ These are **breaking changes**; see [Migration from 2.x to 3.0.0](#migration-fro
   is needed), and the redundant `_LirpRawInitializer` load-time guard is gone. Applying lirp-ksp
   still yields the zero-reflection direct-call path; the fallback only trades that for reflection on
   property getters.
+- **Construction-free SQL persistence of non-public entities** — `SqlRepository.loadFromStore` can
+  now rebuild an entity whose primary constructor is `internal` or `private` — and therefore
+  unreachable from a separate persistence module — without a public factory. A table definition opts
+  in by implementing the new `RawConstructibleTableDef`: it supplies the constructor argument values
+  via `constructorParams` and the entity's binary name via `entityClassName`, and leaves `fromRow`
+  unused. Construction is delegated to a `LirpRawConstructor` co-located with the entity (resolved by
+  the `_LirpRawConstructor` `Class.forName` convention, mirroring `_LirpRawInitializer`), which alone
+  reaches the non-public constructor; remaining fields are still populated through
+  `LirpRawInitializer`. This makes the SQL bulk-load path symmetric with the reflective JSON
+  construction path for entities a persistence module cannot construct directly. KSP generation of
+  `_LirpRawConstructor` is not yet provided — hand-author the class for now.
 - **Registry-source projections** — `RegistryProjection` (core) and `RegistryFxProjection`
   (FX) project a `Registry`'s entities into buckets, complementing the existing aggregate-source
   projections. Registry-backed projections are `AutoCloseable` so their registry subscription can

--- a/lirp-api/api/lirp-api.api
+++ b/lirp-api/api/lirp-api.api
@@ -347,6 +347,10 @@ public final class net/transgressoft/lirp/persistence/LirpDeserializationExcepti
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public abstract interface class net/transgressoft/lirp/persistence/LirpRawConstructor {
+	public abstract fun construct (Ljava/util/Map;)Ljava/lang/Object;
+}
+
 public abstract interface class net/transgressoft/lirp/persistence/LirpRawInitializer {
 	public abstract fun getEntries ()Ljava/util/List;
 }

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/LirpRawConstructor.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/LirpRawConstructor.kt
@@ -1,0 +1,57 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+/**
+ * Internal API consumed by KSP-generated or hand-authored code; not intended for direct use by
+ * application code.
+ *
+ * Builds a bare entity instance from its primary-constructor argument values during SQL bulk-load.
+ * Used by `SqlRepository.loadFromStore` (via a `RawConstructibleTableDef`) so the construction step
+ * lives in the entity's own module — where its primary constructor is reachable even when that
+ * constructor is `internal` or `private` — instead of in the persistence module that maps columns.
+ * This is the construction counterpart to [LirpRawInitializer], which only populates the remaining
+ * `var` / reactive-backed fields on an already-constructed instance.
+ *
+ * The implementation is resolved at runtime by appending the `_LirpRawConstructor` suffix to the
+ * entity's binary name (the same `Class.forName` convention used for the other generated accessors),
+ * so it must be a top-level class in the entity's package with a public no-arg constructor.
+ *
+ * JSON deserialization does not consult this SPI: `LirpEntitySerializer` constructs reactive entities
+ * reflectively via their primary constructor instead.
+ *
+ * Implementations call the entity's primary constructor directly, mapping each required parameter from
+ * [construct]'s `params` map. For example, an entity declared as
+ * `internal class Foo internal constructor(val id: Int, val name: String)` is built by
+ * `Foo(params["id"] as Int, params["name"] as String)`.
+ *
+ * @param E the entity type this constructor was generated or hand-authored for
+ */
+interface LirpRawConstructor<E> {
+
+    /**
+     * Builds a fresh entity from its primary-constructor argument values.
+     *
+     * @param params primary-constructor argument values keyed by parameter name, as produced by the
+     *   matching `RawConstructibleTableDef.constructorParams`. Optional constructor parameters absent
+     *   from the map fall back to their declared defaults.
+     * @return the constructed entity, with only its constructor-supplied fields set; remaining fields
+     *   are populated separately through [LirpRawInitializer].
+     */
+    fun construct(params: Map<String, Any?>): E
+}

--- a/lirp-core/api/lirp-core.api
+++ b/lirp-core/api/lirp-core.api
@@ -862,7 +862,9 @@ public abstract class net/transgressoft/lirp/persistence/RegistryBase : net/tran
 	public synthetic fun isEventActive (Lnet/transgressoft/lirp/event/EventType;)Z
 	public fun iterator ()Ljava/util/Iterator;
 	public fun lazySearch (Ljava/util/function/Predicate;)Lkotlin/sequences/Sequence;
+	public static final fun publicRawConstructorFor (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRawConstructor;
 	public static final fun publicRawInitializerFor (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRawInitializer;
+	public static final fun rawConstructorFor$net_transgressoft_lirp_core (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRawConstructor;
 	public static final fun rawInitializerFor$net_transgressoft_lirp_core (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRawInitializer;
 	public static final fun refAccessorFor$net_transgressoft_lirp_core (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRefAccessor;
 	public static final fun registerRepository (Ljava/lang/Class;Lnet/transgressoft/lirp/persistence/Repository;)V
@@ -887,6 +889,7 @@ public abstract class net/transgressoft/lirp/persistence/RegistryBase : net/tran
 
 public final class net/transgressoft/lirp/persistence/RegistryBase$Companion {
 	public final fun deregisterRepository (Ljava/lang/Class;)V
+	public final fun publicRawConstructorFor (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRawConstructor;
 	public final fun publicRawInitializerFor (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRawInitializer;
 	public final fun registerRepository (Ljava/lang/Class;Lnet/transgressoft/lirp/persistence/Repository;)V
 }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/KspAccessorLoader.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/KspAccessorLoader.kt
@@ -39,6 +39,7 @@ internal object KspAccessorLoader {
     internal const val REF_ACCESSOR_SUFFIX = "_LirpRefAccessor"
     internal const val VIA_ACCESSOR_SUFFIX = "_LirpViaAccessor"
     internal const val RAW_INITIALIZER_SUFFIX = "_LirpRawInitializer"
+    internal const val RAW_CONSTRUCTOR_SUFFIX = "_LirpRawConstructor"
     internal const val REGISTRY_INFO_SUFFIX = "_LirpRegistryInfo"
 
     // Uses Optional as the map value to cache both "found" and "not found" states —

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
@@ -857,5 +857,33 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
         @JvmStatic
         fun publicRawInitializerFor(entityClass: Class<*>): LirpRawInitializer<Any> =
             rawInitializerFor(entityClass)
+
+        /**
+         * Returns the [LirpRawConstructor] for [entityClass], loading it via [KspAccessorLoader] on
+         * first call and caching the result, or `null` when none exists.
+         *
+         * Unlike [rawInitializerFor], absence is not an error: most entities are constructed through
+         * `SqlTableDef.fromRow` and have no constructor SPI. A `_LirpRawConstructor` exists only for
+         * entities whose table descriptor opts into construction delegation (a
+         * `RawConstructibleTableDef`); the SQL load path enforces presence at its own call site when
+         * that opt-in is declared.
+         */
+        @JvmStatic
+        internal fun rawConstructorFor(entityClass: Class<*>): LirpRawConstructor<Any>? =
+            KspAccessorLoader.load(entityClass, KspAccessorLoader.RAW_CONSTRUCTOR_SUFFIX)
+
+        /**
+         * Public cross-module entry point for [rawConstructorFor].
+         *
+         * `lirp-sql` (a separate Gradle / Kotlin module) needs to resolve raw constructors from
+         * `SqlRepository.loadFromStore`. Kotlin `internal` visibility is module-scoped, so the
+         * cross-module call site goes through this thin public wrapper. The actual cache and accessor
+         * lookup live in [rawConstructorFor] via [KspAccessorLoader].
+         *
+         * @return the resolved constructor, or `null` when the entity has no `_LirpRawConstructor`.
+         */
+        @JvmStatic
+        fun publicRawConstructorFor(entityClass: Class<*>): LirpRawConstructor<Any>? =
+            rawConstructorFor(entityClass)
     }
 }

--- a/lirp-sql-api/api/lirp-sql-api.api
+++ b/lirp-sql-api/api/lirp-sql-api.api
@@ -58,6 +58,16 @@ public abstract interface class net/transgressoft/lirp/persistence/sql/JunctionT
 	public abstract fun isOrdered ()Z
 }
 
+public abstract interface class net/transgressoft/lirp/persistence/sql/RawConstructibleTableDef : net/transgressoft/lirp/persistence/sql/SqlTableDef {
+	public abstract fun constructorParams (Lorg/jetbrains/exposed/v1/core/ResultRow;Lorg/jetbrains/exposed/v1/core/Table;)Ljava/util/Map;
+	public fun fromRow (Lorg/jetbrains/exposed/v1/core/ResultRow;Lorg/jetbrains/exposed/v1/core/Table;)Ljava/lang/Object;
+	public abstract fun getEntityClassName ()Ljava/lang/String;
+}
+
+public final class net/transgressoft/lirp/persistence/sql/RawConstructibleTableDef$DefaultImpls {
+	public static fun fromRow (Lnet/transgressoft/lirp/persistence/sql/RawConstructibleTableDef;Lorg/jetbrains/exposed/v1/core/ResultRow;Lorg/jetbrains/exposed/v1/core/Table;)Ljava/lang/Object;
+}
+
 public abstract interface class net/transgressoft/lirp/persistence/sql/SqlTableDef : net/transgressoft/lirp/persistence/LirpTableDef {
 	public abstract fun applyRow (Ljava/lang/Object;Lorg/jetbrains/exposed/v1/core/ResultRow;Lorg/jetbrains/exposed/v1/core/Table;)V
 	public abstract fun applyScalarRow (Ljava/lang/Object;Lorg/jetbrains/exposed/v1/core/ResultRow;Lorg/jetbrains/exposed/v1/core/Table;Lnet/transgressoft/lirp/persistence/LirpRawInitializer;)V

--- a/lirp-sql-api/src/main/kotlin/net/transgressoft/lirp/persistence/sql/RawConstructibleTableDef.kt
+++ b/lirp-sql-api/src/main/kotlin/net/transgressoft/lirp/persistence/sql/RawConstructibleTableDef.kt
@@ -1,0 +1,77 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+
+/**
+ * Opt-in [SqlTableDef] variant that delegates entity construction to the entity's own module instead
+ * of building the instance inside [fromRow].
+ *
+ * The standard [SqlTableDef.fromRow] must return a fully constructed entity, which forces the table
+ * definition to call the entity's primary constructor. When the table definition lives in a different
+ * Gradle module from the entity and that constructor is `internal` or `private`, `fromRow` cannot
+ * compile without a public factory. Implementing this interface removes that requirement: the table
+ * definition supplies only the constructor argument *values* (via [constructorParams]), and
+ * `SqlRepository.loadFromStore` builds the instance through the entity's
+ * `LirpRawConstructor` — resolved by appending `_LirpRawConstructor` to [entityClassName] — which is
+ * co-located with the entity and therefore reaches its non-public constructor.
+ *
+ * Remaining `var` / reactive-backed fields are still populated by [applyScalarRow] through the
+ * entity's `LirpRawInitializer`, exactly as for a [fromRow]-based table definition.
+ *
+ * Implementers override [entityClassName], [constructorParams], [toParams], [applyRow], and
+ * [applyScalarRow]; [fromRow] must not be overridden — `SqlRepository` routes construction through
+ * the constructor SPI and never calls it.
+ *
+ * @param E The entity type this table definition maps.
+ */
+interface RawConstructibleTableDef<E> : SqlTableDef<E> {
+
+    /**
+     * Binary name of the concrete entity class to construct (e.g.
+     * `net.transgressoft.example.MyEntity`). `SqlRepository` appends `_LirpRawConstructor` and
+     * resolves the constructor via `Class.forName`, mirroring the convention used for the entity's
+     * other generated accessors.
+     */
+    val entityClassName: String
+
+    /**
+     * Extracts the primary-constructor argument values for one entity from [row].
+     *
+     * The returned map is keyed by constructor parameter name and consumed by the entity's
+     * `LirpRawConstructor`. Only constructor parameters need to be present — every other field is
+     * restored afterward by [applyScalarRow]. Optional constructor parameters may be omitted to fall
+     * back to their declared defaults.
+     *
+     * @param row The Exposed result row for the entity being reconstructed.
+     * @param table The [Table] whose column references are looked up by name.
+     * @return constructor argument values keyed by parameter name.
+     */
+    fun constructorParams(row: ResultRow, table: Table): Map<String, Any?>
+
+    /**
+     * Never invoked for a [RawConstructibleTableDef] — construction is delegated to the entity's
+     * `LirpRawConstructor`. Present only to satisfy the [SqlTableDef] contract.
+     */
+    override fun fromRow(row: ResultRow, table: Table): E =
+        throw UnsupportedOperationException(
+            "RawConstructibleTableDef delegates construction to the entity's LirpRawConstructor; fromRow is unused"
+        )
+}

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryRawConstructorIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryRawConstructorIntegrationTest.kt
@@ -1,0 +1,330 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.event.StandardCrudEvent
+import net.transgressoft.lirp.persistence.ColumnDef
+import net.transgressoft.lirp.persistence.ColumnType
+import net.transgressoft.lirp.persistence.LirpRawConstructor
+import net.transgressoft.lirp.persistence.LirpRawInitializer
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.withDatabaseTest
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withTests
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import org.junit.jupiter.api.DisplayName
+import java.util.Collections
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Test entity whose primary constructor is `internal`, standing in for a domain aggregate that a
+ * persistence module in another Gradle module could not construct directly. All persisted state is
+ * carried by constructor parameters so the entity is fully rebuilt by its [LirpRawConstructor] alone.
+ */
+class RawCtorEntity internal constructor(
+    override val id: Int,
+    val label: String,
+    val score: Int
+) : ReactiveEntityBase<Int, RawCtorEntity>() {
+    override val uniqueId: String get() = id.toString()
+
+    override fun clone(): RawCtorEntity = RawCtorEntity(id, label, score)
+}
+
+/**
+ * Co-located constructor SPI for [RawCtorEntity]. Resolved by `SqlRepository.loadFromStore` via
+ * `Class.forName` on the entity's binary name plus the `_LirpRawConstructor` suffix. Being in the
+ * entity's own module, it reaches the `internal` constructor — the persistence-side
+ * [RawConstructibleTableDef] never does.
+ */
+@Suppress("ClassName")
+class RawCtorEntity_LirpRawConstructor : LirpRawConstructor<RawCtorEntity> {
+    override fun construct(params: Map<String, Any?>): RawCtorEntity =
+        RawCtorEntity(
+            id = params["id"] as Int,
+            label = params["label"] as String,
+            score = params["score"] as Int
+        )
+}
+
+/**
+ * Construction-free [SqlTableDef] for [RawCtorEntity]: it maps columns and extracts constructor
+ * argument values from a row, but delegates construction to [RawCtorEntity_LirpRawConstructor]. It
+ * does not implement [fromRow] — the inherited default throws, proving that a successful load went
+ * through the constructor SPI rather than `fromRow`.
+ */
+object RawCtorEntityTableDef : RawConstructibleTableDef<RawCtorEntity> {
+    override val tableName = "raw_ctor_entities"
+    override val entityClassName = "net.transgressoft.lirp.persistence.sql.RawCtorEntity"
+    override val columns =
+        listOf(
+            ColumnDef("id", ColumnType.IntType, nullable = false, primaryKey = true),
+            ColumnDef("label", ColumnType.VarcharType(100), nullable = false, primaryKey = false),
+            ColumnDef("score", ColumnType.IntType, nullable = false, primaryKey = false)
+        )
+
+    @Suppress("UNCHECKED_CAST")
+    override fun constructorParams(row: ResultRow, table: Table): Map<String, Any?> {
+        val cols = table.columns.associateBy { it.name }
+        return mapOf(
+            "id" to row[cols["id"]!! as Column<Int>],
+            "label" to row[cols["label"]!! as Column<String>],
+            "score" to row[cols["score"]!! as Column<Int>]
+        )
+    }
+
+    override fun toParams(entity: RawCtorEntity, table: Table): Map<Column<*>, Any?> {
+        val cols = table.columns.associateBy { it.name }
+        return mapOf(
+            cols["id"]!! to entity.id,
+            cols["label"]!! to entity.label,
+            cols["score"]!! to entity.score
+        )
+    }
+
+    override fun applyRow(entity: RawCtorEntity, row: ResultRow, table: Table) {
+        // No-op: all state is immutable and supplied at construction; only reachable via @Version
+        // optimistic-lock recovery, which this entity does not use.
+    }
+
+    override fun applyScalarRow(entity: RawCtorEntity, row: ResultRow, table: Table, rawInit: LirpRawInitializer<RawCtorEntity>) {
+        // No-op: every field is a constructor parameter, so the entity is complete after construction.
+    }
+}
+
+/**
+ * Versioned variant of [RawCtorEntity] with an `internal` constructor. `id`, `tag`, and the
+ * optimistic-lock `version` are constructor parameters rebuilt by its [LirpRawConstructor]; `note`
+ * is a non-constructor reactive field restored separately through its [LirpRawInitializer]. The mix
+ * exercises the optimistic-lock recovery path, which must both construct the instance and hydrate
+ * its non-constructor scalars before re-inserting it.
+ */
+class VersionedRawCtorEntity internal constructor(
+    override val id: Int,
+    val tag: String,
+    initialVersion: Long
+) : ReactiveEntityBase<Int, VersionedRawCtorEntity>() {
+
+    var version: Long by reactiveProperty(initialVersion)
+    var note: String by reactiveProperty("")
+
+    override val uniqueId: String get() = id.toString()
+
+    override fun clone(): VersionedRawCtorEntity =
+        VersionedRawCtorEntity(id, tag, version).also { copy ->
+            copy.withEventsDisabled { copy.note = note }
+        }
+}
+
+/** Co-located constructor SPI for [VersionedRawCtorEntity], reaching its `internal` constructor. */
+@Suppress("ClassName")
+class VersionedRawCtorEntity_LirpRawConstructor : LirpRawConstructor<VersionedRawCtorEntity> {
+    override fun construct(params: Map<String, Any?>): VersionedRawCtorEntity =
+        VersionedRawCtorEntity(
+            id = params["id"] as Int,
+            tag = params["tag"] as String,
+            initialVersion = params["version"] as Long
+        )
+}
+
+/**
+ * Construction-free [SqlTableDef] for [VersionedRawCtorEntity] that also opts into optimistic
+ * locking via [VersionedTableDef]. Construction (version included) is delegated to
+ * [VersionedRawCtorEntity_LirpRawConstructor]; `fromRow` stays unimplemented and throws.
+ */
+object VersionedRawCtorTableDef :
+    RawConstructibleTableDef<VersionedRawCtorEntity>,
+    VersionedTableDef<VersionedRawCtorEntity> {
+    override val tableName = "versioned_raw_ctor_entities"
+    override val entityClassName = "net.transgressoft.lirp.persistence.sql.VersionedRawCtorEntity"
+    override val columns =
+        listOf(
+            ColumnDef("id", ColumnType.IntType, nullable = false, primaryKey = true),
+            ColumnDef("tag", ColumnType.VarcharType(100), nullable = false, primaryKey = false),
+            ColumnDef("note", ColumnType.VarcharType(100), nullable = false, primaryKey = false),
+            ColumnDef("version", ColumnType.LongType, nullable = false, primaryKey = false, isVersion = true)
+        )
+
+    @Suppress("UNCHECKED_CAST")
+    override fun constructorParams(row: ResultRow, table: Table): Map<String, Any?> {
+        val cols = table.columns.associateBy { it.name }
+        return mapOf(
+            "id" to row[cols["id"]!! as Column<Int>],
+            "tag" to row[cols["tag"]!! as Column<String>],
+            "version" to row[cols["version"]!! as Column<Long>]
+        )
+    }
+
+    override fun toParams(entity: VersionedRawCtorEntity, table: Table): Map<Column<*>, Any?> {
+        val cols = table.columns.associateBy { it.name }
+        return mapOf(
+            cols["id"]!! to entity.id,
+            cols["tag"]!! to entity.tag,
+            cols["note"]!! to entity.note,
+            cols["version"]!! to entity.version
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun applyRow(entity: VersionedRawCtorEntity, row: ResultRow, table: Table) {
+        // Refresh the mutable non-PK fields; `tag` is an immutable constructor field. Reachable on
+        // the in-memory-survivor conflict path, not on the DELETE-defeat reconstruct path tested here.
+        val cols = table.columns.associateBy { it.name }
+        entity.note = row[cols["note"]!! as Column<String>]
+        entity.version = row[cols["version"]!! as Column<Long>]
+    }
+
+    override fun bumpVersion(entity: VersionedRawCtorEntity, newVersion: Long) {
+        entity.version = newVersion
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun applyScalarRow(
+        entity: VersionedRawCtorEntity,
+        row: ResultRow,
+        table: Table,
+        rawInit: LirpRawInitializer<VersionedRawCtorEntity>
+    ) {
+        // Restore the non-constructor `note` field through the entity's raw initializer, mirroring
+        // the bulk-load scalar pass. `id`, `tag`, and `version` are constructor parameters.
+        val cols = table.columns.associateBy { it.name }
+        val note = row[cols["note"]!! as Column<String>]
+        rawInit.entries.first { it.name == "note" }.silentSetter(entity, note)
+    }
+}
+
+/**
+ * Integration tests for the construction-delegation SPI: when a table definition is a
+ * [RawConstructibleTableDef], `SqlRepository` builds entities through the entity's co-located
+ * [LirpRawConstructor] — never through [SqlTableDef.fromRow] — so an entity with a non-public
+ * constructor can be mapped from a separate module without any public construction factory.
+ *
+ * Covers both paths that materialize an entity from a row: the bulk load in `SqlEntityLoader` and
+ * the optimistic-lock recovery reconstruct in `OptimisticLockRecovery`. Runs against PostgreSQL,
+ * MySQL, MariaDB, SQLite, and H2 via the shared database harness.
+ */
+@DisplayName("SqlRepository RawConstructor Integration")
+internal class SqlRepositoryRawConstructorIntegrationTest : FunSpec({
+
+    // Opens a short-lived Exposed transaction against [dataSource] so a "third-party writer" can
+    // bump a row's version independently of the repository, making the DELETE-defeat conflict
+    // deterministic instead of timing-sensitive.
+    fun <T> rawTransaction(dataSource: HikariDataSource, block: Table.() -> T): T {
+        val db = Database.connect(dataSource)
+        val exposed = ExposedTableInterpreter().interpret(VersionedRawCtorTableDef)
+        return transaction(db) { exposed.table.block() }
+    }
+
+    context("[SqlRepository] bulk load builds internal entities via LirpRawConstructor, not fromRow") {
+        withTests(databases) { db ->
+            withDatabaseTest(db, RawCtorEntityTableDef) { dataSource ->
+                // Seed via a first repository instance; writes go through toParams only.
+                val seedRepo = SqlRepository(dataSource, RawCtorEntityTableDef)
+                try {
+                    repeat(8) { i -> seedRepo.add(RawCtorEntity(i, "label-$i", 100 + i)) }
+                } finally {
+                    seedRepo.close()
+                }
+
+                // A fresh repository bulk-loads from the store. Construction is delegated to
+                // RawCtorEntity_LirpRawConstructor; fromRow is never invoked.
+                val repo = SqlRepository(dataSource, RawCtorEntityTableDef)
+                try {
+                    repo.size() shouldBe 8
+                    for (i in 0 until 8) {
+                        val entity = repo.findById(i).orElseThrow()
+                        entity.label shouldBe "label-$i"
+                        entity.score shouldBe 100 + i
+                    }
+                } finally {
+                    repo.close()
+                }
+            }
+        }
+    }
+
+    context("[SqlRepository] rebuilds an internal versioned entity via LirpRawConstructor during DELETE-defeat recovery") {
+        withTests(databases) { db ->
+            withDatabaseTest(db, VersionedRawCtorTableDef) { dataSource ->
+                val conflicts = Collections.synchronizedList(mutableListOf<StandardCrudEvent.Conflict<*, *>>())
+                val repo = SqlRepository(dataSource, VersionedRawCtorTableDef)
+                try {
+                    repo.subscribe { event ->
+                        if (event is StandardCrudEvent.Conflict<*, *>) conflicts.add(event)
+                    }
+
+                    repo.add(VersionedRawCtorEntity(7, "tag-7", 0L).apply { note = "note-7" })
+
+                    // Wait until the row is persisted at version 0 before the third-party bump.
+                    eventually(10.seconds) {
+                        val version =
+                            rawTransaction(dataSource) {
+                                @Suppress("UNCHECKED_CAST")
+                                selectAll()
+                                    .where { (columns.first { it.name == "id" } as Column<Int>) eq 7 }
+                                    .singleOrNull()
+                                    ?.let { row ->
+                                        @Suppress("UNCHECKED_CAST")
+                                        row[columns.first { it.name == "version" } as Column<Long>]
+                                    }
+                            }
+                        version shouldBe 0L
+                    }
+
+                    // Third-party writer bumps the version so our subsequent versioned DELETE
+                    // (WHERE version = 0) is defeated, driving the Case 2b reconstruct path.
+                    rawTransaction(dataSource) {
+                        @Suppress("UNCHECKED_CAST")
+                        update({ (columns.first { it.name == "id" } as Column<Int>) eq 7 }) { row ->
+                            @Suppress("UNCHECKED_CAST")
+                            row[columns.first { it.name == "version" } as Column<Long>] = 1L
+                        }
+                    }
+
+                    repo.remove(repo.findById(7).orElseThrow())
+
+                    eventually(15.seconds) { conflicts.size shouldBe 1 }
+
+                    // The entity is rebuilt through VersionedRawCtorEntity_LirpRawConstructor (fromRow
+                    // throws) and re-inserted with the canonical version. `note` is a non-constructor
+                    // field, so its restoration proves recovery also runs the scalar-row pass via the
+                    // LirpRawInitializer rather than re-inserting a partially hydrated instance.
+                    eventually(5.seconds) {
+                        val recovered = repo.findById(7).orElseThrow()
+                        recovered.tag shouldBe "tag-7"
+                        recovered.version shouldBe 1L
+                        recovered.note shouldBe "note-7"
+                    }
+                } finally {
+                    repo.close()
+                }
+            }
+        }
+    }
+})

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/OptimisticLockRecovery.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/OptimisticLockRecovery.kt
@@ -18,10 +18,14 @@
 package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.entity.ReactiveEntity
+import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.StandardCrudEvent
+import net.transgressoft.lirp.persistence.LirpRawConstructor
+import net.transgressoft.lirp.persistence.LirpRawInitializer
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -50,6 +54,8 @@ import kotlin.uuid.toKotlinUuid
  */
 internal class OptimisticLockRecovery<K : Comparable<K>, R : ReactiveEntity<K, R>>(
     private val tableDef: SqlTableDef<R>,
+    private val publicRawInitializerFor: (Class<*>) -> LirpRawInitializer<Any>,
+    private val publicRawConstructorFor: (Class<*>) -> LirpRawConstructor<Any>?,
     private val table: Table,
     private val pkCol: Column<*>,
     private val versionCol: Column<Long>,
@@ -65,6 +71,53 @@ internal class OptimisticLockRecovery<K : Comparable<K>, R : ReactiveEntity<K, R
     private val emitRecoveryFailed: (K, Long, Exception) -> Unit
 ) {
     private val log = KotlinLogging.logger(javaClass.name)
+
+    // Mirrors SqlEntityLoader: when the table definition opts into construction delegation, the
+    // canonical row is rebuilt through the entity's co-located LirpRawConstructor rather than fromRow.
+    @Suppress("UNCHECKED_CAST")
+    private val rawConstructibleTableDef: RawConstructibleTableDef<R>? = tableDef as? RawConstructibleTableDef<R>
+
+    @Suppress("UNCHECKED_CAST")
+    private val rawConstructor: LirpRawConstructor<R>? by lazy {
+        rawConstructibleTableDef?.let { rc ->
+            val entityClass = Class.forName(rc.entityClassName)
+            (
+                publicRawConstructorFor(entityClass)
+                    ?: error(
+                        "RawConstructibleTableDef '${tableDef::class.qualifiedName}' declares " +
+                            "entityClassName='${rc.entityClassName}' but no " +
+                            "${rc.entityClassName}_LirpRawConstructor was found on the classpath"
+                    )
+            ) as LirpRawConstructor<R>
+        }
+    }
+
+    // Mirrors SqlEntityLoader's load flow: the raw constructor only sets constructor-supplied fields,
+    // so any remaining persisted scalar/reactive state must still be restored through the entity's
+    // LirpRawInitializer before the reconstructed instance is re-inserted. Otherwise Case 2b would
+    // resurrect a partially hydrated entity carrying default values for non-constructor columns.
+    private fun reconstruct(row: ResultRow): R {
+        val rc = rawConstructibleTableDef ?: return tableDef.fromRow(row, table)
+        val entity = rawConstructor!!.construct(rc.constructorParams(row, table))
+        resolveRawInitializer(entity)?.let { rawInit ->
+            if (entity is ReactiveEntityBase<*, *>) {
+                entity.withEventsDisabled { tableDef.applyScalarRow(entity, row, table, rawInit) }
+            } else {
+                tableDef.applyScalarRow(entity, row, table, rawInit)
+            }
+        }
+        return entity
+    }
+
+    // Null when the entity has no generated/hand-authored LirpRawInitializer — every persisted field
+    // is then a constructor parameter and the construct() result is already complete.
+    private fun resolveRawInitializer(entity: R): LirpRawInitializer<R>? =
+        try {
+            @Suppress("UNCHECKED_CAST")
+            publicRawInitializerFor(entity::class.java) as LirpRawInitializer<R>
+        } catch (_: IllegalStateException) {
+            null
+        }
 
     /**
      * Shared recovery path for a single conflict accumulated during a flush. Re-SELECTs the
@@ -143,7 +196,7 @@ internal class OptimisticLockRecovery<K : Comparable<K>, R : ReactiveEntity<K, R
             // Case 2b: our DELETE was defeated. The entity is no longer in in-memory state
             // but the canonical row exists — reconstruct and re-insert without enqueueing an
             // insert PendingOp (the row is already persisted).
-            val reconstructed = tableDef.fromRow(canonicalRow, table)
+            val reconstructed = reconstruct(canonicalRow)
             hydrateJunctions(reconstructed)
             // Suppress the Create event that would otherwise fire from addToMemoryOnly →
             // VolatileRepository.add. Recovery should look like a single Conflict to

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlEntityLoader.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlEntityLoader.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.entity.ReactiveEntity
 import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.LirpRawConstructor
 import net.transgressoft.lirp.persistence.LirpRawInitializer
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ResultRow
@@ -48,7 +49,8 @@ internal class SqlEntityLoader<K : Comparable<K>, R : ReactiveEntity<K, R>>(
     private val exposedTable: ExposedTable,
     private val junctionTables: Map<JunctionTableDef, ExposedJunctionTable>,
     private val db: Database,
-    private val publicRawInitializerFor: (Class<*>) -> LirpRawInitializer<Any>
+    private val publicRawInitializerFor: (Class<*>) -> LirpRawInitializer<Any>,
+    private val publicRawConstructorFor: (Class<*>) -> LirpRawConstructor<Any>?
 ) {
     private val table: Table = exposedTable.table
 
@@ -56,6 +58,29 @@ internal class SqlEntityLoader<K : Comparable<K>, R : ReactiveEntity<K, R>>(
     // safe — JunctionAware members are typed on the same self-type R as this loader's tableDef.
     @Suppress("UNCHECKED_CAST")
     private val junctionAware: JunctionAware<R>? = tableDef as? JunctionAware<R>
+
+    // Non-null when the table definition opts into construction delegation: the entity is built by
+    // its co-located LirpRawConstructor instead of tableDef.fromRow, so a persistence-module table
+    // definition can map an entity whose primary constructor is not reachable across the module wall.
+    @Suppress("UNCHECKED_CAST")
+    private val rawConstructibleTableDef: RawConstructibleTableDef<R>? = tableDef as? RawConstructibleTableDef<R>
+
+    // Resolved once (a RawConstructibleTableDef maps a single concrete entity type via
+    // entityClassName); polymorphic per-row construction stays on the fromRow path.
+    @Suppress("UNCHECKED_CAST")
+    private val rawConstructor: LirpRawConstructor<R>? by lazy {
+        rawConstructibleTableDef?.let { rc ->
+            val entityClass = Class.forName(rc.entityClassName)
+            (
+                publicRawConstructorFor(entityClass)
+                    ?: error(
+                        "RawConstructibleTableDef '${tableDef::class.qualifiedName}' declares " +
+                            "entityClassName='${rc.entityClassName}' but no " +
+                            "${rc.entityClassName}_LirpRawConstructor was found on the classpath"
+                    )
+            ) as LirpRawConstructor<R>
+        }
+    }
 
     /**
      * Loads all rows from the entity table (and its junction tables when present) into a
@@ -91,12 +116,22 @@ internal class SqlEntityLoader<K : Comparable<K>, R : ReactiveEntity<K, R>>(
         val rawInitByClass = mutableMapOf<Class<*>, LirpRawInitializer<R>?>()
         val entities =
             table.selectAll().map { row ->
-                val entity = tableDef.fromRow(row, table)
+                val entity = constructEntity(row)
                 val rawInit = rawInitByClass.getOrPut(entity::class.java) { resolveRawInitializer(entity) }
                 rawInit?.let { applyScalarRow(entity, row, it) }
                 entity
             }
         return entities.associateBy { it.id }
+    }
+
+    /**
+     * Builds a single entity from [row]. Delegates to the entity's [LirpRawConstructor] when the
+     * table definition is a [RawConstructibleTableDef] (construction lives in the entity's module),
+     * otherwise calls [SqlTableDef.fromRow] as usual.
+     */
+    private fun constructEntity(row: ResultRow): R {
+        val rc = rawConstructibleTableDef ?: return tableDef.fromRow(row, table)
+        return rawConstructor!!.construct(rc.constructorParams(row, table))
     }
 
     private fun resolveRawInitializer(entity: R): LirpRawInitializer<R>? =

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
@@ -223,12 +223,14 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
         // can react.
         activateEvents(CrudEvent.Type.RECOVERY_FAILED)
         schemaInstaller = SqlSchemaInstaller(dataSource, tableDef, exposedTable, junctionTables, db)
-        entityLoader = SqlEntityLoader(tableDef, exposedTable, junctionTables, db, ::publicRawInitializerFor)
+        entityLoader = SqlEntityLoader(tableDef, exposedTable, junctionTables, db, ::publicRawInitializerFor, ::publicRawConstructorFor)
         writePipeline = SqlWritePipeline(tableDef, exposedTable, junctionTables, pkCol, versionCol)
         recovery =
             versionCol?.let { vc ->
                 OptimisticLockRecovery(
                     tableDef = tableDef,
+                    publicRawInitializerFor = ::publicRawInitializerFor,
+                    publicRawConstructorFor = ::publicRawConstructorFor,
                     table = exposedTable.table,
                     pkCol = pkCol,
                     versionCol = vc,


### PR DESCRIPTION
Closes #270.

## Problem

`SqlRepository` bulk-load reconstructs each row through `SqlTableDef.fromRow`, which must return a fully built entity — forcing the table definition to call the entity's primary constructor. When the table definition lives in a different Gradle module from the entity and that constructor is `internal` or `private`, `fromRow` cannot compile without exposing a public construction factory.

This blocked a clean "mapping-only persistence module" layout, where an application keeps its reactive entities (and their non-public constructors) in one module and the SQL/JSON mapping in separate, opt-in modules. The JSON path already supports it — `LirpEntitySerializer` constructs entities reflectively via their primary constructor — but the SQL path had no equivalent construction hook.

## Change

An opt-in construction-delegation SPI, symmetric with the existing `LirpRawInitializer` population SPI:

- **lirp-api** — `LirpRawConstructor<E> { construct(params): E }`, resolved by the `_LirpRawConstructor` `Class.forName` convention and co-located with the entity so it alone reaches the non-public constructor.
- **lirp-core** — `KspAccessorLoader.RAW_CONSTRUCTOR_SUFFIX` and `RegistryBase.publicRawConstructorFor` (returns `null` when absent — the SPI is opt-in).
- **lirp-sql-api** — `RawConstructibleTableDef<E> : SqlTableDef<E>` exposing `entityClassName` + `constructorParams(row, table)`; its default `fromRow` throws, since construction is delegated.
- **lirp-sql** — `SqlEntityLoader` and `OptimisticLockRecovery` build the instance via the constructor SPI when the table definition opts in, otherwise fall back to `fromRow`; `SqlRepository` wires the resolver.

A persistence-module table definition then maps an entity with a non-public constructor without any factory: it supplies only the constructor argument values, and the repository builds the entity through the entity's co-located `LirpRawConstructor`. Remaining fields are still populated via `LirpRawInitializer`. This makes the SQL bulk-load path symmetric with the reflective JSON construction path and keeps `lirp-sql` off the entity module's compile classpath.

## Testing

`SqlRepositoryRawConstructorIntegrationTest` runs against PostgreSQL, MySQL, MariaDB, SQLite, and H2, covering **both** paths that materialize an entity from a row:

- **bulk load** via `SqlEntityLoader` — an `internal`-constructor entity rebuilt without ever calling `fromRow`;
- **optimistic-lock recovery** via `OptimisticLockRecovery` — DELETE-defeat resurrection of a versioned `internal` entity, rebuilt (version included) through the constructor SPI.

`lirp-core` and `lirp-sql` unit suites and `ktlintCheck` pass.

## Notes

- Missing SPI is fail-loud: a `RawConstructibleTableDef` whose declared `entityClassName` has no `_LirpRawConstructor` on the classpath fails the load with a clear error.
- KSP generation of `_LirpRawConstructor` is not yet provided — the class is hand-authored for now.
- Wiki updated: *SQL Mappings → Construction-free mapping of non-public entities*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)