### PR TITLE
Support contextual serializers for non-@Serializable field types in LirpEntitySerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ These are **breaking changes**; see [Migration from 2.x to 3.0.0](#migration-fro
   is needed), and the redundant `_LirpRawInitializer` load-time guard is gone. Applying lirp-ksp
   still yields the zero-reflection direct-call path; the fallback only trades that for reflection on
   property getters.
+- **Contextual serializers for non-`@Serializable` field types** — `LirpEntitySerializer` and the
+  `lirpSerializer(sample, serializersModule)` factory now accept a `SerializersModule` and resolve the
+  serializers for nested constructor-parameter and reactive-property field types through it. An entity
+  whose field types are not `@Serializable` — including third-party or polymorphic types the consumer
+  cannot annotate — can now be persisted by registering a contextual serializer for each such type
+  instead of annotating the domain model. This gives the JSON path the same bring-your-own-mapping
+  flexibility the SQL path already offers through `ColumnConverter`. The parameter defaults to an empty
+  module, so existing callers are unaffected.
 - **Construction-free SQL persistence of non-public entities** — `SqlRepository.loadFromStore` can
   now rebuild an entity whose primary constructor is `internal` or `private` — and therefore
   unreachable from a separate persistence module — without a public factory. A table definition opts

--- a/lirp-core/api/lirp-core.api
+++ b/lirp-core/api/lirp-core.api
@@ -1000,7 +1000,8 @@ public final class net/transgressoft/lirp/persistence/json/LirpEntityPolymorphic
 }
 
 public final class net/transgressoft/lirp/persistence/json/LirpEntitySerializer : kotlinx/serialization/KSerializer {
-	public fun <init> (Lkotlin/reflect/KClass;Lnet/transgressoft/lirp/entity/ReactiveEntityBase;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lnet/transgressoft/lirp/entity/ReactiveEntityBase;Lkotlinx/serialization/modules/SerializersModule;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lnet/transgressoft/lirp/entity/ReactiveEntityBase;Lkotlinx/serialization/modules/SerializersModule;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/transgressoft/lirp/entity/ReactiveEntityBase;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
@@ -43,6 +43,8 @@ import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
 
 /**
@@ -60,20 +62,31 @@ import kotlinx.serialization.serializer
  * round-tripping still works without code generation — at the cost of reflection on the property
  * getters. Applying lirp-ksp restores the zero-reflection direct-call path.
  *
+ * Serializers for nested constructor-parameter and reactive-property field types are resolved
+ * through the supplied [serializersModule], so an entity whose field types are not `@Serializable`
+ * can still be persisted by registering a contextual serializer for each such type. With the default
+ * empty module, resolution falls back to the reflective built-in/`@Serializable` lookup — identical
+ * to the behavior of consumers that register no contextual serializers. This mirrors the
+ * `ColumnConverter` escape hatch the SQL persistence layer already offers.
+ *
  * Usage: pass a sample entity instance to the [lirpSerializer] factory function to build
  * the serializer, then use it with [MapSerializer] when constructing a [JsonFileRepository]:
  * ```kotlin
- * val serializer = lirpSerializer(MyEntity(defaultId))
+ * val module = SerializersModule { contextual(Artist::class, ArtistSerializer) }
+ * val serializer = lirpSerializer(MyEntity(defaultId), module)
  * val repo = JsonFileRepository(file, MapSerializer(Int.serializer(), serializer))
  * ```
  *
  * @param E the entity type
  * @param kClass the entity's [KClass]
  * @param sampleInstance a sample entity used to discover delegate properties at construction time
+ * @param serializersModule module consulted to resolve serializers for nested field types, enabling
+ *   contextual serializers for types that are not `@Serializable`; defaults to an empty module
  */
 class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
     private val kClass: KClass<E>,
-    sampleInstance: E
+    sampleInstance: E,
+    private val serializersModule: SerializersModule = EmptySerializersModule()
 ) : KSerializer<E> {
 
     /**
@@ -142,7 +155,7 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
                     val prop =
                         memberProps[param.name!!]
                             ?: error("Constructor param '${param.name}' has no corresponding member property on ${kClass.simpleName}")
-                    ConstructorParamInfo(param, serializer(param.type), prop)
+                    ConstructorParamInfo(param, serializersModule.serializer(param.type), prop)
                 }
 
         // Track constructor params that are also reactive delegates — they are serialized as
@@ -286,11 +299,11 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
             qualifiedName.endsWith("BooleanProperty") -> serializer<Boolean>()
             qualifiedName.endsWith("ObjectProperty") -> {
                 val typeArg = prop?.returnType?.arguments?.firstOrNull()?.type
-                if (typeArg != null) serializer(typeArg) else serializer<String?>()
+                if (typeArg != null) serializersModule.serializer(typeArg) else serializer<String?>()
             }
             else -> {
                 val value = delegate.javaClass.getMethod("get").invoke(delegate)
-                if (value != null) serializer(value::class.createType()) else serializer<String?>()
+                if (value != null) serializersModule.serializer(value::class.createType()) else serializer<String?>()
             }
         }
     }
@@ -530,7 +543,7 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
                         name = name,
                         getter = { entity: E -> prop.get(entity) },
                         silentSetter = { entity: E, value -> writeReactivePropertyBackingField<Any?>(entity, name, value) },
-                        serializer = serializer(prop.returnType)
+                        serializer = serializersModule.serializer(prop.returnType)
                     )
                 }
         return object : LirpReactivePropertyAccessor<E> {
@@ -571,7 +584,11 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
  * Creates a [LirpEntitySerializer] for the given entity type by introspecting a [sample] instance.
  *
  * @param sample any instance of the entity class — used to discover delegate properties
+ * @param serializersModule module consulted to resolve serializers for nested field types, enabling
+ *   contextual serializers for field types that are not `@Serializable`; defaults to an empty module
  * @return a [KSerializer] that serializes/deserializes entities via delegate introspection
  */
-inline fun <reified E : ReactiveEntityBase<*, *>> lirpSerializer(sample: E): LirpEntitySerializer<E> =
-    LirpEntitySerializer(E::class, sample)
+inline fun <reified E : ReactiveEntityBase<*, *>> lirpSerializer(
+    sample: E,
+    serializersModule: SerializersModule = EmptySerializersModule()
+): LirpEntitySerializer<E> = LirpEntitySerializer(E::class, sample, serializersModule)

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializerTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializerTest.kt
@@ -31,9 +31,20 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.encoding.encodeStructure
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 
 // --- Fixture entities for LirpEntitySerializer tests ---
 
@@ -120,6 +131,84 @@ class CombinedDelegate(override val id: Int) : ReactiveEntityBase<Int, CombinedD
     }
 
     override fun hashCode(): Int = 31 * (31 * id + name.hashCode()) + tracks.referenceIds.hashCode()
+}
+
+/**
+ * A plain value type that is deliberately NOT `@Serializable`, modeling a domain type a consumer owns
+ * but chooses not to annotate (or cannot, e.g. a third-party type).
+ */
+class Coordinate(val latitude: Double, val longitude: Double) {
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is Coordinate && latitude == other.latitude && longitude == other.longitude)
+
+    override fun hashCode(): Int = 31 * latitude.hashCode() + longitude.hashCode()
+}
+
+/**
+ * Hand-written contextual serializer for the non-`@Serializable` [Coordinate], registered in a
+ * [SerializersModule] and resolved by [LirpEntitySerializer] without annotating the domain type.
+ */
+object CoordinateSerializer : KSerializer<Coordinate> {
+    override val descriptor =
+        buildClassSerialDescriptor("Coordinate") {
+            element<Double>("latitude")
+            element<Double>("longitude")
+        }
+
+    override fun serialize(encoder: Encoder, value: Coordinate) {
+        encoder.encodeStructure(descriptor) {
+            encodeDoubleElement(descriptor, 0, value.latitude)
+            encodeDoubleElement(descriptor, 1, value.longitude)
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): Coordinate =
+        decoder.decodeStructure(descriptor) {
+            var latitude = 0.0
+            var longitude = 0.0
+            while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    0 -> latitude = decodeDoubleElement(descriptor, 0)
+                    1 -> longitude = decodeDoubleElement(descriptor, 1)
+                    CompositeDecoder.DECODE_DONE -> break
+                    else -> error("Unexpected element index $index")
+                }
+            }
+            Coordinate(latitude, longitude)
+        }
+}
+
+/** Entity with a constructor parameter whose type is the non-`@Serializable` [Coordinate]. */
+class OriginEntity(override val id: Int, val origin: Coordinate) : ReactiveEntityBase<Int, OriginEntity>() {
+    override val uniqueId: String get() = id.toString()
+
+    override fun clone(): OriginEntity = OriginEntity(id, origin)
+
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is OriginEntity && id == other.id && origin == other.origin)
+
+    override fun hashCode(): Int = 31 * id + origin.hashCode()
+}
+
+/**
+ * A `private` entity whose reactive property holds the non-`@Serializable` [Coordinate]. The KSP
+ * structural processors skip private classes, so no `_LirpReactivePropertyAccessor` is generated and
+ * the reflection-based reactive-property fallback resolves the field serializer through the supplied
+ * module — exercising the contextual path on a site distinct from [OriginEntity]'s constructor
+ * parameter. (Were KSP to process this class, its codegen could not resolve a serializer for the
+ * non-`@Serializable` field, so its absence is what keeps the fallback under test.)
+ */
+private class WaypointEntity(override val id: Int) : ReactiveEntityBase<Int, WaypointEntity>() {
+    var waypoint: Coordinate by reactiveProperty(Coordinate(0.0, 0.0))
+    override val uniqueId: String get() = id.toString()
+
+    override fun clone(): WaypointEntity =
+        WaypointEntity(id).also { copy -> copy.withEventsDisabled { copy.waypoint = waypoint } }
+
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is WaypointEntity && id == other.id && waypoint == other.waypoint)
+
+    override fun hashCode(): Int = 31 * id + waypoint.hashCode()
 }
 
 /**
@@ -250,6 +339,60 @@ class LirpEntitySerializerTest : StringSpec({
         shouldThrow<IllegalStateException> {
             lirpSerializer(entity)
         }.message shouldContain "configure KSP"
+    }
+
+    "entity with a non-serializable field type fails to build a serializer without a contextual module" {
+        shouldThrow<SerializationException> {
+            lirpSerializer(OriginEntity(1, Coordinate(40.0, -3.0)))
+        }
+    }
+
+    "entity with a non-serializable field type round-trips when its serializer is registered contextually" {
+        val module = SerializersModule { contextual(Coordinate::class, CoordinateSerializer) }
+        val original = OriginEntity(7, Coordinate(40.4168, -3.7038))
+        val serializer = lirpSerializer(original, module)
+
+        val jsonStr = json.encodeToString(serializer, original)
+        jsonStr shouldContain "\"origin\""
+        jsonStr shouldContain "40.4168"
+
+        val decoded = json.decodeFromString(serializer, jsonStr)
+        decoded.id shouldBe 7
+        decoded.origin shouldBe Coordinate(40.4168, -3.7038)
+    }
+
+    "MapSerializer round-trips entities whose field is resolved by a contextual serializer" {
+        val module = SerializersModule { contextual(Coordinate::class, CoordinateSerializer) }
+        val mapSerializer = MapSerializer(Int.serializer(), lirpSerializer(OriginEntity(0, Coordinate(0.0, 0.0)), module))
+        val entities =
+            mapOf(
+                1 to OriginEntity(1, Coordinate(1.0, 2.0)),
+                2 to OriginEntity(2, Coordinate(3.0, 4.0))
+            )
+        val jsonStr = json.encodeToString(mapSerializer, entities)
+        val decoded = json.decodeFromString(mapSerializer, jsonStr)
+        decoded[1]?.origin shouldBe Coordinate(1.0, 2.0)
+        decoded[2]?.origin shouldBe Coordinate(3.0, 4.0)
+    }
+
+    "reactive property of a non-serializable type round-trips via the reflection fallback when registered contextually" {
+        val module = SerializersModule { contextual(Coordinate::class, CoordinateSerializer) }
+        val original = WaypointEntity(3).apply { waypoint = Coordinate(51.5074, -0.1278) }
+        val serializer = lirpSerializer(original, module)
+
+        val jsonStr = json.encodeToString(serializer, original)
+        jsonStr shouldContain "\"waypoint\""
+        jsonStr shouldContain "51.5074"
+
+        val decoded = json.decodeFromString(serializer, jsonStr)
+        decoded.id shouldBe 3
+        decoded.waypoint shouldBe Coordinate(51.5074, -0.1278)
+    }
+
+    "reactive property of a non-serializable type fails to build a serializer without a contextual module" {
+        shouldThrow<SerializationException> {
+            lirpSerializer(WaypointEntity(1))
+        }
     }
 })
 

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxJsonSerializationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxJsonSerializationTest.kt
@@ -17,6 +17,7 @@
 
 package net.transgressoft.lirp.persistence.fx
 
+import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.persistence.json.lirpSerializer
 import net.transgressoft.lirp.testing.reactiveScope
 import io.kotest.core.annotation.DisplayName
@@ -25,9 +26,17 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
+import javafx.beans.property.ObjectProperty
 import javafx.collections.ObservableList
 import javafx.collections.ObservableSet
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 
 /**
  * Tests verifying JSON serialization round-trips for entities using [fxAggregateList],
@@ -191,4 +200,57 @@ class FxJsonSerializationTest : StringSpec({
 
         decoded.descriptionProperty.get() shouldBe null
     }
+
+    "fx object property holding a non-serializable type round-trips when registered contextually" {
+        val module = SerializersModule { contextual(Tempo::class, TempoSerializer) }
+        val tempoSerializer = lirpSerializer(TempoEntity(0), module)
+        val original = TempoEntity(7).apply { tempoProperty.set(Tempo(128.5)) }
+
+        val encoded = json.encodeToString(tempoSerializer, original)
+        encoded shouldContain "\"tempoProperty\""
+        encoded shouldContain "128.5"
+
+        val decoded = json.decodeFromString(tempoSerializer, encoded)
+        decoded.id shouldBe 7
+        decoded.tempoProperty.get() shouldBe Tempo(128.5)
+    }
 })
+
+/**
+ * A non-`@Serializable` value type carried in a JavaFX [ObjectProperty], modeling a third-party or
+ * domain type the consumer does not annotate. Resolved through a contextual [TempoSerializer].
+ */
+class Tempo(val beatsPerMinute: Double) {
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is Tempo && beatsPerMinute == other.beatsPerMinute)
+
+    override fun hashCode(): Int = beatsPerMinute.hashCode()
+}
+
+/** Hand-written contextual serializer for the non-`@Serializable` [Tempo]. */
+object TempoSerializer : KSerializer<Tempo> {
+    override val descriptor = PrimitiveSerialDescriptor("Tempo", PrimitiveKind.DOUBLE)
+
+    override fun serialize(encoder: Encoder, value: Tempo) = encoder.encodeDouble(value.beatsPerMinute)
+
+    override fun deserialize(decoder: Decoder): Tempo = Tempo(decoder.decodeDouble())
+}
+
+/**
+ * A `private` entity whose `fxObject` scalar holds the non-`@Serializable` [Tempo]. The declared
+ * `ObjectProperty<Tempo>` type keeps it off the KSP FxScalar accessor, so [LirpEntitySerializer]
+ * resolves the value serializer through the reflection fallback's `ObjectProperty` branch — the
+ * third nested-field site threaded through the supplied module.
+ */
+private class TempoEntity(override val id: Int, initialTempo: Tempo? = null) : ReactiveEntityBase<Int, TempoEntity>() {
+    override val uniqueId: String get() = "tempo-$id"
+
+    val tempoProperty: ObjectProperty<Tempo?> by fxObject<Tempo>(initialTempo, dispatchToFxThread = false)
+
+    override fun clone(): TempoEntity = TempoEntity(id, tempoProperty.get())
+
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is TempoEntity && id == other.id && tempoProperty.get() == other.tempoProperty.get())
+
+    override fun hashCode(): Int = 31 * id + (tempoProperty.get()?.hashCode() ?: 0)
+}


