### PR TITLE
Query Diagnostics / EXPLAIN API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,63 @@ All notable changes to **LIRP (Lightweight Reactive Persistence)** are documente
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — 3.0.0
+## [Unreleased] — 3.1.0
+
+Small, additive improvements on top of the 3.0.0 release: per-bucket ordering for registry
+projections, and a read-only query-diagnostics (`EXPLAIN`) surface over the in-memory query
+planner. One internal type relocation (`ViaStrategy`) is the only breaking change.
+
+### Added
+
+- **Per-bucket ordering for registry projections** — all four registry projection factories
+  (`registryProjection`, `registryMultiKeyProjection`, `registryFxProjection`,
+  `registryFxMultiKeyProjection`) and their `valueTransform` / two-phase `dataTransform`+`fxFactory`
+  overloads now accept an optional `entryOrdering: Comparator<E>? = null` parameter placed
+  immediately after `keyExtractor`. When a comparator is supplied, each per-key bucket `List<E>` is
+  kept sorted incrementally — new entities are inserted at their comparator position using a
+  stable upper-bound binary search, so equal elements retain arrival order (a newly arriving equal
+  element is placed after the existing run of equal elements). An in-place mutation to a sort-key
+  property re-positions the element within its bucket so the list remains ordered without a
+  full re-sort. A `valueTransform` or `dataTransform` callback always receives the already-ordered
+  `List<E>`; for FX variants, ordering is applied on the background thread before the FX-thread
+  dispatch, consistent with the existing off-thread transform contract. Omitting the parameter
+  (`null`) preserves the prior insertion order and is binary compatible.
+  See [#278](https://github.com/octaviospain/lirp/issues/278).
+
+- **Query diagnostics API** — two new extension functions on `Registry<K, E>` expose the query
+  planner's internal decisions without altering query semantics.
+  `explainQuery { }` mirrors the `query { }` DSL but returns a `QueryDiagnostic` snapshot
+  instead of a result sequence; the result sequence is **never consumed**, making it safe to call
+  without side-effects (equivalent to SQL `EXPLAIN`).
+  `queryWithDiagnostics { }` executes the query eagerly and returns a `DiagnosedQuery<E>` pairing
+  the result sequence with a `QueryDiagnostic`.
+  Both functions are in `lirp-core` and visible via Kotlin extension syntax on any `Registry`.
+  The following public types in `net.transgressoft.lirp.persistence.query` (module `lirp-api`) support them:
+  - `QueryDiagnostic` — the full diagnostic snapshot: chosen `Strategy`, list of `IndexHit`s,
+    post-filter predicate count, optional `ViaStrategy` for cross-aggregate queries, planning time
+    in nanoseconds, and (for `queryWithDiagnostics` only) execution time in nanoseconds.
+  - `DiagnosedQuery<T>` — pairs a result `Sequence<T>` with a `QueryDiagnostic`.
+  - `IndexHit` — per-predicate breakdown: property name, index name, `IndexHitType`, and an optional
+    selectivity whose meaning depends on the hit type — candidate count for `RANGE`, number of
+    distinct probed values for `MULTI`, and `null` for `EXACT` (not computed at plan time).
+  - `IndexHitType` — `EXACT` (equality lookup), `MULTI` (`isIn` set lookup), or `RANGE` (comparison).
+  - `Strategy` — the planner's chosen retrieval mode: `INDEX_ONLY`, `INDEX_THEN_FILTER`, or
+    `SCAN_ONLY`.
+  See [#151](https://github.com/octaviospain/lirp/issues/151).
+
+### Changed
+
+- **`ViaStrategy` moved from `lirp-core` to `lirp-api`** — the enum class
+  `net.transgressoft.lirp.persistence.query.ViaStrategy` is now declared in the `lirp-api`
+  artifact. The **package name is unchanged**, so any source import of the fully-qualified name
+  (`import net.transgressoft.lirp.persistence.query.ViaStrategy`) recompiles without modification.
+  Consumers that depend on `lirp-core` at the binary level and reference `ViaStrategy` must
+  ensure they also declare a `lirp-api` dependency; because `lirp-core` already pulls in
+  `lirp-api` transitively, a standard Gradle or Maven dependency on `lirp-core` is sufficient
+  with no extra `implementation("net.transgressoft:lirp-api:…")` line needed.
+  See [#151](https://github.com/octaviospain/lirp/issues/151).
+
+## [3.0.0] - 2026-06-23
 
 The 3.0.0 line expands the projection API from a single aggregate-source, single-key,
 identity-only map into a full matrix: aggregate **and** registry sources, single-key **and**
@@ -116,8 +172,6 @@ These are **breaking changes**; see [Migration from 2.x to 3.0.0](#migration-fro
   independent error handler so individual subscribers can observe failures without routing them
   to the publisher-level handler.
 
-### Added
-
 - **Two-phase FX-safe value transform** — new `dataTransform` / `fxFactory` overloads on
   `fxProjection`, `registryFxProjection`, `fxMultiKeyProjection`, and
   `registryFxMultiKeyProjection` split bucket projection into an off-thread data-extraction
@@ -137,21 +191,6 @@ These are **breaking changes**; see [Migration from 2.x to 3.0.0](#migration-fro
   navigation member) for the case where the reference key is computed rather than a stored scalar;
   the scalar form above is the recommended default. See
   [GitHub #255](https://github.com/octaviospain/lirp/issues/255).
-
-- **Per-bucket ordering for registry projections** — all four registry projection factories
-  (`registryProjection`, `registryMultiKeyProjection`, `registryFxProjection`,
-  `registryFxMultiKeyProjection`) and their `valueTransform` / two-phase `dataTransform`+`fxFactory`
-  overloads now accept an optional `entryOrdering: Comparator<E>? = null` parameter placed
-  immediately after `keyExtractor`. When a comparator is supplied, each per-key bucket `List<E>` is
-  kept sorted incrementally — new entities are inserted at their comparator position using a
-  stable upper-bound binary search, so equal elements retain arrival order (a newly arriving equal
-  element is placed after the existing run of equal elements). An in-place mutation to a sort-key
-  property re-positions the element within its bucket so the list remains ordered without a
-  full re-sort. A `valueTransform` or `dataTransform` callback always receives the already-ordered
-  `List<E>`; for FX variants, ordering is applied on the background thread before the FX-thread
-  dispatch, consistent with the existing off-thread transform contract. Omitting the parameter
-  (`null`) preserves the prior insertion order and is binary compatible.
-  See [#278](https://github.com/octaviospain/lirp/issues/278).
 
 ### Changed
 
@@ -183,8 +222,6 @@ These are **breaking changes**; see [Migration from 2.x to 3.0.0](#migration-fro
   `FxProjectionMap` → `FxProjection`, the `MultiKey*` / `Transformed*` variants, and the matching
   `projectionMap(…)` → `projection(…)` factory functions). See
   [Migration](#projection-types-and-factories-drop-the-map-suffix) below.
-
-### Removed
 
 - **Entity-clone fields on mutation events** — `ReactiveMutationEvent.oldEntity` /
   `ReactiveMutationEvent.newEntity` have been removed. The two-arg constructor

--- a/lirp-api/api/lirp-api.api
+++ b/lirp-api/api/lirp-api.api
@@ -567,3 +567,80 @@ public final class net/transgressoft/lirp/persistence/json/JsonRepository$Defaul
 	public static fun subscribeAsync (Lnet/transgressoft/lirp/persistence/json/JsonRepository;Lkotlin/jvm/functions/Function2;Lnet/transgressoft/lirp/event/LirpErrorHandler;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 }
 
+public final class net/transgressoft/lirp/persistence/query/DiagnosedQuery {
+	public fun <init> (Lkotlin/sequences/Sequence;Lnet/transgressoft/lirp/persistence/query/QueryDiagnostic;)V
+	public final fun component1 ()Lkotlin/sequences/Sequence;
+	public final fun component2 ()Lnet/transgressoft/lirp/persistence/query/QueryDiagnostic;
+	public final fun copy (Lkotlin/sequences/Sequence;Lnet/transgressoft/lirp/persistence/query/QueryDiagnostic;)Lnet/transgressoft/lirp/persistence/query/DiagnosedQuery;
+	public static synthetic fun copy$default (Lnet/transgressoft/lirp/persistence/query/DiagnosedQuery;Lkotlin/sequences/Sequence;Lnet/transgressoft/lirp/persistence/query/QueryDiagnostic;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/query/DiagnosedQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDiagnostic ()Lnet/transgressoft/lirp/persistence/query/QueryDiagnostic;
+	public final fun getResults ()Lkotlin/sequences/Sequence;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/transgressoft/lirp/persistence/query/IndexHit {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lnet/transgressoft/lirp/persistence/query/IndexHitType;Ljava/lang/Integer;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lnet/transgressoft/lirp/persistence/query/IndexHitType;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lnet/transgressoft/lirp/persistence/query/IndexHitType;Ljava/lang/Integer;)Lnet/transgressoft/lirp/persistence/query/IndexHit;
+	public static synthetic fun copy$default (Lnet/transgressoft/lirp/persistence/query/IndexHit;Ljava/lang/String;Ljava/lang/String;Lnet/transgressoft/lirp/persistence/query/IndexHitType;Ljava/lang/Integer;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/query/IndexHit;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndexName ()Ljava/lang/String;
+	public final fun getPropertyName ()Ljava/lang/String;
+	public final fun getSelectivity ()Ljava/lang/Integer;
+	public final fun getType ()Lnet/transgressoft/lirp/persistence/query/IndexHitType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/transgressoft/lirp/persistence/query/IndexHitType : java/lang/Enum {
+	public static final field EXACT Lnet/transgressoft/lirp/persistence/query/IndexHitType;
+	public static final field MULTI Lnet/transgressoft/lirp/persistence/query/IndexHitType;
+	public static final field RANGE Lnet/transgressoft/lirp/persistence/query/IndexHitType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lnet/transgressoft/lirp/persistence/query/IndexHitType;
+	public static fun values ()[Lnet/transgressoft/lirp/persistence/query/IndexHitType;
+}
+
+public final class net/transgressoft/lirp/persistence/query/QueryDiagnostic {
+	public fun <init> (Lnet/transgressoft/lirp/persistence/query/Strategy;Ljava/util/List;ILnet/transgressoft/lirp/persistence/query/ViaStrategy;JLjava/lang/Long;)V
+	public final fun component1 ()Lnet/transgressoft/lirp/persistence/query/Strategy;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()I
+	public final fun component4 ()Lnet/transgressoft/lirp/persistence/query/ViaStrategy;
+	public final fun component5 ()J
+	public final fun component6 ()Ljava/lang/Long;
+	public final fun copy (Lnet/transgressoft/lirp/persistence/query/Strategy;Ljava/util/List;ILnet/transgressoft/lirp/persistence/query/ViaStrategy;JLjava/lang/Long;)Lnet/transgressoft/lirp/persistence/query/QueryDiagnostic;
+	public static synthetic fun copy$default (Lnet/transgressoft/lirp/persistence/query/QueryDiagnostic;Lnet/transgressoft/lirp/persistence/query/Strategy;Ljava/util/List;ILnet/transgressoft/lirp/persistence/query/ViaStrategy;JLjava/lang/Long;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/query/QueryDiagnostic;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExecutionTimeNs ()Ljava/lang/Long;
+	public final fun getIndexHits ()Ljava/util/List;
+	public final fun getPlanningTimeNs ()J
+	public final fun getPostFilterPredicateCount ()I
+	public final fun getStrategy ()Lnet/transgressoft/lirp/persistence/query/Strategy;
+	public final fun getViaStrategy ()Lnet/transgressoft/lirp/persistence/query/ViaStrategy;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/transgressoft/lirp/persistence/query/Strategy : java/lang/Enum {
+	public static final field INDEX_ONLY Lnet/transgressoft/lirp/persistence/query/Strategy;
+	public static final field INDEX_THEN_FILTER Lnet/transgressoft/lirp/persistence/query/Strategy;
+	public static final field SCAN_ONLY Lnet/transgressoft/lirp/persistence/query/Strategy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lnet/transgressoft/lirp/persistence/query/Strategy;
+	public static fun values ()[Lnet/transgressoft/lirp/persistence/query/Strategy;
+}
+
+public final class net/transgressoft/lirp/persistence/query/ViaStrategy : java/lang/Enum {
+	public static final field HASH_JOIN Lnet/transgressoft/lirp/persistence/query/ViaStrategy;
+	public static final field PER_PARENT_LOOP Lnet/transgressoft/lirp/persistence/query/ViaStrategy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lnet/transgressoft/lirp/persistence/query/ViaStrategy;
+	public static fun values ()[Lnet/transgressoft/lirp/persistence/query/ViaStrategy;
+}
+

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/query/DiagnosedQuery.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/query/DiagnosedQuery.kt
@@ -1,0 +1,33 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.query
+
+/**
+ * Result of `queryWithDiagnostics`, pairing the eager result sequence with a [QueryDiagnostic].
+ *
+ * `results` wraps the already-materialised entity list as a [Sequence] so call sites are
+ * uniform with the existing `query` extension. Iterating `results` more than once is safe —
+ * the underlying list is retained.
+ *
+ * @param T the entity type
+ * @see QueryDiagnostic
+ */
+data class DiagnosedQuery<T>(
+    val results: Sequence<T>,
+    val diagnostic: QueryDiagnostic
+)

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/query/IndexHit.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/query/IndexHit.kt
@@ -1,0 +1,40 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.query
+
+/**
+ * Records a single predicate leaf that was resolved through an index during query planning.
+ *
+ * `propertyName` is the Kotlin property name on the entity (e.g. `"category"`).
+ * `indexName` is the storage index name, which may differ when a custom name is set via
+ * [@PersistenceMapping][net.transgressoft.lirp.persistence.PersistenceMapping].
+ * `type` classifies the kind of index lookup performed for this leaf.
+ * `selectivity` quantifies the lookup, with a meaning that depends on [type]: for [IndexHitType.RANGE]
+ * it is the number of candidate entities the index slice returned; for [IndexHitType.MULTI] it is the
+ * number of distinct values probed (one index lookup per value); for [IndexHitType.EXACT] it is `null`,
+ * since the candidate count is not computed at plan time.
+ *
+ * @see QueryDiagnostic
+ * @see IndexHitType
+ */
+data class IndexHit(
+    val propertyName: String,
+    val indexName: String,
+    val type: IndexHitType,
+    val selectivity: Int?
+)

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/query/IndexHitType.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/query/IndexHitType.kt
@@ -1,0 +1,39 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.query
+
+/**
+ * Classifies the kind of index lookup performed for a single predicate leaf, as recorded
+ * in an [IndexHit].
+ *
+ * Each constant corresponds to one predicate shape that the query planner can push to a
+ * hash or sorted index, avoiding a full in-memory scan for that leaf.
+ *
+ * @see IndexHit
+ */
+enum class IndexHitType {
+
+    /** The predicate leaf was an exact-equality match resolved through an index lookup. */
+    EXACT,
+
+    /** The predicate leaf was a membership check resolved as a union of index lookups. */
+    MULTI,
+
+    /** The predicate leaf was a range comparison pushed to a sorted index. */
+    RANGE
+}

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/query/QueryDiagnostic.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/query/QueryDiagnostic.kt
@@ -1,0 +1,45 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.query
+
+/**
+ * Diagnostic snapshot produced by the `explainQuery` and `queryWithDiagnostics` extension
+ * functions in the `lirp-core` module.
+ *
+ * `strategy` is the planner's chosen retrieval mode for the query. `indexHits` lists every
+ * predicate leaf that was pushed to an index; an empty list means no index was used.
+ * `postFilterPredicateCount` is the number of predicate leaves that were NOT resolved by any
+ * index and require a post-filter pass over the candidate set; zero for [Strategy.INDEX_ONLY]
+ * queries. `viaStrategy` is non-null when the query contained a cross-aggregate `via` arm, and
+ * `null` for single-aggregate queries. `planningTimeNs` is the nanosecond duration of strategy
+ * selection and index-leaf extraction, measured via [System.nanoTime]. `executionTimeNs` is
+ * non-null only when the query was executed via `queryWithDiagnostics`; `null` when produced
+ * by `explainQuery` (plan-only, no entity iteration).
+ *
+ * @see Strategy
+ * @see ViaStrategy
+ * @see IndexHit
+ */
+data class QueryDiagnostic(
+    val strategy: Strategy,
+    val indexHits: List<IndexHit>,
+    val postFilterPredicateCount: Int,
+    val viaStrategy: ViaStrategy?,
+    val planningTimeNs: Long,
+    val executionTimeNs: Long?
+)

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/query/Strategy.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/query/Strategy.kt
@@ -1,0 +1,42 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.query
+
+/**
+ * The retrieval mode chosen by the query planner for a given query against a [net.transgressoft.lirp.persistence.Registry].
+ *
+ * The planner inspects predicate leaves and available index metadata to select the most
+ * efficient strategy before execution. The chosen strategy is exposed via [QueryDiagnostic.strategy]
+ * so callers can understand why a query performed as it did.
+ *
+ * @see QueryDiagnostic
+ */
+enum class Strategy {
+
+    /**
+     * Every predicate leaf is fully resolved by an index — exact equality, membership, or a
+     * sorted-range slice — so results come directly from the index with no post-filtering.
+     */
+    INDEX_ONLY,
+
+    /** Some leaves are index-resolved, but others require a post-filter pass over the candidates. */
+    INDEX_THEN_FILTER,
+
+    /** No leaf can be resolved through an index; a full in-memory scan is required. */
+    SCAN_ONLY
+}

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/query/ViaStrategy.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/query/ViaStrategy.kt
@@ -1,0 +1,43 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.query
+
+/**
+ * Execution strategy for cross-aggregate `via … anyMatch/allMatch/noneMatch/where` predicates.
+ *
+ * Selected per-query based on the cardinality estimate
+ * `|children matching predicate| < |parents| × avg-refs-per-parent`. Never cached
+ * across queries; re-estimated on every execution. The chosen strategy is exposed via
+ * [QueryDiagnostic.viaStrategy] whenever a cross-aggregate query is planned or executed.
+ *
+ * @see QueryDiagnostic
+ */
+enum class ViaStrategy {
+    /**
+     * Iterates parents lazily; for each parent, reads the live `parentProp` collection and
+     * applies the via predicate directly.
+     */
+    PER_PARENT_LOOP,
+
+    /**
+     * Pre-filters the child registry by the child predicate, materialises matching ids into
+     * a [HashSet], then per-parent tests `parentProp` reads (live) against that set with the
+     * quantifier appropriate to the via operator.
+     */
+    HASH_JOIN
+}

--- a/lirp-core/api/lirp-core.api
+++ b/lirp-core/api/lirp-core.api
@@ -1345,7 +1345,9 @@ public final class net/transgressoft/lirp/persistence/query/QueryBuilder {
 }
 
 public final class net/transgressoft/lirp/persistence/query/RegistryQueryExtensionsKt {
+	public static final fun explainQueryRegistry (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/persistence/query/QueryDiagnostic;
 	public static final fun queryRegistry (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;)Lkotlin/sequences/Sequence;
+	public static final fun queryWithDiagnosticsRegistry (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/persistence/query/DiagnosedQuery;
 }
 
 public final class net/transgressoft/lirp/persistence/query/ViaAllMatch : net/transgressoft/lirp/persistence/query/Predicate {
@@ -1391,14 +1393,6 @@ public final class net/transgressoft/lirp/persistence/query/ViaSingleStep {
 	public fun <init> (Lkotlin/reflect/KProperty1;Lnet/transgressoft/lirp/persistence/Registry;)V
 	public final fun getChildRegistry ()Lnet/transgressoft/lirp/persistence/Registry;
 	public final fun getParentProp ()Lkotlin/reflect/KProperty1;
-}
-
-public final class net/transgressoft/lirp/persistence/query/ViaStrategy : java/lang/Enum {
-	public static final field HASH_JOIN Lnet/transgressoft/lirp/persistence/query/ViaStrategy;
-	public static final field PER_PARENT_LOOP Lnet/transgressoft/lirp/persistence/query/ViaStrategy;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lnet/transgressoft/lirp/persistence/query/ViaStrategy;
-	public static fun values ()[Lnet/transgressoft/lirp/persistence/query/ViaStrategy;
 }
 
 public final class net/transgressoft/lirp/persistence/query/ViaWhere : net/transgressoft/lirp/persistence/query/Predicate {

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/QueryPlanner.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/QueryPlanner.kt
@@ -27,29 +27,6 @@ import kotlin.reflect.KProperty1
 private val log = KotlinLogging.logger {}
 
 /**
- * Execution strategy for cross-aggregate `via … anyMatch/allMatch/noneMatch/where` predicates.
- *
- * Selected per-query by [QueryPlanner.chooseStrategy] based on the cardinality estimate
- * `|children matching predicate| < |parents| × avg-refs-per-parent`. Never cached
- * across queries; re-estimated on every execution.
- */
-enum class ViaStrategy {
-    /**
-     * Iterates parents lazily; for each parent, reads the live `parentProp` collection and
-     * applies the Via* node's `matches` directly (delegates child resolution via
-     * [Registry.findById]).
-     */
-    PER_PARENT_LOOP,
-
-    /**
-     * Pre-filters the child registry by the child predicate, materialises matching ids into
-     * a [HashSet], then per-parent tests `parentProp` reads (live) against that set with the
-     * quantifier appropriate to the Via* operator.
-     */
-    HASH_JOIN
-}
-
-/**
  * Plans and executes [Query] instances against a [Registry], selecting the optimal
  * retrieval strategy based on indexed property metadata.
  *
@@ -87,29 +64,6 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
     private val viaJoinExecutor = ViaJoinExecutor<T>()
 
     /**
-     * Execution strategy selected by the planner.
-     */
-    enum class Strategy {
-        /** All predicate leaves are indexed equality checks; results come directly from the index. */
-        INDEX_ONLY,
-
-        /** Some leaves are indexed equality checks, but others require post-filtering. */
-        INDEX_THEN_FILTER,
-
-        /** No indexed equality leaves are present; a full in-memory scan is required. */
-        SCAN_ONLY
-    }
-
-    /**
-     * Result of query planning, containing the chosen strategy and a lazy [Sequence]
-     * of matching entities.
-     *
-     * @param strategy the chosen execution strategy
-     * @param results a lazy sequence of matching entities
-     */
-    data class Plan<T>(val strategy: Strategy, val results: Sequence<T>)
-
-    /**
      * Internal discriminated leaf representation used during index candidate extraction.
      *
      * [Single] carries a single exact value (from [Predicate.Eq]); [Multi] carries a value-set
@@ -120,16 +74,49 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
      * The [RangeSlice.candidates] set holds `T` instances erased to `Any`; callers must
      * suppress the unchecked-cast warning when retrieving them as `Set<T>`.
      */
-    private sealed interface IndexableLeaf {
+    internal sealed interface IndexableLeaf {
+        val propertyName: String
         val indexName: String
 
-        data class Single(override val indexName: String, val value: Any) : IndexableLeaf
+        data class Single(override val propertyName: String, override val indexName: String, val value: Any) : IndexableLeaf
 
-        data class Multi(override val indexName: String, val values: Set<Any>) : IndexableLeaf
+        data class Multi(override val propertyName: String, override val indexName: String, val values: Set<Any>) : IndexableLeaf
 
         /** [candidates] erased to `Set<Any>` — type-safely `Set<T>` at construction. */
-        data class RangeSlice(override val indexName: String, val candidates: Set<Any>) : IndexableLeaf
+        data class RangeSlice(override val propertyName: String, override val indexName: String, val candidates: Set<Any>) : IndexableLeaf
     }
+
+    /**
+     * Planning result carrying the chosen strategy, index leaves, post-filter count, via-strategy,
+     * and a lazy result sequence.
+     *
+     * `strategy` is the retrieval mode selected by the planner. `indexLeaves` lists every predicate
+     * leaf that was pushed to an index. `postFilterCount` is the number of predicate leaves not
+     * resolved by any index, requiring a post-filter pass over the candidate set. `viaStrategy` is
+     * non-null when the query contained a cross-aggregate `via` arm. `results` is the lazy entity
+     * sequence, which may include ordering and pagination applied on top of the candidate set.
+     *
+     * @param strategy the chosen execution strategy
+     * @param indexLeaves the index-resolved leaves, in extraction order
+     * @param postFilterCount the number of predicate leaves that require post-filtering
+     * @param viaStrategy the via-join strategy when a cross-aggregate arm is present, or `null`
+     * @param results a lazy sequence of matching entities
+     */
+    internal data class PlanContext<T>(
+        val strategy: Strategy,
+        val indexLeaves: List<IndexableLeaf>,
+        val postFilterCount: Int,
+        val viaStrategy: ViaStrategy?,
+        val results: Sequence<T>
+    )
+
+    private data class SelectResult<T>(
+        val strategy: Strategy,
+        val indexLeaves: List<IndexableLeaf>,
+        val postFilterCount: Int,
+        val viaStrategy: ViaStrategy?,
+        val candidates: Sequence<T>
+    )
 
     /**
      * Executes [query] against [registry], selecting the optimal strategy.
@@ -160,90 +147,133 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
      *
      * @param query the query to execute
      * @param registry the registry to search
-     * @return a [Plan] containing the strategy and result sequence
+     * @return a [PlanContext] containing the strategy, index leaves, post-filter count, via-strategy, and result sequence
      */
-    fun execute(query: Query<T>, registry: Registry<*, T>): Plan<T> {
+    fun execute(query: Query<T>, registry: Registry<*, T>): PlanContext<T> {
         // Normalise Via* fold rules before any strategy selection.
         // ViaNormalizer is a no-op for predicates without Via* nodes, so this stays cheap
         // for queries that do not use cross-aggregate traversal.
         val pred = query.predicate?.let { normalize(it) }
-        val (strategy, candidates) = selectStrategyAndCandidates(pred, registry)
+        val (strategy, indexLeaves, postFilterCount, viaStrat, candidates) = selectStrategyAndCandidates(pred, registry)
         val ordered = applyOrdering(candidates, query.orderBy)
         val sliced = applyPagination(ordered, query.offset, query.limit)
-        return Plan(strategy, sliced)
+        return PlanContext(strategy, indexLeaves, postFilterCount, viaStrat, sliced)
     }
 
     private fun selectStrategyAndCandidates(
         pred: Predicate<T>?,
         registry: Registry<*, T>
-    ): Pair<Strategy, Sequence<T>> {
-        if (pred == null) return Strategy.SCAN_ONLY to registry.asSequence()
+    ): SelectResult<T> {
+        if (pred == null) return SelectResult(Strategy.SCAN_ONLY, emptyList(), 0, null, registry.asSequence())
         // Empty-In short-circuit: x ∈ ∅ is always false — no entities can match.
         if (pred is Predicate.In<*, *> && (pred as Predicate.In<T, *>).values.isEmpty()) {
-            return Strategy.INDEX_ONLY to emptySequence()
+            return SelectResult(Strategy.INDEX_ONLY, emptyList(), 0, null, emptySequence())
         }
         if (containsVia(pred)) {
             // Cross-aggregate path: split hybrid predicate, choose Via strategy, apply
             // any NonVia arm as a lazy post-filter. Strategy reported to callers is
             // still SCAN_ONLY at the parent level (no index acceleration on Via* nodes).
-            return Strategy.SCAN_ONLY to executeViaPlan(pred, registry)
+            // The NonVia arm of a hybrid And(NonVia, Via*) is post-filtered, so its leaves
+            // count toward postFilterCount; a bare or multi-Via* predicate has none.
+            val viaStrat = strategyFor(pred, registry)
+            val (nonViaArm, _) = splitHybridAnd(pred)
+            val viaPostFilterCount = nonViaArm?.let { countLeaves(it) } ?: 0
+            return SelectResult(Strategy.SCAN_ONLY, emptyList(), viaPostFilterCount, viaStrat, executeViaPlan(pred, registry))
         }
         val indexable = extractIndexableLeaves(pred)
         if (indexable.isEmpty()) {
             log.trace { "QueryPlanner: no indexable leaves — full scan on ${registry.size()} entities" }
-            return Strategy.SCAN_ONLY to registry.asSequence().filter { pred.matches(it) }
+            return SelectResult(Strategy.SCAN_ONLY, emptyList(), countLeaves(pred), null, registry.asSequence().filter { pred.matches(it) })
         }
         return indexAcceleratedCandidates(pred, indexable, registry)
     }
+
+    /**
+     * Counts the non-Via predicate leaves in [pred]. Used to compute the post-filter count
+     * for scan paths where no index acceleration is available.
+     *
+     * Composite nodes (And, Or) recurse into both arms. Not-wrapped leaves count as one leaf
+     * (the inner leaf). Via* nodes are not counted — they are reported via [PlanContext.viaStrategy].
+     */
+    private fun countLeaves(pred: Predicate<T>): Int =
+        when (pred) {
+            is Predicate.Eq<*, *>, is Predicate.In<*, *>,
+            is Predicate.Gt<*, *>, is Predicate.Gte<*, *>,
+            is Predicate.Lt<*, *>, is Predicate.Lte<*, *> -> 1
+            is Predicate.Not<*> -> {
+                @Suppress("UNCHECKED_CAST")
+                countLeaves((pred as Predicate.Not<T>).inner)
+            }
+            is Predicate.And<*> -> {
+                @Suppress("UNCHECKED_CAST")
+                val a = pred as Predicate.And<T>
+                countLeaves(a.left) + countLeaves(a.right)
+            }
+            is Predicate.Or<*> -> {
+                @Suppress("UNCHECKED_CAST")
+                val o = pred as Predicate.Or<T>
+                countLeaves(o.left) + countLeaves(o.right)
+            }
+            else -> 0
+        }
 
     private fun indexAcceleratedCandidates(
         pred: Predicate<T>,
         indexable: List<IndexableLeaf>,
         registry: Registry<*, T>
-    ): Pair<Strategy, Sequence<T>> {
+    ): SelectResult<T> {
         // Use the internal non-copying index read when available (RegistryBase), falling back to the
         // public defensive-copy findByIndex for any other Registry implementation.
         val noCopyRegistry = registry as? RegistryBase<*, T>
-        var working: Set<T>? = null
-        for (leaf in indexable) {
-            val hit: Collection<T> =
-                when (leaf) {
-                    is IndexableLeaf.Single ->
-                        noCopyRegistry?.findByIndexNoCopy(leaf.indexName, leaf.value)
-                            ?: registry.findByIndex(leaf.indexName, leaf.value)
-                    is IndexableLeaf.Multi ->
-                        leaf.values.flatMapTo(HashSet()) { v ->
-                            noCopyRegistry?.findByIndexNoCopy(leaf.indexName, v)
-                                ?: registry.findByIndex(leaf.indexName, v)
-                        }
-                    // RangeSlice candidates are pre-materialised from NavigableMap bucket sets —
-                    // no further findByIndex dispatch needed. The cast is safe: RangeSlice is
-                    // constructed only via rangeLeaf(), which receives Set<T> from rangeSlice().
-                    is IndexableLeaf.RangeSlice -> {
-                        @Suppress("UNCHECKED_CAST")
-                        leaf.candidates as Set<T>
-                    }
-                }
-            working = working?.let { it intersect hit } ?: hit.toHashSet()
-            if (working.isEmpty()) break
-        }
-        val candidateSet = working ?: emptySet()
         val strategy = if (allLeavesAreIndexedEq(pred)) Strategy.INDEX_ONLY else Strategy.INDEX_THEN_FILTER
-        val candidates =
-            when (strategy) {
-                Strategy.INDEX_ONLY -> candidateSet.asSequence()
-                // When any In leaf contains null, null-valued entities are not reachable via the index
-                // (null keys are not stored). A full registry scan with pred.matches is required so
-                // null-matching entities are included alongside the index-resolved candidates.
-                Strategy.INDEX_THEN_FILTER ->
-                    if (containsInWithNull(pred)) {
-                        registry.asSequence().filter { pred.matches(it) }
-                    } else {
-                        candidateSet.asSequence().filter { pred.matches(it) }
-                    }
-                else -> candidateSet.asSequence().filter { pred.matches(it) }
+        // When any In leaf contains null, the index cannot resolve null-valued entities (null keys
+        // are not stored), so execution falls back to a full scan re-evaluating every leaf — none
+        // are effectively index-resolved, so the whole predicate is post-filtered.
+        val nullInScan = containsInWithNull(pred)
+        val postFilterCount =
+            when {
+                strategy == Strategy.INDEX_ONLY -> 0
+                nullInScan -> countLeaves(pred)
+                else -> countLeaves(pred) - indexable.size
             }
-        return strategy to candidates
+        // Candidate resolution (index reads, intersection, post-filter scan) is deferred into the
+        // returned sequence so the planner stays plan-only until a terminal operation consumes the
+        // results — honoring the lazy contract in execute()'s KDoc and keeping explainQuery cheap.
+        val candidates =
+            sequence {
+                var working: Set<T>? = null
+                for (leaf in indexable) {
+                    val hit: Collection<T> =
+                        when (leaf) {
+                            is IndexableLeaf.Single ->
+                                noCopyRegistry?.findByIndexNoCopy(leaf.indexName, leaf.value)
+                                    ?: registry.findByIndex(leaf.indexName, leaf.value)
+                            is IndexableLeaf.Multi ->
+                                leaf.values.flatMapTo(HashSet()) { v ->
+                                    noCopyRegistry?.findByIndexNoCopy(leaf.indexName, v)
+                                        ?: registry.findByIndex(leaf.indexName, v)
+                                }
+                            // RangeSlice candidates are pre-materialised from NavigableMap bucket sets —
+                            // no further findByIndex dispatch needed. The cast is safe: RangeSlice is
+                            // constructed only via rangeLeaf(), which receives Set<T> from rangeSlice().
+                            is IndexableLeaf.RangeSlice -> {
+                                @Suppress("UNCHECKED_CAST")
+                                leaf.candidates as Set<T>
+                            }
+                        }
+                    working = working?.let { it intersect hit } ?: hit.toHashSet()
+                    if (working.isEmpty()) break
+                }
+                val candidateSet = working ?: emptySet()
+                val resolved =
+                    when {
+                        strategy == Strategy.INDEX_ONLY -> candidateSet.asSequence()
+                        nullInScan -> registry.asSequence().filter { pred.matches(it) }
+                        else -> candidateSet.asSequence().filter { pred.matches(it) }
+                    }
+                yieldAll(resolved)
+            }
+        return SelectResult(strategy, indexable, postFilterCount, null, candidates)
     }
 
     /**
@@ -333,7 +363,9 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
     private fun applyOrdering(candidates: Sequence<T>, orderBy: List<OrderClause<T>>): Sequence<T> {
         if (orderBy.isEmpty()) return candidates
         val cmp = composeComparator(orderBy)
-        return candidates.toList().sortedWith(cmp).asSequence()
+        // Defer the materialise-and-sort to the first terminal operation so planning stays
+        // execution-free; the sort runs when the consumer iterates, not at plan() / execute() time.
+        return sequence { yieldAll(candidates.toList().sortedWith(cmp)) }
     }
 
     private fun applyPagination(seq: Sequence<T>, offset: Int, limit: Int?): Sequence<T> {
@@ -357,7 +389,7 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
             is Predicate.Eq<*, *> -> {
                 val eq = pred as Predicate.Eq<T, Any?>
                 if (isIndexed(eq.prop) && eq.value != null) {
-                    listOf(IndexableLeaf.Single(indexNameFor(eq.prop), eq.value))
+                    listOf(IndexableLeaf.Single(eq.prop.name, indexNameFor(eq.prop), eq.value))
                 } else {
                     emptyList()
                 }
@@ -370,11 +402,11 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
                 // allLeavesAreIndexedEq classifies the leaf as resolved (null !in []) while it
                 // contributes no candidates, and a sibling Eq's candidates leak through INDEX_ONLY.
                 if (inPred.values.isEmpty()) {
-                    return listOf(IndexableLeaf.Multi(indexNameFor(inPred.prop), emptySet()))
+                    return listOf(IndexableLeaf.Multi(inPred.prop.name, indexNameFor(inPred.prop), emptySet()))
                 }
                 val nonNullValues = inPred.values.filterNotNull().toSet()
                 if (nonNullValues.isEmpty()) emptyList()
-                else listOf(IndexableLeaf.Multi(indexNameFor(inPred.prop), nonNullValues))
+                else listOf(IndexableLeaf.Multi(inPred.prop.name, indexNameFor(inPred.prop), nonNullValues))
             }
             is Predicate.Gt<*, *> -> rangeLeaf(pred as Predicate.Gt<T, *>)
             is Predicate.Gte<*, *> -> rangeLeaf(pred as Predicate.Gte<T, *>)
@@ -415,7 +447,7 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
         if (!isSortedIndexed(prop)) return emptyList()
         val candidates = rangeSlice(pred) ?: return emptyList()
         @Suppress("UNCHECKED_CAST")
-        return listOf(IndexableLeaf.RangeSlice(indexNameFor(prop), candidates as Set<Any>))
+        return listOf(IndexableLeaf.RangeSlice(prop.name, indexNameFor(prop), candidates as Set<Any>))
     }
 
     /**
@@ -599,8 +631,6 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
      * bypassing the [Registry.query] entry point. The returned sequence yields parents
      * at the per-parent boundary so a test may mutate a parent's `parentProp` between
      * two `.next()` calls and observe the live read on the very next yield.
-     *
-     * Not part of the public API; consumed by Plan 05 Task 1 case 3.
      *
      * @param predicate the query predicate (must already be a Via* node or contain one)
      * @param parentRegistry the registry holding the parent entities

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/RegistryQueryExtensions.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/RegistryQueryExtensions.kt
@@ -22,6 +22,7 @@ import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.StandardCrudEvent.Read
 import net.transgressoft.lirp.persistence.Registry
 import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.query.QueryPlanner.IndexableLeaf
 
 /**
  * Executes a type-safe query against this registry using the Kotlin DSL.
@@ -50,9 +51,7 @@ import net.transgressoft.lirp.persistence.RegistryBase
  * **Cross-aggregate queries:** when the predicate contains a `via … anyMatch /
  * allMatch / noneMatch / where` chain, the planner reads `parentProp` and
  * `childRegistry` directly from the captured Via* AST nodes. No `LirpViaAccessor`
- * callback is required for the in-memory path; the accessor contract emitted by
- * Plan 02's `LirpViaAccessorProcessor` is reserved for the future SQL pushdown
- * path and for `RegistryBase.viaAccessorFor` (Plan 04).
+ * callback is required for the in-memory path.
  *
  * @param block DSL builder block defining the query predicate, ordering, and pagination
  * @return A lazy [Sequence] of matching entities
@@ -83,6 +82,146 @@ fun <K, T> Registry<K, T>.query(block: QueryBuilder<T>.() -> Unit): Sequence<T>
         plan.results
     }
 }
+
+/**
+ * Plans a query without executing it, returning a [QueryDiagnostic] describing the planner's
+ * chosen strategy and index usage.
+ *
+ * Analogous to SQL `EXPLAIN`: the DSL block is compiled into a query plan and the planner
+ * selects a strategy and extracts index leaves, but the result sequence is **never
+ * materialised** — no entity iteration occurs. This makes `explainQuery` cheap to call for
+ * diagnostic purposes without paying the execution cost.
+ *
+ * Example:
+ * ```kotlin
+ * val diagnostic = repo.explainQuery {
+ *     where { category eq "electronics" }
+ *     orderBy(price, Direction.DESC)
+ * }
+ * println(diagnostic.strategy)      // INDEX_ONLY
+ * println(diagnostic.indexHits)     // [IndexHit(propertyName=category, ...)]
+ * println(diagnostic.executionTimeNs) // null — plan-only, no execution
+ * ```
+ *
+ * The returned [QueryDiagnostic.executionTimeNs] is always `null`. Use [queryWithDiagnostics]
+ * when you need both the results and execution timing (SQL `EXPLAIN ANALYZE` equivalent).
+ *
+ * For cross-aggregate `via` queries the result sequence is still not materialised, but choosing
+ * between the per-parent-loop and hash-join strategies samples parent keys and inspects the child
+ * registry — so a `via` plan is not strictly zero-cost, unlike a single-aggregate plan.
+ *
+ * @param block DSL builder block defining the query predicate, ordering, and pagination
+ * @return A [QueryDiagnostic] describing strategy, index hits, post-filter count, via-strategy,
+ *   and planning duration; `executionTimeNs` is always `null`
+ */
+@JvmName("explainQueryRegistry")
+fun <K, T> Registry<K, T>.explainQuery(block: QueryBuilder<T>.() -> Unit): QueryDiagnostic
+    where K : Comparable<K>, T : IdentifiableEntity<K> {
+    val t0 = System.nanoTime()
+    val built = QueryBuilder<T>().apply(block).build()
+
+    val base = this as? RegistryBase<K, T>
+    val planner =
+        if (base != null) {
+            QueryPlanner(
+                isIndexed = { base.isPropertyIndexed(it) },
+                indexNameFor = { base.indexNameFor(it) ?: it.name },
+                isSortedIndexed = { base.isPropertySortedIndexed(it) },
+                sortedBucketFor = { name -> base.sortedBucketFor(name) }
+            )
+        } else {
+            QueryPlanner(isIndexed = { false }, indexNameFor = { it.name })
+        }
+
+    val context = planner.execute(built, this)
+    val planningTimeNs = System.nanoTime() - t0
+    // results sequence is NOT consumed — plan-only guarantee (no terminal operation called)
+    return QueryDiagnostic(
+        strategy = context.strategy,
+        indexHits = context.indexLeaves.map { it.toIndexHit() },
+        postFilterPredicateCount = context.postFilterCount,
+        viaStrategy = context.viaStrategy,
+        planningTimeNs = planningTimeNs,
+        executionTimeNs = null
+    )
+}
+
+/**
+ * Executes a query and returns both the results and a [QueryDiagnostic] with full timing.
+ *
+ * Analogous to SQL `EXPLAIN ANALYZE`: the DSL block is planned, the result sequence is eagerly
+ * materialised, and execution time is recorded. The returned [DiagnosedQuery.results] wraps
+ * the already-materialised list as a [Sequence] for uniformity with the [query] extension;
+ * iterating `results` more than once is safe.
+ *
+ * Example:
+ * ```kotlin
+ * val diagnosed = repo.queryWithDiagnostics {
+ *     where { category eq "electronics" }
+ * }
+ * val results = diagnosed.results.toList()
+ * val diagnostic = diagnosed.diagnostic
+ * println(diagnostic.planningTimeNs)   // nanoseconds spent in strategy selection
+ * println(diagnostic.executionTimeNs)  // nanoseconds spent materialising results (non-null)
+ * ```
+ *
+ * Use [explainQuery] when you only need the plan without paying the execution cost.
+ *
+ * @param block DSL builder block defining the query predicate, ordering, and pagination
+ * @return A [DiagnosedQuery] pairing the eagerly-materialised result sequence with a
+ *   [QueryDiagnostic] where `executionTimeNs` is always non-null
+ */
+@JvmName("queryWithDiagnosticsRegistry")
+fun <K, T> Registry<K, T>.queryWithDiagnostics(block: QueryBuilder<T>.() -> Unit): DiagnosedQuery<T>
+    where K : Comparable<K>, T : IdentifiableEntity<K> {
+    val t0 = System.nanoTime()
+    val built = QueryBuilder<T>().apply(block).build()
+
+    val base = this as? RegistryBase<K, T>
+    val planner =
+        if (base != null) {
+            QueryPlanner(
+                isIndexed = { base.isPropertyIndexed(it) },
+                indexNameFor = { base.indexNameFor(it) ?: it.name },
+                isSortedIndexed = { base.isPropertySortedIndexed(it) },
+                sortedBucketFor = { name -> base.sortedBucketFor(name) }
+            )
+        } else {
+            QueryPlanner(isIndexed = { false }, indexNameFor = { it.name })
+        }
+
+    val context = planner.execute(built, this)
+    val planningTimeNs = System.nanoTime() - t0
+    val t1 = System.nanoTime()
+    val results = context.results.toList()
+    val executionTimeNs = System.nanoTime() - t1
+    val diagnostic =
+        QueryDiagnostic(
+            strategy = context.strategy,
+            indexHits = context.indexLeaves.map { it.toIndexHit() },
+            postFilterPredicateCount = context.postFilterCount,
+            viaStrategy = context.viaStrategy,
+            planningTimeNs = planningTimeNs,
+            executionTimeNs = executionTimeNs
+        )
+    return DiagnosedQuery(results = results.asSequence(), diagnostic = diagnostic)
+}
+
+/**
+ * Maps an internal [IndexableLeaf] to the public [IndexHit] type.
+ *
+ * [IndexableLeaf.Single] (from [Predicate.Eq]) maps to [IndexHitType.EXACT] with null selectivity,
+ * since the exact candidate count is not computable at plan time without executing the index lookup.
+ * [IndexableLeaf.Multi] (from [Predicate.In]) maps to [IndexHitType.MULTI] with selectivity equal
+ * to the number of distinct values in the set. [IndexableLeaf.RangeSlice] (from range predicates)
+ * maps to [IndexHitType.RANGE] with selectivity equal to the pre-materialised candidate count.
+ */
+private fun IndexableLeaf.toIndexHit(): IndexHit =
+    when (this) {
+        is IndexableLeaf.Single -> IndexHit(propertyName, indexName, IndexHitType.EXACT, selectivity = null)
+        is IndexableLeaf.Multi -> IndexHit(propertyName, indexName, IndexHitType.MULTI, selectivity = values.size)
+        is IndexableLeaf.RangeSlice -> IndexHit(propertyName, indexName, IndexHitType.RANGE, selectivity = candidates.size)
+    }
 
 /**
  * Wraps a [Sequence] so that a [Read] event is emitted on the first terminal operation.

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/IsInOperatorTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/IsInOperatorTest.kt
@@ -97,7 +97,7 @@ internal class IsInOperatorTest : StringSpec({
             )
         val plan = planner.execute(query { where { IsInFixture::category isIn emptyList() } }, repo)
 
-        plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+        plan.strategy shouldBe Strategy.INDEX_ONLY
         plan.results.toList().shouldBeEmpty()
     }
 
@@ -128,7 +128,7 @@ internal class IsInOperatorTest : StringSpec({
                 query { where { IsInFixture::sku isIn listOf("sku-a", "sku-b") } },
                 repo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.SCAN_ONLY
+        plan.strategy shouldBe Strategy.SCAN_ONLY
         plan.results.toList().map { it.sku } shouldContainExactlyInAnyOrder listOf("sku-a", "sku-b")
     }
 
@@ -148,7 +148,7 @@ internal class IsInOperatorTest : StringSpec({
                 query { where { IsInFixture::category isIn listOf("electronics", "books") } },
                 repo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+        plan.strategy shouldBe Strategy.INDEX_ONLY
         plan.results.toList().map { it.id } shouldContainExactlyInAnyOrder listOf(1, 2, 3)
     }
 
@@ -167,7 +167,7 @@ internal class IsInOperatorTest : StringSpec({
                 query { where { IsInFixture::category isIn listOf("electronics", null) } },
                 repo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.INDEX_THEN_FILTER
+        plan.strategy shouldBe Strategy.INDEX_THEN_FILTER
         plan.results.toList().map { it.id } shouldContainExactlyInAnyOrder listOf(1, 2)
     }
 
@@ -187,7 +187,7 @@ internal class IsInOperatorTest : StringSpec({
                 query { where { (IsInFixture::category eq "electronics") and (IsInFixture::sku isIn listOf("sku-a", "sku-b")) } },
                 repo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+        plan.strategy shouldBe Strategy.INDEX_ONLY
         plan.results.toList().map { it.id } shouldContainExactlyInAnyOrder listOf(1, 2)
     }
 
@@ -216,7 +216,7 @@ internal class IsInOperatorTest : StringSpec({
         val plan = planner.execute(query { where { pred } }, repo)
 
         // The Or arm contains In(null,...) nested inside the And — planner must detect null and use INDEX_THEN_FILTER.
-        plan.strategy shouldBe QueryPlanner.Strategy.INDEX_THEN_FILTER
+        plan.strategy shouldBe Strategy.INDEX_THEN_FILTER
         plan.results.toList().map { it.id } shouldContainExactlyInAnyOrder listOf(3)
     }
 
@@ -238,7 +238,7 @@ internal class IsInOperatorTest : StringSpec({
                 query { where { (IsInFixture::category eq "electronics") and (IsInFixture::sku isIn emptyList()) } },
                 repo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+        plan.strategy shouldBe Strategy.INDEX_ONLY
         plan.results.toList().shouldBeEmpty()
     }
 
@@ -262,7 +262,7 @@ internal class IsInOperatorTest : StringSpec({
                 },
                 repo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.SCAN_ONLY
+        plan.strategy shouldBe Strategy.SCAN_ONLY
         plan.results.toList().map { it.id } shouldContainExactlyInAnyOrder listOf(1, 2)
     }
 })

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/QueryDiagnosticsExtensionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/QueryDiagnosticsExtensionTest.kt
@@ -1,0 +1,157 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.query
+
+import net.transgressoft.lirp.persistence.LirpContext
+import net.transgressoft.lirp.persistence.VolatileRepository
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Integration tests for [explainQuery] and [queryWithDiagnostics] against real repositories,
+ * verifying diagnostic accuracy across all three retrieval strategies.
+ */
+@DisplayName("Query Diagnostics Extension")
+internal class QueryDiagnosticsExtensionTest : FunSpec({
+
+    lateinit var ctx: LirpContext
+    lateinit var productRepo: ProductVolatileRepo
+
+    beforeTest {
+        ctx = LirpContext()
+        productRepo = ProductVolatileRepo(ctx)
+        productRepo.create(1, "books", 10.0, 5, "Book A")
+        productRepo.create(2, "electronics", 100.0, 10, "Gadget")
+        productRepo.create(3, "books", 15.0, 3, "Book B")
+        productRepo.create(4, "electronics", 50.0, 8, "Tablet")
+    }
+
+    afterTest { ctx.close() }
+
+    test("explainQuery returns INDEX_ONLY for indexed Eq with one EXACT index hit") {
+        val diagnostic = productRepo.explainQuery { where { Product::category eq "books" } }
+
+        diagnostic.strategy shouldBe Strategy.INDEX_ONLY
+        diagnostic.indexHits shouldHaveSize 1
+        diagnostic.indexHits[0].propertyName shouldBe "category"
+        diagnostic.indexHits[0].type shouldBe IndexHitType.EXACT
+        diagnostic.postFilterPredicateCount shouldBe 0
+    }
+
+    test("explainQuery executionTimeNs is null") {
+        val diagnostic = productRepo.explainQuery { where { Product::category eq "books" } }
+
+        diagnostic.executionTimeNs.shouldBeNull()
+    }
+
+    test("explainQuery planningTimeNs is non-negative") {
+        val diagnostic = productRepo.explainQuery { where { Product::category eq "books" } }
+
+        (diagnostic.planningTimeNs >= 0) shouldBe true
+    }
+
+    test("explainQuery returns SCAN_ONLY with empty indexHits for non-indexed predicate") {
+        val diagnostic = productRepo.explainQuery { where { Product::price gt 20.0 } }
+
+        diagnostic.strategy shouldBe Strategy.SCAN_ONLY
+        diagnostic.indexHits.shouldBeEmpty()
+    }
+
+    test("explainQuery returns INDEX_THEN_FILTER with positive postFilterPredicateCount for indexed-Eq AND non-indexed range") {
+        val diagnostic =
+            productRepo.explainQuery {
+                where { (Product::category eq "electronics") and (Product::price gt 60.0) }
+            }
+
+        diagnostic.strategy shouldBe Strategy.INDEX_THEN_FILTER
+        diagnostic.postFilterPredicateCount shouldBe 1
+        diagnostic.indexHits shouldHaveSize 1
+    }
+
+    test("queryWithDiagnostics planningTimeNs is non-negative") {
+        val diagnosed = productRepo.queryWithDiagnostics { where { Product::category eq "books" } }
+
+        (diagnosed.diagnostic.planningTimeNs >= 0) shouldBe true
+    }
+
+    test("queryWithDiagnostics executionTimeNs is non-null") {
+        val diagnosed = productRepo.queryWithDiagnostics { where { Product::category eq "books" } }
+
+        diagnosed.diagnostic.executionTimeNs.shouldNotBeNull()
+        (diagnosed.diagnostic.executionTimeNs!! >= 0) shouldBe true
+    }
+
+    test("queryWithDiagnostics results match query results for indexed Eq") {
+        val block: QueryBuilder<Product>.() -> Unit = { where { Product::category eq "books" } }
+
+        val queryResult = productRepo.query(block).toList()
+        val diagnosed = productRepo.queryWithDiagnostics(block)
+        val diagnosedResult = diagnosed.results.toList()
+
+        diagnosedResult.map { it.id }.toSet() shouldBe queryResult.map { it.id }.toSet()
+        diagnosedResult shouldHaveSize queryResult.size
+    }
+
+    test("queryWithDiagnostics results match query results for SCAN_ONLY predicate") {
+        val block: QueryBuilder<Product>.() -> Unit = { where { Product::price gt 20.0 } }
+
+        val queryResult = productRepo.query(block).toList()
+        val diagnosedResult = productRepo.queryWithDiagnostics(block).results.toList()
+
+        diagnosedResult.map { it.id }.toSet() shouldBe queryResult.map { it.id }.toSet()
+    }
+
+    test("queryWithDiagnostics results can be iterated more than once") {
+        val diagnosed = productRepo.queryWithDiagnostics { where { Product::category eq "books" } }
+
+        val first = diagnosed.results.toList()
+        val second = diagnosed.results.toList()
+        first shouldBe second
+    }
+
+    test("explainQuery on In predicate returns MULTI IndexHit with correct selectivity") {
+        val diagnostic =
+            productRepo.explainQuery {
+                where { Product::category isIn listOf("books", "electronics") }
+            }
+
+        diagnostic.strategy shouldBe Strategy.INDEX_ONLY
+        diagnostic.indexHits shouldHaveSize 1
+        diagnostic.indexHits[0].type shouldBe IndexHitType.MULTI
+        diagnostic.indexHits[0].selectivity shouldBe 2
+    }
+
+    test("explainQuery on sorted-indexed range predicate returns RANGE IndexHit") {
+        val rangeRepo =
+            object : VolatileRepository<Int, RangeFixture>(ctx, "RangeRepo") {}
+        (1..10).forEach { i ->
+            rangeRepo.add(RangeFixture(i, if (i % 2 == 0) "X" else "Y", i * 4, null))
+        }
+
+        val diagnostic = rangeRepo.explainQuery { where { RangeFixture::age gt 20 } }
+
+        diagnostic.indexHits shouldHaveSize 1
+        diagnostic.indexHits[0].type shouldBe IndexHitType.RANGE
+        diagnostic.indexHits[0].selectivity shouldBe 5
+    }
+})

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/QueryPlannerTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/QueryPlannerTest.kt
@@ -22,6 +22,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 
 /**
@@ -65,7 +66,7 @@ internal class QueryPlannerTest : FunSpec({
                 query { where { Product::category eq "books" } },
                 productRepo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+        plan.strategy shouldBe Strategy.INDEX_ONLY
         plan.results.toList().map { it.name } shouldContainExactlyInAnyOrder listOf("Book A", "Book B")
     }
 
@@ -75,7 +76,7 @@ internal class QueryPlannerTest : FunSpec({
                 query { where { (Product::category eq "electronics") and (Product::price gt 60.0) } },
                 productRepo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.INDEX_THEN_FILTER
+        plan.strategy shouldBe Strategy.INDEX_THEN_FILTER
         plan.results.toList().map { it.name } shouldContainExactlyInAnyOrder listOf("Gadget")
     }
 
@@ -85,7 +86,7 @@ internal class QueryPlannerTest : FunSpec({
                 query { where { Product::price gt 20.0 } },
                 productRepo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.SCAN_ONLY
+        plan.strategy shouldBe Strategy.SCAN_ONLY
         plan.results.toList().map { it.name } shouldContainExactlyInAnyOrder listOf("Gadget", "Tablet")
     }
 
@@ -95,7 +96,7 @@ internal class QueryPlannerTest : FunSpec({
                 query { where { (Employee::department eq "eng") and (Employee::level eq 5) } },
                 employeeRepo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+        plan.strategy shouldBe Strategy.INDEX_ONLY
         plan.results.toList().map { it.name } shouldContainExactlyInAnyOrder listOf("Alice", "Bob")
     }
 
@@ -105,7 +106,7 @@ internal class QueryPlannerTest : FunSpec({
                 query { where { (Product::category eq "books") or (Product::category eq "electronics") } },
                 productRepo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.SCAN_ONLY
+        plan.strategy shouldBe Strategy.SCAN_ONLY
         plan.results.toList() shouldHaveSize 4
     }
 
@@ -115,7 +116,7 @@ internal class QueryPlannerTest : FunSpec({
                 query { where { !(Product::category eq "books") } },
                 productRepo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.SCAN_ONLY
+        plan.strategy shouldBe Strategy.SCAN_ONLY
         plan.results.toList().map { it.name } shouldContainExactlyInAnyOrder listOf("Gadget", "Tablet")
     }
 
@@ -125,7 +126,7 @@ internal class QueryPlannerTest : FunSpec({
                 query { where { (Product::category eq "books") and (Product::category eq "sports") } },
                 productRepo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+        plan.strategy shouldBe Strategy.INDEX_ONLY
         plan.results.toList().shouldBeEmpty()
     }
 
@@ -135,7 +136,7 @@ internal class QueryPlannerTest : FunSpec({
                 query { where { Product::category eq null } },
                 productRepo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.SCAN_ONLY
+        plan.strategy shouldBe Strategy.SCAN_ONLY
         plan.results.toList().shouldBeEmpty()
     }
 
@@ -145,7 +146,7 @@ internal class QueryPlannerTest : FunSpec({
                 query<Product> { },
                 productRepo
             )
-        plan.strategy shouldBe QueryPlanner.Strategy.SCAN_ONLY
+        plan.strategy shouldBe Strategy.SCAN_ONLY
         plan.results.toList() shouldHaveSize 4
     }
 
@@ -215,5 +216,34 @@ internal class QueryPlannerTest : FunSpec({
                 productRepo
             )
         plan.results.toList().map { it.name } shouldBe listOf("Book B", "Tablet")
+    }
+
+    test("PlanContext indexLeaves non-empty for INDEX_ONLY query") {
+        val context = productPlanner.execute(query { where { Product::category eq "books" } }, productRepo)
+        context.indexLeaves shouldHaveSize 1
+        context.indexLeaves[0].propertyName shouldBe "category"
+        context.postFilterCount shouldBe 0
+        context.viaStrategy.shouldBeNull()
+    }
+
+    test("PlanContext postFilterCount is 1 for INDEX_THEN_FILTER query") {
+        val context =
+            productPlanner.execute(
+                query { where { (Product::category eq "electronics") and (Product::price gt 60.0) } },
+                productRepo
+            )
+        context.strategy shouldBe Strategy.INDEX_THEN_FILTER
+        context.postFilterCount shouldBe 1
+    }
+
+    test("PlanContext indexLeaves empty for SCAN_ONLY query") {
+        val context = productPlanner.execute(query { where { Product::price gt 20.0 } }, productRepo)
+        context.strategy shouldBe Strategy.SCAN_ONLY
+        context.indexLeaves.shouldBeEmpty()
+    }
+
+    test("PlanContext viaStrategy is null for non-Via query") {
+        val context = productPlanner.execute(query { where { Product::category eq "books" } }, productRepo)
+        context.viaStrategy.shouldBeNull()
     }
 })

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/SortedIndexRangePlannerTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/SortedIndexRangePlannerTest.kt
@@ -102,7 +102,7 @@ internal class SortedIndexRangePlannerTest : StringSpec({
         withFreshRepo { repo ->
             val plan = planner(repo).execute(query { where { RangeFixture::age gt 30 } }, repo)
 
-            plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+            plan.strategy shouldBe Strategy.INDEX_ONLY
             plan.results.toSet() shouldBe fixtures.filter { it.age > 30 }.toSet()
         }
     }
@@ -111,7 +111,7 @@ internal class SortedIndexRangePlannerTest : StringSpec({
         withFreshRepo { repo ->
             val plan = planner(repo).execute(query { where { RangeFixture::age gte 32 } }, repo)
 
-            plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+            plan.strategy shouldBe Strategy.INDEX_ONLY
             plan.results.toSet() shouldBe fixtures.filter { it.age >= 32 }.toSet()
         }
     }
@@ -120,7 +120,7 @@ internal class SortedIndexRangePlannerTest : StringSpec({
         withFreshRepo { repo ->
             val plan = planner(repo).execute(query { where { RangeFixture::age lt 36 } }, repo)
 
-            plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+            plan.strategy shouldBe Strategy.INDEX_ONLY
             plan.results.toSet() shouldBe fixtures.filter { it.age < 36 }.toSet()
         }
     }
@@ -129,7 +129,7 @@ internal class SortedIndexRangePlannerTest : StringSpec({
         withFreshRepo { repo ->
             val plan = planner(repo).execute(query { where { RangeFixture::age lte 36 } }, repo)
 
-            plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+            plan.strategy shouldBe Strategy.INDEX_ONLY
             plan.results.toSet() shouldBe fixtures.filter { it.age <= 36 }.toSet()
         }
     }
@@ -138,7 +138,7 @@ internal class SortedIndexRangePlannerTest : StringSpec({
         withFreshRepo { repo ->
             val plan = planner(repo).execute(query { where { RangeFixture::age eq 32 } }, repo)
 
-            plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+            plan.strategy shouldBe Strategy.INDEX_ONLY
             plan.results.toSet() shouldBe fixtures.filter { it.age == 32 }.toSet()
         }
     }
@@ -148,7 +148,7 @@ internal class SortedIndexRangePlannerTest : StringSpec({
             // category is hash-indexed (not sorted), so range queries must scan
             val plan = planner(repo).execute(query { where { RangeFixture::category gt "books" } }, repo)
 
-            plan.strategy shouldBe QueryPlanner.Strategy.SCAN_ONLY
+            plan.strategy shouldBe Strategy.SCAN_ONLY
             plan.results.toSet() shouldBe fixtures.filter { it.category > "books" }.toSet()
         }
     }
@@ -158,7 +158,7 @@ internal class SortedIndexRangePlannerTest : StringSpec({
             // id is not in the accessor — not indexed at all
             val plan = planner(repo).execute(query { where { RangeFixture::id gt 5 } }, repo)
 
-            plan.strategy shouldBe QueryPlanner.Strategy.SCAN_ONLY
+            plan.strategy shouldBe Strategy.SCAN_ONLY
             plan.results.toSet() shouldBe fixtures.filter { it.id > 5 }.toSet()
         }
     }
@@ -168,7 +168,7 @@ internal class SortedIndexRangePlannerTest : StringSpec({
             // age ∈ (25, 40) exclusive-exclusive
             val plan = planner(repo).execute(query { where { (RangeFixture::age gt 25) and (RangeFixture::age lt 40) } }, repo)
 
-            plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+            plan.strategy shouldBe Strategy.INDEX_ONLY
             plan.results.toSet() shouldBe fixtures.filter { it.age in 26..<40 }.toSet()
         }
     }
@@ -181,7 +181,7 @@ internal class SortedIndexRangePlannerTest : StringSpec({
                     query { where { (RangeFixture::category eq "X") and (RangeFixture::age gte 30) } }, repo
                 )
 
-            plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+            plan.strategy shouldBe Strategy.INDEX_ONLY
             plan.results.toSet() shouldBe fixtures.filter { it.category == "X" && it.age >= 30 }.toSet()
         }
     }
@@ -190,7 +190,7 @@ internal class SortedIndexRangePlannerTest : StringSpec({
         withFreshRepo { repo ->
             val plan = planner(repo).execute(query { where { RangeFixture::age gt 99999 } }, repo)
 
-            plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+            plan.strategy shouldBe Strategy.INDEX_ONLY
             plan.results.toList().shouldBeEmpty()
         }
     }
@@ -202,7 +202,7 @@ internal class SortedIndexRangePlannerTest : StringSpec({
                     query { where { (RangeFixture::age gt 48) or (RangeFixture::age lt 24) } }, repo
                 )
 
-            plan.strategy shouldBe QueryPlanner.Strategy.SCAN_ONLY
+            plan.strategy shouldBe Strategy.SCAN_ONLY
             plan.results.toSet() shouldBe fixtures.filter { it.age !in 24..48 }.toSet()
         }
     }
@@ -214,7 +214,7 @@ internal class SortedIndexRangePlannerTest : StringSpec({
 
             val plan = planner(repo).execute(query { where { RangeFixture::nick gt "a" } }, repo)
 
-            plan.strategy shouldBe QueryPlanner.Strategy.INDEX_ONLY
+            plan.strategy shouldBe Strategy.INDEX_ONLY
             // Only entities with non-null nick > "a" are returned; null-nick entities are excluded
             val expected = fixtures.filter { it.nick != null && it.nick > "a" }.toSet()
             plan.results.toSet() shouldBe expected

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/ViaPlannerTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/ViaPlannerTest.kt
@@ -21,6 +21,7 @@ import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
 /**
@@ -264,13 +265,38 @@ internal class ViaPlannerTest : FunSpec({
         // Strategy is HASH_JOIN on the Via arm (never silent fallback)
         planner.strategyFor(hybrid, playlists) shouldBe ViaStrategy.HASH_JOIN
 
-        val results =
+        val context =
             planner.execute(
                 Query(predicate = hybrid, orderBy = emptyList(), limit = null, offset = 0),
                 playlists
-            ).results.toList().map { it.id }
+            )
+        // The non-via arm (name eq "X") is applied as a post-filter, so it counts as one residual leaf.
+        context.postFilterCount shouldBe 1
+        val results = context.results.toList().map { it.id }
         // Intersection of name="X" and via match = {0, 2, 4}
         results shouldContainExactlyInAnyOrder listOf(0, 2, 4)
+    }
+
+    test("PlanContext viaStrategy is non-null for cross-aggregate via predicate") {
+        val tracks =
+            TrackRepo().apply {
+                repeat(100) { add(Track(it, "t$it", if (it == 0) 999.0 else 1.0)) }
+            }
+        val playlists =
+            PlaylistRepo().apply {
+                repeat(50) { p -> add(Playlist(p, "p$p", (0 until 20).toList(), null)) }
+            }
+        val via = Playlist::trackIds via tracks anyMatch { Track::price gt 500.0 }
+        val planner = nonIndexedPlanner()
+        val context =
+            planner.execute(
+                Query(predicate = via, orderBy = emptyList(), limit = null, offset = 0),
+                playlists
+            )
+        context.viaStrategy.shouldNotBeNull()
+        context.viaStrategy shouldBe planner.strategyFor(via, playlists)
+        // A bare via predicate has no non-via post-filter arm.
+        context.postFilterCount shouldBe 0
     }
 
     test("hybrid predicate result preserves Sequence laziness - taking only first N elements does not iterate beyond N parents") {


### PR DESCRIPTION
## Summary

Exposes the Query DSL planner's decisions as a public, opt-in diagnostics API so consumers can inspect **how** a query will run — the chosen strategy, which predicate leaves hit an index and how selective they were, the residual post-filter work, and planning/execution timing — mirroring SQL's `EXPLAIN` / `EXPLAIN ANALYZE`. The existing `query { }` extension is unchanged; callers who don't opt in see no difference.

Closes #151.

## New public API

Two extension functions on `Registry<K, T>` (in `lirp-core`):

- **`explainQuery { } : QueryDiagnostic`** — plans the query and returns a diagnostic snapshot **without executing it** (the result sequence is never consumed). `executionTimeNs` is always `null`. Equivalent to SQL `EXPLAIN`.
- **`queryWithDiagnostics { } : DiagnosedQuery<T>`** — eagerly executes, returning the results paired with a diagnostic that includes execution timing. Equivalent to SQL `EXPLAIN ANALYZE`.

Six pure-data types in the new `lirp-api` package `net.transgressoft.lirp.persistence.query` back the API: `QueryDiagnostic`, `DiagnosedQuery<T>`, `IndexHit`, `IndexHitType`, `Strategy`, `ViaStrategy`.

```kotlin
val diagnostic = repo.explainQuery {
    where { (Product::category eq "books") and (Product::price gt 20.0) }
}
diagnostic.strategy                 // INDEX_THEN_FILTER
diagnostic.postFilterPredicateCount // 1  (price > 20.0 is not indexed)
diagnostic.indexHits                // [IndexHit(propertyName=category, type=EXACT, ...)]
diagnostic.executionTimeNs          // null — nothing was executed
```

## Implementation notes

- `QueryPlanner` now separates planning data from execution via an inspectable `PlanContext` (strategy, index leaves, post-filter count, via-strategy, results). The existing `query { }` behavior is byte-for-byte unchanged.
- Index leaves now carry the entity property name so it can be surfaced in `IndexHit`.

## Breaking change

`ViaStrategy` moved from `lirp-core` to the `lirp-api` package `net.transgressoft.lirp.persistence.query` (alongside `Strategy`). The **package name is unchanged**, so a source import of the fully-qualified name recompiles without modification; consumers depending on `lirp-core` already pull in `lirp-api` transitively. Documented in `CHANGELOG.md` under the new 3.1.0 section.

## Verification

- `gradle build` green — all module tests pass and all `apiCheck` ABI gates pass on the integrated branch; both `.api` baselines rebaselined for the additions and the `ViaStrategy` move.
- New Kotest coverage exercises all three strategies (`INDEX_ONLY` / `INDEX_THEN_FILTER` / `SCAN_ONLY`), a cross-aggregate `via` case, timing nullability, and result parity between `queryWithDiagnostics` and `query`.
- Aggregate coverage held above baseline (line 87.89%, branch 73.21%).
- Wiki updated with a complete worked example.
