### PR TITLE
Ship built-in default ColumnConverters for common JDK value types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ These are **breaking changes**; see [Migration from 2.x to 3.0.0](#migration-fro
 
 ### Added
 
+- **Built-in default `ColumnConverter`s for common JDK value types** — `PathColumnConverter`,
+  `DurationColumnConverter`, `InstantColumnConverter`, `OffsetDateTimeColumnConverter`,
+  `UriColumnConverter`, `UrlColumnConverter`, and `BigIntegerColumnConverter` ship in `lirp-api` and
+  are bound automatically when an entity property's declared type matches — no
+  `@PersistenceProperty(converter = …)` annotation and no registration required. `Path`, `URI`,
+  `URL`, `Instant`, `OffsetDateTime`, and `BigInteger` map to a `TEXT` column; `Duration` maps to a
+  `BIGINT` of nanoseconds. A consumer-supplied converter for the same type always wins, and
+  `length` / `precision` / `scale` hints refine a default-converter column exactly as they do an
+  explicit one. Types lirp already maps natively (`LocalDate`, `LocalDateTime`, `UUID`,
+  `BigDecimal`) are intentionally excluded. The change is additive and backward compatible: existing
+  hand-written converters keep working unchanged.
 - **Typed mutation events** — `PropertyChanged<K, R, V>` and `BatchChanged<K, R>` are now the
   primary event types emitted when reactive properties change. Both carry immutable value scalars
   (`oldValue`, `newValue`, `property`, `versionAtMutation`, `oldIndexKey`, `newIndexKey`) captured

--- a/lirp-api/api/lirp-api.api
+++ b/lirp-api/api/lirp-api.api
@@ -197,6 +197,15 @@ public abstract interface class net/transgressoft/lirp/persistence/AggregateColl
 	public abstract fun resolveAll ()Ljava/util/Collection;
 }
 