### PR DESCRIPTION
Closes #272

## Problem

`LirpEntitySerializer` resolved a serializer for every nested constructor-parameter and reactive-property field type via kotlinx's reflective resolver, which only finds built-in and compile-time `@Serializable` serializers. It never consulted a `SerializersModule`, so the **contextual** serializer mechanism was bypassed. As a result an entity could not be JSON-persisted if any nested field type was not `@Serializable` — constructing the serializer threw `SerializationException: Serializer for class 'X' is not found`.

This blocked two legitimate cases:

1. **Field types the consumer does not own** (`java.time.Duration`, locale/currency value types, third-party types) — they cannot be annotated with `@Serializable`.
2. **Domain models kept serialization-framework-free** (hexagonal/DDD layering) where serialization knowledge belongs at the persistence boundary rather than on the domain types.

The SQL path already offers a "bring your own mapping" escape hatch via `ColumnConverter`; the JSON path had no equivalent.

## What changed

- `LirpEntitySerializer` and the `lirpSerializer(sample, serializersModule)` factory now accept an optional `SerializersModule` and resolve nested-field serializers through the module-aware `SerializersModule.serializer(KType)` overload.
- The module is threaded through all three nested-field resolution sites: **constructor parameters**, the **reactive-property reflection fallback** (entities whose module does not apply KSP), and the **`fxObject` `ObjectProperty<T>`** scalar path.
- Aggregate-collection key resolution is unchanged — keys are constrained to the supported ID types.

```kotlin
val module = SerializersModule { contextual(Coordinate::class, CoordinateSerializer) }
val serializer = lirpSerializer(Place(0, Coordinate(0.0, 0.0)), module)
val repo = JsonFileRepository(file, MapSerializer(Int.serializer(), serializer))
```

## Backward compatibility

The parameter defaults to an empty module. `serializer(type)` is exactly `EmptySerializersModule().serializer(type)`, so with the default, resolution falls back to the reflective built-in/`@Serializable` lookup — behavior is identical for existing callers. Not a breaking change; CHANGELOG updated under additive features.

## Testing

- New tests in `LirpEntitySerializerTest` (lirp-core) cover the **constructor-parameter** site and the **reactive-property reflection-fallback** site with a non-`@Serializable` value type resolved contextually — including the failure path when no module is supplied.
- A new test in `FxJsonSerializationTest` (lirp-fx) covers the **`fxObject` `ObjectProperty<T>`** site contextually.
- Full `:lirp-core:test`, `:lirp-fx:test` and `ktlintCheck` pass. Only test code was added on top of the implementation, so coverage does not regress.

## Docs

The feature is documented in the wiki under JSON Persistence → Framework Serializer → *Contextual serializers for non-`@Serializable` field types*.