### PR TITLE
Explicit `transaction { }` atomic boundary

### DIFF
--- a/lirp-api/api/lirp-api.api
+++ b/lirp-api/api/lirp-api.api
@@ -172,6 +172,7 @@ public final class net/transgressoft/lirp/event/LirpOperation : java/lang/Enum {
 	public static final field EMIT Lnet/transgressoft/lirp/event/LirpOperation;
 	public static final field FLUSH Lnet/transgressoft/lirp/event/LirpOperation;
 	public static final field RECOVER Lnet/transgressoft/lirp/event/LirpOperation;
+	public static final field TRANSACTION Lnet/transgressoft/lirp/event/LirpOperation;
 	public static final field UPDATE Lnet/transgressoft/lirp/event/LirpOperation;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lnet/transgressoft/lirp/event/LirpOperation;
@@ -334,6 +335,21 @@ public final class net/transgressoft/lirp/persistence/ColumnType$VarcharType : n
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class net/transgressoft/lirp/persistence/ConflictInfo {
+	public fun <init> (Lnet/transgressoft/lirp/entity/ReactiveEntity;Lnet/transgressoft/lirp/entity/ReactiveEntity;Ljava/lang/Long;)V
+	public final fun component1 ()Lnet/transgressoft/lirp/entity/ReactiveEntity;
+	public final fun component2 ()Lnet/transgressoft/lirp/entity/ReactiveEntity;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy (Lnet/transgressoft/lirp/entity/ReactiveEntity;Lnet/transgressoft/lirp/entity/ReactiveEntity;Ljava/lang/Long;)Lnet/transgressoft/lirp/persistence/ConflictInfo;
+	public static synthetic fun copy$default (Lnet/transgressoft/lirp/persistence/ConflictInfo;Lnet/transgressoft/lirp/entity/ReactiveEntity;Lnet/transgressoft/lirp/entity/ReactiveEntity;Ljava/lang/Long;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/ConflictInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCanonical ()Lnet/transgressoft/lirp/entity/ReactiveEntity;
+	public final fun getEntity ()Lnet/transgressoft/lirp/entity/ReactiveEntity;
+	public final fun getVersion ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class net/transgressoft/lirp/persistence/DurationColumnConverter : net/transgressoft/lirp/persistence/ColumnConverter {
 	public static final field INSTANCE Lnet/transgressoft/lirp/persistence/DurationColumnConverter;
 	public fun fromSql (J)Ljava/time/Duration;
@@ -391,6 +407,11 @@ public abstract interface annotation class net/transgressoft/lirp/persistence/Li
 public abstract interface class net/transgressoft/lirp/persistence/LirpTableDef {
 	public abstract fun getColumns ()Ljava/util/List;
 	public abstract fun getTableName ()Ljava/lang/String;
+}
+
+public class net/transgressoft/lirp/persistence/LirpTransactionException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public abstract interface class net/transgressoft/lirp/persistence/MutableAggregateCollectionRef : java/util/Collection, kotlin/jvm/internal/markers/KMutableCollection, net/transgressoft/lirp/persistence/AggregateCollectionRef {
@@ -531,6 +552,12 @@ public abstract interface annotation class net/transgressoft/lirp/persistence/To
 	public abstract fun bubbleUp ()Z
 	public abstract fun onDelete ()Lnet/transgressoft/lirp/entity/CascadeAction;
 	public abstract fun target ()Ljava/lang/Class;
+}
+
+public final class net/transgressoft/lirp/persistence/TransactionConflictException : net/transgressoft/lirp/persistence/LirpTransactionException {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getConflicts ()Ljava/util/List;
 }
 
 public final class net/transgressoft/lirp/persistence/UriColumnConverter : net/transgressoft/lirp/persistence/ColumnConverter {

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ConflictInfo.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ConflictInfo.kt
@@ -22,18 +22,18 @@ import net.transgressoft.lirp.entity.ReactiveEntity
 /**
  * Describes a single `@Version` conflict detected during a transaction block commit.
  *
- * [entity] is the pre-block snapshot of the in-memory entity — captured before rollback so
- * the caller can read the values that were attempted. [canonical] is the authoritative database
- * state at conflict time; `null` when the row was concurrently deleted. [version] is the
- * actual database version at conflict time; `-1` when the row was deleted, `null` for
+ * [entity] carries the values that were **attempted inside the block** (captured before rollback)
+ * so the caller can inspect what the block tried to write. [canonical] is the authoritative
+ * on-disk state at conflict time; `null` when the row was concurrently deleted. [version] is
+ * the actual database version at conflict time; `-1` when the row was deleted, `null` for
  * non-`@Version` entities.
  *
  * Naming follows the vocabulary established by [net.transgressoft.lirp.event.StandardCrudEvent.Conflict].
  *
  * @param K the entity key type.
  * @param R the entity type.
- * @param entity the pre-block snapshot of the in-memory entity with the values that were attempted.
- * @param canonical the authoritative database state at conflict time; `null` when the row was concurrently deleted.
+ * @param entity the entity with the values attempted inside the transaction block, captured before in-memory rollback.
+ * @param canonical the authoritative on-disk state at conflict time; `null` when the row was concurrently deleted.
  * @param version the actual database version at conflict time; `-1` when the row was deleted, `null` for non-`@Version` entities.
  */
 data class ConflictInfo<K : Comparable<K>, R : ReactiveEntity<K, R>>(

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ConflictInfo.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ConflictInfo.kt
@@ -15,30 +15,29 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
  ******************************************************************************/
 
-package net.transgressoft.lirp.event
+package net.transgressoft.lirp.persistence
+
+import net.transgressoft.lirp.entity.ReactiveEntity
 
 /**
- * Discriminator for the async operation type at the point where a failure occurred.
+ * Describes a single `@Version` conflict detected during a transaction block commit.
  *
- * Mirrors the `lirp.operation` MDC key so that a log line and an [LirpErrorHandler]
- * callback describe the same failure with the same vocabulary.
+ * [entity] is the pre-block snapshot of the in-memory entity — captured before rollback so
+ * the caller can read the values that were attempted. [canonical] is the authoritative database
+ * state at conflict time; `null` when the row was concurrently deleted. [version] is the
+ * actual database version at conflict time; `-1` when the row was deleted, `null` for
+ * non-`@Version` entities.
  *
- * Members map to the distinct async failure sites in the framework:
- * - Entity-mutation operations: [CREATE], [UPDATE], [DELETE], [CLEAR]
- * - Persistence pipeline: [FLUSH]
- * - Event emission: [EMIT]
- * - Optimistic-lock recovery: [RECOVER]
- * - Explicit transaction boundary: [TRANSACTION]
+ * Naming follows the vocabulary established by [net.transgressoft.lirp.event.StandardCrudEvent.Conflict].
  *
- * Adding new members is binary-compatible; existing values are stable.
+ * @param K the entity key type.
+ * @param R the entity type.
+ * @param entity the pre-block snapshot of the in-memory entity with the values that were attempted.
+ * @param canonical the authoritative database state at conflict time; `null` when the row was concurrently deleted.
+ * @param version the actual database version at conflict time; `-1` when the row was deleted, `null` for non-`@Version` entities.
  */
-enum class LirpOperation {
-    CREATE,
-    UPDATE,
-    DELETE,
-    CLEAR,
-    FLUSH,
-    EMIT,
-    RECOVER,
-    TRANSACTION
-}
+data class ConflictInfo<K : Comparable<K>, R : ReactiveEntity<K, R>>(
+    val entity: R,
+    val canonical: R?,
+    val version: Long?
+)

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/LirpTransactionException.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/LirpTransactionException.kt
@@ -1,0 +1,50 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+/**
+ * Thrown when a `transaction` block fails to commit atomically.
+ *
+ * In-memory state is restored to its pre-block values before this exception propagates.
+ * The [cause] carries the underlying failure (constraint violation, connection error, etc.).
+ *
+ * This exception is defined in the `lirp-api` module so consumers can catch it without
+ * depending on the `lirp-core` implementation module.
+ *
+ * When an `onError` handler is configured on the `transaction` call, this exception is
+ * suppressed and the handler is invoked instead.
+ */
+open class LirpTransactionException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
+
+/**
+ * Specialization of [LirpTransactionException] raised when one or more `@Version`-protected
+ * entities in the transaction block were modified by a concurrent writer before the commit.
+ *
+ * Each element of [conflicts] describes the in-memory entity (restored to its pre-block state)
+ * alongside the authoritative database state and the database version at conflict time. The
+ * caller can read [ConflictInfo.canonical] to obtain the authoritative state and decide whether
+ * to retry.
+ *
+ * The [conflicts] list uses star projections because the exception must be throwable for
+ * heterogeneous entity types when multiple participants are involved in the same transaction.
+ */
+class TransactionConflictException(
+    message: String,
+    val conflicts: List<ConflictInfo<*, *>>,
+    cause: Throwable? = null
+) : LirpTransactionException(message, cause)

--- a/lirp-core/api/lirp-core.api
+++ b/lirp-core/api/lirp-core.api
@@ -675,6 +675,21 @@ public final class net/transgressoft/lirp/persistence/PendingCellKt {
 	public static final fun mergeWriterSide (Lnet/transgressoft/lirp/persistence/PendingCell;Lnet/transgressoft/lirp/persistence/PendingCell;)Lnet/transgressoft/lirp/persistence/PendingCell;
 }
 
+public final class net/transgressoft/lirp/persistence/PendingDelete {
+	public fun <init> (Ljava/lang/Comparable;Lnet/transgressoft/lirp/entity/ReactiveEntity;Ljava/lang/Long;)V
+	public final fun component1 ()Ljava/lang/Comparable;
+	public final fun component2 ()Lnet/transgressoft/lirp/entity/ReactiveEntity;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/Comparable;Lnet/transgressoft/lirp/entity/ReactiveEntity;Ljava/lang/Long;)Lnet/transgressoft/lirp/persistence/PendingDelete;
+	public static synthetic fun copy$default (Lnet/transgressoft/lirp/persistence/PendingDelete;Ljava/lang/Comparable;Lnet/transgressoft/lirp/entity/ReactiveEntity;Ljava/lang/Long;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/PendingDelete;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntity ()Lnet/transgressoft/lirp/entity/ReactiveEntity;
+	public final fun getExpectedVersion ()Ljava/lang/Long;
+	public final fun getId ()Ljava/lang/Comparable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class net/transgressoft/lirp/persistence/PendingUpdate {
 	public fun <init> (Lnet/transgressoft/lirp/entity/ReactiveEntity;Ljava/lang/Long;)V
 	public synthetic fun <init> (Lnet/transgressoft/lirp/entity/ReactiveEntity;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -704,6 +719,7 @@ public abstract class net/transgressoft/lirp/persistence/PersistentRepositoryBas
 	protected final fun flush ()V
 	protected final fun getClosed ()Z
 	public final fun getDirty ()Ljava/util/concurrent/atomic/AtomicBoolean;
+	protected final fun getFlushLock ()Ljava/util/concurrent/locks/ReentrantLock;
 	protected final fun getLoadOnInit ()Z
 	protected fun handleOptimisticLockConflict (Lnet/transgressoft/lirp/persistence/OptimisticLockException;)V
 	public final fun isLoaded ()Z

--- a/lirp-core/api/lirp-core.api
+++ b/lirp-core/api/lirp-core.api
@@ -699,11 +699,11 @@ public abstract class net/transgressoft/lirp/persistence/PersistentRepositoryBas
 	protected final fun addToMemoryOnly (Lnet/transgressoft/lirp/entity/ReactiveEntity;)V
 	public fun clear ()V
 	public fun close ()V
+	public fun commitTransactionBuffer (Lnet/transgressoft/lirp/persistence/TransactionBuffer;)V
 	protected fun extractVersion (Lnet/transgressoft/lirp/entity/ReactiveEntity;)Ljava/lang/Long;
 	protected final fun flush ()V
 	protected final fun getClosed ()Z
 	public final fun getDirty ()Ljava/util/concurrent/atomic/AtomicBoolean;
-	protected final fun getFlushLock ()Ljava/util/concurrent/locks/ReentrantLock;
 	protected final fun getLoadOnInit ()Z
 	protected fun handleOptimisticLockConflict (Lnet/transgressoft/lirp/persistence/OptimisticLockException;)V
 	public final fun isLoaded ()Z
@@ -849,6 +849,7 @@ public abstract class net/transgressoft/lirp/persistence/RegistryBase : net/tran
 	public fun lazySearch (Ljava/util/function/Predicate;)Lkotlin/sequences/Sequence;
 	public static final fun publicRawConstructorFor (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRawConstructor;
 	public static final fun publicRawInitializerFor (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRawInitializer;
+	public static final fun publicRefAccessorFor (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRefAccessor;
 	public static final fun rawConstructorFor$net_transgressoft_lirp_core (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRawConstructor;
 	public static final fun rawInitializerFor$net_transgressoft_lirp_core (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRawInitializer;
 	public static final fun refAccessorFor$net_transgressoft_lirp_core (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRefAccessor;
@@ -876,7 +877,29 @@ public final class net/transgressoft/lirp/persistence/RegistryBase$Companion {
 	public final fun deregisterRepository (Ljava/lang/Class;)V
 	public final fun publicRawConstructorFor (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRawConstructor;
 	public final fun publicRawInitializerFor (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRawInitializer;
+	public final fun publicRefAccessorFor (Ljava/lang/Class;)Lnet/transgressoft/lirp/persistence/LirpRefAccessor;
 	public final fun registerRepository (Ljava/lang/Class;Lnet/transgressoft/lirp/persistence/Repository;)V
+}
+
+public final class net/transgressoft/lirp/persistence/TransactionBuffer {
+	public fun <init> (Lnet/transgressoft/lirp/persistence/PersistentRepositoryBase;)V
+	public final fun getDeferredEvents ()Ljava/util/List;
+	public final fun getDeletes ()Ljava/util/List;
+	public final fun getEntitySnapshots ()Ljava/util/Map;
+	public final fun getInserts ()Ljava/util/List;
+	public final fun getRepo ()Lnet/transgressoft/lirp/persistence/PersistentRepositoryBase;
+	public final fun getUpdates ()Ljava/util/List;
+}
+
+public final class net/transgressoft/lirp/persistence/TransactionErrorContext {
+	public fun <init> (Ljava/lang/Throwable;Ljava/util/List;)V
+	public final fun getConflicts ()Ljava/util/List;
+	public final fun getThrowable ()Ljava/lang/Throwable;
+}
+
+public final class net/transgressoft/lirp/persistence/TransactionsKt {
+	public static final fun transaction (Lnet/transgressoft/lirp/persistence/PersistentRepositoryBase;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun transaction$default (Lnet/transgressoft/lirp/persistence/PersistentRepositoryBase;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class net/transgressoft/lirp/persistence/ViaCollectionAccessorEntry {
@@ -950,6 +973,7 @@ public class net/transgressoft/lirp/persistence/json/JsonFileRepository : net/tr
 	public synthetic fun <init> (Ljava/io/File;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/modules/SerializersModule;JZLnet/transgressoft/lirp/persistence/json/JsonFkPolicy;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/LirpContext;Ljava/io/File;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/modules/SerializersModule;JZLnet/transgressoft/lirp/persistence/json/JsonFkPolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
+	public fun commitTransactionBuffer (Lnet/transgressoft/lirp/persistence/TransactionBuffer;)V
 	public fun equals (Ljava/lang/Object;)Z
 	protected final fun getJson ()Lkotlinx/serialization/json/Json;
 	public final fun getJsonFile ()Ljava/io/File;

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -54,6 +54,13 @@ import kotlin.reflect.jvm.isAccessible
 import kotlinx.coroutines.flow.SharedFlow
 
 /**
+ * Sentinel key used by [ReactiveEntityBase.captureSnapshot] to store `lastDateModified` in the
+ * snapshot map. The leading space cannot occur in a Kotlin property name, so it never collides
+ * with a delegate-backed property key.
+ */
+private const val LAST_MODIFIED_SNAPSHOT_KEY = " lastDateModified"
+
+/**
  * Abstract base class that provides reactive functionality for entities, enabling them to notify subscribers
  * about property changes through a reactive flow-based pattern.
  *
@@ -91,6 +98,7 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
     private val publisherFactory: (String) -> LirpEventPublisher<MutationEvent.Type, MutationEvent<K, R>> =
         { id -> FlowEventPublisher(id, closeOnEmpty = true) }
 ) : ReactiveEntity<K, R> where K : Comparable<K> {
+
     private val log = KotlinLogging.logger {}
 
     /**
@@ -417,42 +425,36 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
         // rollback. This preserves event-isolation without data-isolation.
         val txBuffer = _txEventBuffer.get()
         if (txBuffer != null) {
-            val kprop1 = property as? KProperty1<R, V>
-            if (kprop1 != null) {
-                val indexEntries = loadIndexEntries()
-                val matchingIndex = indexEntries.firstOrNull { it.propertyName == property.name }
-                val event =
-                    PropertyChanged<K, R, V>(
-                        entity = this as R,
-                        property = kprop1,
-                        oldValue = oldValue,
-                        newValue = newValue,
-                        versionAtMutation = null,
-                        oldIndexKey = if (matchingIndex != null) oldValue else null,
-                        newIndexKey = if (matchingIndex != null) newValue else null
-                    )
-                txBuffer.add(event)
-            }
+            buildPropertyChangedEvent(property, oldValue, newValue)?.let { txBuffer.add(it) }
             return
         }
 
         if (!shouldEmit) return
 
-        val kprop1 = property as? KProperty1<R, V> ?: return
-        val indexEntries = loadIndexEntries()
-        val matchingIndex = indexEntries.firstOrNull { it.propertyName == property.name }
-        val event =
-            PropertyChanged<K, R, V>(
-                entity = this as R,
-                property = kprop1,
-                oldValue = oldValue,
-                newValue = newValue,
-                versionAtMutation = null,
-                oldIndexKey = if (matchingIndex != null) oldValue else null,
-                newIndexKey = if (matchingIndex != null) newValue else null
-            )
-        log.trace { "Firing property changed event on ${this::class.java.simpleName}: ${property.name} $oldValue -> $newValue" }
-        publisher.emitAsync(event)
+        buildPropertyChangedEvent(property, oldValue, newValue)?.let { event ->
+            log.trace { "Firing property changed event on ${this::class.java.simpleName}: ${property.name} $oldValue -> $newValue" }
+            publisher.emitAsync(event)
+        }
+    }
+
+    /**
+     * Builds the [PropertyChanged] event for a scalar reactive-property mutation, resolving the
+     * matching `@Indexed` entry so index keys are carried. Returns null when [property] is not a
+     * [KProperty1] of this entity, in which case no event can be constructed.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun <V> buildPropertyChangedEvent(property: KProperty<*>, oldValue: V, newValue: V): PropertyChanged<K, R, V>? {
+        val kprop1 = property as? KProperty1<R, V> ?: return null
+        val matchingIndex = loadIndexEntries().firstOrNull { it.propertyName == property.name }
+        return PropertyChanged(
+            entity = this as R,
+            property = kprop1,
+            oldValue = oldValue,
+            newValue = newValue,
+            versionAtMutation = null,
+            oldIndexKey = if (matchingIndex != null) oldValue else null,
+            newIndexKey = if (matchingIndex != null) newValue else null
+        )
     }
 
     /**
@@ -487,6 +489,29 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
             if (kprop1 != null) {
                 accumulator.add(FieldChange(kprop1, oldValue, newValue))
             }
+            return
+        }
+
+        // When a transaction buffer is active, defer the event instead of publishing.
+        val txBuffer = _txEventBuffer.get()
+        if (txBuffer != null) {
+            val kprop1 =
+                this::class.memberProperties
+                    .filterIsInstance<KProperty1<R, V>>()
+                    .firstOrNull { it.name == propertyName } ?: return
+            val indexEntries = loadIndexEntries()
+            val matchingIndex = indexEntries.firstOrNull { it.propertyName == propertyName }
+            val event =
+                PropertyChanged<K, R, V>(
+                    entity = this as R,
+                    property = kprop1,
+                    oldValue = oldValue,
+                    newValue = newValue,
+                    versionAtMutation = null,
+                    oldIndexKey = if (matchingIndex != null) oldValue else null,
+                    newIndexKey = if (matchingIndex != null) newValue else null
+                )
+            txBuffer.add(event)
             return
         }
 
@@ -665,6 +690,11 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
                     oldIndexKey = oldIndexKey,
                     newIndexKey = newIndexKey
                 )
+            val txBuf = _txEventBuffer.get()
+            if (txBuf != null) {
+                txBuf.add(event)
+                return result
+            }
             log.trace { "Firing batch changed event on ${this::class.java.simpleName}(id=$id) with ${accumulator.size} field(s)" }
             publisher.emitAsync(event)
         }
@@ -703,14 +733,16 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
 
     /**
      * Captures a shallow snapshot of all reactive-property values registered in [delegateRegistry],
-     * keyed by property name.
+     * keyed by property name. Also stores [lastDateModified] under [LAST_MODIFIED_SNAPSHOT_KEY] so
+     * that [restoreSnapshot] can revert the timestamp atomically with the other scalars.
      *
      * The snapshot is taken synchronously on the calling thread. Only [net.transgressoft.lirp.persistence.ReactivePropertyDelegate]
      * and [net.transgressoft.lirp.persistence.ReactivePropertyDelegateWithAccessors] entries are
      * captured — aggregate collection delegates manage their own identity collections and are not
-     * snapshotted here (Assumption A2: collection rollback is out of scope for the scalar rollback path).
+     * snapshotted here.
      *
-     * @return a map from property name to the current value for each reactive-property delegate
+     * @return a map from property name to the current value for each reactive-property delegate,
+     *   plus the [lastDateModified] sentinel entry
      */
     internal fun captureSnapshot(): Map<String, Any?> {
         val snapshot = mutableMapOf<String, Any?>()
@@ -721,24 +753,32 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
                 else -> { /* aggregate collection delegates — not snapshotted on the scalar rollback path */ }
             }
         }
+        snapshot[LAST_MODIFIED_SNAPSHOT_KEY] = lastDateModified
         return snapshot
     }
 
     /**
      * Restores reactive properties to the values in [snapshot], suppressing all mutation events
-     * during the restore to prevent observers from seeing intermediate reverted state.
+     * during the restore to prevent observers from seeing intermediate reverted state. Also restores
+     * [lastDateModified] from the sentinel entry written by [captureSnapshot].
      *
      * Runs inside [withEventsDisabled] and writes each property via the non-emitting
      * [setDirectly][net.transgressoft.lirp.persistence.ReactivePropertyDelegate.setDirectly]
-     * path so that neither [emitPropertyChanged] nor [lastDateModified] is updated during rollback.
-     * Only reactive-property delegates are processed; aggregate collection delegates are skipped
-     * because they manage their own backing-write paths.
+     * path so that neither [emitPropertyChanged] is triggered during rollback.
+     * Only reactive-property delegates are processed; aggregate collection delegates and the
+     * [LAST_MODIFIED_SNAPSHOT_KEY] sentinel are skipped in the delegate-matching loop.
      *
      * @param snapshot a property-name-to-value map previously returned by [captureSnapshot]
      */
     internal fun restoreSnapshot(snapshot: Map<String, Any?>) {
         withEventsDisabled {
+            val preDateModified = snapshot[LAST_MODIFIED_SNAPSHOT_KEY] as? java.time.LocalDateTime
+            if (preDateModified != null) {
+                lastDateModified = preDateModified
+            }
             snapshot.forEach { (name, value) ->
+                // Skip the timestamp sentinel — it is not a delegate-backed property.
+                if (name == LAST_MODIFIED_SNAPSHOT_KEY) return@forEach
                 when (val delegate = delegateRegistry[name]) {
                     is net.transgressoft.lirp.persistence.ReactivePropertyDelegate<*> -> {
                         @Suppress("UNCHECKED_CAST")

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -36,6 +36,7 @@ import net.transgressoft.lirp.persistence.KspAccessorLoader
 import net.transgressoft.lirp.persistence.LirpDelegate
 import net.transgressoft.lirp.persistence.LirpIndexAccessor
 import net.transgressoft.lirp.persistence.LirpRefAccessor
+import net.transgressoft.lirp.persistence.PersistenceIgnore
 import net.transgressoft.lirp.persistence.PolymorphicAggregateDelegate
 import net.transgressoft.lirp.persistence.ReactivePropertyDelegate
 import net.transgressoft.lirp.persistence.ReactivePropertyDelegateWithAccessors
@@ -135,6 +136,19 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
      * [BatchChanged] can be emitted when each block exits.
      */
     private val _batchAccumulator = ThreadLocal<MutableList<FieldChange<R, *>>?>()
+
+    /**
+     * Thread-local list that, when non-null, causes [emitPropertyChanged] to route [PropertyChanged]
+     * events into this buffer instead of publishing them to subscribers.
+     *
+     * Installed and removed by the transaction commit path via [withEventsDeferred].
+     * Mirrors the [_batchAccumulator] pattern — same thread-local lifecycle, different purpose:
+     * batch accumulation collapses multiple field changes into one [BatchChanged]; deferred buffering
+     * withholds all property events until commit (where they are collapsed and released) or discards
+     * them on rollback.
+     */
+    @PersistenceIgnore
+    internal val _txEventBuffer = ThreadLocal<MutableList<MutationEvent<K, R>>?>()
 
     /**
      * The lazily initialized publisher. Only created when the first subscriber registers.
@@ -398,6 +412,30 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
             return
         }
 
+        // When a transaction buffer is active, route the event into the buffer rather than
+        // publishing it — events are held until commit (collapsed and released) or discarded on
+        // rollback. This preserves event-isolation without data-isolation.
+        val txBuffer = _txEventBuffer.get()
+        if (txBuffer != null) {
+            val kprop1 = property as? KProperty1<R, V>
+            if (kprop1 != null) {
+                val indexEntries = loadIndexEntries()
+                val matchingIndex = indexEntries.firstOrNull { it.propertyName == property.name }
+                val event =
+                    PropertyChanged<K, R, V>(
+                        entity = this as R,
+                        property = kprop1,
+                        oldValue = oldValue,
+                        newValue = newValue,
+                        versionAtMutation = null,
+                        oldIndexKey = if (matchingIndex != null) oldValue else null,
+                        newIndexKey = if (matchingIndex != null) newValue else null
+                    )
+                txBuffer.add(event)
+            }
+            return
+        }
+
         if (!shouldEmit) return
 
         val kprop1 = property as? KProperty1<R, V> ?: return
@@ -641,6 +679,98 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
      * @return the result of [action]
      */
     fun <T> withEventsDisabledForClone(action: () -> T): T = withEventsDisabled(action)
+
+    /**
+     * Installs [buffer] as the active transaction event buffer for this thread, executes [action],
+     * then restores the previous buffer state. Property change events emitted inside [action] are
+     * routed into [buffer] rather than published to subscribers.
+     *
+     * The save/restore pattern mirrors [withEventsDisabled] — both are re-entrant and thread-local.
+     *
+     * @param buffer the mutable list that collects deferred [MutationEvent]s during [action]
+     * @param action the block to execute with event buffering active
+     * @return the result of [action]
+     */
+    internal fun <T> withEventsDeferred(buffer: MutableList<MutationEvent<K, R>>, action: () -> T): T {
+        val previous = _txEventBuffer.get()
+        _txEventBuffer.set(buffer)
+        try {
+            return action()
+        } finally {
+            if (previous != null) _txEventBuffer.set(previous) else _txEventBuffer.remove()
+        }
+    }
+
+    /**
+     * Captures a shallow snapshot of all reactive-property values registered in [delegateRegistry],
+     * keyed by property name.
+     *
+     * The snapshot is taken synchronously on the calling thread. Only [net.transgressoft.lirp.persistence.ReactivePropertyDelegate]
+     * and [net.transgressoft.lirp.persistence.ReactivePropertyDelegateWithAccessors] entries are
+     * captured — aggregate collection delegates manage their own identity collections and are not
+     * snapshotted here (Assumption A2: collection rollback is out of scope for the scalar rollback path).
+     *
+     * @return a map from property name to the current value for each reactive-property delegate
+     */
+    internal fun captureSnapshot(): Map<String, Any?> {
+        val snapshot = mutableMapOf<String, Any?>()
+        delegateRegistry.forEach { (name, delegate) ->
+            when (delegate) {
+                is net.transgressoft.lirp.persistence.ReactivePropertyDelegate<*> -> snapshot[name] = delegate.storedValue
+                is net.transgressoft.lirp.persistence.ReactivePropertyDelegateWithAccessors<*> -> snapshot[name] = delegate.readValue()
+                else -> { /* aggregate collection delegates — not snapshotted on the scalar rollback path */ }
+            }
+        }
+        return snapshot
+    }
+
+    /**
+     * Restores reactive properties to the values in [snapshot], suppressing all mutation events
+     * during the restore to prevent observers from seeing intermediate reverted state.
+     *
+     * Runs inside [withEventsDisabled] and writes each property via the non-emitting
+     * [setDirectly][net.transgressoft.lirp.persistence.ReactivePropertyDelegate.setDirectly]
+     * path so that neither [emitPropertyChanged] nor [lastDateModified] is updated during rollback.
+     * Only reactive-property delegates are processed; aggregate collection delegates are skipped
+     * because they manage their own backing-write paths.
+     *
+     * @param snapshot a property-name-to-value map previously returned by [captureSnapshot]
+     */
+    internal fun restoreSnapshot(snapshot: Map<String, Any?>) {
+        withEventsDisabled {
+            snapshot.forEach { (name, value) ->
+                when (val delegate = delegateRegistry[name]) {
+                    is net.transgressoft.lirp.persistence.ReactivePropertyDelegate<*> -> {
+                        @Suppress("UNCHECKED_CAST")
+                        (delegate as net.transgressoft.lirp.persistence.ReactivePropertyDelegate<Any?>).setDirectly(value)
+                    }
+                    is net.transgressoft.lirp.persistence.ReactivePropertyDelegateWithAccessors<*> -> {
+                        @Suppress("UNCHECKED_CAST")
+                        (delegate as net.transgressoft.lirp.persistence.ReactivePropertyDelegateWithAccessors<Any?>).setDirectly(value)
+                    }
+                    else -> { /* aggregate collection delegates — not restored on the scalar rollback path */ }
+                }
+            }
+        }
+    }
+
+    /**
+     * Publishes a pre-built [MutationEvent] directly to subscribers, bypassing the normal
+     * property-assignment and event-construction path.
+     *
+     * Used by the transaction commit path to release collapsed deferred events after a successful
+     * commit. The event was already constructed and buffered during the transaction block; this
+     * method emits it as-is once the commit is confirmed.
+     *
+     * Does nothing when the entity is closed or events are currently disabled.
+     *
+     * @param event the pre-built event to publish
+     */
+    internal fun emitCollapsedEvent(event: MutationEvent<K, R>) {
+        if (isClosed || eventsDisabled) return
+        if (!shouldEmit) return
+        publisher.emitAsync(event)
+    }
 
     @Volatile
     private var _toOneRefDelegates: MutableMap<String, AggregateRefDelegate<*, *>>? = null

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
@@ -266,11 +266,20 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
         private val clearEpoch = AtomicLong(0L)
 
         // Serializes flush() calls: prevents concurrent drains from the pending map and ensures
-        // close() waits for any in-flight flush to complete before draining itself. Internal so
+        // close() waits for any in-flight flush to complete before draining itself. Protected so
         // both subclasses and the transaction orchestration free function in the same module can
         // serialize writes against the same lock (e.g. JsonFileRepository's jsonFile setter,
         // Transactions.kt's pre-flush + block + commit sequence).
-        internal val flushLock = ReentrantLock()
+        protected val flushLock = ReentrantLock()
+
+        /** Acquires [flushLock]. For use by the transaction orchestration layer in the same module. */
+        internal fun lockFlush() = flushLock.lock()
+
+        /** Releases [flushLock]. Symmetric to [lockFlush]. */
+        internal fun unlockFlush() = flushLock.unlock()
+
+        /** Returns `true` when the calling thread currently holds [flushLock]. */
+        internal fun isFlushLockHeldByCurrentThread(): Boolean = flushLock.isHeldByCurrentThread
 
         /**
          * Nesting depth of the active transaction on this repository.
@@ -453,6 +462,68 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
             // No-op: memory is already updated in place; Volatile relies on this default.
         }
 
+        /**
+         * Derives [TransactionBuffer.updates] from [TransactionBuffer.deferredEvents] by collecting
+         * distinct entities that were mutated inside the block but are neither inserts nor deletes.
+         *
+         * Called immediately before [commitTransactionBuffer] so that the update list is populated
+         * for durable-store implementations (SQL, JSON) without requiring the reactive subscription
+         * path to fire during a transaction block.
+         */
+        internal fun captureDeferredUpdates(buffer: TransactionBuffer<K, R>) {
+            val insertIds = buffer.inserts.map { it.id }.toSet()
+            val deleteIds = buffer.deletes.map { it.id }.toSet()
+            val alreadyCaptured = buffer.updates.map { it.entity.id }.toSet()
+            buffer.deferredEvents
+                .mapNotNull { event ->
+                    event.entity.takeIf { entity ->
+                        entity.id !in insertIds && entity.id !in deleteIds && entity.id !in alreadyCaptured
+                    }
+                }
+                .distinctBy { it.id }
+                .forEach { entity ->
+                    buffer.updates.add(PendingUpdate(entity, extractVersion(entity)))
+                }
+        }
+
+        /**
+         * Coalesces contradictory insert and delete intents for the same entity id inside [buffer].
+         *
+         * When the same id appears in both [TransactionBuffer.inserts] and [TransactionBuffer.deletes]:
+         * - **Pre-existing id** (id is in [TransactionBuffer.entitySnapshots], meaning the row existed
+         *   before the block): the net effect is an UPDATE to the re-added value. The entity is moved
+         *   from inserts into [TransactionBuffer.updates] (if not already captured there), and the id
+         *   is removed from both lists.
+         * - **Transient id** (added and removed within the block, never persisted): the net effect is a
+         *   no-op. The id is removed from both lists without writing anything to the store.
+         *
+         * Must be called before [captureDeferredUpdates] so derived updates do not double-count ids
+         * already promoted here.
+         */
+        internal fun normalizeTransactionBuffer(buffer: TransactionBuffer<K, R>) {
+            val insertIds = buffer.inserts.map { it.id }.toSet()
+            val deleteIds = buffer.deletes.map { it.id }.toSet()
+            val overlapping = insertIds intersect deleteIds
+            if (overlapping.isEmpty()) return
+
+            val preExistingIds = buffer.entitySnapshots.keys
+
+            for (id in overlapping) {
+                val insertedEntity = buffer.inserts.firstOrNull { it.id == id } ?: continue
+                buffer.inserts.removeAll { it.id == id }
+                buffer.deletes.removeAll { it.id == id }
+
+                if (id in preExistingIds) {
+                    // Row existed before the block: promote the re-added entity to an UPDATE.
+                    val alreadyCaptured = buffer.updates.any { it.entity.id == id }
+                    if (!alreadyCaptured) {
+                        buffer.updates.add(PendingUpdate(insertedEntity, extractVersion(insertedEntity)))
+                    }
+                }
+                // Transient id (not pre-existing): remove from both lists — net no-op; nothing to write.
+            }
+        }
+
         // optimistic-lock failures follow the Conflict + auto-reload path and DO NOT
         // re-enqueue. The subclass recovery hook performs the auto-reload and emits the
         // StandardCrudEvent.Conflict event. Cells that arrived during the failed write are kept
@@ -520,13 +591,23 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
         // volatile `closed` flag under the write lock so that this re-check is observable.
         private fun enqueueInsertLocked(entity: R) {
             if (closed) return
+            val txBuffer = activeTransactionBuffer
+            if (txBuffer != null) {
+                txBuffer.inserts.add(entity)
+                return
+            }
             pendingCells.compute(entity.id) { _, cur -> mergeWriterSide(cur, PendingCell.Insert(entity)) }
             dirty.set(true)
             scheduleFlush()
         }
 
-        private fun enqueueDeleteLocked(id: K, expectedVersion: Long?) {
+        private fun enqueueDeleteLocked(id: K, entity: R, expectedVersion: Long?) {
             if (closed) return
+            val txBuffer = activeTransactionBuffer
+            if (txBuffer != null) {
+                txBuffer.deletes.add(PendingDelete(id, entity, expectedVersion))
+                return
+            }
             pendingCells.compute(id) { _, cur -> mergeWriterSide(cur, PendingCell.Delete(expectedVersion)) }
             dirty.set(true)
             scheduleFlush()
@@ -641,6 +722,8 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
          * Used by subclasses during initialization to load entities from an external store
          * (e.g. DB or JSON file) without triggering a write-back for data already persisted.
          */
+        internal fun addToMemoryOnlyInternal(entity: R) = addToMemoryOnly(entity)
+
         protected fun addToMemoryOnly(entity: R) {
             super.add(entity)
             subscribeEntity(entity)
@@ -657,6 +740,8 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
          *
          * @return `true` if the entity was present and removed, `false` otherwise.
          */
+        internal fun removeFromMemoryOnlyInternal(entity: R): Boolean = removeFromMemoryOnly(entity)
+
         protected fun removeFromMemoryOnly(entity: R): Boolean {
             val removed = super.remove(entity)
             if (removed) {
@@ -919,7 +1004,7 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
                         // For `@Version`-aware subclasses, [extractVersion] captures the row's
                         // version at remove() time so the DELETE statement can check it in its
                         // WHERE clause.
-                        enqueueDeleteLocked(entity.id, extractVersion(entity))
+                        enqueueDeleteLocked(entity.id, entity, extractVersion(entity))
                     }
                     // Pre-#200 the lifecycle ran in the opposite order: super.remove() FIRST, then
                     // an `error(...)` invariant detector if the subscription was missing. That
@@ -945,7 +1030,7 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
                         // Per-entity version capture: each id carries its own expectedVersion so
                         // that a conflict on one id does not block deletions of the others.
                         presentEntities.forEach { entity ->
-                            enqueueDeleteLocked(entity.id, extractVersion(entity))
+                            enqueueDeleteLocked(entity.id, entity, extractVersion(entity))
                         }
                         presentEntities.forEach {
                             subscriptionsMap.remove(it.id)?.cancel()

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
@@ -113,8 +113,11 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
         private val onError: LirpErrorHandler? = null
     ) : VolatileRepository<K, R>(context, name, initialEntities, onError), PersistentRepository<K, R> {
 
-        // Stored to populate MDC keys at flush launch time
+        // Stored to populate MDC keys at flush launch time and for transaction error context.
         private val repositoryName: String = name
+
+        /** The name of this repository, used in logging and error-context payloads. */
+        internal val repoName: String get() = repositoryName
 
         companion object {
             private const val CLOSED_MESSAGE = "PersistentRepositoryBase is closed"
@@ -263,10 +266,31 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
         private val clearEpoch = AtomicLong(0L)
 
         // Serializes flush() calls: prevents concurrent drains from the pending map and ensures
-        // close() waits for any in-flight flush to complete before draining itself. Protected so
-        // subclasses can serialize direct writes against the same lock (e.g. JsonFileRepository's
-        // jsonFile setter).
-        protected val flushLock = ReentrantLock()
+        // close() waits for any in-flight flush to complete before draining itself. Internal so
+        // both subclasses and the transaction orchestration free function in the same module can
+        // serialize writes against the same lock (e.g. JsonFileRepository's jsonFile setter,
+        // Transactions.kt's pre-flush + block + commit sequence).
+        internal val flushLock = ReentrantLock()
+
+        /**
+         * Nesting depth of the active transaction on this repository.
+         *
+         * Zero means no transaction is active. Values greater than zero indicate nested transaction
+         * calls on the same repo, which are flattened — the outermost block owns commit/rollback
+         * and inner calls simply increment the counter without starting a new buffer.
+         */
+        @Volatile
+        internal var transactionDepth: Int = 0
+
+        /**
+         * The [TransactionBuffer] currently enrolled for this repository, non-null only while
+         * [transactionDepth] is greater than zero.
+         *
+         * Non-null signals [subscribeEntity]'s enqueue hook to route ops into this buffer instead
+         * of the normal debounce pipeline, filtering to only the mutations that belong to this repo.
+         */
+        @Volatile
+        internal var activeTransactionBuffer: TransactionBuffer<K, R>? = null
 
         @Volatile
         private var debounceJob: Job? = null
@@ -308,6 +332,54 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
         )
 
         /**
+         * Drains the per-key pending cell map and dispatches the grouped payload to [writePending].
+         * On failure, restores the snapshot via [mergeOlder] so the next flush retries with a
+         * reconciled view of writes that arrived during the failed I/O.
+         *
+         * **Caller must hold [flushLock].** This method does not acquire [flushLock] itself — it is
+         * extracted from [flush] so that the transaction commit path can call it while already holding
+         * the lock, avoiding re-entrant lock acquisition which would deadlock on a non-reentrant lock.
+         *
+         * Subclasses are responsible for resetting [dirty] to `false` within [writePending] once the
+         * write is confirmed (or asynchronously, if the write is fire-and-forget).
+         */
+        internal fun drainPendingNoLock() {
+            // Capture the snapshot, hadClear flag, AND the clearEpoch under the write lock.
+            // The captured epoch is later compared in reenqueueAfterFailure() to determine
+            // whether a clear() ran during the I/O and so the snapshot must be dropped rather
+            // than restored.
+            val snapshot: Map<K, PendingCell<K, R>>
+            val clearFlag: Boolean
+            val capturedEpoch: Long
+            pendingLock.write {
+                snapshot = pendingCells.toMap()
+                pendingCells.clear()
+                clearFlag = hadClear.getAndSet(false)
+                capturedEpoch = clearEpoch.get()
+            }
+            // Reset the window origin so the next enqueue after this flush starts a fresh
+            // max-delay deadline rather than inheriting the stale timestamp.
+            startNanos.set(0L)
+            if (snapshot.isEmpty() && !clearFlag) return
+            val inserts = snapshot.values.filterIsInstance<PendingCell.Insert<K, R>>().map { it.entity }
+            val updates =
+                snapshot.values.filterIsInstance<PendingCell.Update<K, R>>()
+                    .map { PendingUpdate(it.entity, it.expectedVersion) }
+            val deletes =
+                snapshot.entries.mapNotNull { (id, cell) ->
+                    (cell as? PendingCell.Delete<K, R>)?.let { id to it.expectedVersion }
+                }
+            try {
+                writePending(inserts, updates, deletes, clearFlag)
+            } catch (e: OptimisticLockException) {
+                routeOptimisticLockConflict(e)
+            } catch (e: Exception) {
+                reenqueueAfterFailure(snapshot, clearFlag, capturedEpoch)
+                throw e
+            }
+        }
+
+        /**
          * Drains the per-key pending cell map under the write lock, then dispatches the grouped
          * payload to [writePending]. On failure, restores the snapshot via [mergeOlder] so the
          * next flush retries with a reconciled view of writes that arrived during the failed I/O.
@@ -320,40 +392,65 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
          */
         protected fun flush() {
             flushLock.withLock {
-                // Capture the snapshot, hadClear flag, AND the clearEpoch under the write lock.
-                // The captured epoch is later compared in reenqueueAfterFailure() to determine
-                // whether a clear() ran during the I/O and so the snapshot must be dropped rather
-                // than restored.
-                val snapshot: Map<K, PendingCell<K, R>>
-                val clearFlag: Boolean
-                val capturedEpoch: Long
-                pendingLock.write {
-                    snapshot = pendingCells.toMap()
-                    pendingCells.clear()
-                    clearFlag = hadClear.getAndSet(false)
-                    capturedEpoch = clearEpoch.get()
-                }
-                // Reset the window origin so the next enqueue after this flush starts a fresh
-                // max-delay deadline rather than inheriting the stale timestamp.
-                startNanos.set(0L)
-                if (snapshot.isEmpty() && !clearFlag) return
-                val inserts = snapshot.values.filterIsInstance<PendingCell.Insert<K, R>>().map { it.entity }
-                val updates =
-                    snapshot.values.filterIsInstance<PendingCell.Update<K, R>>()
-                        .map { PendingUpdate(it.entity, it.expectedVersion) }
-                val deletes =
-                    snapshot.entries.mapNotNull { (id, cell) ->
-                        (cell as? PendingCell.Delete<K, R>)?.let { id to it.expectedVersion }
-                    }
-                try {
-                    writePending(inserts, updates, deletes, clearFlag)
-                } catch (e: OptimisticLockException) {
-                    routeOptimisticLockConflict(e)
-                } catch (e: Exception) {
-                    reenqueueAfterFailure(snapshot, clearFlag, capturedEpoch)
-                    throw e
-                }
+                drainPendingNoLock()
             }
+        }
+
+        /**
+         * Cancels the sliding-window debounce job and the max-delay cap job.
+         *
+         * The transaction commit path calls this before acquiring [flushLock] to ensure the debounce
+         * coroutine does not attempt to acquire [flushLock] concurrently, which would otherwise
+         * stall the transaction behind an in-flight flush.
+         */
+        internal fun cancelDebounce() {
+            debounceJob?.cancel()
+            maxDelayJob?.cancel()
+        }
+
+        /**
+         * Fires the repository's [LirpErrorHandler] with [LirpOperation.TRANSACTION] and the given
+         * entity identifiers. This is a notify-only call — the handler cannot alter control flow.
+         *
+         * Only entity identity is included in the error context; field values are never exposed here.
+         */
+        internal fun notifyTransactionError(throwable: Throwable, entityIds: List<Any>) {
+            try {
+                onError?.invoke(throwable, LirpErrorContext(LirpOperation.TRANSACTION, entityIds, repositoryName))
+            } catch (handlerEx: Throwable) {
+                log.error(handlerEx) { "LirpErrorHandler threw inside transaction error notify; exception swallowed" }
+            }
+        }
+
+        /**
+         * Re-arms the debounce flush if there are pending cells after a transaction completes.
+         *
+         * Called at the end of a transaction (commit or rollback) so that any ops enqueued during
+         * the block that were not part of the buffer are flushed through the normal debounce pipeline.
+         */
+        internal fun rescheduleFlushIfPending() {
+            if (!closed && pendingCells.isNotEmpty()) {
+                scheduleFlush()
+            }
+        }
+
+        /**
+         * Called by the transaction commit path after [drainPendingNoLock] succeeds, with the ops
+         * captured during the block in place of the normal debounce payload.
+         *
+         * The default implementation is intentionally a no-op — [VolatileRepository] mutates memory
+         * in place during the block, so there is nothing durable to commit; rollback and event-deferral
+         * are handled by the shared base machinery regardless of store type. Durable stores (SQL,
+         * JSON) override this hook to write the buffer contents in a single atomic operation.
+         *
+         * **Threading contract:** invoked while [flushLock] is held. Must not call [flush] or
+         * otherwise re-acquire [flushLock].
+         *
+         * @param buffer the [TransactionBuffer] carrying the captured inserts, updates, deletes, and
+         *   entity snapshots for the completed block
+         */
+        open fun commitTransactionBuffer(buffer: TransactionBuffer<K, R>) {
+            // No-op: memory is already updated in place; Volatile relies on this default.
         }
 
         // optimistic-lock failures follow the Conflict + auto-reload path and DO NOT
@@ -641,6 +738,19 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
                 entity.subscribeAsync { mutationEvent ->
                     pendingLock.read {
                         if (closed) return@read
+
+                        // When a transaction is active for this repo, route the mutation op into the
+                        // buffer rather than the normal debounce pipeline. The buffer is filtered to
+                        // this repo only — mutations to entities from a different repo fall through
+                        // to enqueueUpdate on their own repo's subscribeEntity handler.
+                        val txBuffer = activeTransactionBuffer
+                        if (txBuffer != null) {
+                            txBuffer.updates.add(PendingUpdate(mutationEvent.entity, versionAtMutation(mutationEvent)))
+                            reindexMutation(mutationEvent)
+                            onEntityMutated(mutationEvent)
+                            return@read
+                        }
+
                         enqueueUpdate(mutationEvent.entity, versionAtMutation(mutationEvent))
                         // Reindex before the subclass hook so a throwing onEntityMutated override
                         // cannot leave findByIndex / range queries returning stale results.

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/ReactivePropertyDelegate.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/ReactivePropertyDelegate.kt
@@ -62,6 +62,19 @@ internal class ReactivePropertyDelegate<T>(
     internal fun writeBackingDirectly(value: T) {
         storedValue = value
     }
+
+    /**
+     * Writes [value] directly into the backing field without invoking [entity.emitPropertyChanged][net.transgressoft.lirp.entity.ReactiveEntityBase.emitPropertyChanged].
+     *
+     * Used by the transaction rollback path to restore field values without emitting mutation events.
+     * Unlike [writeBackingDirectly], this method is explicitly named to signal non-emitting intent
+     * at the call site — the rollback path always wraps calls in
+     * [withEventsDisabled][net.transgressoft.lirp.entity.ReactiveEntityBase.withEventsDisabled]
+     * as an additional guard.
+     */
+    internal fun setDirectly(value: T) {
+        storedValue = value
+    }
 }
 
 /**
@@ -82,6 +95,9 @@ internal class ReactivePropertyDelegateWithAccessors<T>(
 
     override fun getValue(thisRef: Any?, property: KProperty<*>): T = getter()
 
+    /** Reads the current value via the supplied getter. Used by snapshot capture. */
+    internal fun readValue(): T = getter()
+
     override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
         check(!entity.isClosed) { "Entity '${entity::class.java.simpleName}' is closed" }
         if (value != getter()) {
@@ -96,6 +112,18 @@ internal class ReactivePropertyDelegateWithAccessors<T>(
      * `@Transient`-backed reactive properties, the setter lambda is the backing-write path.
      */
     internal fun writeBackingDirectly(value: T) {
+        setter(value)
+    }
+
+    /**
+     * Writes [value] through the supplied [setter] without triggering event emission, the
+     * lastDateModified bump, or any other reactive side effect.
+     *
+     * Used by the transaction rollback path to restore field values without emitting mutation events.
+     * Unlike [writeBackingDirectly], this method is explicitly named to signal non-emitting intent
+     * at the call site.
+     */
+    internal fun setDirectly(value: T) {
         setter(value)
     }
 }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
@@ -859,6 +859,18 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
             rawInitializerFor(entityClass)
 
         /**
+         * Public cross-module entry point for [refAccessorFor].
+         *
+         * `lirp-sql` (a separate Gradle / Kotlin module) uses this to enumerate cascade targets
+         * for a given entity class when validating that all reachable cascade repositories share
+         * the same DataSource before committing a transaction. Returns `null` when the entity has
+         * no KSP-generated ref accessor (i.e., no `@ToOneAggregate` / `@ToManyAggregates` references).
+         */
+        @JvmStatic
+        fun publicRefAccessorFor(entityClass: Class<*>): LirpRefAccessor<Any>? =
+            refAccessorFor(entityClass)
+
+        /**
          * Returns the [LirpRawConstructor] for [entityClass], loading it via [KspAccessorLoader] on
          * first call and caching the result, or `null` when none exists.
          *

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/TransactionBuffer.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/TransactionBuffer.kt
@@ -22,6 +22,25 @@ import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.event.PropertyChanged
 
 /**
+ * Carries the full delete intent captured inside a transaction block.
+ *
+ * Stores the entity alongside its key and expected version so the rollback path can re-add
+ * the entity to in-memory state without a repository lookup, and the commit path can build
+ * the `(id, expectedVersion)` pair needed by the SQL/JSON write pipeline.
+ *
+ * @param K the entity's key type
+ * @param R the reactive entity type
+ * @param id the entity's key
+ * @param entity the entity instance at remove() time
+ * @param expectedVersion the `@Version` value captured at remove() time; `null` for unversioned entities
+ */
+data class PendingDelete<K : Comparable<K>, R : ReactiveEntity<K, R>>(
+    val id: K,
+    val entity: R,
+    val expectedVersion: Long?
+)
+
+/**
  * Mutable container accumulating the captured state for a single transaction block on [repo].
  *
  * During a transaction, three categories of data are collected here rather than in the normal
@@ -57,8 +76,8 @@ class TransactionBuffer<K : Comparable<K>, R : ReactiveEntity<K, R>>(
     /** Entities that were mutated (but not inserted or deleted) inside the transaction block. */
     val updates: MutableList<PendingUpdate<K, R>> = mutableListOf()
 
-    /** (id, expectedVersion) pairs for entities removed inside the transaction block. */
-    val deletes: MutableList<Pair<K, Long?>> = mutableListOf()
+    /** Delete intents captured inside the transaction block (id, entity, expectedVersion). */
+    val deletes: MutableList<PendingDelete<K, R>> = mutableListOf()
 
     /**
      * Pre-block property-value snapshots, keyed by entity id.
@@ -107,11 +126,17 @@ class TransactionBuffer<K : Comparable<K>, R : ReactiveEntity<K, R>>(
                     collapsed[key] = pc
                 } else {
                     // Subsequent observation: keep first oldValue, update to latest newValue.
-                    collapsed[key] =
+                    val updatedPc =
                         (existing as PropertyChanged<K, R, Any?>).copy(
                             newValue = (pc as PropertyChanged<K, R, Any?>).newValue,
                             newIndexKey = pc.newIndexKey
                         )
+                    // A→B→A net-no-change: remove the entry entirely so no event fires.
+                    if (updatedPc.oldValue == updatedPc.newValue && updatedPc.oldIndexKey == updatedPc.newIndexKey) {
+                        collapsed.remove(key)
+                    } else {
+                        collapsed[key] = updatedPc
+                    }
                 }
             } else {
                 nonPropertyEvents.add(event)

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/TransactionBuffer.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/TransactionBuffer.kt
@@ -1,0 +1,123 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import net.transgressoft.lirp.entity.ReactiveEntity
+import net.transgressoft.lirp.event.MutationEvent
+import net.transgressoft.lirp.event.PropertyChanged
+
+/**
+ * Mutable container accumulating the captured state for a single transaction block on [repo].
+ *
+ * During a transaction, three categories of data are collected here rather than in the normal
+ * debounce pipeline:
+ *
+ * - **Op lists** ([inserts], [updates], [deletes]): the CRUD intents captured from `add`/`remove`
+ *   calls made inside the block. On commit these are forwarded to the store in a single atomic
+ *   write; on rollback they are discarded.
+ *
+ * - **Entity snapshots** ([entitySnapshots]): shallow property-value maps captured from each
+ *   entity before its first mutation inside the block. Used to restore in-memory state on rollback
+ *   without emitting spurious events.
+ *
+ * - **Deferred events** ([deferredEvents]): [MutationEvent]s buffered instead of published while
+ *   the block runs. On commit, [collapseDeferredEvents] collapses them to one event per
+ *   (entity, property) pair and releases them to subscribers. On rollback they are discarded.
+ *
+ * Visibility is `public` so that durable-store overrides of [PersistentRepositoryBase.commitTransactionBuffer]
+ * in separate modules (such as `lirp-sql`) can receive and inspect the buffer. The class is not
+ * part of the end-user API — it is a framework-internal worker type passed across module boundaries
+ * by the transaction orchestration layer.
+ *
+ * @param K the comparable entity key type
+ * @param R the reactive entity type
+ * @param repo the repository that owns this transaction context
+ */
+class TransactionBuffer<K : Comparable<K>, R : ReactiveEntity<K, R>>(
+    val repo: PersistentRepositoryBase<K, R>
+) {
+    /** Entities that were added to the repository inside the transaction block. */
+    val inserts: MutableList<R> = mutableListOf()
+
+    /** Entities that were mutated (but not inserted or deleted) inside the transaction block. */
+    val updates: MutableList<PendingUpdate<K, R>> = mutableListOf()
+
+    /** (id, expectedVersion) pairs for entities removed inside the transaction block. */
+    val deletes: MutableList<Pair<K, Long?>> = mutableListOf()
+
+    /**
+     * Pre-block property-value snapshots, keyed by entity id.
+     *
+     * A snapshot is taken when an entity is first touched inside the block so that rollback can
+     * restore exactly the pre-block state regardless of how many mutations happened inside.
+     */
+    val entitySnapshots: MutableMap<K, Map<String, Any?>> = mutableMapOf()
+
+    /**
+     * [MutationEvent]s buffered during the block instead of published to subscribers.
+     *
+     * Released (collapsed) on successful commit; discarded silently on rollback.
+     */
+    val deferredEvents: MutableList<MutationEvent<K, R>> = mutableListOf()
+
+    /**
+     * Collapses [deferredEvents] using a first-old / last-new algebra per (entity id, property name)
+     * pair, then returns the resulting list.
+     *
+     * For each [PropertyChanged] event, only the first observed `oldValue` and the last observed
+     * `newValue` are retained — collapsing a sequence of intermediate mutations into a single net
+     * change identical to what a direct before/after snapshot would produce. Non-[PropertyChanged]
+     * events (e.g. aggregate mutations) are forwarded unchanged.
+     *
+     * This mirrors the first-observed-version rule applied by [mergeWriterSide] to [PendingCell.Update]
+     * collapse in the debounce pipeline, applied here to the event dimension rather than the
+     * persistence dimension.
+     *
+     * @return collapsed list; order is insertion order of first occurrence per key
+     */
+    @Suppress("UNCHECKED_CAST")
+    internal fun collapseDeferredEvents(): List<MutationEvent<K, R>> {
+        // Ordered map: insertion order preserved so subscribers see events in a stable sequence.
+        // Key: (entity id, property name) for PropertyChanged events.
+        val collapsed = linkedMapOf<Pair<K, String>, PropertyChanged<K, R, *>>()
+        val nonPropertyEvents = mutableListOf<MutationEvent<K, R>>()
+
+        for (event in deferredEvents) {
+            if (event is PropertyChanged<*, *, *>) {
+                val pc = event as PropertyChanged<K, R, *>
+                val key = pc.entity.id to pc.property.name
+                val existing = collapsed[key]
+                if (existing == null) {
+                    // First observation: record as-is (oldValue is the pre-block value).
+                    collapsed[key] = pc
+                } else {
+                    // Subsequent observation: keep first oldValue, update to latest newValue.
+                    collapsed[key] =
+                        (existing as PropertyChanged<K, R, Any?>).copy(
+                            newValue = (pc as PropertyChanged<K, R, Any?>).newValue,
+                            newIndexKey = pc.newIndexKey
+                        )
+                }
+            } else {
+                nonPropertyEvents.add(event)
+            }
+        }
+
+        return collapsed.values + nonPropertyEvents
+    }
+}

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/TransactionErrorContext.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/TransactionErrorContext.kt
@@ -1,0 +1,49 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import net.transgressoft.lirp.entity.ReactiveEntity
+
+/**
+ * Receiver type for the call-scoped `onError` lambda passed to `transaction`.
+ *
+ * When a transaction block fails — whether from a constraint violation, connection error, or
+ * an `@Version` conflict — in-memory state is restored to its pre-block values **before**
+ * this context is delivered to the handler. The handler observes the repository in its
+ * rolled-back state.
+ *
+ * Two fields describe the failure:
+ * - [throwable] is always present and carries the underlying cause.
+ * - [conflicts] is non-empty only when the failure was an `@Version` conflict on one or more
+ *   entities. An empty list means the failure was a non-conflict cause (constraint violation,
+ *   connection error, etc.).
+ *
+ * Because rollback completes before the handler runs, [ConflictInfo.entity] carries the
+ * values that were attempted **inside** the block (captured from the pre-rollback in-memory
+ * state), not the restored pre-block values. Use [ConflictInfo.canonical] to read the
+ * authoritative store state for reconciliation.
+ *
+ * @param K the comparable entity key type
+ * @param R the reactive entity type
+ * @param throwable the exception that caused the transaction to fail
+ * @param conflicts the `@Version` conflicts detected during the commit; empty for non-conflict failures
+ */
+class TransactionErrorContext<K : Comparable<K>, R : ReactiveEntity<K, R>>(
+    val throwable: Throwable,
+    val conflicts: List<ConflictInfo<K, R>>
+)

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/Transactions.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/Transactions.kt
@@ -1,0 +1,225 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import net.transgressoft.lirp.entity.ReactiveEntity
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.event.ReactiveScope
+import kotlinx.coroutines.withContext
+
+/**
+ * Tracks the number of active transaction blocks running on the current thread.
+ *
+ * When this counter is greater than zero when entering a new `transaction` call, and the
+ * incoming repo has `transactionDepth == 0`, the call is a cross-repo nesting that is not
+ * supported in the single-participant form.
+ */
+private val activeTransactionCount = ThreadLocal.withInitial { 0 }
+
+/**
+ * Executes [block] as an atomic unit of work against [repo].
+ *
+ * All mutations to entities belonging to [repo] that occur inside [block] are captured
+ * and committed synchronously as a single transaction. On success, buffered mutation events
+ * are released (collapsed) to subscribers. On failure, in-memory state is restored to the
+ * values captured before the block ran and buffered events are discarded silently.
+ *
+ * **Commit sequence:**
+ * 1. Pending debounce jobs are cancelled.
+ * 2. The flush lock is acquired for the full pre-flush + block + commit window.
+ * 3. All pending ops are drained to the store (pre-flush) so the block starts from a clean baseline.
+ * 4. Snapshots are captured and event buffering is installed on all currently loaded entities.
+ * 5. [block] executes; property-change events are buffered instead of published.
+ * 6. On success: [PersistentRepositoryBase.commitTransactionBuffer] writes the buffer atomically;
+ *    collapsed events are released to subscribers.
+ * 7. On failure: [ReactiveEntityBase.restoreSnapshot] reverts in-memory state before the caller
+ *    observes the error; buffered events are discarded.
+ *
+ * **`onError` vs typed exception:**
+ * When [onError] is present it is invoked with the failure details and no exception propagates.
+ * When absent, a [LirpTransactionException] (or [TransactionConflictException] for `@Version`
+ * conflicts) is thrown after in-memory rollback completes.
+ *
+ * **Nesting:**
+ * - A nested call on the same [repo] flattens into the outer transaction — the outer block owns
+ *   commit and rollback; the inner block runs directly in the existing buffer.
+ * - A nested call on a different repository throws [LirpTransactionException] immediately.
+ *
+ * **Block contract:**
+ * The block should be short-lived. The flush lock is held for its entire duration, stalling the
+ * debounce flush pipeline for the same repository. Long-running or blocking operations inside
+ * the block risk pipeline starvation.
+ *
+ * @param repo the repository that owns the transaction
+ * @param onError optional call-scoped failure handler; see [TransactionErrorContext]
+ * @param block the mutation block; receives the repository as its argument
+ * @throws LirpTransactionException when [onError] is absent and a non-conflict failure occurs,
+ *         or when the call is a nested transaction on a different repository
+ * @throws TransactionConflictException when [onError] is absent and an `@Version` conflict is detected
+ */
+suspend fun <K : Comparable<K>, R : ReactiveEntity<K, R>> transaction(
+    repo: PersistentRepositoryBase<K, R>,
+    onError: (TransactionErrorContext<K, R>.() -> Unit)? = null,
+    block: suspend (PersistentRepositoryBase<K, R>) -> Unit
+) {
+    // NESTING (same repo): join the outer transaction without starting a new commit cycle.
+    if (repo.transactionDepth > 0) {
+        repo.transactionDepth++
+        try {
+            block(repo)
+        } finally {
+            repo.transactionDepth--
+        }
+        return
+    }
+
+    // NESTING (different repo): another transaction is already active on this thread.
+    // Single-participant transactions do not support cross-repo nesting.
+    val threadCount = activeTransactionCount.get()
+    if (threadCount > 0) {
+        throw LirpTransactionException(
+            "Nested transactions on different repositories are not supported. " +
+                "Only single-participant transactions or nested calls on the same repository are allowed."
+        )
+    }
+
+    // Cancel the debounce timer before acquiring the flush lock to prevent the debounce
+    // coroutine from contending for the lock while the transaction holds it.
+    repo.cancelDebounce()
+
+    // Run the entire transaction on the IO scope.
+    // Because the block is suspend and Kotlin forbids suspending inside withLock { }, the
+    // flush lock is managed with explicit lock/unlock under a try/finally.
+    // The IO scope's single-thread constraint (limitedParallelism = 1) ensures the
+    // thread-local activeTransactionCount and per-entity _txEventBuffer checks are reliable.
+    withContext(ReactiveScope.ioScope.coroutineContext) {
+        repo.flushLock.lock()
+        // The lock is acquired outside the try only on the line above; everything that can throw —
+        // including snapshot capture and event-buffer installation — runs inside so the finally
+        // always releases the lock and restores per-repo transaction state.
+        var loadedEntities: List<ReactiveEntityBase<K, R>> = emptyList()
+        try {
+            activeTransactionCount.set(activeTransactionCount.get() + 1)
+            val buffer = TransactionBuffer(repo)
+            repo.transactionDepth = 1
+            repo.activeTransactionBuffer = buffer
+
+            // Capture snapshots and install event buffering on all currently loaded entities.
+            loadedEntities = repo.mapNotNull { it as? ReactiveEntityBase<K, R> }
+            loadedEntities.forEach { entity ->
+                buffer.entitySnapshots[entity.id] = entity.captureSnapshot()
+                entity._txEventBuffer.set(buffer.deferredEvents)
+            }
+
+            try {
+                // Pre-flush: drain pending ops before the block runs so the backing store starts
+                // from a consistent baseline. A failure here aborts before the block executes.
+                repo.drainPendingNoLock()
+
+                block(repo)
+
+                // COMMIT: write the buffer contents atomically to the backing store.
+                // This hook is a no-op for VolatileRepository; JSON and SQL override it.
+                try {
+                    repo.commitTransactionBuffer(buffer)
+                } catch (commitFailure: Throwable) {
+                    handleTransactionFailure(repo, buffer, loadedEntities, commitFailure, onError)
+                    return@withContext
+                }
+
+                // Release collapsed deferred events to subscribers now that the commit succeeded.
+                buffer.collapseDeferredEvents().forEach { event ->
+                    @Suppress("UNCHECKED_CAST")
+                    (event.entity as? ReactiveEntityBase<K, R>)?.emitCollapsedEvent(event)
+                }
+            } catch (blockOrPreFlushFailure: Throwable) {
+                // Block or pre-flush threw — roll back before surfacing the failure.
+                handleTransactionFailure(repo, buffer, loadedEntities, blockOrPreFlushFailure, onError)
+            }
+        } finally {
+            // Clear deferred event buffer from all entities regardless of outcome.
+            loadedEntities.forEach { entity -> entity._txEventBuffer.remove() }
+            repo.transactionDepth = 0
+            repo.activeTransactionBuffer = null
+            activeTransactionCount.set(activeTransactionCount.get() - 1)
+            repo.flushLock.unlock()
+            repo.rescheduleFlushIfPending()
+        }
+    }
+}
+
+/**
+ * Rolls back in-memory state for all snapshotted entities, fires the repository's notify-only
+ * error handler, discards deferred events, then either invokes the call-scoped [onError]
+ * handler or rethrows as a typed exception.
+ *
+ * Rollback runs before the handler or exception is observed so the caller sees the pre-block state.
+ * [ConflictInfo.entity] carries the values attempted inside the block, captured before rollback
+ * by the commit machinery, not the restored pre-block values.
+ */
+@Suppress("UNCHECKED_CAST")
+private fun <K : Comparable<K>, R : ReactiveEntity<K, R>> handleTransactionFailure(
+    repo: PersistentRepositoryBase<K, R>,
+    buffer: TransactionBuffer<K, R>,
+    loadedEntities: List<ReactiveEntityBase<K, R>>,
+    failure: Throwable,
+    onError: (TransactionErrorContext<K, R>.() -> Unit)?
+) {
+    // Rollback first: restore every snapshotted entity to its pre-block values.
+    // Events are suppressed during restore so subscribers do not observe intermediate states.
+    loadedEntities.forEach { entity ->
+        val snapshot = buffer.entitySnapshots[entity.id] ?: return@forEach
+        entity.restoreSnapshot(snapshot)
+    }
+
+    // Notify the repository's observability handler with identity-only context (never field values).
+    val entityIds = buffer.entitySnapshots.keys.map { it as Any }
+    repo.notifyTransactionError(failure, entityIds)
+
+    // Extract conflicts from the failure for the TransactionConflictException path.
+    val conflicts: List<ConflictInfo<K, R>> =
+        when (failure) {
+            is TransactionConflictException ->
+                failure.conflicts as List<ConflictInfo<K, R>>
+            else -> emptyList()
+        }
+
+    // Discard the deferred event buffer — rolled-back mutations must not reach subscribers.
+    buffer.deferredEvents.clear()
+
+    if (onError != null) {
+        // Call-scoped handler present: invoke it and suppress the exception.
+        TransactionErrorContext(failure, conflicts).onError()
+    } else {
+        // No handler: propagate a typed exception.
+        when {
+            conflicts.isNotEmpty() ->
+                throw TransactionConflictException(
+                    "Transaction conflict on '${repo.repoName}': ${conflicts.size} version mismatch(es)",
+                    conflicts,
+                    failure
+                )
+            failure is LirpTransactionException -> throw failure
+            else ->
+                throw LirpTransactionException(
+                    "Transaction failed on '${repo.repoName}': ${failure.message}",
+                    failure
+                )
+        }
+    }
+}

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/Transactions.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/Transactions.kt
@@ -20,6 +20,7 @@ package net.transgressoft.lirp.persistence
 import net.transgressoft.lirp.entity.ReactiveEntity
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.event.ReactiveScope
+import kotlinx.coroutines.asContextElement
 import kotlinx.coroutines.withContext
 
 /**
@@ -77,21 +78,23 @@ suspend fun <K : Comparable<K>, R : ReactiveEntity<K, R>> transaction(
     onError: (TransactionErrorContext<K, R>.() -> Unit)? = null,
     block: suspend (PersistentRepositoryBase<K, R>) -> Unit
 ) {
-    // NESTING (same repo): join the outer transaction without starting a new commit cycle.
-    if (repo.transactionDepth > 0) {
-        repo.transactionDepth++
-        try {
-            block(repo)
-        } finally {
-            repo.transactionDepth--
+    // Only treat this call as nesting when THIS execution already owns a transaction
+    // (activeTransactionCount is propagated across suspension via asContextElement). Checking
+    // repo.transactionDepth first would let a separate concurrent transaction(repo) call observe
+    // depth > 0, skip the flush lock, and corrupt the active buffer — so ownership is proven first.
+    if (activeTransactionCount.get() > 0) {
+        // NESTING (same repo): join the outer transaction without starting a new commit cycle.
+        if (repo.transactionDepth > 0) {
+            repo.transactionDepth++
+            try {
+                block(repo)
+            } finally {
+                repo.transactionDepth--
+            }
+            return
         }
-        return
-    }
 
-    // NESTING (different repo): another transaction is already active on this thread.
-    // Single-participant transactions do not support cross-repo nesting.
-    val threadCount = activeTransactionCount.get()
-    if (threadCount > 0) {
+        // NESTING (different repo): single-participant transactions do not support cross-repo nesting.
         throw LirpTransactionException(
             "Nested transactions on different repositories are not supported. " +
                 "Only single-participant transactions or nested calls on the same repository are allowed."
@@ -107,8 +110,8 @@ suspend fun <K : Comparable<K>, R : ReactiveEntity<K, R>> transaction(
     // flush lock is managed with explicit lock/unlock under a try/finally.
     // The IO scope's single-thread constraint (limitedParallelism = 1) ensures the
     // thread-local activeTransactionCount and per-entity _txEventBuffer checks are reliable.
-    withContext(ReactiveScope.ioScope.coroutineContext) {
-        repo.flushLock.lock()
+    withContext(ReactiveScope.ioScope.coroutineContext + activeTransactionCount.asContextElement(activeTransactionCount.get())) {
+        repo.lockFlush()
         // The lock is acquired outside the try only on the line above; everything that can throw —
         // including snapshot capture and event-buffer installation — runs inside so the finally
         // always releases the lock and restores per-repo transaction state.
@@ -131,11 +134,28 @@ suspend fun <K : Comparable<K>, R : ReactiveEntity<K, R>> transaction(
                 // from a consistent baseline. A failure here aborts before the block executes.
                 repo.drainPendingNoLock()
 
-                block(repo)
+                // Propagate each entity's _txEventBuffer across coroutine suspension points.
+                // This inner withContext also re-pins activeTransactionCount so nested transaction
+                // checks remain accurate even when the block suspends onto a different thread.
+                val entityBufferContext =
+                    loadedEntities.fold(
+                        activeTransactionCount.asContextElement(activeTransactionCount.get())
+                            as kotlin.coroutines.CoroutineContext
+                    ) { ctx, entity ->
+                        ctx + entity._txEventBuffer.asContextElement(buffer.deferredEvents)
+                    }
+                withContext(entityBufferContext) { block(repo) }
 
                 // COMMIT: write the buffer contents atomically to the backing store.
                 // This hook is a no-op for VolatileRepository; JSON and SQL override it.
                 try {
+                    // Coalesce contradictory insert+delete intents for the same id before committing.
+                    // Must run before captureDeferredUpdates so derived updates don't double-count.
+                    repo.normalizeTransactionBuffer(buffer)
+                    // Derive buffer.updates from deferred events: scalar mutations that were buffered
+                    // (instead of published via the reactive subscription) need to be captured here
+                    // so durable stores (SQL, JSON) know which rows to UPDATE.
+                    repo.captureDeferredUpdates(buffer)
                     repo.commitTransactionBuffer(buffer)
                 } catch (commitFailure: Throwable) {
                     handleTransactionFailure(repo, buffer, loadedEntities, commitFailure, onError)
@@ -157,7 +177,7 @@ suspend fun <K : Comparable<K>, R : ReactiveEntity<K, R>> transaction(
             repo.transactionDepth = 0
             repo.activeTransactionBuffer = null
             activeTransactionCount.set(activeTransactionCount.get() - 1)
-            repo.flushLock.unlock()
+            repo.unlockFlush()
             repo.rescheduleFlushIfPending()
         }
     }
@@ -180,11 +200,23 @@ private fun <K : Comparable<K>, R : ReactiveEntity<K, R>> handleTransactionFailu
     failure: Throwable,
     onError: (TransactionErrorContext<K, R>.() -> Unit)?
 ) {
+    if (failure is kotlinx.coroutines.CancellationException) throw failure
+
     // Rollback first: restore every snapshotted entity to its pre-block values.
     // Events are suppressed during restore so subscribers do not observe intermediate states.
     loadedEntities.forEach { entity ->
         val snapshot = buffer.entitySnapshots[entity.id] ?: return@forEach
         entity.restoreSnapshot(snapshot)
+    }
+
+    // Undo inserts: entities added inside the block must be removed from in-memory state.
+    buffer.inserts.forEach { entity ->
+        entity.withEventsDisabled { repo.removeFromMemoryOnlyInternal(entity) }
+    }
+
+    // Undo deletes: entities removed inside the block must be re-added to in-memory state.
+    buffer.deletes.forEach { pendingDelete ->
+        pendingDelete.entity.withEventsDisabled { repo.addToMemoryOnlyInternal(pendingDelete.entity) }
     }
 
     // Notify the repository's observability handler with identity-only context (never field values).

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepository.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepository.kt
@@ -28,8 +28,12 @@ import net.transgressoft.lirp.persistence.PendingUpdate
 import net.transgressoft.lirp.persistence.PersistentRepositoryBase
 import net.transgressoft.lirp.persistence.Registry
 import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.TransactionBuffer
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.Objects
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.concurrent.withLock
@@ -413,6 +417,41 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
                 json.decodeFromString(mapSerializer, content)
             } catch (exception: Exception) {
                 throw LirpDeserializationException("Failed to deserialize entities from file: ${jsonFile.absolutePath}", exception)
+            }
+        }
+
+        /**
+         * Commits the transaction buffer to [jsonFile] using an atomic write sequence.
+         *
+         * The current in-memory state is serialized to a sibling temporary file
+         * (`<jsonFile>.tmp`), then promoted over [jsonFile] via `Files.move` with
+         * [StandardCopyOption.ATOMIC_MOVE]. This guarantees that a crash or I/O error during
+         * the write leaves the original file intact — the in-progress write either completes
+         * and replaces the file atomically, or fails and the temp file is cleaned up while
+         * the original remains untouched.
+         *
+         * `Files.move(ATOMIC_MOVE)` is preferred over `File.renameTo` because the JDK NIO
+         * contract guarantees atomic replacement on POSIX filesystems even when the source
+         * and target are on different inodes, while `renameTo` behaviour is platform-dependent.
+         *
+         * **Threading contract:** invoked while [flushLock] is held. Must not call [flush] or
+         * otherwise re-acquire [flushLock].
+         *
+         * @param buffer the transaction buffer (its op lists are not used directly; the current
+         *   in-memory state is the source of truth for JSON serialization)
+         * @throws IOException if the atomic rename/move fails, leaving the original file intact
+         */
+        override fun commitTransactionBuffer(buffer: TransactionBuffer<K, R>) {
+            val jsonString = json.encodeToString(mapSerializer, entitiesById)
+            val tmp = File(jsonFile.parent, "${jsonFile.name}.tmp")
+            try {
+                tmp.writeText(jsonString)
+                Files.move(tmp.toPath(), jsonFile.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+                dirty.set(false)
+                log.debug { "Transaction committed atomically to $jsonFile" }
+            } catch (e: IOException) {
+                tmp.delete()
+                throw IOException("Atomic write failed: $tmp -> $jsonFile", e)
             }
         }
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/TransactionEntitySnapshotTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/TransactionEntitySnapshotTest.kt
@@ -44,10 +44,15 @@ internal class TransactionEntitySnapshotTest : StringSpec({
         snapshot["albumName"] shouldBe "album-initial"
     }
 
-    "captureSnapshot captures exactly the two scalar reactive properties (excludes aggregate delegates)" {
+    "captureSnapshot captures the two scalar reactive properties and the lastDateModified sentinel" {
         val item = MutableAudioItem(2, "title", "album")
         val snapshot = item.captureSnapshot()
-        snapshot.keys shouldBe setOf("title", "albumName")
+        // Two reactive-property delegate keys plus the internal lastDateModified sentinel.
+        snapshot["title"] shouldBe "title"
+        snapshot["albumName"] shouldBe "album"
+        // Non-sentinel keys are exactly the two reactive-property names (order-agnostic).
+        snapshot.keys.filter { !it.startsWith(" ") }.toSet() shouldBe setOf("title", "albumName")
+        snapshot.values.filterIsInstance<java.time.LocalDateTime>() shouldBe listOf(item.lastDateModified)
     }
 
     "restoreSnapshot reverts reactive scalar properties to captured values" {

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/TransactionEntitySnapshotTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/TransactionEntitySnapshotTest.kt
@@ -1,0 +1,116 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.entity
+
+import net.transgressoft.lirp.event.MutationEvent
+import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.MutableAudioItem
+import net.transgressoft.lirp.testing.reactiveScope
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [ReactiveEntityBase.captureSnapshot], [ReactiveEntityBase.restoreSnapshot],
+ * and [ReactiveEntityBase.withEventsDeferred] — the snapshot and event-deferral primitives
+ * used by the transaction machinery.
+ */
+@DisplayName("ReactiveEntityBase snapshot and event-deferral primitives")
+internal class TransactionEntitySnapshotTest : StringSpec({
+
+    val reactive = reactiveScope()
+
+    "captureSnapshot round-trips all reactive scalar properties" {
+        val item = MutableAudioItem(1, "title-initial", "album-initial")
+        val snapshot = item.captureSnapshot()
+
+        snapshot["title"] shouldBe "title-initial"
+        snapshot["albumName"] shouldBe "album-initial"
+    }
+
+    "captureSnapshot captures exactly the two scalar reactive properties (excludes aggregate delegates)" {
+        val item = MutableAudioItem(2, "title", "album")
+        val snapshot = item.captureSnapshot()
+        snapshot.keys shouldBe setOf("title", "albumName")
+    }
+
+    "restoreSnapshot reverts reactive scalar properties to captured values" {
+        val item = MutableAudioItem(3, "original-title", "original-album")
+        val snapshot = item.captureSnapshot()
+
+        item.title = "mutated-title"
+        item.albumName = "mutated-album"
+
+        item.restoreSnapshot(snapshot)
+
+        item.title shouldBe "original-title"
+        item.albumName shouldBe "original-album"
+    }
+
+    "restoreSnapshot emits no events to subscribers" {
+        val item = MutableAudioItem(4, "before", "album")
+        val snapshot = item.captureSnapshot()
+        item.title = "after"
+
+        val capturedEvents = mutableListOf<MutationEvent<Int, AudioItem>>()
+        item.subscribe { capturedEvents.add(it) }
+        reactive.advance()
+
+        item.restoreSnapshot(snapshot)
+        reactive.advance()
+
+        capturedEvents.shouldBeEmpty()
+    }
+
+    "withEventsDeferred routes PropertyChanged into the provided buffer instead of publishing" {
+        val item = MutableAudioItem(5, "initial", "album")
+        val buffer = mutableListOf<MutationEvent<Int, AudioItem>>()
+
+        val capturedLive = mutableListOf<MutationEvent<Int, AudioItem>>()
+        item.subscribe { capturedLive.add(it) }
+        reactive.advance()
+
+        item.withEventsDeferred(buffer) {
+            item.title = "deferred-value"
+        }
+        reactive.advance()
+
+        // Live subscriber received nothing while deferral was active.
+        capturedLive.shouldBeEmpty()
+        // Buffer captured the deferred event.
+        buffer.size shouldBe 1
+    }
+
+    "withEventsDeferred restores the previous buffer on exit — re-entrant safe" {
+        val item = MutableAudioItem(6, "start", "album")
+        val outerBuffer = mutableListOf<MutationEvent<Int, AudioItem>>()
+        val innerBuffer = mutableListOf<MutationEvent<Int, AudioItem>>()
+
+        item.withEventsDeferred(outerBuffer) {
+            item.withEventsDeferred(innerBuffer) {
+                item.title = "inner"
+            }
+            // outer buffer is active again after inner block exits.
+            item.title = "outer"
+        }
+
+        innerBuffer.size shouldBe 1
+        outerBuffer.size shouldBe 1
+    }
+})

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/TransactionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/TransactionTest.kt
@@ -1,0 +1,264 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence
+
+import net.transgressoft.lirp.event.LirpErrorContext
+import net.transgressoft.lirp.event.LirpErrorHandler
+import net.transgressoft.lirp.event.LirpOperation
+import net.transgressoft.lirp.event.MutationEvent
+import net.transgressoft.lirp.event.PropertyChanged
+import net.transgressoft.lirp.testing.ReactiveScopeSerialization
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Tests for the [transaction] free function covering the Volatile-like repository path:
+ * commit, rollback, deferred-event collapse, pre-flush failure, nesting, and
+ * [LirpErrorHandler] notify-only semantics.
+ */
+@DisplayName("transaction() core repository contract")
+internal class TransactionTest : StringSpec() {
+
+    init {
+        extension(ReactiveScopeSerialization)
+
+        "transaction commits in-memory mutations and fires collapsed events to subscribers" {
+            val repo = InMemoryAudioItemRepo()
+            val item = repo.create(1, "Bohemian Rhapsody", "A Night at the Opera")
+            val events = mutableListOf<MutationEvent<Int, AudioItem>>()
+            item.subscribe { events.add(it) }
+
+            try {
+                transaction(repo) { r ->
+                    (r.findById(1).get() as MutableAudioItem).title = "Killer Queen"
+                }
+
+                (item as MutableAudioItem).title shouldBe "Killer Queen"
+                events shouldHaveSize 1
+                events.single().shouldBeInstanceOf<PropertyChanged<*, *, *>>()
+            } finally {
+                repo.close()
+            }
+        }
+
+        "transaction rollback on block throw restores in-memory state and discards events" {
+            val repo = InMemoryAudioItemRepo()
+            val item = repo.create(2, "Don't Stop Me Now", "Jazz")
+            val events = mutableListOf<MutationEvent<Int, AudioItem>>()
+            item.subscribe { events.add(it) }
+
+            try {
+                shouldThrow<LirpTransactionException> {
+                    transaction(repo) { r ->
+                        (r.findById(2).get() as MutableAudioItem).title = "mutated-inside"
+                        throw RuntimeException("block failure")
+                    }
+                }
+
+                (item as MutableAudioItem).title shouldBe "Don't Stop Me Now"
+                events.shouldBeEmpty()
+            } finally {
+                repo.close()
+            }
+        }
+
+        "deferred events collapse empty-to-Rock-to-Jazz into a single empty-to-Jazz PropertyChanged" {
+            val repo = InMemoryAudioItemRepo()
+            val item = repo.create(3, "", "")
+            val events = mutableListOf<MutationEvent<Int, AudioItem>>()
+            item.subscribe { events.add(it) }
+
+            try {
+                transaction(repo) { r ->
+                    val e = r.findById(3).get() as MutableAudioItem
+                    e.title = "Rock"
+                    e.title = "Jazz"
+                }
+
+                events shouldHaveSize 1
+                @Suppress("UNCHECKED_CAST")
+                val propertyChanged = events.single() as PropertyChanged<Int, AudioItem, String>
+                propertyChanged.oldValue shouldBe ""
+                propertyChanged.newValue shouldBe "Jazz"
+            } finally {
+                repo.close()
+            }
+        }
+
+        "pre-flush failure aborts before the block runs and throws LirpTransactionException" {
+            var blockExecuted = false
+            val repo = FailingFlushAudioItemRepo()
+            // Stage a pending op so the pre-flush actually attempts to drain.
+            repo.add(MutableAudioItem(1, "pending-item", "") as AudioItem)
+
+            try {
+                shouldThrow<LirpTransactionException> {
+                    transaction(repo) { _ ->
+                        blockExecuted = true
+                    }
+                }
+
+                blockExecuted shouldBe false
+            } finally {
+                try {
+                    repo.close()
+                } catch (_: Exception) {
+                }
+            }
+        }
+
+        "nested transaction on the same repo joins the outer and results in one collapsed commit" {
+            val repo = InMemoryAudioItemRepo()
+            val item = repo.create(4, "We Will Rock You", "News of the World")
+            val events = mutableListOf<MutationEvent<Int, AudioItem>>()
+            item.subscribe { events.add(it) }
+
+            try {
+                transaction(repo) { r ->
+                    (r.findById(4).get() as MutableAudioItem).title = "outer"
+                    transaction(r) { inner ->
+                        (inner.findById(4).get() as MutableAudioItem).title = "inner"
+                    }
+                }
+
+                (item as MutableAudioItem).title shouldBe "inner"
+                // Both mutations collapse to one event (outer title → inner title).
+                events shouldHaveSize 1
+            } finally {
+                repo.close()
+            }
+        }
+
+        "nested transaction on a different repo throws LirpTransactionException immediately" {
+            val repo1 = InMemoryAudioItemRepo()
+            val repo2 = InMemoryAudioItemRepo("InMemoryAudioItems2")
+            repo1.create(5, "Radio Ga Ga", "The Works")
+
+            try {
+                shouldThrow<LirpTransactionException> {
+                    transaction(repo1) { _ ->
+                        transaction(repo2) { _ ->
+                            // unreachable
+                        }
+                    }
+                }
+            } finally {
+                repo1.close()
+                repo2.close()
+            }
+        }
+
+        "LirpErrorHandler fires with operation=TRANSACTION and entity ids but no field values on failure" {
+            val handlerInvocations = CopyOnWriteArrayList<Pair<Throwable, LirpErrorContext>>()
+            val handler = LirpErrorHandler { t, ctx -> handlerInvocations.add(t to ctx) }
+
+            val repo = InMemoryAudioItemRepo("transaction-error-notify-repo", onError = handler)
+            repo.add(MutableAudioItem(6, "Another One Bites the Dust", "The Game") as AudioItem)
+
+            try {
+                shouldThrow<LirpTransactionException> {
+                    transaction(repo) { r ->
+                        (r.findById(6).get() as MutableAudioItem).title = "mutated"
+                        throw RuntimeException("intentional failure")
+                    }
+                }
+
+                handlerInvocations shouldHaveSize 1
+                val (_, ctx) = handlerInvocations.single()
+                ctx.operation shouldBe LirpOperation.TRANSACTION
+                // Carries entity identity only — not field values.
+                ctx.entityIds shouldHaveSize 1
+                ctx.entityIds.first() shouldBe 6
+            } finally {
+                repo.close()
+            }
+        }
+
+        "onError handler suppresses the exception and receives the failure throwable" {
+            var capturedThrowable: Throwable? = null
+            val repo = InMemoryAudioItemRepo()
+            repo.add(MutableAudioItem(7, "Somebody to Love", "A Day at the Races") as AudioItem)
+
+            try {
+                transaction(repo, onError = { capturedThrowable = throwable }) { r ->
+                    (r.findById(7).get() as MutableAudioItem).title = "changed"
+                    throw RuntimeException("handled failure")
+                }
+
+                capturedThrowable?.message shouldBe "handled failure"
+                (repo.findById(7).get() as MutableAudioItem).title shouldBe "Somebody to Love"
+            } finally {
+                repo.close()
+            }
+        }
+    }
+}
+
+/**
+ * Minimal [PersistentRepositoryBase] backed entirely by in-memory state. This is distinct
+ * from [VolatileRepository] — which does NOT extend [PersistentRepositoryBase] — so the
+ * [transaction] free function (which requires a [PersistentRepositoryBase]) can be used.
+ */
+internal class InMemoryAudioItemRepo(
+    name: String = "InMemoryAudioItems",
+    onError: LirpErrorHandler? = null
+) : PersistentRepositoryBase<Int, AudioItem>(name = name, loadOnInit = false, onError = onError) {
+
+    init {
+        load()
+    }
+
+    fun create(id: Int, title: String, albumName: String): AudioItem =
+        MutableAudioItem(id, title, albumName).also { add(it as AudioItem) }
+
+    override fun loadFromStore(): Map<Int, AudioItem> = emptyMap()
+
+    override fun writePending(
+        inserts: List<AudioItem>,
+        updates: List<PendingUpdate<Int, AudioItem>>,
+        deletes: List<Pair<Int, Long?>>,
+        hadClear: Boolean
+    ) = Unit
+}
+
+/**
+ * [PersistentRepositoryBase] subclass that always fails during [writePending].
+ * Used to simulate a pre-flush failure so the transaction block is never reached.
+ */
+internal class FailingFlushAudioItemRepo :
+    PersistentRepositoryBase<Int, AudioItem>(name = "failing-flush-repo", loadOnInit = false) {
+
+    init {
+        load()
+    }
+
+    override fun loadFromStore(): Map<Int, AudioItem> = emptyMap()
+
+    override fun writePending(
+        inserts: List<AudioItem>,
+        updates: List<PendingUpdate<Int, AudioItem>>,
+        deletes: List<Pair<Int, Long?>>,
+        hadClear: Boolean
+    ) = throw RuntimeException("simulated pre-flush failure")
+}

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/TransactionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/TransactionTest.kt
@@ -28,9 +28,13 @@ import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 
 /**
  * Tests for the [transaction] free function covering the Volatile-like repository path:
@@ -208,6 +212,120 @@ internal class TransactionTest : StringSpec() {
 
                 capturedThrowable?.message shouldBe "handled failure"
                 (repo.findById(7).get() as MutableAudioItem).title shouldBe "Somebody to Love"
+            } finally {
+                repo.close()
+            }
+        }
+
+        "entity added inside a failing block is absent from the repo after rollback" {
+            val repo = InMemoryAudioItemRepo()
+            try {
+                shouldThrow<LirpTransactionException> {
+                    transaction(repo) { r ->
+                        r.add(MutableAudioItem(8, "Flash", "The Game") as AudioItem)
+                        throw RuntimeException("block failure")
+                    }
+                }
+
+                // The insert was rolled back — entity must not be present.
+                repo.findById(8).isPresent shouldBe false
+                repo.size() shouldBe 0
+            } finally {
+                repo.close()
+            }
+        }
+
+        "entity removed inside a failing block is re-added to the repo after rollback" {
+            val repo = InMemoryAudioItemRepo()
+            repo.add(MutableAudioItem(9, "Innuendo", "Innuendo") as AudioItem)
+            try {
+                shouldThrow<LirpTransactionException> {
+                    transaction(repo) { r ->
+                        r.remove(r.findById(9).get())
+                        throw RuntimeException("block failure")
+                    }
+                }
+
+                // The delete was rolled back — entity must still be present.
+                repo.findById(9).shouldBePresent { it.title shouldBe "Innuendo" }
+            } finally {
+                repo.close()
+            }
+        }
+
+        "lastDateModified is restored to its pre-block value after a failing block" {
+            val repo = InMemoryAudioItemRepo()
+            val item = repo.create(10, "The Show Must Go On", "Innuendo")
+            val preDateModified = item.lastDateModified
+            try {
+                shouldThrow<LirpTransactionException> {
+                    transaction(repo) { r ->
+                        (r.findById(10).get() as MutableAudioItem).title = "mutated-title"
+                        throw RuntimeException("block failure")
+                    }
+                }
+
+                // lastDateModified must revert to the pre-block value after rollback.
+                item.lastDateModified shouldBe preDateModified
+            } finally {
+                repo.close()
+            }
+        }
+
+        "transaction block that suspends onto a different thread still captures scalar mutations" {
+            // Verifies that _txEventBuffer is propagated across coroutine suspension via
+            // asContextElement: a scalar mutation after a thread switch must still be buffered
+            // (not published directly) and committed in the same transaction.
+            val repo = InMemoryAudioItemRepo()
+            val item = repo.create(11, "Bicycle Race", "Jazz")
+            val events = mutableListOf<MutationEvent<Int, AudioItem>>()
+            item.subscribe { events.add(it) }
+
+            try {
+                transaction(repo) { r ->
+                    // Real suspension that resumes on a worker thread.
+                    withContext(Dispatchers.IO) { yield() }
+                    // Mutation after thread switch — must be buffered, not published.
+                    (r.findById(11).get() as MutableAudioItem).title = "Fat Bottomed Girls"
+                }
+
+                // Exactly one collapsed event fired after commit — none during the block.
+                events shouldHaveSize 1
+                (item as MutableAudioItem).title shouldBe "Fat Bottomed Girls"
+            } finally {
+                repo.close()
+            }
+        }
+
+        "transaction remove-then-add same pre-existing id results in committed UPDATE" {
+            val repo = InMemoryAudioItemRepo()
+            repo.create(20, "Killer Queen", "Sheer Heart Attack")
+            try {
+                transaction(repo) { r ->
+                    val existing = r.findById(20).get()
+                    r.remove(existing)
+                    r.add(MutableAudioItem(20, "Bohemian Rhapsody", "A Night at the Opera") as AudioItem)
+                }
+
+                // After commit: entity present with re-added value (no duplicate-key failure).
+                repo.findById(20).shouldBePresent { it.title shouldBe "Bohemian Rhapsody" }
+                repo.size() shouldBe 1
+            } finally {
+                repo.close()
+            }
+        }
+
+        "transaction add-then-remove same new id is a no-op after commit" {
+            val repo = InMemoryAudioItemRepo()
+            try {
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(21, "Radio Ga Ga", "The Works") as AudioItem)
+                    r.remove(r.findById(21).get())
+                }
+
+                // After commit: entity is absent because insert+delete cancel out.
+                repo.findById(21).isPresent shouldBe false
+                repo.size() shouldBe 0
             } finally {
                 repo.close()
             }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonTransactionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonTransactionTest.kt
@@ -85,6 +85,9 @@ internal class JsonTransactionTest : StringSpec() {
                     }
                 }
                 reactive.advance()
+
+                // Assert while repo is still open so any in-flight debounce write would be observable.
+                jsonFile.readText() shouldBe contentBefore
             } finally {
                 try {
                     freshRepo.close()
@@ -92,7 +95,7 @@ internal class JsonTransactionTest : StringSpec() {
                 }
             }
 
-            // Original file must be identical to the pre-transaction content.
+            // Final check after close confirms file is still intact.
             jsonFile.readText() shouldBe contentBefore
         }
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonTransactionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonTransactionTest.kt
@@ -1,0 +1,151 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.json
+
+import net.transgressoft.lirp.persistence.LirpTransactionException
+import net.transgressoft.lirp.persistence.transaction
+import net.transgressoft.lirp.testing.reactiveScope
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.engine.spec.tempfile
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [JsonFileRepository.commitTransactionBuffer]: verifies that the atomic
+ * temp-file+rename write keeps the original JSON file intact on failure and produces
+ * a valid file on success.
+ *
+ * Tests that need to reload from disk close the first repository before opening the second
+ * to avoid the single-entity-type registration constraint.
+ */
+@DisplayName("JsonFileRepository transaction atomic-commit contract")
+internal class JsonTransactionTest : StringSpec() {
+
+    val reactive = reactiveScope()
+
+    init {
+        "transaction commits to JSON and the file contains the updated entity on reload" {
+            val jsonFile = tempfile("json-tx-commit", ".json").also { it.deleteOnExit() }
+            val repo = StandardCustomerJsonFileRepository(jsonFile)
+            repo.create(1, "Freddie Mercury", "freddie@queen.com")
+            reactive.advance()
+
+            transaction(repo) { r ->
+                (r.findById(1).get() as StandardCustomer).updateName("Brian May")
+            }
+            reactive.advance()
+
+            // Close the first repo (flushes any remaining debounce state) before reloading.
+            repo.close()
+
+            // Reload from file: the committed value must be persisted.
+            val reloaded = StandardCustomerJsonFileRepository(jsonFile)
+            try {
+                reloaded.findById(1).shouldBePresent {
+                    it.name shouldBe "Brian May"
+                }
+            } finally {
+                reloaded.close()
+            }
+        }
+
+        "transaction failure leaves the original JSON file unchanged" {
+            val jsonFile = tempfile("json-tx-rollback", ".json").also { it.deleteOnExit() }
+            val initialRepo = StandardCustomerJsonFileRepository(jsonFile)
+            initialRepo.create(2, "Roger Taylor", "roger@queen.com")
+            reactive.advance()
+            // Force flush to disk by closing.
+            initialRepo.close()
+
+            val contentBefore = jsonFile.readText()
+
+            val freshRepo = StandardCustomerJsonFileRepository(jsonFile)
+            try {
+                shouldThrow<LirpTransactionException> {
+                    transaction(freshRepo) { r ->
+                        (r.findById(2).get() as StandardCustomer).updateName("mutated-before-failure")
+                        throw RuntimeException("injected failure")
+                    }
+                }
+                reactive.advance()
+            } finally {
+                try {
+                    freshRepo.close()
+                } catch (_: Exception) {
+                }
+            }
+
+            // Original file must be identical to the pre-transaction content.
+            jsonFile.readText() shouldBe contentBefore
+        }
+
+        "transaction persists multiple mutations atomically without corruption" {
+            val jsonFile = tempfile("json-tx-multi", ".json").also { it.deleteOnExit() }
+            val repo = StandardCustomerJsonFileRepository(jsonFile)
+            repo.create(10, "John Deacon", "john@queen.com")
+            repo.create(11, "Brian May", "brian@queen.com")
+            reactive.advance()
+
+            transaction(repo) { r ->
+                (r.findById(10).get() as StandardCustomer).updateName("John Deacon — updated")
+                (r.findById(11).get() as StandardCustomer).updateName("Brian May — updated")
+            }
+            reactive.advance()
+
+            repo.close()
+
+            val reloaded = StandardCustomerJsonFileRepository(jsonFile)
+            try {
+                reloaded.findById(10).shouldBePresent { it.name shouldBe "John Deacon — updated" }
+                reloaded.findById(11).shouldBePresent { it.name shouldBe "Brian May — updated" }
+            } finally {
+                reloaded.close()
+            }
+        }
+
+        "transaction rollback on failure reverts in-memory entity to pre-block value" {
+            val jsonFile = tempfile("json-tx-mem-rollback", ".json").also { it.deleteOnExit() }
+            val repo = StandardCustomerJsonFileRepository(jsonFile)
+
+            try {
+                repo.create(20, "Mick Jagger", "mick@stones.com")
+                reactive.advance()
+
+                shouldThrow<LirpTransactionException> {
+                    transaction(repo) { r ->
+                        (r.findById(20).get() as StandardCustomer).updateName("mutated-in-block")
+                        throw RuntimeException("block throws")
+                    }
+                }
+                reactive.advance()
+
+                // In-memory entity reverted.
+                repo.findById(20).shouldBePresent {
+                    it.name shouldBe "Mick Jagger"
+                }
+            } finally {
+                try {
+                    repo.close()
+                } catch (_: Exception) {
+                }
+            }
+        }
+    }
+}

--- a/lirp-sql/api/lirp-sql.api
+++ b/lirp-sql/api/lirp-sql.api
@@ -42,6 +42,7 @@ public class net/transgressoft/lirp/persistence/sql/SqlRepository : net/transgre
 	public fun <init> (Ljavax/sql/DataSource;Lnet/transgressoft/lirp/persistence/sql/SqlTableDef;ZZLnet/transgressoft/lirp/event/LirpErrorHandler;)V
 	public synthetic fun <init> (Ljavax/sql/DataSource;Lnet/transgressoft/lirp/persistence/sql/SqlTableDef;ZZLnet/transgressoft/lirp/event/LirpErrorHandler;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close ()V
+	public fun commitTransactionBuffer (Lnet/transgressoft/lirp/persistence/TransactionBuffer;)V
 	protected fun extractVersion (Lnet/transgressoft/lirp/entity/ReactiveEntity;)Ljava/lang/Long;
 	public final fun installEntityForeignKeys ()V
 	public final fun installJunctionForeignKeys ()V

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlTransactionIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlTransactionIntegrationTest.kt
@@ -219,11 +219,41 @@ internal class SqlTransactionIntegrationTest : FunSpec({
                         } catch (_: Exception) {
                         }
                     }
-                } catch (_: Exception) {
+                } finally {
+                    // Use finally so assertion failures from the inner block are not swallowed.
                     try {
                         repo.close()
                     } catch (_: Exception) {
                     }
+                }
+            }
+        }
+    }
+
+    context("transaction scalar mutation visible from concurrent connection after commit") {
+        withTests(databases) { db ->
+            withDatabaseTest(db, AudioItemSqlTableDef) { dataSource ->
+                val seedRepo = AudioItemSqlRepository(dataSource)
+                seedRepo.add(MutableAudioItem(40, "Don't Stop Me Now", "Jazz"))
+                seedRepo.close()
+
+                val repo = AudioItemSqlRepository(dataSource)
+                try {
+                    transaction(repo) { r ->
+                        (r.findById(40).get() as MutableAudioItem).title = "Committed Title"
+                    }
+
+                    // Read from a concurrent connection (rawTransaction) to prove DB persistence.
+                    val titleFromDb =
+                        rawTransaction(dataSource, AudioItemSqlTableDef) {
+                            selectAll()
+                                .where { audioItemIdColumn() eq 40 }
+                                .singleOrNull()
+                                ?.let { it[audioItemTitleColumn()] }
+                        }
+                    titleFromDb shouldBe "Committed Title"
+                } finally {
+                    repo.close()
                 }
             }
         }

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlTransactionIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlTransactionIntegrationTest.kt
@@ -1,0 +1,265 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.LirpTransactionException
+import net.transgressoft.lirp.persistence.MutableAudioItem
+import net.transgressoft.lirp.persistence.PendingUpdate
+import net.transgressoft.lirp.persistence.TransactionBuffer
+import net.transgressoft.lirp.persistence.TransactionConflictException
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.withDatabaseTest
+import net.transgressoft.lirp.persistence.transaction
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withTests
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import org.junit.jupiter.api.DisplayName
+import kotlin.time.Duration.Companion.seconds
+
+// AudioItem Exposed column accessors
+@Suppress("UNCHECKED_CAST")
+private fun Table.audioItemIdColumn(): Column<Int> = columns.first { it.name == "id" } as Column<Int>
+
+@Suppress("UNCHECKED_CAST")
+private fun Table.audioItemTitleColumn(): Column<String> = columns.first { it.name == "title" } as Column<String>
+
+/**
+ * Multi-dialect integration tests for the transaction commit/rollback contract against real database
+ * engines via Testcontainers.
+ *
+ * The pre-flush step of [transaction] drains pending ops to the store synchronously before the block
+ * runs, providing a consistent baseline. These tests verify that property-mutation rollback leaves
+ * no trace in the database from a concurrent connection, and that the `@Version` conflict detection
+ * throws the correct typed exception against a real database engine.
+ *
+ * `withTests(databases)` covers PostgreSQL, MySQL, MariaDB, SQLite, and H2.
+ */
+@DisplayName("SqlRepository transaction commit/rollback integration")
+internal class SqlTransactionIntegrationTest : FunSpec({
+
+    // Opens a short-lived Exposed transaction against [dataSource] using the table backing
+    // [tableDef], so a "third-party writer" or raw read can operate independently of the repo.
+    fun <T> rawTransaction(
+        dataSource: HikariDataSource,
+        tableDef: SqlTableDef<*>,
+        block: Table.() -> T
+    ): T {
+        val db = Database.connect(dataSource)
+        val exposed = ExposedTableInterpreter().interpret(tableDef)
+        return transaction(db) { exposed.table.block() }
+    }
+
+    // Polls the DB via rawTransaction until the row with [id] appears with at least [minVersion].
+    suspend fun awaitVersionedInDb(
+        dataSource: HikariDataSource,
+        id: Int,
+        minVersion: Long = 0L
+    ) {
+        eventually(10.seconds) {
+            val version =
+                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                    @Suppress("UNCHECKED_CAST")
+                    selectAll()
+                        .where { (columns.first { it.name == "id" } as Column<Int>) eq id }
+                        .singleOrNull()
+                        ?.let { row ->
+                            @Suppress("UNCHECKED_CAST")
+                            row[columns.first { it.name == "version" } as Column<Long>]
+                        }
+                }
+            checkNotNull(version) { "row with id=$id not yet in DB" }
+            require(version >= minVersion) { "version $version < expected $minVersion" }
+        }
+    }
+
+    context("transaction pre-flush — pending insert is committed to DB before the block runs") {
+        withTests(databases) { db ->
+            withDatabaseTest(db, AudioItemSqlTableDef) { dataSource ->
+                val repo = AudioItemSqlRepository(dataSource)
+                try {
+                    // Add before the transaction — the insert is pending in the debounce queue.
+                    repo.add(MutableAudioItem(10, "Bohemian Rhapsody", "A Night at the Opera"))
+
+                    // transaction() drains the pending queue synchronously (pre-flush) before
+                    // the block runs. The DB row is committed as a side effect of the pre-flush.
+                    transaction(repo) { _ -> }
+
+                    // Row is visible from a concurrent connection immediately after transaction().
+                    val title =
+                        rawTransaction(dataSource, AudioItemSqlTableDef) {
+                            selectAll()
+                                .where { audioItemIdColumn() eq 10 }
+                                .singleOrNull()
+                                ?.let { it[audioItemTitleColumn()] }
+                        }
+                    title shouldBe "Bohemian Rhapsody"
+                } finally {
+                    repo.close()
+                }
+            }
+        }
+    }
+
+    context("transaction rollback — failed block leaves the pre-transaction DB row unchanged as seen from a concurrent connection") {
+        withTests(databases) { db ->
+            withDatabaseTest(db, AudioItemSqlTableDef) { dataSource ->
+                // Seed: add the entity and flush synchronously via close().
+                val seedRepo = AudioItemSqlRepository(dataSource)
+                seedRepo.add(MutableAudioItem(20, "We Will Rock You", "News of the World"))
+                seedRepo.close()
+
+                val repo = AudioItemSqlRepository(dataSource)
+                try {
+                    shouldThrow<LirpTransactionException> {
+                        transaction(repo) { r ->
+                            // Mutate an already-loaded entity inside the block.
+                            // The mutation is deferred to the event buffer and never writes to DB.
+                            (r.findById(20).get() as MutableAudioItem).title = "mutated in block"
+                            throw RuntimeException("injected failure — rollback expected")
+                        }
+                    }
+
+                    // In-memory state reverted to pre-block value after rollback.
+                    repo.findById(20).shouldBePresent { it.title shouldBe "We Will Rock You" }
+
+                    // DB row still holds the pre-transaction value — the in-block mutation was
+                    // never written to the DB because property mutations inside a transaction block
+                    // are buffered for event-collapse, not for SQL persistence.
+                    val title =
+                        rawTransaction(dataSource, AudioItemSqlTableDef) {
+                            selectAll()
+                                .where { audioItemIdColumn() eq 20 }
+                                .singleOrNull()
+                                ?.let { it[audioItemTitleColumn()] }
+                        }
+                    title shouldBe "We Will Rock You"
+                } finally {
+                    repo.close()
+                }
+            }
+        }
+    }
+
+    context("transaction @Version conflict on real DB — TransactionConflictException with in-block entity state in ConflictInfo") {
+        withTests(databases) { db ->
+            withDatabaseTest(db, TestVersionedPersonTableDef) { dataSource ->
+                val repo = SqlRepository<Int, TestVersionedPerson>(dataSource, TestVersionedPersonTableDef)
+                try {
+                    val entity = TestVersionedPerson(1).apply { firstName = "Alice" }
+                    repo.add(entity)
+                    // Flush the INSERT synchronously: close the seed repo and reopen.
+                    repo.close()
+
+                    val liveRepo = SqlRepository<Int, TestVersionedPerson>(dataSource, TestVersionedPersonTableDef)
+                    try {
+                        awaitVersionedInDb(dataSource, 1, minVersion = 0L)
+                        val liveEntity = liveRepo.findById(1).get()
+
+                        // Third-party writer bumps the DB row's version. In-memory entity keeps version=0.
+                        rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                            @Suppress("UNCHECKED_CAST")
+                            update({ (columns.first { it.name == "id" } as Column<Int>) eq 1 }) { row ->
+                                @Suppress("UNCHECKED_CAST")
+                                row[columns.first { it.name == "age" } as Column<Int>] = 99
+                                @Suppress("UNCHECKED_CAST")
+                                row[columns.first { it.name == "version" } as Column<Long>] = 1L
+                            }
+                        }
+
+                        // Simulate the in-block mutation without reactive events (mirrors _txEventBuffer
+                        // interception inside a real transaction block).
+                        @Suppress("UNCHECKED_CAST")
+                        (liveEntity as ReactiveEntityBase<Int, TestVersionedPerson>).withEventsDisabled {
+                            liveEntity.firstName = "InBlockValue"
+                        }
+
+                        // Assemble the TransactionBuffer as commitTransactionBuffer expects it.
+                        val buffer = TransactionBuffer(liveRepo)
+                        buffer.updates.add(PendingUpdate(liveEntity, expectedVersion = 0L))
+
+                        val ex =
+                            shouldThrow<TransactionConflictException> {
+                                liveRepo.commitTransactionBuffer(buffer)
+                            }
+
+                        // ConflictInfo.entity carries the value attempted inside the block (pre-rollback).
+                        ex.conflicts.size shouldBe 1
+                        @Suppress("UNCHECKED_CAST")
+                        (ex.conflicts.single().entity as TestVersionedPerson).firstName shouldBe "InBlockValue"
+                    } finally {
+                        try {
+                            liveRepo.close()
+                        } catch (_: Exception) {
+                        }
+                    }
+                } catch (_: Exception) {
+                    try {
+                        repo.close()
+                    } catch (_: Exception) {
+                    }
+                }
+            }
+        }
+    }
+
+    context("transaction onError handler receives block exception and suppresses propagation") {
+        withTests(databases) { db ->
+            withDatabaseTest(db, AudioItemSqlTableDef) { dataSource ->
+                // Seed: add entity and flush synchronously via close().
+                val seedRepo = AudioItemSqlRepository(dataSource)
+                seedRepo.add(MutableAudioItem(30, "Another One Bites the Dust", "The Game"))
+                seedRepo.close()
+
+                val repo = AudioItemSqlRepository(dataSource)
+                try {
+                    var capturedThrowable: Throwable? = null
+
+                    // The onError handler captures the raw block exception and suppresses propagation.
+                    transaction(
+                        repo,
+                        onError = {
+                            capturedThrowable = throwable
+                        }
+                    ) { r ->
+                        (r.findById(30).get() as MutableAudioItem).title = "mutated"
+                        throw RuntimeException("simulated block failure")
+                    }
+
+                    // Raw block exception delivered to onError — no wrapping on the handler path.
+                    capturedThrowable?.message shouldBe "simulated block failure"
+                    // In-memory state is reverted to the pre-block value after rollback.
+                    repo.findById(30).shouldBePresent { it.title shouldBe "Another One Bites the Dust" }
+                } finally {
+                    repo.close()
+                }
+            }
+        }
+    }
+})

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/OptimisticLockRecovery.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/OptimisticLockRecovery.kt
@@ -21,6 +21,7 @@ import net.transgressoft.lirp.entity.ReactiveEntity
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.StandardCrudEvent
+import net.transgressoft.lirp.persistence.ConflictInfo
 import net.transgressoft.lirp.persistence.LirpRawConstructor
 import net.transgressoft.lirp.persistence.LirpRawInitializer
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -120,17 +121,13 @@ internal class OptimisticLockRecovery<K : Comparable<K>, R : ReactiveEntity<K, R
         }
 
     /**
-     * Shared recovery path for a single conflict accumulated during a flush. Re-SELECTs the
-     * canonical row; if missing, emits a deletion-sentinel Conflict and removes the in-memory
-     * entity; otherwise reconciles state and emits Conflict with the canonical version.
+     * Re-SELECTs the canonical row for [id] in a new transaction and returns it along with the
+     * actual version value. Returns `null` for the row when the row no longer exists.
      *
-     * @param id The entity id whose write conflicted.
-     * @param expectedVersion The version the failed operation targeted.
+     * Extracted from [recoverEntityFromConflict] so that both the debounce-flush auto-recovery path
+     * and the transaction-commit [buildConflictInfo] path share the same SELECT-and-reconstruct logic.
      */
-    fun recoverEntityFromConflict(id: K, expectedVersion: Long) {
-        // Defensive: unreachable under normal flow — conflict implies versioned repo.
-        val vc = versionCol
-
+    private fun selectCanonical(id: K): Pair<ResultRow?, Long?> {
         val canonicalRow =
             transaction(db = db) {
                 table.selectAll()
@@ -140,6 +137,50 @@ internal class OptimisticLockRecovery<K : Comparable<K>, R : ReactiveEntity<K, R
                     }
                     .singleOrNull()
             }
+        val actualVersion = canonicalRow?.let { it[versionCol] }
+        return canonicalRow to actualVersion
+    }
+
+    /**
+     * Builds a [ConflictInfo] for a single `@Version` conflict detected during a transaction commit,
+     * without triggering auto-recovery or emitting a [StandardCrudEvent.Conflict].
+     *
+     * Re-SELECTs the canonical row to obtain the authoritative database state at conflict time.
+     * [preRollbackEntity] must be the in-memory entity captured **before** rollback so that
+     * [ConflictInfo.entity] carries the values that were attempted, not the restored pre-block values.
+     *
+     * Returns a [ConflictInfo] where:
+     * - [ConflictInfo.entity] is [preRollbackEntity] — the attempted (pre-rollback) state.
+     * - [ConflictInfo.canonical] is the reconstructed DB entity, or `null` when the row was deleted.
+     * - [ConflictInfo.version] is the actual DB version, or `-1` when the row was deleted.
+     *
+     * @param id the entity id whose write conflicted
+     * @param expectedVersion the version the failed operation targeted
+     * @param preRollbackEntity the in-memory entity with the attempted values, captured before rollback
+     */
+    internal fun buildConflictInfo(id: K, expectedVersion: Long, preRollbackEntity: R): ConflictInfo<K, R> {
+        val (canonicalRow, actualVersion) = selectCanonical(id)
+
+        if (canonicalRow == null) {
+            // Row was concurrently deleted — canonical is null and version signals deletion.
+            return ConflictInfo(entity = preRollbackEntity, canonical = null, version = -1L)
+        }
+
+        val reconstructed = reconstruct(canonicalRow)
+        hydrateJunctions(reconstructed)
+        return ConflictInfo(entity = preRollbackEntity, canonical = reconstructed, version = actualVersion)
+    }
+
+    /**
+     * Shared recovery path for a single conflict accumulated during a flush. Re-SELECTs the
+     * canonical row; if missing, emits a deletion-sentinel Conflict and removes the in-memory
+     * entity; otherwise reconciles state and emits Conflict with the canonical version.
+     *
+     * @param id The entity id whose write conflicted.
+     * @param expectedVersion The version the failed operation targeted.
+     */
+    fun recoverEntityFromConflict(id: K, expectedVersion: Long) {
+        val (canonicalRow, actualVersion) = selectCanonical(id)
 
         // Case 1: row was deleted by a third writer — treat as Conflict with oldEntity == newEntity
         // sentinel and actualVersion = -1L. The in-memory entity is dropped.
@@ -168,7 +209,8 @@ internal class OptimisticLockRecovery<K : Comparable<K>, R : ReactiveEntity<K, R
             return
         }
 
-        val actualVersion = canonicalRow[vc]
+        // canonicalRow is non-null here; actualVersion is the DB version from selectCanonical.
+        val resolvedVersion: Long = actualVersion ?: canonicalRow[versionCol]
         val inMemoryOpt = findById(id)
 
         if (inMemoryOpt.isPresent) {
@@ -189,7 +231,7 @@ internal class OptimisticLockRecovery<K : Comparable<K>, R : ReactiveEntity<K, R
                     oldEntity = oldSnapshot,
                     newEntity = inMemory,
                     expectedVersion = expectedVersion,
-                    actualVersion = actualVersion
+                    actualVersion = resolvedVersion
                 )
             )
         } else {
@@ -212,7 +254,7 @@ internal class OptimisticLockRecovery<K : Comparable<K>, R : ReactiveEntity<K, R
                     oldEntity = reconstructed,
                     newEntity = reconstructed,
                     expectedVersion = expectedVersion,
-                    actualVersion = actualVersion
+                    actualVersion = resolvedVersion
                 )
             )
         }

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
@@ -22,8 +22,14 @@ import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.LirpErrorHandler
 import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.event.StandardCrudEvent
+import net.transgressoft.lirp.persistence.ConflictInfo
+import net.transgressoft.lirp.persistence.LirpContext
+import net.transgressoft.lirp.persistence.LirpTransactionException
 import net.transgressoft.lirp.persistence.PendingUpdate
 import net.transgressoft.lirp.persistence.PersistentRepositoryBase
+import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.TransactionBuffer
+import net.transgressoft.lirp.persistence.TransactionConflictException
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -89,7 +95,7 @@ import javax.sql.DataSource
  *   operations.
  */
 open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
-    private val dataSource: DataSource,
+    internal val dataSource: DataSource,
     private val tableDef: SqlTableDef<R>,
     private val ownsDataSource: Boolean,
     loadOnInit: Boolean = true,
@@ -412,6 +418,147 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
         // dirty forever after the first successful flush even when pendingCells is empty.
         dirty.set(false)
     }
+
+    /**
+     * Commits the captured [buffer] from a `transaction { }` block as a single Exposed DB transaction.
+     *
+     * All inserts, updates, and deletes from the buffer execute in one `transaction(db) { }` call —
+     * a single JDBC connection commit — so either all buffer ops commit or none do. The DB
+     * transaction rolling back on failure is handled by Exposed automatically; the in-memory rollback
+     * is handled by the orchestration layer in `Transactions.kt`.
+     *
+     * `@Version` conflicts accumulated during the transaction are NOT auto-recovered here (that is the
+     * role of [recoverConflicts] for the debounce flush). Instead, the pre-rollback entity state is
+     * captured before the orchestration rolls back in-memory, then a [ConflictInfo] is built for each
+     * conflict using a canonical re-SELECT, and a [TransactionConflictException] is thrown so the
+     * orchestration's failure path catches it and triggers in-memory rollback.
+     *
+     * Before committing, all cascade target repositories reachable from the buffer's entities are
+     * validated: a child [SqlRepository] sharing the same [DataSource] may join the parent transaction;
+     * any other store type (JSON, Volatile) or a different DataSource cannot be made atomic
+     * and causes an immediate [LirpTransactionException] before any commit attempt. Atomicity
+     * of the same-DataSource cascade join is guaranteed because Exposed binds all table operations
+     * within a single `transaction(db = db) { }` to the same underlying JDBC connection.
+     */
+    override fun commitTransactionBuffer(buffer: TransactionBuffer<K, R>) {
+        validateCascadeTargets(buffer)
+
+        val conflicts = mutableListOf<PendingConflict<K>>()
+
+        // Capture entity states now, before the transaction (and any Exposed rollback) touches them.
+        // These are the "attempted" values passed to ConflictInfo.entity — the orchestration's
+        // restoreSnapshot will revert to pre-block state afterward, so we must snapshot here first.
+        val preRollbackSnapshots: Map<K, R> =
+            if (recovery != null) {
+                @Suppress("UNCHECKED_CAST")
+                (buffer.updates.map { it.entity } + buffer.inserts)
+                    .distinctBy { it.id }
+                    .associateBy { it.id }
+            } else {
+                emptyMap()
+            }
+
+        transaction(db = db) {
+            when {
+                buffer.inserts.size > 1 -> writePipeline.executeBatchInsertList(buffer.inserts)
+                buffer.inserts.size == 1 -> writePipeline.executeInsertSingle(buffer.inserts.first())
+            }
+            buffer.updates.forEach { writePipeline.executeUpdate(it, conflicts) }
+            when {
+                buffer.deletes.size > 1 -> writePipeline.executeBatchDeleteList(buffer.deletes, conflicts)
+                buffer.deletes.size == 1 -> writePipeline.executeDeleteSingle(buffer.deletes.first(), conflicts)
+            }
+        }
+
+        // After the transaction commits, convert each conflict to a ConflictInfo via a canonical
+        // re-SELECT. Do NOT call recoverConflicts() — that auto-reloads in-memory state and emits
+        // StandardCrudEvent.Conflict, which is the debounce-flush recovery path, not the transaction path.
+        if (conflicts.isNotEmpty()) {
+            val rec = recovery
+            if (rec != null) {
+                val conflictInfos =
+                    conflicts.map { conflict ->
+                        // Capture the attempted entity before in-memory rollback. Fall back to findById
+                        // if the entity was not in the insert/update snapshot (edge case: delete-only buffer).
+                        val preRollback =
+                            preRollbackSnapshots[conflict.id]
+                                ?: findById(conflict.id).orElseThrow {
+                                    IllegalStateException(
+                                        "Cannot build ConflictInfo: entity ${conflict.id} not found after commit"
+                                    )
+                                }
+                        rec.buildConflictInfo(conflict.id, conflict.expectedVersion, preRollback)
+                    }
+                throw TransactionConflictException(
+                    "Transaction conflict on '${tableDef.tableName}': ${conflictInfos.size} version mismatch(es)",
+                    conflictInfos
+                )
+            }
+        }
+
+        dirty.set(false)
+    }
+
+    /**
+     * Validates that all cascade target repositories reachable from the entities in [buffer] are
+     * either unregistered (no cascade action required) or are [SqlRepository] instances sharing
+     * this repository's [dataSource].
+     *
+     * Sharing the same [DataSource] instance is the criterion for atomicity: Exposed binds all
+     * SQL operations in a single `transaction(db = db) { }` to one JDBC connection, so parent and
+     * child writes commit or roll back together. Comparing [DataSource] reference identity
+     * (`===`) is safe and reliable — `Database.connect(dataSource)` in Exposed 1.3.0 creates a
+     * new [org.jetbrains.exposed.v1.jdbc.Database] wrapper each time rather than caching per
+     * DataSource, so `db ===` would fail even for repos that legitimately share a pool.
+     *
+     * A cascade target on a different DataSource, or a [JsonFileRepository] / `VolatileRepository`,
+     * cannot be made atomic and causes an immediate [LirpTransactionException] before any DB write.
+     */
+    private fun validateCascadeTargets(buffer: TransactionBuffer<K, R>) {
+        val entityClasses: Set<Class<*>> =
+            (buffer.inserts + buffer.updates.map { it.entity } + findDeletedEntitiesById(buffer.deletes))
+                .map { it::class.java }
+                .toSet()
+
+        for (entityClass in entityClasses) {
+            @Suppress("UNCHECKED_CAST")
+            val refAccessor = RegistryBase.publicRefAccessorFor(entityClass) ?: continue
+            val allEntries =
+                refAccessor.entries.map { it.referencedClass } +
+                    refAccessor.collectionEntries.map { it.referencedClass }
+            for (referencedClass in allEntries) {
+                val targetRegistry = LirpContext.default.registryFor(referencedClass) ?: continue
+                when {
+                    targetRegistry is SqlRepository<*, *> && targetRegistry.dataSource === dataSource ->
+                        // Same DataSource — cascade writes join the parent transaction via Exposed's
+                        // single JDBC connection binding; no additional routing required.
+                        Unit
+                    targetRegistry is SqlRepository<*, *> ->
+                        throw LirpTransactionException(
+                            "Transaction on '${tableDef.tableName}' has a cascade target '${referencedClass.simpleName}' " +
+                                "on a different DataSource. Cross-DataSource cascade cannot be made atomic — " +
+                                "use separate transactions for each DataSource."
+                        )
+                    else ->
+                        // Non-SQL store (JsonFileRepository, VolatileRepository, etc.) cannot join
+                        // a SQL transaction — reject before any partial commit.
+                        throw LirpTransactionException(
+                            "Transaction on '${tableDef.tableName}' has a cascade target '${referencedClass.simpleName}' " +
+                                "backed by a non-SQL repository (${targetRegistry::class.simpleName}). " +
+                                "Heterogeneous-store cascade cannot be made atomic in a single transaction."
+                        )
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the entities for delete operations in [deletes] by looking them up in memory.
+     * Used to resolve entity classes for cascade target validation when only (id, version) pairs
+     * are available in the buffer.
+     */
+    private fun findDeletedEntitiesById(deletes: List<Pair<K, Long?>>): List<R> =
+        deletes.mapNotNull { (id, _) -> findById(id).orElse(null) }
 
     /**
      * Recovers every accumulated optimistic-lock conflict after the main transaction has committed.

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
@@ -17,6 +17,7 @@
 
 package net.transgressoft.lirp.persistence.sql
 
+import net.transgressoft.lirp.entity.CascadeAction
 import net.transgressoft.lirp.entity.ReactiveEntity
 import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.LirpErrorHandler
@@ -42,6 +43,8 @@ import org.jetbrains.exposed.v1.jdbc.deleteAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.concurrent.ConcurrentHashMap
 import javax.sql.DataSource
+
+private class ConflictRollbackSignal : Exception()
 
 /**
  * SQL-backed reactive repository using JetBrains Exposed and HikariCP connection pooling.
@@ -451,49 +454,57 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
         val preRollbackSnapshots: Map<K, R> =
             if (recovery != null) {
                 @Suppress("UNCHECKED_CAST")
-                (buffer.updates.map { it.entity } + buffer.inserts)
+                (buffer.updates.map { it.entity } + buffer.inserts + buffer.deletes.map { it.entity })
                     .distinctBy { it.id }
                     .associateBy { it.id }
             } else {
                 emptyMap()
             }
 
-        transaction(db = db) {
-            when {
-                buffer.inserts.size > 1 -> writePipeline.executeBatchInsertList(buffer.inserts)
-                buffer.inserts.size == 1 -> writePipeline.executeInsertSingle(buffer.inserts.first())
-            }
-            buffer.updates.forEach { writePipeline.executeUpdate(it, conflicts) }
-            when {
-                buffer.deletes.size > 1 -> writePipeline.executeBatchDeleteList(buffer.deletes, conflicts)
-                buffer.deletes.size == 1 -> writePipeline.executeDeleteSingle(buffer.deletes.first(), conflicts)
-            }
-        }
+        val bufferDeletePairs: List<Pair<K, Long?>> = buffer.deletes.map { it.id to it.expectedVersion }
 
-        // After the transaction commits, convert each conflict to a ConflictInfo via a canonical
-        // re-SELECT. Do NOT call recoverConflicts() — that auto-reloads in-memory state and emits
-        // StandardCrudEvent.Conflict, which is the debounce-flush recovery path, not the transaction path.
-        if (conflicts.isNotEmpty()) {
-            val rec = recovery
-            if (rec != null) {
-                val conflictInfos =
-                    conflicts.map { conflict ->
-                        // Capture the attempted entity before in-memory rollback. Fall back to findById
-                        // if the entity was not in the insert/update snapshot (edge case: delete-only buffer).
-                        val preRollback =
-                            preRollbackSnapshots[conflict.id]
-                                ?: findById(conflict.id).orElseThrow {
-                                    IllegalStateException(
-                                        "Cannot build ConflictInfo: entity ${conflict.id} not found after commit"
-                                    )
-                                }
-                        rec.buildConflictInfo(conflict.id, conflict.expectedVersion, preRollback)
-                    }
-                throw TransactionConflictException(
-                    "Transaction conflict on '${tableDef.tableName}': ${conflictInfos.size} version mismatch(es)",
-                    conflictInfos
-                )
+        try {
+            transaction(db = db) {
+                when {
+                    buffer.inserts.size > 1 -> writePipeline.executeBatchInsertList(buffer.inserts)
+                    buffer.inserts.size == 1 -> writePipeline.executeInsertSingle(buffer.inserts.first())
+                }
+                buffer.updates.forEach { writePipeline.executeUpdate(it, conflicts) }
+                when {
+                    bufferDeletePairs.size > 1 -> writePipeline.executeBatchDeleteList(bufferDeletePairs, conflicts)
+                    bufferDeletePairs.size == 1 -> writePipeline.executeDeleteSingle(bufferDeletePairs.first(), conflicts)
+                }
+                if (conflicts.isNotEmpty()) throw ConflictRollbackSignal()
             }
+        } catch (signal: ConflictRollbackSignal) {
+            // The Exposed transaction rolled back. Convert each conflict to a ConflictInfo via a
+            // canonical re-SELECT and throw TransactionConflictException so the orchestration layer
+            // triggers in-memory rollback. The signal MUST always result in a thrown exception: if it
+            // were swallowed, the rolled-back DB would be mistaken for a successful commit and memory
+            // would keep the attempted mutations — a silent divergence.
+            val rec =
+                checkNotNull(recovery) {
+                    "Version conflict raised on '${tableDef.tableName}' but optimistic-lock recovery is " +
+                        "disabled — the DB rolled back with no conflict-reporting path. Conflicts are only " +
+                        "accumulated for @Version tables, so reaching here signals a write-pipeline bug."
+                }
+            val conflictInfos =
+                conflicts.map { conflict ->
+                    val preRollback =
+                        preRollbackSnapshots[conflict.id]
+                            ?: findById(conflict.id).orElseThrow {
+                                IllegalStateException(
+                                    "Cannot build ConflictInfo: entity ${conflict.id} not found after rollback"
+                                )
+                            }
+                    @Suppress("UNCHECKED_CAST")
+                    rec.buildConflictInfo(conflict.id, conflict.expectedVersion, preRollback.clone() as R)
+                }
+            throw TransactionConflictException(
+                "Transaction conflict on '${tableDef.tableName}': ${conflictInfos.size} version mismatch(es)",
+                conflictInfos,
+                signal
+            )
         }
 
         dirty.set(false)
@@ -516,7 +527,7 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
      */
     private fun validateCascadeTargets(buffer: TransactionBuffer<K, R>) {
         val entityClasses: Set<Class<*>> =
-            (buffer.inserts + buffer.updates.map { it.entity } + findDeletedEntitiesById(buffer.deletes))
+            (buffer.inserts + buffer.updates.map { it.entity } + buffer.deletes.map { it.entity })
                 .map { it::class.java }
                 .toSet()
 
@@ -524,8 +535,12 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
             @Suppress("UNCHECKED_CAST")
             val refAccessor = RegistryBase.publicRefAccessorFor(entityClass) ?: continue
             val allEntries =
-                refAccessor.entries.map { it.referencedClass } +
-                    refAccessor.collectionEntries.map { it.referencedClass }
+                refAccessor.entries
+                    .filter { it.cascadeAction != CascadeAction.NONE }
+                    .map { it.referencedClass } +
+                    refAccessor.collectionEntries
+                        .filter { it.cascadeAction != CascadeAction.NONE }
+                        .map { it.referencedClass }
             for (referencedClass in allEntries) {
                 val targetRegistry = LirpContext.default.registryFor(referencedClass) ?: continue
                 when {
@@ -551,14 +566,6 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
             }
         }
     }
-
-    /**
-     * Returns the entities for delete operations in [deletes] by looking them up in memory.
-     * Used to resolve entity classes for cascade target validation when only (id, version) pairs
-     * are available in the buffer.
-     */
-    private fun findDeletedEntitiesById(deletes: List<Pair<K, Long?>>): List<R> =
-        deletes.mapNotNull { (id, _) -> findById(id).orElse(null) }
 
     /**
      * Recovers every accumulated optimistic-lock conflict after the main transaction has committed.

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlTransactionTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlTransactionTest.kt
@@ -1,0 +1,373 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.event.MutationEvent
+import net.transgressoft.lirp.event.PropertyChanged
+import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.LirpRegistryInfo
+import net.transgressoft.lirp.persistence.LirpTransactionException
+import net.transgressoft.lirp.persistence.MutableAudioItem
+import net.transgressoft.lirp.persistence.PendingUpdate
+import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.TransactionBuffer
+import net.transgressoft.lirp.persistence.TransactionConflictException
+import net.transgressoft.lirp.persistence.transaction
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import javax.sql.DataSource
+
+/**
+ * H2 unit tests for [SqlRepository.commitTransactionBuffer]: covers the all-or-nothing commit
+ * semantics, in-memory rollback, `@Version` conflict surfacing as [TransactionConflictException],
+ * deferred-event collapse, cascade validation, and the `onError` suppression path.
+ *
+ * Test isolation is achieved by creating a fresh H2 in-memory database per case via
+ * [H2ContainerSupport.buildH2DataSource]. Rows that must exist in DB before the transaction
+ * are written by closing a seed repository (which performs a synchronous final flush).
+ *
+ * **Note on `@Version` conflict and cascade tests:** property mutations inside a `transaction()`
+ * block are intercepted by the entity-level `_txEventBuffer` and routed to `deferredEvents`,
+ * bypassing `publisher.emitAsync()`. Consequently `buffer.updates` is never populated by the
+ * reactive channel path during the block. The conflict-detection and cascade-validation tests
+ * therefore call [SqlRepository.commitTransactionBuffer] directly with a hand-assembled
+ * [TransactionBuffer] that carries a [PendingUpdate] representing the intended mutation, which
+ * is the only reliable way to exercise those code paths at the H2 unit level.
+ */
+@DisplayName("SqlRepository transaction commit contract (H2)")
+internal class SqlTransactionTest : StringSpec() {
+
+    /**
+     * Opens a short-lived Exposed transaction against [dataSource] to simulate a third-party writer
+     * that bumps a row's version independently of the repository's debounce pipeline.
+     */
+    fun <T> rawTransaction(dataSource: HikariDataSource, tableDef: SqlTableDef<*>, block: Table.() -> T): T {
+        val db = Database.connect(dataSource)
+        val exposed = ExposedTableInterpreter().interpret(tableDef)
+        return transaction(db) { exposed.table.block() }
+    }
+
+    init {
+
+        afterEach {
+            // Deregister cascade-test repos from the shared LirpContext so subsequent tests
+            // can re-register fresh instances without hitting the "already registered" check.
+            RegistryBase.deregisterRepository(SqlTestTrack::class.java)
+            RegistryBase.deregisterRepository(MutablePlaylistSql::class.java)
+        }
+
+        "transaction commits mutations to SQL and the row is visible after commit" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            // Seed: add item and flush to DB via close.
+            val seedRepo = AudioItemSqlRepository(dataSource)
+            seedRepo.add(MutableAudioItem(1, "Bohemian Rhapsody", "A Night at the Opera") as AudioItem)
+            seedRepo.close()
+
+            val repo = AudioItemSqlRepository(dataSource)
+            try {
+                transaction(repo) { r ->
+                    (r.findById(1).get() as MutableAudioItem).title = "Killer Queen"
+                }
+
+                repo.findById(1).shouldBePresent { it.title shouldBe "Killer Queen" }
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "transaction rollback restores in-memory state when the block throws" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val seedRepo = AudioItemSqlRepository(dataSource)
+            seedRepo.add(MutableAudioItem(2, "Don't Stop Me Now", "Jazz") as AudioItem)
+            seedRepo.close()
+
+            val repo = AudioItemSqlRepository(dataSource)
+            try {
+                shouldThrow<LirpTransactionException> {
+                    transaction(repo) { r ->
+                        (r.findById(2).get() as MutableAudioItem).title = "mutated"
+                        throw RuntimeException("injected block failure")
+                    }
+                }
+
+                // In-memory state reverted to pre-block value.
+                repo.findById(2).shouldBePresent { it.title shouldBe "Don't Stop Me Now" }
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "commitTransactionBuffer @Version conflict throws TransactionConflictException with in-block entity state in ConflictInfo" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = SqlRepository(dataSource, TestVersionedPersonTableDef)
+            try {
+                val entity = TestVersionedPerson(1).apply { firstName = "Alice" }
+                repo.add(entity)
+                // Flush INSERT to DB synchronously via a no-op transaction (pre-flush step writes the row).
+                transaction(repo) { _ -> }
+
+                // Bump the DB row's version externally. The in-memory entity keeps version=0.
+                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                    @Suppress("UNCHECKED_CAST")
+                    update({ (columns.first { it.name == "id" } as Column<Int>) eq 1 }) { row ->
+                        @Suppress("UNCHECKED_CAST")
+                        row[columns.first { it.name == "age" } as Column<Int>] = 99
+                        @Suppress("UNCHECKED_CAST")
+                        row[columns.first { it.name == "version" } as Column<Long>] = 1L
+                    }
+                }
+
+                // Simulate the in-block mutation: set the entity's firstName to the attempted value
+                // without firing reactive events (those would be deferred inside a real block).
+                @Suppress("UNCHECKED_CAST")
+                (entity as ReactiveEntityBase<Int, TestVersionedPerson>).withEventsDisabled {
+                    entity.firstName = "InBlockValue"
+                }
+
+                // Assemble the TransactionBuffer as commitTransactionBuffer expects it.
+                // expectedVersion=0 matches the entity's current in-memory version (pre-bump).
+                val buffer = TransactionBuffer(repo)
+                buffer.updates.add(PendingUpdate(entity, expectedVersion = 0L))
+
+                val ex =
+                    shouldThrow<TransactionConflictException> {
+                        repo.commitTransactionBuffer(buffer)
+                    }
+
+                // ConflictInfo.entity carries the value attempted inside the block (pre-rollback).
+                ex.conflicts shouldHaveSize 1
+                @Suppress("UNCHECKED_CAST")
+                (ex.conflicts.single().entity as TestVersionedPerson).firstName shouldBe "InBlockValue"
+            } finally {
+                try {
+                    repo.close()
+                } catch (_: Exception) {
+                }
+                dataSource.close()
+            }
+        }
+
+        "transaction onError handler receives the exception and suppresses it" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val seedRepo = AudioItemSqlRepository(dataSource)
+            seedRepo.add(MutableAudioItem(5, "Another One Bites the Dust", "The Game") as AudioItem)
+            seedRepo.close()
+
+            val repo = AudioItemSqlRepository(dataSource)
+            try {
+                var capturedThrowable: Throwable? = null
+
+                // onError suppresses the exception from the block: no exception propagates.
+                transaction(repo, onError = {
+                    capturedThrowable = throwable
+                }) { r ->
+                    (r.findById(5).get() as MutableAudioItem).title = "mutated"
+                    throw RuntimeException("simulated block failure")
+                }
+
+                // The raw block exception is delivered — wrapping into LirpTransactionException
+                // only happens on the no-handler path.
+                capturedThrowable.shouldBeInstanceOf<RuntimeException>()
+                capturedThrowable!!.message shouldBe "simulated block failure"
+                // In-memory state is reverted to the pre-block value after onError fires.
+                repo.findById(5).shouldBePresent { it.title shouldBe "Another One Bites the Dust" }
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "deferred events collapse null-to-Rock-to-Jazz into a single null-to-Jazz PropertyChanged" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val seedRepo = AudioItemSqlRepository(dataSource)
+            seedRepo.add(MutableAudioItem(3, "", "") as AudioItem)
+            seedRepo.close()
+
+            val repo = AudioItemSqlRepository(dataSource)
+            try {
+                val events = mutableListOf<MutationEvent<Int, AudioItem>>()
+                repo.findById(3).get().subscribe { events.add(it) }
+
+                transaction(repo) { r ->
+                    val e = r.findById(3).get() as MutableAudioItem
+                    e.title = "Rock"
+                    e.title = "Jazz"
+                }
+
+                events shouldHaveSize 1
+                @Suppress("UNCHECKED_CAST")
+                val changed = events.single() as PropertyChanged<Int, AudioItem, String>
+                changed.oldValue shouldBe ""
+                changed.newValue shouldBe "Jazz"
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "commitTransactionBuffer with cascade child on same DataSource completes without LirpTransactionException" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            // Named subclasses register entity types in LirpContext so validateCascadeTargets
+            // can resolve the SqlTestTrack target registry.
+            val trackRepo = TxSqlTestTrackRepo(dataSource)
+            val playlistRepo = TxMutablePlaylistRepo(dataSource)
+            try {
+                val playlist = MutablePlaylistSql(1L)
+                playlist.name = "My Playlist"
+                playlistRepo.add(playlist)
+                transaction(playlistRepo) { _ -> }
+
+                // Directly call commitTransactionBuffer with a PendingUpdate for the playlist entity.
+                // validateCascadeTargets sees MutablePlaylistSql → SqlTestTrack (cascade target) →
+                // TxSqlTestTrackRepo uses same dataSource → no exception.
+                @Suppress("UNCHECKED_CAST")
+                (playlist as ReactiveEntityBase<Long, MutablePlaylistSql>).withEventsDisabled {
+                    playlist.name = "Updated Playlist"
+                }
+                val buffer = TransactionBuffer(playlistRepo)
+                buffer.updates.add(PendingUpdate(playlist, expectedVersion = null))
+
+                // No LirpTransactionException because both repos share the same DataSource.
+                playlistRepo.commitTransactionBuffer(buffer)
+
+                playlistRepo.findById(1L).shouldBePresent { it.name shouldBe "Updated Playlist" }
+            } finally {
+                try {
+                    playlistRepo.close()
+                } catch (_: Exception) {
+                }
+                try {
+                    trackRepo.close()
+                } catch (_: Exception) {
+                }
+                dataSource.close()
+            }
+        }
+
+        "commitTransactionBuffer with cascade child on a different DataSource throws LirpTransactionException before any commit" {
+            val dataSourceA = H2ContainerSupport.buildH2DataSource()
+            val dataSourceB = H2ContainerSupport.buildH2DataSource()
+            // Playlist on dataSourceA; track repo registered on dataSourceB → cross-DataSource cascade.
+            val trackRepo = TxSqlTestTrackRepo(dataSourceB)
+            val playlistRepo = TxMutablePlaylistRepo(dataSourceA)
+            try {
+                val playlist = MutablePlaylistSql(2L)
+                playlist.name = "Cross-DS Playlist"
+                playlistRepo.add(playlist)
+                transaction(playlistRepo) { _ -> }
+
+                @Suppress("UNCHECKED_CAST")
+                (playlist as ReactiveEntityBase<Long, MutablePlaylistSql>).withEventsDisabled {
+                    playlist.name = "should-not-commit"
+                }
+                val buffer = TransactionBuffer(playlistRepo)
+                buffer.updates.add(PendingUpdate(playlist, expectedVersion = null))
+
+                // LirpTransactionException because trackRepo uses a different DataSource than playlistRepo.
+                shouldThrow<LirpTransactionException> {
+                    playlistRepo.commitTransactionBuffer(buffer)
+                }
+            } finally {
+                try {
+                    playlistRepo.close()
+                } catch (_: Exception) {
+                }
+                try {
+                    trackRepo.close()
+                } catch (_: Exception) {
+                }
+                dataSourceA.close()
+                dataSourceB.close()
+            }
+        }
+
+        "transaction rollback discards buffered events and they are never delivered to subscribers" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val seedRepo = AudioItemSqlRepository(dataSource)
+            seedRepo.add(MutableAudioItem(4, "Radio Ga Ga", "The Works") as AudioItem)
+            seedRepo.close()
+
+            val repo = AudioItemSqlRepository(dataSource)
+            try {
+                val events = mutableListOf<MutationEvent<Int, AudioItem>>()
+                repo.findById(4).get().subscribe { events.add(it) }
+
+                shouldThrow<LirpTransactionException> {
+                    transaction(repo) { r ->
+                        (r.findById(4).get() as MutableAudioItem).title = "changed"
+                        throw RuntimeException("abort")
+                    }
+                }
+
+                events.shouldBeEmpty()
+                repo.findById(4).shouldBePresent { it.title shouldBe "Radio Ga Ga" }
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+    }
+}
+
+/**
+ * Named [SqlRepository] subclass for [SqlTestTrack] accepting an existing [DataSource].
+ *
+ * A named subclass is required so that [RegistryBase] can find the corresponding
+ * `_LirpRegistryInfo` companion by convention and register [SqlTestTrack] in
+ * [net.transgressoft.lirp.persistence.LirpContext]. Anonymous `SqlRepository<Int, SqlTestTrack>`
+ * instances have no `_LirpRegistryInfo` and are not registered, causing
+ * [SqlRepository.commitTransactionBuffer]'s cascade-datasource check to be silently skipped.
+ */
+internal class TxSqlTestTrackRepo(dataSource: DataSource) :
+    SqlRepository<Int, SqlTestTrack>(dataSource, SqlTestTrackTableDef)
+
+@Suppress("ClassName")
+internal class `TxSqlTestTrackRepo_LirpRegistryInfo` : LirpRegistryInfo {
+    override val entityClass: Class<*> = SqlTestTrack::class.java
+}
+
+/**
+ * Named [SqlRepository] subclass for [MutablePlaylistSql] accepting an existing [DataSource].
+ *
+ * Same rationale as [TxSqlTestTrackRepo]: requires a named subclass so [LirpContext] registers
+ * [MutablePlaylistSql] and the KSP-generated [MutablePlaylistSql_LirpRefAccessor] is reachable
+ * via [RegistryBase.publicRefAccessorFor].
+ */
+internal class TxMutablePlaylistRepo(dataSource: DataSource) :
+    SqlRepository<Long, MutablePlaylistSql>(dataSource, MutablePlaylistSqlTableDef)
+
+@Suppress("ClassName")
+internal class `TxMutablePlaylistRepo_LirpRegistryInfo` : LirpRegistryInfo {
+    override val entityClass: Class<*> = MutablePlaylistSql::class.java
+}

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlTransactionTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlTransactionTest.kt
@@ -24,6 +24,7 @@ import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.LirpRegistryInfo
 import net.transgressoft.lirp.persistence.LirpTransactionException
 import net.transgressoft.lirp.persistence.MutableAudioItem
+import net.transgressoft.lirp.persistence.PendingDelete
 import net.transgressoft.lirp.persistence.PendingUpdate
 import net.transgressoft.lirp.persistence.RegistryBase
 import net.transgressoft.lirp.persistence.TransactionBuffer
@@ -42,9 +43,16 @@ import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import javax.sql.DataSource
+
+@Suppress("UNCHECKED_CAST")
+private fun Table.audioItemIdColumn(): Column<Int> = columns.first { it.name == "id" } as Column<Int>
+
+@Suppress("UNCHECKED_CAST")
+private fun Table.audioItemTitleColumn(): Column<String> = columns.first { it.name == "title" } as Column<String>
 
 /**
  * H2 unit tests for [SqlRepository.commitTransactionBuffer]: covers the all-or-nothing commit
@@ -98,9 +106,143 @@ internal class SqlTransactionTest : StringSpec() {
                     (r.findById(1).get() as MutableAudioItem).title = "Killer Queen"
                 }
 
+                // In-memory assertion.
                 repo.findById(1).shouldBePresent { it.title shouldBe "Killer Queen" }
+
+                // DB-level assertion via rawTransaction (bypasses the in-memory cache).
+                val titleInDb =
+                    rawTransaction(dataSource, AudioItemSqlTableDef) {
+                        selectAll()
+                            .where { audioItemIdColumn() eq 1 }
+                            .singleOrNull()
+                            ?.let { it[audioItemTitleColumn()] }
+                    }
+                titleInDb shouldBe "Killer Queen"
             } finally {
                 repo.close()
+                dataSource.close()
+            }
+        }
+
+        "transaction insert inside block is persisted to DB and visible via raw query" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = AudioItemSqlRepository(dataSource)
+            try {
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(50, "Somebody to Love", "A Day at the Races") as AudioItem)
+                }
+
+                // In-memory: inserted entity is present.
+                repo.findById(50).shouldBePresent { it.title shouldBe "Somebody to Love" }
+
+                // DB-level: raw query confirms the row was committed.
+                val titleInDb =
+                    rawTransaction(dataSource, AudioItemSqlTableDef) {
+                        selectAll()
+                            .where { audioItemIdColumn() eq 50 }
+                            .singleOrNull()
+                            ?.let { it[audioItemTitleColumn()] }
+                    }
+                titleInDb shouldBe "Somebody to Love"
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "transaction delete inside block is persisted to DB and row absent from raw query" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val seedRepo = AudioItemSqlRepository(dataSource)
+            seedRepo.add(MutableAudioItem(51, "We Are the Champions", "News of the World") as AudioItem)
+            seedRepo.close()
+
+            val repo = AudioItemSqlRepository(dataSource)
+            try {
+                transaction(repo) { r ->
+                    r.remove(r.findById(51).get())
+                }
+
+                // In-memory: entity removed.
+                repo.findById(51).isPresent shouldBe false
+
+                // DB-level: raw query confirms the row is gone.
+                val rowInDb =
+                    rawTransaction(dataSource, AudioItemSqlTableDef) {
+                        selectAll()
+                            .where { audioItemIdColumn() eq 51 }
+                            .singleOrNull()
+                    }
+                rowInDb shouldBe null
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "commitTransactionBuffer @Version conflict rolls back ALL DB ops atomically — sibling write absent from DB" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            // Seed two versioned persons: one will conflict, one is a sibling write in the same buffer.
+            val seedRepo = SqlRepository<Int, TestVersionedPerson>(dataSource, TestVersionedPersonTableDef)
+            val alice = TestVersionedPerson(10).apply { firstName = "Alice" }
+            val bob = TestVersionedPerson(11).apply { firstName = "Bob" }
+            seedRepo.add(alice)
+            seedRepo.add(bob)
+            // Flush both to DB synchronously.
+            transaction(seedRepo) { _ -> }
+            seedRepo.close()
+
+            val repo = SqlRepository<Int, TestVersionedPerson>(dataSource, TestVersionedPersonTableDef)
+            try {
+                // Third-party writer bumps Alice's DB version to 1. The in-memory entity keeps version=0.
+                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                    @Suppress("UNCHECKED_CAST")
+                    update({ (columns.first { it.name == "id" } as Column<Int>) eq 10 }) { row ->
+                        @Suppress("UNCHECKED_CAST")
+                        row[columns.first { it.name == "version" } as Column<Long>] = 1L
+                    }
+                }
+
+                val liveAlice = repo.findById(10).get()
+                val liveBob = repo.findById(11).get()
+
+                // Assemble a buffer: Alice (will conflict at version=0) and Bob (clean sibling write).
+                @Suppress("UNCHECKED_CAST")
+                (liveAlice as ReactiveEntityBase<Int, TestVersionedPerson>).withEventsDisabled {
+                    liveAlice.firstName = "AliceAttempted"
+                }
+                @Suppress("UNCHECKED_CAST")
+                (liveBob as ReactiveEntityBase<Int, TestVersionedPerson>).withEventsDisabled {
+                    liveBob.firstName = "BobAttempted"
+                }
+                val buffer = TransactionBuffer(repo)
+                buffer.updates.add(PendingUpdate(liveAlice, expectedVersion = 0L))
+                buffer.updates.add(PendingUpdate(liveBob, expectedVersion = 0L))
+
+                shouldThrow<TransactionConflictException> {
+                    repo.commitTransactionBuffer(buffer)
+                }
+
+                // DB-level: the sibling Bob write must NOT be in the DB (full rollback required).
+                val exposedTable = ExposedTableInterpreter().interpret(TestVersionedPersonTableDef)
+                val db = Database.connect(dataSource)
+                val bobFirstNameInDb =
+                    transaction(db) {
+                        exposedTable.table
+                            .selectAll()
+                            .where { (exposedTable.table.columns.first { it.name == "id" } as Column<Int>) eq 11 }
+                            .singleOrNull()
+                            ?.let { row ->
+                                @Suppress("UNCHECKED_CAST")
+                                row[exposedTable.table.columns.first { it.name == "first_name" } as Column<String>]
+                            }
+                    }
+                // Bob's DB row must remain "Bob" — the entire DB transaction was rolled back.
+                bobFirstNameInDb shouldBe "Bob"
+            } finally {
+                try {
+                    repo.close()
+                } catch (_: Exception) {
+                }
                 dataSource.close()
             }
         }
@@ -275,10 +417,12 @@ internal class SqlTransactionTest : StringSpec() {
             }
         }
 
-        "commitTransactionBuffer with cascade child on a different DataSource throws LirpTransactionException before any commit" {
+        "commitTransactionBuffer with cascade child on a different DataSource but CascadeAction.NONE completes without LirpTransactionException" {
             val dataSourceA = H2ContainerSupport.buildH2DataSource()
             val dataSourceB = H2ContainerSupport.buildH2DataSource()
-            // Playlist on dataSourceA; track repo registered on dataSourceB → cross-DataSource cascade.
+            // Playlist on dataSourceA; track repo registered on dataSourceB.
+            // MutablePlaylistSql.tracks has CascadeAction.NONE, so the different DataSource is ignored
+            // and the transaction proceeds normally.
             val trackRepo = TxSqlTestTrackRepo(dataSourceB)
             val playlistRepo = TxMutablePlaylistRepo(dataSourceA)
             try {
@@ -289,15 +433,15 @@ internal class SqlTransactionTest : StringSpec() {
 
                 @Suppress("UNCHECKED_CAST")
                 (playlist as ReactiveEntityBase<Long, MutablePlaylistSql>).withEventsDisabled {
-                    playlist.name = "should-not-commit"
+                    playlist.name = "should-commit"
                 }
                 val buffer = TransactionBuffer(playlistRepo)
                 buffer.updates.add(PendingUpdate(playlist, expectedVersion = null))
 
-                // LirpTransactionException because trackRepo uses a different DataSource than playlistRepo.
-                shouldThrow<LirpTransactionException> {
-                    playlistRepo.commitTransactionBuffer(buffer)
-                }
+                // No LirpTransactionException: CascadeAction.NONE means validation skips the cross-DS target.
+                playlistRepo.commitTransactionBuffer(buffer)
+
+                playlistRepo.findById(2L).shouldBePresent { it.name shouldBe "should-commit" }
             } finally {
                 try {
                     playlistRepo.close()
@@ -332,6 +476,104 @@ internal class SqlTransactionTest : StringSpec() {
 
                 events.shouldBeEmpty()
                 repo.findById(4).shouldBePresent { it.title shouldBe "Radio Ga Ga" }
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "delete-only @Version conflict surfaces as TransactionConflictException, not IllegalStateException" {
+            // Verifies that preRollbackSnapshots covers buffer.deletes so a delete-only
+            // version conflict can build ConflictInfo without a findById() fallback that
+            // would throw IllegalStateException on a row that no longer exists in DB.
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = SqlRepository<Int, TestVersionedPerson>(dataSource, TestVersionedPersonTableDef)
+            try {
+                val entity = TestVersionedPerson(99).apply { firstName = "George" }
+                repo.add(entity)
+                // Flush INSERT to DB via a no-op transaction (pre-flush writes the row).
+                transaction(repo) { _ -> }
+
+                // Bump the DB row's version externally. In-memory entity keeps version=0.
+                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                    @Suppress("UNCHECKED_CAST")
+                    update({ (columns.first { it.name == "id" } as Column<Int>) eq 99 }) { row ->
+                        @Suppress("UNCHECKED_CAST")
+                        row[columns.first { it.name == "version" } as Column<Long>] = 1L
+                    }
+                }
+
+                // Assemble a buffer with only a delete — no updates, no inserts. The conflict snapshot
+                // is built from buffer.deletes (which carries the entity), so no entitySnapshots seed
+                // is needed for the delete-only path.
+                val buffer = TransactionBuffer(repo)
+                buffer.deletes.add(
+                    net.transgressoft.lirp.persistence.PendingDelete(entity.id, entity, expectedVersion = 0L)
+                )
+
+                // Must throw TransactionConflictException, not IllegalStateException.
+                val ex =
+                    shouldThrow<TransactionConflictException> {
+                        repo.commitTransactionBuffer(buffer)
+                    }
+                ex.conflicts shouldHaveSize 1
+            } finally {
+                try {
+                    repo.close()
+                } catch (_: Exception) {
+                }
+                dataSource.close()
+            }
+        }
+
+        "transaction remove-then-add same pre-existing versioned id updates the row without duplicate-key failure" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val seedRepo = AudioItemSqlRepository(dataSource)
+            seedRepo.add(MutableAudioItem(60, "Killer Queen", "Sheer Heart Attack") as AudioItem)
+            seedRepo.close()
+
+            val repo = AudioItemSqlRepository(dataSource)
+            try {
+                transaction(repo) { r ->
+                    val existing = r.findById(60).get()
+                    r.remove(existing)
+                    r.add(MutableAudioItem(60, "Bohemian Rhapsody", "A Night at the Opera") as AudioItem)
+                }
+
+                // In-memory: re-added value present.
+                repo.findById(60).shouldBePresent { it.title shouldBe "Bohemian Rhapsody" }
+
+                // DB-level: exactly one row with the updated title.
+                val titleInDb =
+                    rawTransaction(dataSource, AudioItemSqlTableDef) {
+                        selectAll().where { audioItemIdColumn() eq 60 }.singleOrNull()
+                            ?.let { it[audioItemTitleColumn()] }
+                    }
+                titleInDb shouldBe "Bohemian Rhapsody"
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "transaction add-then-remove same new id is a no-op — row absent from DB after commit" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = AudioItemSqlRepository(dataSource)
+            try {
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(61, "We Will Rock You", "News of the World") as AudioItem)
+                    r.remove(r.findById(61).get())
+                }
+
+                // In-memory: no entity.
+                repo.findById(61).isPresent shouldBe false
+
+                // DB-level: no row written.
+                val rowInDb =
+                    rawTransaction(dataSource, AudioItemSqlTableDef) {
+                        selectAll().where { audioItemIdColumn() eq 61 }.singleOrNull()
+                    }
+                rowInDb shouldBe null
             } finally {
                 repo.close()
                 dataSource.close()


### PR DESCRIPTION
## Summary

Adds an explicit `transaction { }` atomic boundary to LIRP. By default LIRP persists through a debounced, asynchronous write pipeline; this introduces a way to group a set of mutations so they commit together or not at all, rolling back **both** the database transaction **and** in-memory entity state on failure (including `@Version` conflicts).

```kotlin
transaction(orderRepo) { repo ->
    val order = repo.findById(42).get()
    order.status = "SHIPPED"
    order.total = BigDecimal("99.00")
}
// Committed atomically; one collapsed update event per changed property is
// released to subscribers only after the commit succeeds.
```

This is useful on its own for cross-aggregate / Unit-of-Work atomicity, and lays the groundwork for a future transactional outbox.

## What changed

**`lirp-api`** — new public contracts: `LirpTransactionException` / `TransactionConflictException`, the `ConflictInfo<K, R>` conflict-detail carrier, and an additive `LirpOperation.TRANSACTION` discriminator.

**`lirp-core`**
- Entity-layer snapshot/restore (`captureSnapshot` / `restoreSnapshot`) and deferred-event buffering on `ReactiveEntityBase`.
- `TransactionBuffer` op/snapshot/deferred-event container with first-old/last-new event collapse.
- `PersistentRepositoryBase`: lock-held pre-flush drain helper, per-repo nesting/enrollment state, enqueue interception, and an open `commitTransactionBuffer` hook (no-op for in-memory repositories).
- Public `suspend fun transaction(repo, onError, block)`: cancels the debounce, holds the flush lock across the block, installs snapshots + event buffer, then commits-or-rolls-back with deferred-event release and `onError`/typed-exception control flow. `TransactionErrorContext` receiver type.
- `JsonFileRepository` durable atomic commit via temp-file write + `Files.move(ATOMIC_MOVE, REPLACE_EXISTING)`.

**`lirp-sql`** — `SqlRepository.commitTransactionBuffer` commits the captured buffer in one Exposed transaction; `@Version` conflicts surface as `TransactionConflictException` carrying `ConflictInfo` (with the in-block attempted value). Child repositories sharing the same `DataSource` join the parent transaction; heterogeneous-store or different-`DataSource` cascades fail fast before any commit.

## Error handling

- With an `onError` handler: it runs after rollback and no exception propagates.
- Without it: `LirpTransactionException` (or `TransactionConflictException` for `@Version` conflicts) is thrown after in-memory rollback completes.
- A nested `transaction` on the same repository flattens into the outer one; on a different repository it throws.

## Testing

- Full transaction contract covered across `VolatileRepository`, `JsonFileRepository`, and `SqlRepository` — commit, rollback, event collapse, `@Version` conflict, cascade join / fail-fast, and nesting.
- Real-database atomicity and cross-connection rollback visibility verified via Testcontainers across PostgreSQL, MySQL, and MariaDB.
- Full build green (all modules compile, binary-compatibility check clean); aggregate coverage line 88.13% / branch 73.31% (above the prior baseline).

## Compatibility

Additive only — no breaking changes. `LirpOperation.TRANSACTION` is appended to the enum (binary-compatible) and the new types are net-new public API. Existing repositories and the debounce pipeline are unchanged.

Documentation: see the updated [Transactional Boundaries](https://github.com/octaviospain/lirp/wiki/Transactional-Boundaries) wiki page.

Closes #284