+public final class net/transgressoft/lirp/persistence/BigIntegerColumnConverter : net/transgressoft/lirp/persistence/ColumnConverter {
+	public static final field INSTANCE Lnet/transgressoft/lirp/persistence/BigIntegerColumnConverter;
+	public synthetic fun fromSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun fromSql (Ljava/lang/String;)Ljava/math/BigInteger;
+	public fun getSqlType ()Lnet/transgressoft/lirp/persistence/ColumnType;
+	public synthetic fun toSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toSql (Ljava/math/BigInteger;)Ljava/lang/String;
+}
+
 public abstract interface class net/transgressoft/lirp/persistence/ColumnConverter {
 	public abstract fun fromSql (Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getSqlType ()Lnet/transgressoft/lirp/persistence/ColumnType;
@@ -326,6 +335,15 @@ public final class net/transgressoft/lirp/persistence/ColumnType$VarcharType : n
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class net/transgressoft/lirp/persistence/DurationColumnConverter : net/transgressoft/lirp/persistence/ColumnConverter {
+	public static final field INSTANCE Lnet/transgressoft/lirp/persistence/DurationColumnConverter;
+	public fun fromSql (J)Ljava/time/Duration;
+	public synthetic fun fromSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun getSqlType ()Lnet/transgressoft/lirp/persistence/ColumnType;
+	public synthetic fun toSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toSql (Ljava/time/Duration;)Ljava/lang/Long;
+}
+
 public abstract interface annotation class net/transgressoft/lirp/persistence/ElementCollection : java/lang/annotation/Annotation {
 	public abstract fun elementConverter ()Ljava/lang/Class;
 }
@@ -340,6 +358,15 @@ public abstract interface annotation class net/transgressoft/lirp/persistence/Em
 public abstract interface annotation class net/transgressoft/lirp/persistence/Indexed : java/lang/annotation/Annotation {
 	public abstract fun name ()Ljava/lang/String;
 	public abstract fun sorted ()Z
+}
+
+public final class net/transgressoft/lirp/persistence/InstantColumnConverter : net/transgressoft/lirp/persistence/ColumnConverter {
+	public static final field INSTANCE Lnet/transgressoft/lirp/persistence/InstantColumnConverter;
+	public synthetic fun fromSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun fromSql (Ljava/lang/String;)Ljava/time/Instant;
+	public fun getSqlType ()Lnet/transgressoft/lirp/persistence/ColumnType;
+	public synthetic fun toSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toSql (Ljava/time/Instant;)Ljava/lang/String;
 }
 
 public final class net/transgressoft/lirp/persistence/LirpDeserializationException : java/lang/RuntimeException {
@@ -376,12 +403,30 @@ public abstract interface class net/transgressoft/lirp/persistence/MutableAggreg
 	public abstract fun remove (Lnet/transgressoft/lirp/entity/IdentifiableEntity;)Z
 }
 
+public final class net/transgressoft/lirp/persistence/OffsetDateTimeColumnConverter : net/transgressoft/lirp/persistence/ColumnConverter {
+	public static final field INSTANCE Lnet/transgressoft/lirp/persistence/OffsetDateTimeColumnConverter;
+	public synthetic fun fromSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun fromSql (Ljava/lang/String;)Ljava/time/OffsetDateTime;
+	public fun getSqlType ()Lnet/transgressoft/lirp/persistence/ColumnType;
+	public synthetic fun toSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toSql (Ljava/time/OffsetDateTime;)Ljava/lang/String;
+}
+
 public final class net/transgressoft/lirp/persistence/OptimisticLockException : java/lang/RuntimeException {
 	public fun <init> (Ljava/lang/String;Ljava/lang/Object;JLjava/lang/Long;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;JLjava/lang/Long;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getActualVersion ()Ljava/lang/Long;
 	public final fun getEntityId ()Ljava/lang/Object;
 	public final fun getExpectedVersion ()J
+}
+
+public final class net/transgressoft/lirp/persistence/PathColumnConverter : net/transgressoft/lirp/persistence/ColumnConverter {
+	public static final field INSTANCE Lnet/transgressoft/lirp/persistence/PathColumnConverter;
+	public synthetic fun fromSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun fromSql (Ljava/lang/String;)Ljava/nio/file/Path;
+	public fun getSqlType ()Lnet/transgressoft/lirp/persistence/ColumnType;
+	public synthetic fun toSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toSql (Ljava/nio/file/Path;)Ljava/lang/String;
 }
 
 public abstract interface annotation class net/transgressoft/lirp/persistence/PersistenceCreator : java/lang/annotation/Annotation {
@@ -487,6 +532,24 @@ public abstract interface annotation class net/transgressoft/lirp/persistence/To
 	public abstract fun bubbleUp ()Z
 	public abstract fun onDelete ()Lnet/transgressoft/lirp/entity/CascadeAction;
 	public abstract fun target ()Ljava/lang/Class;
+}
+
+public final class net/transgressoft/lirp/persistence/UriColumnConverter : net/transgressoft/lirp/persistence/ColumnConverter {
+	public static final field INSTANCE Lnet/transgressoft/lirp/persistence/UriColumnConverter;
+	public synthetic fun fromSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun fromSql (Ljava/lang/String;)Ljava/net/URI;
+	public fun getSqlType ()Lnet/transgressoft/lirp/persistence/ColumnType;
+	public synthetic fun toSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toSql (Ljava/net/URI;)Ljava/lang/String;
+}
+
+public final class net/transgressoft/lirp/persistence/UrlColumnConverter : net/transgressoft/lirp/persistence/ColumnConverter {
+	public static final field INSTANCE Lnet/transgressoft/lirp/persistence/UrlColumnConverter;
+	public synthetic fun fromSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun fromSql (Ljava/lang/String;)Ljava/net/URL;
+	public fun getSqlType ()Lnet/transgressoft/lirp/persistence/ColumnType;
+	public synthetic fun toSql (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun toSql (Ljava/net/URL;)Ljava/lang/String;
 }
 
 public abstract interface annotation class net/transgressoft/lirp/persistence/Version : java/lang/annotation/Annotation {

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/DefaultColumnConverters.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/DefaultColumnConverters.kt
@@ -1,0 +1,139 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import java.math.BigInteger
+import java.net.URI
+import java.net.URL
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Duration
+import java.time.Instant
+import java.time.OffsetDateTime
+
+/*
+ * Built-in ColumnConverter singletons for common JDK value types that have an unambiguous,
+ * domain-agnostic mapping to a SQL column.
+ *
+ * Each converter here is bound automatically by KSP when an entity property's declared type matches
+ * the converter's domain type and no explicit @PersistenceProperty(converter = …) is present. A
+ * consumer that needs different storage semantics for one of these types supplies its own converter
+ * via @PersistenceProperty(converter = …), which always takes precedence over the built-in default.
+ *
+ * Only types lirp does not already map natively are covered here. java.time.LocalDate,
+ * java.time.LocalDateTime, java.util.UUID, and java.math.BigDecimal are mapped directly by the SQL
+ * type-inference path and therefore have no built-in converter.
+ *
+ * Domain-specific types (a music genre, a country code, a money wrapper) are intentionally out of
+ * scope: their mapping is consumer knowledge and belongs in a consumer-supplied converter.
+ */
+
+/**
+ * Maps [Path] to its URI-form string. URI encoding preserves platform-independent path semantics so
+ * absolute paths round-trip across operating systems without dialect-specific escaping.
+ *
+ * The round-trip canonicalises platform-specific separators: a parsed value equals
+ * `Paths.get(original.toUri())` rather than the original instance.
+ */
+object PathColumnConverter : ColumnConverter<Path, String> {
+    override val sqlType: ColumnType = ColumnType.TextType
+
+    override fun toSql(value: Path): String = value.toUri().toString()
+
+    override fun fromSql(raw: String): Path = Paths.get(URI(raw))
+}
+
+/**
+ * Maps [Duration] to a `Long` count of nanoseconds, the full-fidelity representation that round-trips
+ * without loss for any duration whose nanosecond total fits in a `Long` (about ±292 years).
+ *
+ * The nanosecond backing avoids the floating-point imprecision a fractional-seconds [Double] would
+ * introduce and preserves sub-second precision that a whole-seconds mapping would truncate.
+ */
+object DurationColumnConverter : ColumnConverter<Duration, Long> {
+    override val sqlType: ColumnType = ColumnType.LongType
+
+    override fun toSql(value: Duration): Long = value.toNanos()
+
+    override fun fromSql(raw: Long): Duration = Duration.ofNanos(raw)
+}
+
+/**
+ * Maps [Instant] to its ISO-8601 string (`Instant.toString()`), a textual, timezone-unambiguous
+ * representation that round-trips losslessly through [Instant.parse].
+ */
+object InstantColumnConverter : ColumnConverter<Instant, String> {
+    override val sqlType: ColumnType = ColumnType.TextType
+
+    override fun toSql(value: Instant): String = value.toString()
+
+    override fun fromSql(raw: String): Instant = Instant.parse(raw)
+}
+
+/**
+ * Maps [OffsetDateTime] to its ISO-8601 string (`OffsetDateTime.toString()`), preserving both the
+ * local date-time and the UTC offset so the value round-trips losslessly through
+ * [OffsetDateTime.parse].
+ */
+object OffsetDateTimeColumnConverter : ColumnConverter<OffsetDateTime, String> {
+    override val sqlType: ColumnType = ColumnType.TextType
+
+    override fun toSql(value: OffsetDateTime): String = value.toString()
+
+    override fun fromSql(raw: String): OffsetDateTime = OffsetDateTime.parse(raw)
+}
+
+/**
+ * Maps [URI] to its string form. The mapping round-trips losslessly because [URI.toString] preserves
+ * the exact components a [URI] was constructed from.
+ */
+object UriColumnConverter : ColumnConverter<URI, String> {
+    override val sqlType: ColumnType = ColumnType.TextType
+
+    override fun toSql(value: URI): String = value.toString()
+
+    override fun fromSql(raw: String): URI = URI(raw)
+}
+
+/**
+ * Maps [URL] to its string form, parsing back through [URI] to obtain a [URL] without the blocking
+ * host-resolution that the deprecated `URL(String)` constructor performs.
+ *
+ * Note that [URL] equality triggers host resolution; consumers that compare persisted URLs should
+ * compare their string forms or use [URI] instead.
+ */
+object UrlColumnConverter : ColumnConverter<URL, String> {
+    override val sqlType: ColumnType = ColumnType.TextType
+
+    override fun toSql(value: URL): String = value.toString()
+
+    override fun fromSql(raw: String): URL = URI(raw).toURL()
+}
+
+/**
+ * Maps [BigInteger] to its base-10 string form. A textual mapping preserves arbitrary precision,
+ * which a fixed-width integer column could not hold; the value round-trips losslessly through the
+ * `BigInteger(String)` constructor.
+ */
+object BigIntegerColumnConverter : ColumnConverter<BigInteger, String> {
+    override val sqlType: ColumnType = ColumnType.TextType
+
+    override fun toSql(value: BigInteger): String = value.toString()
+
+    override fun fromSql(raw: String): BigInteger = BigInteger(raw)
+}

--- a/lirp-api/src/test/kotlin/net/transgressoft/lirp/persistence/DefaultColumnConvertersTest.kt
+++ b/lirp-api/src/test/kotlin/net/transgressoft/lirp/persistence/DefaultColumnConvertersTest.kt
@@ -1,0 +1,79 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.math.BigInteger
+import java.net.URI
+import java.nio.file.Paths
+import java.time.Duration
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * Round-trip and `sqlType` assertions for the built-in default [ColumnConverter] singletons. Each
+ * test verifies that a domain value survives `toSql` followed by `fromSql` and that the declared
+ * persistence scalar matches the documented column shape.
+ */
+class DefaultColumnConvertersTest : StringSpec({
+
+    "PathColumnConverter round-trips a path through its URI form on a Long-free TextType column" {
+        PathColumnConverter.sqlType shouldBe ColumnType.TextType
+        val path = Paths.get("/tmp/song.mp3")
+        PathColumnConverter.fromSql(PathColumnConverter.toSql(path)) shouldBe Paths.get(path.toUri())
+    }
+
+    "DurationColumnConverter round-trips a sub-second duration losslessly through nanos on a LongType column" {
+        DurationColumnConverter.sqlType shouldBe ColumnType.LongType
+        val duration = Duration.ofSeconds(180).plusNanos(123_456_789)
+        DurationColumnConverter.toSql(duration) shouldBe 180_123_456_789
+        DurationColumnConverter.fromSql(DurationColumnConverter.toSql(duration)) shouldBe duration
+    }
+
+    "InstantColumnConverter round-trips an instant through its ISO-8601 form on a TextType column" {
+        InstantColumnConverter.sqlType shouldBe ColumnType.TextType
+        val instant = Instant.parse("2026-06-23T10:15:30.250Z")
+        InstantColumnConverter.fromSql(InstantColumnConverter.toSql(instant)) shouldBe instant
+    }
+
+    "OffsetDateTimeColumnConverter preserves the offset across a round-trip on a TextType column" {
+        OffsetDateTimeColumnConverter.sqlType shouldBe ColumnType.TextType
+        val offsetDateTime = OffsetDateTime.of(2026, 6, 23, 10, 15, 30, 0, ZoneOffset.ofHours(2))
+        OffsetDateTimeColumnConverter.fromSql(OffsetDateTimeColumnConverter.toSql(offsetDateTime)) shouldBe offsetDateTime
+    }
+
+    "UriColumnConverter round-trips a URI through its string form on a TextType column" {
+        UriColumnConverter.sqlType shouldBe ColumnType.TextType
+        val uri = URI("https://example.com/path?query=1#frag")
+        UriColumnConverter.fromSql(UriColumnConverter.toSql(uri)) shouldBe uri
+    }
+
+    "UrlColumnConverter round-trips a URL through its string form on a TextType column" {
+        UrlColumnConverter.sqlType shouldBe ColumnType.TextType
+        val url = URI("https://example.com/path").toURL()
+        UrlColumnConverter.toSql(UrlColumnConverter.fromSql(UrlColumnConverter.toSql(url))) shouldBe url.toString()
+    }
+
+    "BigIntegerColumnConverter round-trips an arbitrary-precision integer on a TextType column" {
+        BigIntegerColumnConverter.sqlType shouldBe ColumnType.TextType
+        val bigInteger = BigInteger("123456789012345678901234567890")
+        BigIntegerColumnConverter.fromSql(BigIntegerColumnConverter.toSql(bigInteger)) shouldBe bigInteger
+    }
+})

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ColumnMetaBuilder.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ColumnMetaBuilder.kt
@@ -118,7 +118,7 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
         // BEFORE invoking resolveConverter (which carries /). This preserves the
         // one-diagnostic-per-site invariant: a misplaced converter on a rejected target emits
         // the target rejection, not the kind/S diagnostics.
-        val converterInfo =
+        val explicitConverterInfo =
             if (hasNonSentinelConverterArgument(persistenceAnnotation)) {
                 when {
                     isPrimaryKey -> {
@@ -147,6 +147,11 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
             } else {
                 null
             }
+
+        // Fall back to a built-in default converter when the consumer declared none and the column's
+        // declared type has a generic JDK mapping. Default converters never apply to PK / @Version /
+        // FK columns (those reject converters outright). An explicit converter always wins.
+        val converterInfo = explicitConverterInfo ?: defaultConverterFor(typeFqn, isPrimaryKey, isVersion, isAggregateBackingScalar)
 
         // When a converter is bound, derive the column type from the converter's declared sqlType
         // (and refine it via compatible @PersistenceProperty hints). Otherwise fall back to the
@@ -218,12 +223,14 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
         // Reuse the converter resolution + hint-refinement pipeline so an
         // `@PersistenceProperty(converter = X::class)` at a scalar leaf inside an `@Embeddable`
         // produces the same column-type expression and fromRow/toParams casts it would at the
-        // top level.
+        // top level. A built-in default converter applies to a leaf of a covered JDK type when the
+        // consumer declared none; an explicit converter always wins. Embedded leaves are never
+        // PK / @Version / aggregate-FK columns, so no role-based suppression is needed here.
         val converterInfo =
             if (hasNonSentinelConverterArgument(persistenceAnnotation)) {
                 resolveConverter(persistenceAnnotation, propertyFqn)
             } else {
-                null
+                DEFAULT_CONVERTERS[childTypeFqn]
             }
 
         val hasExplicitConverter = hasNonSentinelConverterArgument(persistenceAnnotation)
@@ -743,6 +750,22 @@ internal class ColumnMetaBuilder(private val logger: KSPLogger) {
         }
 
         return ConverterInfo(converterFqn = converterFqn, sqlTypeFqn = sFqn)
+    }
+
+    /**
+     * Returns the built-in [ConverterInfo] for [typeFqn] when a default converter covers that domain
+     * type, or null when none applies. Default converters are suppressed on primary-key, `@Version`,
+     * and aggregate-FK columns, whose scalar type is dictated by their role rather than a value
+     * mapping — mirroring the explicit-converter rejection on those same positions.
+     */
+    private fun defaultConverterFor(
+        typeFqn: String,
+        isPrimaryKey: Boolean,
+        isVersion: Boolean,
+        isAggregateBackingScalar: Boolean
+    ): ConverterInfo? {
+        if (isPrimaryKey || isVersion || isAggregateBackingScalar) return null
+        return DEFAULT_CONVERTERS[typeFqn]
     }
 
     // Mutable for SqlTableDef fromRow purposes means: var property with a public setter.

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefConstants.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefConstants.kt
@@ -27,6 +27,13 @@ internal const val SQL_TABLE_DEF_FQN = "net.transgressoft.lirp.persistence.sql.S
 internal const val UUID_FQN = "java.util.UUID"
 internal const val LOCAL_DATE_FQN = "java.time.LocalDate"
 internal const val LOCAL_DATE_TIME_FQN = "java.time.LocalDateTime"
+internal const val DURATION_FQN = "java.time.Duration"
+internal const val INSTANT_FQN = "java.time.Instant"
+internal const val OFFSET_DATE_TIME_FQN = "java.time.OffsetDateTime"
+internal const val PATH_FQN = "java.nio.file.Path"
+internal const val URI_FQN = "java.net.URI"
+internal const val URL_FQN = "java.net.URL"
+internal const val BIG_INTEGER_FQN = "java.math.BigInteger"
 internal const val KOTLIN_STRING_FQN = "kotlin.String"
 internal const val KOTLIN_INT_FQN = "kotlin.Int"
 internal const val KOTLIN_LONG_FQN = "kotlin.Long"
@@ -125,4 +132,26 @@ internal val ELEMENT_COLLECTION_S_TYPES: Set<String> =
     setOf(
         KOTLIN_STRING_FQN, KOTLIN_INT_FQN, KOTLIN_LONG_FQN, KOTLIN_SHORT_FQN,
         KOTLIN_BYTE_FQN, KOTLIN_BOOLEAN_FQN, KOTLIN_DOUBLE_FQN, KOTLIN_FLOAT_FQN
+    )
+
+private const val DEFAULT_CONVERTER_PACKAGE = "net.transgressoft.lirp.persistence"
+
+// Built-in default converters keyed by the domain type FQN they map. A column whose declared type
+// matches one of these keys — and which carries no explicit @PersistenceProperty(converter = …) —
+// is bound to the named converter exactly as if the consumer had annotated it, so the existing
+// converter codegen path (sqlType refinement, fromSql on read, toSql on write) drives the column.
+//
+// Resolution is a fallback: explicit converter resolution runs first in the column builders, so a
+// consumer-supplied converter for the same type always wins. Types lirp already maps natively
+// (LocalDate, LocalDateTime, UUID, BigDecimal) are intentionally absent — adding them here would
+// duplicate the FQN-driven inference path.
+internal val DEFAULT_CONVERTERS: Map<String, ConverterInfo> =
+    mapOf(
+        PATH_FQN to ConverterInfo("$DEFAULT_CONVERTER_PACKAGE.PathColumnConverter", KOTLIN_STRING_FQN),
+        DURATION_FQN to ConverterInfo("$DEFAULT_CONVERTER_PACKAGE.DurationColumnConverter", KOTLIN_LONG_FQN),
+        INSTANT_FQN to ConverterInfo("$DEFAULT_CONVERTER_PACKAGE.InstantColumnConverter", KOTLIN_STRING_FQN),
+        OFFSET_DATE_TIME_FQN to ConverterInfo("$DEFAULT_CONVERTER_PACKAGE.OffsetDateTimeColumnConverter", KOTLIN_STRING_FQN),
+        URI_FQN to ConverterInfo("$DEFAULT_CONVERTER_PACKAGE.UriColumnConverter", KOTLIN_STRING_FQN),
+        URL_FQN to ConverterInfo("$DEFAULT_CONVERTER_PACKAGE.UrlColumnConverter", KOTLIN_STRING_FQN),
+        BIG_INTEGER_FQN to ConverterInfo("$DEFAULT_CONVERTER_PACKAGE.BigIntegerColumnConverter", KOTLIN_STRING_FQN)
     )

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/DefaultConverterCodegenTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/DefaultConverterCodegenTest.kt
@@ -1,0 +1,239 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.ksp
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+
+/**
+ * KSP compilation tests for built-in default converter resolution: a column whose declared type
+ * matches a built-in default ([net.transgressoft.lirp.persistence.DefaultColumnConverters]) is
+ * auto-bound without a `@PersistenceProperty(converter = …)` annotation, and a consumer-supplied
+ * converter for the same type overrides the default.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+class DefaultConverterCodegenTest : StringSpec({
+
+    "TableDefProcessor auto-binds the built-in Path converter for an un-annotated Path column" {
+        val result =
+            KspTestSupport.compile(
+                TableDefProcessorProvider(),
+                SourceFile.kotlin(
+                    "PathDefaultEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import java.nio.file.Path
+
+                    @PersistenceMapping
+                    data class PathDefaultEntity(
+                        override val id: Int,
+                        val location: Path
+                    ) : ReactiveEntityBase<Int, PathDefaultEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = PathDefaultEntity(id, location)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val generated = result.generatedFileContent("PathDefaultEntity_LirpTableDef.kt")
+        generated shouldContain "net.transgressoft.lirp.persistence.PathColumnConverter.sqlType"
+        generated shouldContain "net.transgressoft.lirp.persistence.PathColumnConverter.fromSql("
+        generated shouldContain "net.transgressoft.lirp.persistence.PathColumnConverter.toSql(entity.location)"
+        generated shouldContain "as kotlin.String"
+    }
+
+    "TableDefProcessor auto-binds the built-in Duration converter on a LongType-backed column" {
+        val result =
+            KspTestSupport.compile(
+                TableDefProcessorProvider(),
+                SourceFile.kotlin(
+                    "DurationDefaultEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import java.time.Duration
+
+                    @PersistenceMapping
+                    data class DurationDefaultEntity(
+                        override val id: Int,
+                        val length: Duration
+                    ) : ReactiveEntityBase<Int, DurationDefaultEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = DurationDefaultEntity(id, length)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val generated = result.generatedFileContent("DurationDefaultEntity_LirpTableDef.kt")
+        generated shouldContain "net.transgressoft.lirp.persistence.DurationColumnConverter.sqlType"
+        generated shouldContain "net.transgressoft.lirp.persistence.DurationColumnConverter.fromSql("
+        generated shouldContain "net.transgressoft.lirp.persistence.DurationColumnConverter.toSql(entity.length)"
+        generated shouldContain "as kotlin.Long"
+    }
+
+    "TableDefProcessor auto-binds the built-in URI converter on a nullable column preserving null" {
+        val result =
+            KspTestSupport.compile(
+                TableDefProcessorProvider(),
+                SourceFile.kotlin(
+                    "UriDefaultEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import java.net.URI
+
+                    @PersistenceMapping
+                    data class UriDefaultEntity(
+                        override val id: Int,
+                        val homepage: URI?
+                    ) : ReactiveEntityBase<Int, UriDefaultEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = UriDefaultEntity(id, homepage)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val generated = result.generatedFileContent("UriDefaultEntity_LirpTableDef.kt")
+        generated shouldContain "as? kotlin.String"
+        generated shouldContain "?.let { net.transgressoft.lirp.persistence.UriColumnConverter.fromSql(it) }"
+        generated shouldContain "entity.homepage?.let { net.transgressoft.lirp.persistence.UriColumnConverter.toSql(it) }"
+    }
+
+    "TableDefProcessor honors a length hint on a default-converter column refining TextType to VarcharType" {
+        val result =
+            KspTestSupport.compile(
+                TableDefProcessorProvider(),
+                SourceFile.kotlin(
+                    "HintedPathEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+                    import java.nio.file.Path
+
+                    @PersistenceMapping
+                    data class HintedPathEntity(
+                        override val id: Int,
+                        @PersistenceProperty(length = 1024) val location: Path
+                    ) : ReactiveEntityBase<Int, HintedPathEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = HintedPathEntity(id, location)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val generated = result.generatedFileContent("HintedPathEntity_LirpTableDef.kt")
+        generated shouldContain "ColumnType.VarcharType(1024)"
+        generated shouldContain "net.transgressoft.lirp.persistence.PathColumnConverter.fromSql("
+    }
+
+    "TableDefProcessor lets a consumer-supplied converter override the built-in default for the same type" {
+        val result =
+            KspTestSupport.compile(
+                TableDefProcessorProvider(),
+                SourceFile.kotlin(
+                    "OverriddenPathEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.ColumnConverter
+                    import net.transgressoft.lirp.persistence.ColumnType
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import net.transgressoft.lirp.persistence.PersistenceProperty
+                    import java.nio.file.Path
+                    import java.nio.file.Paths
+
+                    object PlainPathConverter : ColumnConverter<Path, String> {
+                        override val sqlType = ColumnType.TextType
+                        override fun toSql(value: Path): String = value.toString()
+                        override fun fromSql(raw: String): Path = Paths.get(raw)
+                    }
+
+                    @PersistenceMapping
+                    data class OverriddenPathEntity(
+                        override val id: Int,
+                        @PersistenceProperty(converter = PlainPathConverter::class) val location: Path
+                    ) : ReactiveEntityBase<Int, OverriddenPathEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = OverriddenPathEntity(id, location)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val generated = result.generatedFileContent("OverriddenPathEntity_LirpTableDef.kt")
+        generated shouldContain "test.PlainPathConverter.fromSql("
+        generated shouldContain "test.PlainPathConverter.toSql(entity.location)"
+        generated shouldNotContain "PathColumnConverter"
+    }
+
+    "TableDefProcessor auto-binds a built-in default converter on an un-annotated leaf inside an @Embeddable" {
+        val result =
+            KspTestSupport.compile(
+                TableDefProcessorProvider(),
+                SourceFile.kotlin(
+                    "EmbeddedDefaultConverterEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Embeddable
+                    import net.transgressoft.lirp.persistence.Embedded
+                    import net.transgressoft.lirp.persistence.PersistenceMapping
+                    import java.nio.file.Path
+
+                    @Embeddable
+                    data class Media(val name: String, val location: Path)
+
+                    @PersistenceMapping
+                    data class EmbeddedDefaultConverterEntity(
+                        override val id: Int,
+                        @Embedded val media: Media
+                    ) : ReactiveEntityBase<Int, EmbeddedDefaultConverterEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = EmbeddedDefaultConverterEntity(id, media)
+                    }
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val generated = result.generatedFileContent("EmbeddedDefaultConverterEntity_LirpTableDef.kt")
+        generated shouldContain "name = \"media_location\""
+        generated shouldContain "net.transgressoft.lirp.persistence.PathColumnConverter.toSql("
+        generated shouldContain "net.transgressoft.lirp.persistence.PathColumnConverter.fromSql("
+    }
+})

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryDefaultConverterTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryDefaultConverterTest.kt
@@ -1,0 +1,102 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import java.net.URI
+import java.nio.file.Paths
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * H2 round-trip unit tests for the built-in default `ColumnConverter` resolution path — verifies
+ * that the KSP-generated `_LirpTableDef` routes un-annotated [java.nio.file.Path],
+ * [java.time.Duration], [java.time.Instant], and [java.net.URI] columns through the built-in
+ * converters in both directions, with a nullable column preserving `null`.
+ */
+internal class SqlRepositoryDefaultConverterTest : StringSpec({
+
+    fun freshJdbcUrl() = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+
+    "SqlRepository round-trips DefaultConverterFixtureEntity through the built-in converters on H2" {
+        val jdbcUrl = freshJdbcUrl()
+        val originalPath = Paths.get("/tmp/song.mp3")
+        val originalCover = Paths.get("/tmp/cover.png")
+        val originalLength = Duration.ofSeconds(180).plusNanos(123_456_789)
+        val originalInstant = Instant.parse("2026-06-23T10:15:30.250Z")
+        val originalSource = URI("https://example.com/catalog/42")
+        // PathColumnConverter encodes via toUri() and parses via Paths.get(URI(…)), so the round-trip
+        // canonicalises platform-specific separators against the URI-normalised form.
+        val expectedPath = Paths.get(originalPath.toUri())
+        val expectedCover = Paths.get(originalCover.toUri())
+
+        val repo = SqlRepository(jdbcUrl, DefaultConverterFixtureEntity_LirpTableDef)
+        try {
+            repo.add(DefaultConverterFixtureEntity(1, originalPath, originalLength, originalInstant, originalSource, originalCover))
+        } finally {
+            repo.close()
+        }
+
+        val reloaded = SqlRepository(jdbcUrl, DefaultConverterFixtureEntity_LirpTableDef)
+        try {
+            reloaded.findById(1).shouldBePresent {
+                it.path shouldBe expectedPath
+                it.length shouldBe originalLength
+                it.recordedAt shouldBe originalInstant
+                it.source shouldBe originalSource
+                it.coverPath shouldBe expectedCover
+            }
+        } finally {
+            reloaded.close()
+        }
+    }
+
+    "SqlRepository preserves null in a nullable default-converter column on H2" {
+        val jdbcUrl = freshJdbcUrl()
+        val originalPath = Paths.get("/tmp/song.mp3")
+
+        val repo = SqlRepository(jdbcUrl, DefaultConverterFixtureEntity_LirpTableDef)
+        try {
+            repo.add(
+                DefaultConverterFixtureEntity(
+                    id = 2,
+                    path = originalPath,
+                    length = Duration.ofSeconds(60),
+                    recordedAt = Instant.parse("2026-06-23T11:00:00Z"),
+                    source = URI("https://example.com/catalog/2"),
+                    coverPath = null
+                )
+            )
+        } finally {
+            repo.close()
+        }
+
+        val reloaded = SqlRepository(jdbcUrl, DefaultConverterFixtureEntity_LirpTableDef)
+        try {
+            reloaded.findById(2).shouldBePresent {
+                it.coverPath shouldBe null
+                it.path shouldBe Paths.get(originalPath.toUri())
+            }
+        } finally {
+            reloaded.close()
+        }
+    }
+})

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DefaultConverterFixtureEntity.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DefaultConverterFixtureEntity.kt
@@ -1,0 +1,46 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import java.net.URI
+import java.nio.file.Path
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Round-trip fixture for the built-in default `ColumnConverter`s — none of the columns below carry a
+ * `@PersistenceProperty(converter = …)` annotation, so each is bound automatically by KSP from the
+ * declared JDK type. Exercises non-null [Path], [Duration], [Instant], non-null [URI], and a nullable
+ * [Path] to verify the generated `_LirpTableDef` routes reads and writes through the built-in
+ * converters with null preserved end-to-end.
+ */
+@PersistenceMapping(name = "default_converter_entity")
+data class DefaultConverterFixtureEntity(
+    override val id: Int,
+    val path: Path,
+    val length: Duration,
+    val recordedAt: Instant,
+    val source: URI,
+    val coverPath: Path?
+) : ReactiveEntityBase<Int, DefaultConverterFixtureEntity>() {
+    override val uniqueId: String get() = "$id"
+
+    override fun clone(): DefaultConverterFixtureEntity = copy()
+}


### PR DESCRIPTION
## Summary

lirp's SQL persistence previously required a hand-written `ColumnConverter` for every non-primitive column type — including ubiquitous JDK value types whose mapping is generic and domain-agnostic. This ships a set of **built-in default converters** that are bound automatically when a column's declared type matches: no `@PersistenceProperty(converter = …)` annotation and no registration.

## What's included

Built-in `ColumnConverter` singletons in `lirp-api` (`net.transgressoft.lirp.persistence`), bound by KSP when a scalar property's declared type matches and no explicit converter is present:

| Type | Converter | Stored as |
|---|---|---|
| `java.nio.file.Path` | `PathColumnConverter` | `TEXT` (URI form) |
| `java.time.Duration` | `DurationColumnConverter` | `BIGINT` (nanoseconds) |
| `java.time.Instant` | `InstantColumnConverter` | `TEXT` (ISO-8601) |
| `java.time.OffsetDateTime` | `OffsetDateTimeColumnConverter` | `TEXT` (ISO-8601) |
| `java.net.URI` | `UriColumnConverter` | `TEXT` |
| `java.net.URL` | `UrlColumnConverter` | `TEXT` |
| `java.math.BigInteger` | `BigIntegerColumnConverter` | `TEXT` (base-10) |

Types lirp already maps natively (`LocalDate`, `LocalDateTime`, `UUID`, `BigDecimal`) are intentionally excluded — they continue to flow through the direct type-inference path, so no duplicate mapping is introduced.

## Behavior

- A consumer-supplied `@PersistenceProperty(converter = …)` for the same type **always wins** — the defaults are an opt-out baseline.
- `length` / `precision` / `scale` hints refine a default-converter column exactly as they do an explicit one.
- Defaults also apply to bare scalar leaves inside `@Embeddable` value objects.
- Suppressed on primary-key, `@Version`, and `@Aggregate` FK columns, whose scalar type is dictated by their role.
- Additive and backward compatible — existing hand-written converters keep working unchanged.

## Testing

- **`lirp-api`** — round-trip and `sqlType` unit tests for all seven converters.
- **`lirp-ksp`** — KSP codegen tests: auto-binding for top-level columns, nullable preservation, hint refinement (`TEXT` → `VARCHAR`), consumer override of a default, and auto-binding on an un-annotated leaf inside an `@Embeddable`.
- **`lirp-sql`** — H2 round-trip of an un-annotated multi-type entity (`Path`, `Duration`, `Instant`, `URI`), including a nullable column that preserves `null` end-to-end.

Documentation for the feature is on the SQL Mappings wiki page.

Closes #276
