### PR TITLE
Honor includeDeleted()/onlyDeleted() in cross-aggregate via() queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,27 @@ See [Migration from 3.0.0 to 3.1.0](#migration-from-300-to-310) for upgrade step
 
   See [#283](https://github.com/octaviospain/lirp/issues/283).
 
+- **Soft-delete visibility through cross-aggregate `via()` queries** — the `includeDeleted()` /
+  `onlyDeleted()` Query DSL visibility flags are now honored for cross-aggregate `via()` queries,
+  not just direct predicates. A single visibility mode defines one visible set that is applied to
+  **both** parent enumeration and child resolution (strict mirror), across all four via operators
+  (`anyMatch` / `allMatch` / `noneMatch` / `where`) and multi-`via` compounds combined with
+  `and` / `or` / `not`. Under `onlyDeleted()`, an `allMatch` / `noneMatch` over a parent with no
+  soft-deleted children matches vacuously (`true`), mirroring Kotlin stdlib semantics.
+
+  ```kotlin
+  // Soft-deleted playlists that reference a soft-deleted track priced over 100.
+  val deletedHits = playlists.query {
+      onlyDeleted()
+      where { Playlist::trackIds via tracks anyMatch { Track::price gt 100.0 } }
+  }.toList()
+  ```
+
+  The default (no-flag) `via()` path is unchanged and remains active-only. This removes the
+  temporary fail-fast guard that previously threw `IllegalStateException` when a `via()` query
+  was combined with a visibility flag — that combination is now fully supported.
+  See [#294](https://github.com/octaviospain/lirp/issues/294).
+
 ### Changed
 
 - **`ViaStrategy` moved from `lirp-core` to `lirp-api`** — the enum class

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
@@ -506,7 +506,7 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
             val overlapping = insertIds intersect deleteIds
             if (overlapping.isEmpty()) return
 
-            val preExistingIds = buffer.entitySnapshots.keys
+            val preExistingIds = buffer.entitySnapshots.keys.toSet()
 
             for (id in overlapping) {
                 val insertedEntity = buffer.inserts.firstOrNull { it.id == id } ?: continue

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/RegistryBase.kt
@@ -602,42 +602,44 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
      *
      * @throws IllegalStateException if a RESTRICT child is still active
      */
-    @Suppress("UNCHECKED_CAST")
     protected fun validateRestrictForSoftDelete(entity: T) {
-        val entries = refEntries
-        val collEntries = collectionRefEntries
-        if (entries != null) {
-            for (entry in entries) {
-                if (entry.cascadeAction != net.transgressoft.lirp.entity.CascadeAction.RESTRICT) continue
-                val delegate = entry.delegateGetter(entity)
-                val delegate2 = delegate as? AggregateRefDelegate<*, *> ?: continue
+        refEntries?.let { validateScalarRestrictForSoftDelete(entity, it) }
+        collectionRefEntries?.let { validateCollectionRestrictForSoftDelete(entity, it) }
+    }
 
-                @Suppress("UNCHECKED_CAST")
-                val typedDelegate = delegate2 as AggregateRefDelegate<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>
-                // Use rawIterator to look up the child — bypasses the default-exclude soft-delete
-                // filter so a previously-soft-deleted child is visible (and thus allowed by RESTRICT).
-                val boundReg = typedDelegate.boundRegistryInternal() as? RegistryBase<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>
-                val refId = runCatching { typedDelegate.referenceId }.getOrNull()
-                val child = if (boundReg != null && refId != null) boundReg.rawIterator().asSequence().firstOrNull { it.id == refId } else null
-                check(child == null || (child as? SoftDeletable)?.deletedAt != null) {
-                    "Cannot soft-delete '${entity.uniqueId}': referenced scalar child is still active (deletedAt is null)"
-                }
+    /** A RESTRICT-referenced child permits the parent's soft-delete only when it is absent or itself already soft-deleted. */
+    private fun Any?.isInactiveOrAbsent(): Boolean =
+        this == null || (this as? SoftDeletable)?.deletedAt != null
+
+    /** Scalar-reference RESTRICT pass for [validateRestrictForSoftDelete]: a still-active scalar child blocks soft-delete. */
+    @Suppress("UNCHECKED_CAST")
+    private fun validateScalarRestrictForSoftDelete(entity: T, entries: List<RefEntry<*, T>>) {
+        for (entry in entries) {
+            if (entry.cascadeAction != net.transgressoft.lirp.entity.CascadeAction.RESTRICT) continue
+            val typedDelegate =
+                entry.delegateGetter(entity) as AggregateRefDelegate<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>
+            // Use rawIterator to look up the child — bypasses the default-exclude soft-delete
+            // filter so a previously-soft-deleted child is visible (and thus allowed by RESTRICT).
+            val boundReg = typedDelegate.boundRegistryInternal() as? RegistryBase<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>
+            val refId = runCatching { typedDelegate.referenceId }.getOrNull()
+            val child = if (boundReg != null && refId != null) boundReg.rawIterator().asSequence().firstOrNull { it.id == refId } else null
+            check(child.isInactiveOrAbsent()) {
+                "Cannot soft-delete '${entity.uniqueId}': referenced scalar child is still active (deletedAt is null)"
             }
         }
-        if (collEntries != null) {
-            for (entry in collEntries) {
-                if (entry.cascadeAction != net.transgressoft.lirp.entity.CascadeAction.RESTRICT) continue
-                val delegate = entry.delegateGetter(entity)
-                val inner = unwrapCollectionDelegate(delegate) ?: continue
-                val repo = inner.boundRegistryInternal() ?: continue
-                val ids = inner.referenceIds.toSet()
-                for (id in ids) {
-                    val child =
-                        (repo as Registry<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>)
-                            .findById(id as Comparable<Any>).orElse(null)
-                    check(child == null || (child as? SoftDeletable)?.deletedAt != null) {
-                        "Cannot soft-delete '${entity.uniqueId}': referenced child (id=$id) is still active (deletedAt is null)"
-                    }
+    }
+
+    /** Collection-reference RESTRICT pass for [validateRestrictForSoftDelete]: any still-active member blocks soft-delete. */
+    @Suppress("UNCHECKED_CAST")
+    private fun validateCollectionRestrictForSoftDelete(entity: T, collEntries: List<CollectionRefEntry<*, T>>) {
+        for (entry in collEntries) {
+            if (entry.cascadeAction != net.transgressoft.lirp.entity.CascadeAction.RESTRICT) continue
+            val inner = unwrapCollectionDelegate(entry.delegateGetter(entity)) ?: continue
+            val repo = inner.boundRegistryInternal() as? Registry<Comparable<Any>, IdentifiableEntity<Comparable<Any>>> ?: continue
+            for (id in inner.referenceIds.toSet()) {
+                val child = repo.findById(id as Comparable<Any>).orElse(null)
+                check(child.isInactiveOrAbsent()) {
+                    "Cannot soft-delete '${entity.uniqueId}': referenced child (id=$id) is still active (deletedAt is null)"
                 }
             }
         }
@@ -663,7 +665,6 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
      * an [IllegalStateException] is thrown immediately. The set is cleared after the top-level
      * cascade entry point returns.
      */
-    @Suppress("UNCHECKED_CAST")
     protected fun executeSoftCascadeForEntity(entity: T) {
         val entries = refEntries
         val collEntries = collectionRefEntries
@@ -676,40 +677,41 @@ abstract class RegistryBase<K, T : IdentifiableEntity<K>> internal constructor(
                 "Cascade cycle detected: entity '${entity.uniqueId}' is already being cascaded on this thread"
             }
             // CASCADE mutation pass only — RESTRICT was already checked before the parent was mutated.
-            if (entries != null) {
-                for (entry in entries) {
-                    if (entry.cascadeAction != net.transgressoft.lirp.entity.CascadeAction.CASCADE) continue
-                    val delegate = entry.delegateGetter(entity)
-                    val delegate2 = delegate as? AggregateRefDelegate<*, *> ?: continue
-
-                    @Suppress("UNCHECKED_CAST")
-                    val typedDelegate = delegate2 as AggregateRefDelegate<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>
-                    val repo = typedDelegate.boundRegistryInternal() as? Repository<Comparable<Any>, IdentifiableEntity<Comparable<Any>>> ?: continue
-                    val child = typedDelegate.resolve().orElse(null) ?: continue
-                    check(repo.softDelete(child) || isSoftDeleted(child)) {
-                        "Cannot cascade soft-delete '${entity.uniqueId}': referenced child '${child.uniqueId}' was not soft-deleted"
-                    }
-                }
-            }
-            if (collEntries != null) {
-                for (entry in collEntries) {
-                    if (entry.cascadeAction != net.transgressoft.lirp.entity.CascadeAction.CASCADE) continue
-                    val delegate = entry.delegateGetter(entity)
-                    val inner = unwrapCollectionDelegate(delegate) ?: continue
-                    val repo = inner.boundRegistryInternal() ?: continue
-                    if (repo !is Repository<*, *>) continue
-                    val typedRepo = repo as Repository<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>
-                    val ids = inner.referenceIds.toSet()
-                    for (id in ids) {
-                        val child = typedRepo.findById(id as Comparable<Any>).orElse(null) ?: continue
-                        check(typedRepo.softDelete(child) || isSoftDeleted(child)) {
-                            "Cannot cascade soft-delete '${entity.uniqueId}': referenced child '${child.uniqueId}' was not soft-deleted"
-                        }
-                    }
-                }
-            }
+            entries?.let { softCascadeScalarRefs(entity, it) }
+            collEntries?.let { softCascadeCollectionRefs(entity, it) }
         } finally {
             if (isTopLevel) visited.clear()
+        }
+    }
+
+    /** Scalar-reference CASCADE pass for [executeSoftCascadeForEntity]: soft-deletes each referenced child. */
+    @Suppress("UNCHECKED_CAST")
+    private fun softCascadeScalarRefs(entity: T, entries: List<RefEntry<*, T>>) {
+        for (entry in entries) {
+            if (entry.cascadeAction != net.transgressoft.lirp.entity.CascadeAction.CASCADE) continue
+            val typedDelegate =
+                entry.delegateGetter(entity) as AggregateRefDelegate<Comparable<Any>, IdentifiableEntity<Comparable<Any>>>
+            val repo = typedDelegate.boundRegistryInternal() as? Repository<Comparable<Any>, IdentifiableEntity<Comparable<Any>>> ?: continue
+            val child = typedDelegate.resolve().orElse(null) ?: continue
+            check(repo.softDelete(child) || isSoftDeleted(child)) {
+                "Cannot cascade soft-delete '${entity.uniqueId}': referenced child '${child.uniqueId}' was not soft-deleted"
+            }
+        }
+    }
+
+    /** Collection-reference CASCADE pass for [executeSoftCascadeForEntity]: soft-deletes every referenced member. */
+    @Suppress("UNCHECKED_CAST")
+    private fun softCascadeCollectionRefs(entity: T, collEntries: List<CollectionRefEntry<*, T>>) {
+        for (entry in collEntries) {
+            if (entry.cascadeAction != net.transgressoft.lirp.entity.CascadeAction.CASCADE) continue
+            val inner = unwrapCollectionDelegate(entry.delegateGetter(entity)) ?: continue
+            val typedRepo = inner.boundRegistryInternal() as? Repository<Comparable<Any>, IdentifiableEntity<Comparable<Any>>> ?: continue
+            for (id in inner.referenceIds.toSet()) {
+                val child = typedRepo.findById(id as Comparable<Any>).orElse(null) ?: continue
+                check(typedRepo.softDelete(child) || isSoftDeleted(child)) {
+                    "Cannot cascade soft-delete '${entity.uniqueId}': referenced child '${child.uniqueId}' was not soft-deleted"
+                }
+            }
         }
     }
 

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/Transactions.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/Transactions.kt
@@ -132,7 +132,12 @@ suspend fun <K : Comparable<K>, R : ReactiveEntity<K, R>> transaction(
             repo.activeTransactionBuffer = buffer
 
             // Capture snapshots and install event buffering on all currently loaded entities.
-            loadedEntities = repo.mapNotNull { it as? ReactiveEntityBase<K, R> }
+            // The element cast is a safe runtime `is ReactiveEntityBase` check (mapNotNull drops
+            // non-matches); only the erased K/R type arguments are unchecked, which is sound here
+            // because every entity resident in this repository is a ReactiveEntityBase<K, R>.
+            @Suppress("UNCHECKED_CAST")
+            val resident: List<ReactiveEntityBase<K, R>> = repo.mapNotNull { it as? ReactiveEntityBase<K, R> }
+            loadedEntities = resident
             loadedEntities.forEach { entity ->
                 buffer.entitySnapshots[entity.id] = entity.captureSnapshot()
                 entity._txEventBuffer.set(buffer.deferredEvents)

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/ProjectionCore.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/ProjectionCore.kt
@@ -303,7 +303,7 @@ internal class ProjectionCore<K : Comparable<K>, PK : Comparable<PK>, E : Identi
         val oldIndex = bucket.indexOfFirst { it.id == newEntity.id }
         if (oldIndex < 0) return
         // Build the bucket without the entity to compute its new sorted position.
-        val withoutEntity = bucket.toMutableList().also { it.removeAt(oldIndex) }
+        val withoutEntity = bucket.filterIndexed { index, _ -> index != oldIndex }
         var lo = 0
         var hi = withoutEntity.size
         while (lo < hi) {
@@ -333,7 +333,7 @@ internal class ProjectionCore<K : Comparable<K>, PK : Comparable<PK>, E : Identi
         val bucket = backingMap[key] ?: return null
         val oldIndex = bucket.indexOfFirst { it.id == newEntity.id }
         if (oldIndex < 0) return null
-        val withoutEntity = bucket.toMutableList().also { it.removeAt(oldIndex) }
+        val withoutEntity = bucket.filterIndexed { index, _ -> index != oldIndex }
         var lo = 0
         var hi = withoutEntity.size
         while (lo < hi) {

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/Query.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/Query.kt
@@ -75,3 +75,33 @@ data class Query<T : IdentifiableEntity<*>>(
         }
     }
 }
+
+/**
+ * Soft-delete visibility mode for a query's read path, derived from a [Query]'s
+ * [Query.includeDeleted] / [Query.onlyDeleted] flags.
+ *
+ * Used to thread visibility through read-path components that need only the mode and not the
+ * full generic [Query] (e.g. the cross-aggregate via executor), avoiding a `Query<*>`
+ * element-type coupling at those boundaries.
+ */
+internal enum class Visibility {
+    /** Active entities only — the fail-closed default. */
+    ACTIVE_ONLY,
+
+    /** Active and soft-deleted entities. */
+    INCLUDE_DELETED,
+
+    /** Soft-deleted entities only (strict mirror). */
+    ONLY_DELETED
+}
+
+/** The [Visibility] mode implied by this query's mutually-exclusive soft-delete flags. */
+internal fun Query<*>.visibility(): Visibility =
+    when {
+        onlyDeleted -> Visibility.ONLY_DELETED
+        includeDeleted -> Visibility.INCLUDE_DELETED
+        else -> Visibility.ACTIVE_ONLY
+    }
+
+/** A predicate-free, ordering-free, active-only query — the canonical default for optional `query` parameters. */
+internal fun <T : IdentifiableEntity<*>> activeOnlyQuery(): Query<T> = Query(null, emptyList(), null, 0)

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/QueryPlanner.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/QueryPlanner.kt
@@ -184,7 +184,7 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
     private fun selectStrategyAndCandidates(
         pred: Predicate<T>?,
         registry: Registry<*, T>,
-        query: Query<T> = Query(null, emptyList(), null, 0)
+        query: Query<T> = activeOnlyQuery()
     ): SelectResult<T> {
         val base = baseSequence(registry, query)
         if (pred == null) return SelectResult(Strategy.SCAN_ONLY, emptyList(), 0, null, base)
@@ -199,21 +199,13 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
             // The NonVia arm of a hybrid And(NonVia, Via*) is post-filtered, so its leaves
             // count toward postFilterCount; a bare or multi-Via* predicate has none.
             //
-            // includeDeleted()/onlyDeleted() are not supported for Via queries: the parent
-            // enumeration inside ViaJoinExecutor uses Registry.iterator() which excludes
-            // soft-deleted parents, and threading the Query through the entire Via execution
-            // path would require invasive changes to ViaJoinExecutor's public API. Enforce
-            // this limitation explicitly so callers receive a clear error rather than silently
-            // wrong results.
-            check(!query.includeDeleted && !query.onlyDeleted) {
-                "Via queries do not support includeDeleted() or onlyDeleted(): soft-deleted parents " +
-                    "are not enumerated in the cross-aggregate join. Remove the visibility flag or use " +
-                    "a non-Via predicate to query soft-deleted entities."
-            }
+            // Visibility flags (includeDeleted/onlyDeleted) flow through to ViaJoinExecutor,
+            // which applies the same flag-scoped visible set to both parent enumeration and
+            // child resolution. The default (no-flag) active-only fast path is preserved.
             val viaStrat = strategyFor(pred, registry)
             val (nonViaArm, _) = splitHybridAnd(pred)
             val viaPostFilterCount = nonViaArm?.let { countLeaves(it) } ?: 0
-            return SelectResult(Strategy.SCAN_ONLY, emptyList(), viaPostFilterCount, viaStrat, executeViaPlan(pred, registry))
+            return SelectResult(Strategy.SCAN_ONLY, emptyList(), viaPostFilterCount, viaStrat, executeViaPlan(pred, registry, query))
         }
         val indexable = extractIndexableLeaves(pred)
         if (indexable.isEmpty()) {
@@ -256,7 +248,7 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
         pred: Predicate<T>,
         indexable: List<IndexableLeaf>,
         registry: Registry<*, T>,
-        query: Query<T> = Query(null, emptyList(), null, 0)
+        query: Query<T> = activeOnlyQuery()
     ): SelectResult<T> {
         // Use the internal non-copying index read when available (RegistryBase), falling back to the
         // public defensive-copy findByIndex for any other Registry implementation.
@@ -536,20 +528,19 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
      * `And`/`Or`/`Not`). Drives the cross-aggregate branch in [execute].
      */
     private fun containsVia(pred: Predicate<T>): Boolean =
-        when (pred) {
-            is ViaAnyMatch<*, *, *>, is ViaAllMatch<*, *, *>,
-            is ViaNoneMatch<*, *, *>, is ViaWhere<*, *, *> -> true
-            is Predicate.And<*> -> {
+        when {
+            pred.isViaLeaf() -> true
+            pred is Predicate.And<*> -> {
                 @Suppress("UNCHECKED_CAST")
                 val a = pred as Predicate.And<T>
                 containsVia(a.left) || containsVia(a.right)
             }
-            is Predicate.Or<*> -> {
+            pred is Predicate.Or<*> -> {
                 @Suppress("UNCHECKED_CAST")
                 val o = pred as Predicate.Or<T>
                 containsVia(o.left) || containsVia(o.right)
             }
-            is Predicate.Not<*> -> {
+            pred is Predicate.Not<*> -> {
                 @Suppress("UNCHECKED_CAST")
                 val n = pred as Predicate.Not<T>
                 containsVia(n.inner)
@@ -564,11 +555,7 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
      * (including multi-Via* compounds, `Or`-wrapped Via*, or Via* nested under `Not`).
      */
     private fun detectTopLevelVia(pred: Predicate<T>): Predicate<T>? =
-        when (pred) {
-            is ViaAnyMatch<*, *, *>, is ViaAllMatch<*, *, *>,
-            is ViaNoneMatch<*, *, *>, is ViaWhere<*, *, *> -> pred
-            else -> null
-        }
+        if (pred.isViaLeaf()) pred else null
 
     /**
      * Splits an outermost `And(NonVia, Via*)` (or `And(Via*, NonVia)`) into the pair
@@ -621,6 +608,12 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
         parentRegistry: Registry<*, T>,
         sampleCeiling: Int = 100
     ): ViaStrategy {
+        // Cardinality estimation intentionally samples the active-only registry view, even when the
+        // query carries includeDeleted()/onlyDeleted(). This is a performance hint only: both
+        // strategies return identical result sets under any visibility mode (the executor sources
+        // both from one flag-scoped sequence), so an estimate skewed by hidden soft-deleted entities
+        // can pick a worse plan but never a wrong result. Flag-scoped sampling is deferred as a
+        // future tuning refinement.
         val parentSize = parentRegistry.size()
         if (parentSize == 0) return ViaStrategy.PER_PARENT_LOOP
 
@@ -681,9 +674,13 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
      * @param parentRegistry the registry holding the parent entities
      * @return a lazy [Sequence] of parents matching the predicate under the chosen strategy
      */
-    internal fun executeViaSequence(predicate: Predicate<T>, parentRegistry: Registry<*, T>): Sequence<T> {
+    internal fun executeViaSequence(
+        predicate: Predicate<T>,
+        parentRegistry: Registry<*, T>,
+        query: Query<T> = activeOnlyQuery()
+    ): Sequence<T> {
         val normalised = normalize(predicate)
-        return executeViaPlan(normalised, parentRegistry)
+        return executeViaPlan(normalised, parentRegistry, query)
     }
 
     /**
@@ -703,10 +700,12 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
     /**
      * Core Via execution: delegates to [ViaJoinExecutor] which handles strategy dispatch
      * and all hash-join / per-parent-loop implementations. Strategy selection via
-     * [chooseStrategy] and the [ViaStrategy] enum remain in this class.
+     * [chooseStrategy] and the [ViaStrategy] enum remain in this class. The [query] is
+     * forwarded to the executor so visibility flags are applied to both parent enumeration
+     * and child resolution.
      */
-    private fun executeViaPlan(pred: Predicate<T>, parentRegistry: Registry<*, T>): Sequence<T> =
-        viaJoinExecutor.executeViaPlan(pred, parentRegistry, ::splitHybridAnd, ::chooseStrategy)
+    private fun executeViaPlan(pred: Predicate<T>, parentRegistry: Registry<*, T>, query: Query<*>): Sequence<T> =
+        viaJoinExecutor.executeViaPlan(pred, parentRegistry, ::splitHybridAnd, ::chooseStrategy, query.visibility())
 
     /**
      * Composes a [Comparator] from a list of [OrderClause]s.

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/Via.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/Via.kt
@@ -293,6 +293,20 @@ infix fun <TParent : IdentifiableEntity<*>, K : Comparable<K>, TChild : Identifi
     ViaWhere(parentProp, childRegistry, block())
 
 /**
+ * Whether [this] predicate node is one of the four cross-aggregate `Via*` leaves
+ * ([ViaAnyMatch], [ViaAllMatch], [ViaNoneMatch], [ViaWhere]).
+ *
+ * Canonical leaf test shared by the planner's `containsVia` / `detectTopLevelVia` and the
+ * executor's compound traversal, so a new `Via*` subtype is recognised everywhere by updating
+ * this single function.
+ */
+internal fun Predicate<*>.isViaLeaf(): Boolean =
+    this is ViaAnyMatch<*, *, *> ||
+        this is ViaAllMatch<*, *, *> ||
+        this is ViaNoneMatch<*, *, *> ||
+        this is ViaWhere<*, *, *>
+
+/**
  * Walks [predicate] counting nested `Via*` nodes; returns the maximum chain depth observed.
  *
  * `Predicate.And`/`Or`/`Not` are descended into but do not increment the count themselves.

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/ViaJoinExecutor.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/ViaJoinExecutor.kt
@@ -19,6 +19,8 @@ package net.transgressoft.lirp.persistence.query
 
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.persistence.Registry
+import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.isSoftDeleted
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val log = KotlinLogging.logger {}
@@ -28,10 +30,30 @@ private val log = KotlinLogging.logger {}
  * with selection delegated to [QueryPlanner.chooseStrategy]:
  *
  * - [ViaStrategy.PER_PARENT_LOOP]: iterates every parent lazily and applies the Via* node's
- *   `matches` directly, keeping live reads on `parentProp` for each parent individually.
- * - [ViaStrategy.HASH_JOIN]: pre-filters the child registry by the child predicate, materialises
- *   matching ids into a [HashSet], then tests each parent's live `parentProp` collection against
- *   that set with the quantifier appropriate to the Via* operator.
+ *   `matches` directly for the default [Visibility.ACTIVE_ONLY] case. For [Visibility.INCLUDE_DELETED]
+ *   or [Visibility.ONLY_DELETED], a flag-scoped child lookup map is built once and the quantifier is
+ *   applied over the parent's live `parentProp` collection against that map.
+ * - [ViaStrategy.HASH_JOIN]: pre-filters the child registry by the child predicate using the
+ *   flag-scoped child sequence, materialises matching ids into a [HashSet], then tests each
+ *   parent's live `parentProp` collection against that set with the quantifier appropriate to
+ *   the Via* operator.
+ *
+ * Both strategies and the multi-Via* compound fallback honour the same [Visibility] on
+ * both parent enumeration and child resolution, guaranteeing both join strategies return
+ * identical result sets under every visibility mode.
+ *
+ * **Strict-mirror semantics for [Visibility.ONLY_DELETED]:** the visible set on both sides is
+ * `{soft-deleted only}`. A soft-deleted parent matches `onlyDeleted() + allMatch { … }`
+ * vacuously when none of its referenced children are soft-deleted (the flag-scoped child set
+ * is empty, and `all {}` over an empty collection is `true`). Likewise, `noneMatch { … }`
+ * is vacuously `true` for a parent with no soft-deleted children. Example:
+ * `repo.query { onlyDeleted(); where { Playlist::trackIds via tracks anyMatch { Track::title eq "X" } } }`
+ * returns soft-deleted playlists that reference a soft-deleted track titled "X" — active
+ * tracks are invisible in this view.
+ *
+ * The executor consumes only a [Visibility] mode, never the full generic [Query]: it reads no
+ * predicate or ordering, so threading the lighter value type avoids a `Query<*>` element-type
+ * coupling at this boundary.
  *
  * Strategy selection (cardinality estimation, the [ViaStrategy] enum) remains in [QueryPlanner].
  * This class contains only execution — no heuristics, no caching.
@@ -40,57 +62,147 @@ internal class ViaJoinExecutor<T : IdentifiableEntity<*>> {
 
     /**
      * Core Via execution: splits hybrid `And(NonVia, Via*)`, selects a strategy for the
-     * Via* arm, and applies the NonVia arm as a lazy post-filter. Multi-Via*
-     * compounds that cannot be isolated to a single top-level Via* arm fall back to a
-     * per-parent `predicate.matches(p)` loop — each `Via*.matches` handles its own live
-     * access correctness. The returned sequence is fully lazy.
+     * Via* arm, and applies the NonVia arm as a lazy post-filter.
+     *
+     * Multi-Via* compounds (`And(Via*, Via*)`, `Or(Via*, Via*)`) that cannot be isolated to a
+     * single top-level Via* arm are handled via [evaluateCompoundFlagScoped] for non-default
+     * visibility, or a straight `predicate.matches(p)` loop for the default [Visibility.ACTIVE_ONLY]
+     * case (where `Via*.matches()` is correct because child resolution is active-only). The
+     * returned sequence is fully lazy for single-via paths; compound paths materialise each
+     * Via* arm's result set before composing the boolean.
+     *
+     * The default [visibility] value preserves the active-only fast path.
      */
     fun executeViaPlan(
         pred: Predicate<T>,
         parentRegistry: Registry<*, T>,
         splitHybridAnd: (Predicate<T>) -> Pair<Predicate<T>?, Predicate<T>?>,
-        chooseStrategy: (Predicate<T>, Registry<*, T>) -> ViaStrategy
+        chooseStrategy: (Predicate<T>, Registry<*, T>) -> ViaStrategy,
+        visibility: Visibility = Visibility.ACTIVE_ONLY
     ): Sequence<T> {
         val (nonVia, viaArm) = splitHybridAnd(pred)
         if (viaArm == null) {
-            // Multi-Via* compound (e.g. And(Via*, Via*) or Or(Via*, Via*)) — fall back to a
-            // straight per-parent loop: each Via* node's `matches` already handles its own
-            // live-read invariant, so correctness is preserved without strategy selection.
+            // Multi-Via* compound (e.g. And(Via*, Via*) or Or(Via*, Via*)).
             log.debug { "Via planner: multi-Via* compound, falling back to per-parent loop on full predicate" }
-            return sequence {
-                for (p in parentRegistry) {
-                    if (pred.matches(p)) yield(p)
+            if (visibility == Visibility.ACTIVE_ONLY) {
+                // Default active-only fast path: Via*.matches() uses active-only child resolution, which is correct here.
+                return sequence {
+                    for (p in parentRegistry) {
+                        if (pred.matches(p)) yield(p)
+                    }
                 }
             }
+            // Non-default visibility: Via*.matches() resolves children via active-only findById, so we
+            // must evaluate each Via* arm using flag-scoped child resolution and compose the boolean result.
+            return evaluateCompoundFlagScoped(pred, parentRegistry, visibility)
         }
 
         val strategy = chooseStrategy(viaArm, parentRegistry)
         log.trace { "Via executor: dispatching strategy=$strategy for ${viaArm::class.simpleName}" }
         val viaResults =
             when (strategy) {
-                ViaStrategy.PER_PARENT_LOOP -> perParentLoop(viaArm, parentRegistry)
-                ViaStrategy.HASH_JOIN -> hashJoin(viaArm, parentRegistry)
+                ViaStrategy.PER_PARENT_LOOP -> perParentLoop(viaArm, parentRegistry, visibility)
+                ViaStrategy.HASH_JOIN -> hashJoin(viaArm, parentRegistry, visibility)
             }
 
         return if (nonVia != null) viaResults.filter { nonVia.matches(it) } else viaResults
     }
 
     /**
-     * Lazy per-parent loop execution. Each parent is yielded one at a time; live reads of
-     * `parentProp` happen inside the Via* node's `matches` implementation, never cached
-     * here. Suitable as the test seam entry point.
+     * Lazy per-parent loop execution. For the default [Visibility.ACTIVE_ONLY] case, each parent is
+     * tested via the Via* node's `matches` implementation directly (fast path). For non-default
+     * visibility, the flag-scoped child lookup map is built once and the quantifier is applied over
+     * the parent's live `parentProp` collection. Live reads of `parentProp` happen at yield time —
+     * never cached here. Suitable as the test seam entry point.
      */
-    fun perParentLoop(via: Predicate<T>, parentRegistry: Registry<*, T>): Sequence<T> =
-        sequence {
-            for (p in parentRegistry) {
-                if (via.matches(p)) yield(p)
+    fun perParentLoop(
+        via: Predicate<T>,
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility = Visibility.ACTIVE_ONLY
+    ): Sequence<T> {
+        if (visibility == Visibility.ACTIVE_ONLY) {
+            // Default active-only fast path: delegate to Via*.matches() unchanged.
+            return sequence {
+                for (p in parentRegistry) {
+                    if (via.matches(p)) yield(p)
+                }
             }
         }
+        // Non-default visibility: resolve children from the flag-scoped visible set, dispatching
+        // to the operator-specific quantifier (mirrors the hashJoin* dispatch).
+        @Suppress("UNCHECKED_CAST")
+        return when (via) {
+            is ViaAnyMatch<*, *, *> ->
+                perParentAnyMatch(via as ViaAnyMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, parentRegistry, visibility)
+            is ViaAllMatch<*, *, *> ->
+                perParentAllMatch(via as ViaAllMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, parentRegistry, visibility)
+            is ViaNoneMatch<*, *, *> ->
+                perParentNoneMatch(via as ViaNoneMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, parentRegistry, visibility)
+            is ViaWhere<*, *, *> ->
+                perParentWhere(via as ViaWhere<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, parentRegistry, visibility)
+            else -> error("perParentLoop called with non-Via predicate: ${via::class.simpleName}")
+        }
+    }
+
+    private fun perParentAnyMatch(
+        v: ViaAnyMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>,
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility
+    ): Sequence<T> {
+        val childMap = childLookup(v.childRegistry, visibility)
+        return sequence {
+            for (p in flagScopedParentSequence(parentRegistry, visibility)) {
+                if (v.parentProp.get(p).any { childMap[it]?.let(v.childPredicate::matches) == true }) yield(p)
+            }
+        }
+    }
+
+    private fun perParentAllMatch(
+        v: ViaAllMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>,
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility
+    ): Sequence<T> {
+        val childMap = childLookup(v.childRegistry, visibility)
+        return sequence {
+            for (p in flagScopedParentSequence(parentRegistry, visibility)) {
+                val scopedChildren = v.parentProp.get(p).mapNotNull { childMap[it] }
+                if (scopedChildren.isEmpty() || scopedChildren.all(v.childPredicate::matches)) yield(p)
+            }
+        }
+    }
+
+    private fun perParentNoneMatch(
+        v: ViaNoneMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>,
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility
+    ): Sequence<T> {
+        val childMap = childLookup(v.childRegistry, visibility)
+        return sequence {
+            for (p in flagScopedParentSequence(parentRegistry, visibility)) {
+                val scopedChildren = v.parentProp.get(p).mapNotNull { childMap[it] }
+                if (scopedChildren.isEmpty() || scopedChildren.none(v.childPredicate::matches)) yield(p)
+            }
+        }
+    }
+
+    private fun perParentWhere(
+        v: ViaWhere<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>,
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility
+    ): Sequence<T> {
+        val childMap = childLookup(v.childRegistry, visibility)
+        return sequence {
+            for (p in flagScopedParentSequence(parentRegistry, visibility)) {
+                val child = v.parentProp.get(p)?.let { childMap[it] }
+                if (child != null && v.childPredicate.matches(child)) yield(p)
+            }
+        }
+    }
 
     /**
-     * Hash-join execution. Materialises matching child ids into a [HashSet] once, then
-     * iterates parents lazily testing the live `parentProp` collection against the set
-     * with the quantifier appropriate to the Via* operator.
+     * Hash-join execution. Materialises matching child ids into a [HashSet] once using the
+     * flag-scoped child sequence, then iterates parents lazily testing the live `parentProp`
+     * collection against the set with the quantifier appropriate to the Via* operator.
      *
      * **Live-read invariant is preserved.** Although the matching-children set is snapshotted
      * up-front (the strategy's defining property), each parent's `parentProp.get(p)` call
@@ -102,31 +214,143 @@ internal class ViaJoinExecutor<T : IdentifiableEntity<*>> {
      * Via* operator's contract.
      */
     @Suppress("UNCHECKED_CAST")
-    fun hashJoin(via: Predicate<T>, parentRegistry: Registry<*, T>): Sequence<T> =
+    fun hashJoin(
+        via: Predicate<T>,
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility = Visibility.ACTIVE_ONLY
+    ): Sequence<T> =
         when (via) {
             is ViaAnyMatch<*, *, *> ->
-                hashJoinAnyMatch(via as ViaAnyMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, parentRegistry)
+                hashJoinAnyMatch(via as ViaAnyMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, parentRegistry, visibility)
             is ViaAllMatch<*, *, *> ->
-                hashJoinAllMatch(via as ViaAllMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, parentRegistry)
+                hashJoinAllMatch(via as ViaAllMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, parentRegistry, visibility)
             is ViaNoneMatch<*, *, *> ->
-                hashJoinNoneMatch(via as ViaNoneMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, parentRegistry)
+                hashJoinNoneMatch(via as ViaNoneMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, parentRegistry, visibility)
             is ViaWhere<*, *, *> ->
-                hashJoinWhere(via as ViaWhere<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, parentRegistry)
+                hashJoinWhere(via as ViaWhere<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>, parentRegistry, visibility)
             else -> error("hashJoin called with non-Via predicate: ${via::class.simpleName}")
+        }
+
+    /**
+     * Returns the flag-scoped sequence of children from [registry] according to [visibility].
+     * This is the single source of the child visible set for both [ViaStrategy.HASH_JOIN] and
+     * [ViaStrategy.PER_PARENT_LOOP], guaranteeing both join strategies return identical result
+     * sets under every visibility mode.
+     *
+     * - [Visibility.ACTIVE_ONLY]: `registry.asSequence()` — active entities only.
+     * - [Visibility.INCLUDE_DELETED]: all entities via [RegistryBase.rawIterator], bypassing the
+     *   default soft-delete exclusion filter.
+     * - [Visibility.ONLY_DELETED]: same raw iterator filtered to soft-deleted entities only.
+     */
+    private fun <K : Comparable<K>, C : IdentifiableEntity<K>> flagScopedChildSequence(
+        registry: Registry<K, C>,
+        visibility: Visibility
+    ): Sequence<C> {
+        if (visibility == Visibility.ACTIVE_ONLY) return registry.asSequence()
+        val raw =
+            (registry as? RegistryBase<K, C>)?.rawIterator()?.asSequence()
+                ?: registry.asSequence()
+        return if (visibility == Visibility.ONLY_DELETED) raw.filter { isSoftDeleted(it) } else raw
+    }
+
+    /**
+     * Returns the flag-scoped sequence of parents from [parentRegistry] according to [visibility].
+     * Mirrors [flagScopedChildSequence] for the parent side.
+     */
+    private fun flagScopedParentSequence(
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility
+    ): Sequence<T> {
+        if (visibility == Visibility.ACTIVE_ONLY) return parentRegistry.asSequence()
+        val raw =
+            (parentRegistry as? RegistryBase<*, T>)?.rawIterator()?.asSequence()
+                ?: parentRegistry.asSequence()
+        return if (visibility == Visibility.ONLY_DELETED) raw.filter { isSoftDeleted(it) } else raw
+    }
+
+    /**
+     * Evaluates a multi-Via* compound predicate (e.g. `And(Via*, Via*)`, `Or(Via*, Via*)`, or a
+     * `Not`-wrapped Via*) with flag-scoped child resolution. For each `Via*` leaf, the result set
+     * is computed via [perParentLoop] using the flag-scoped child lookup. `And` nodes intersect
+     * the parent sets; `Or` nodes union them; `Not` over a Via*-containing subtree complements
+     * against the flag-scoped parent universe so child resolution stays flag-scoped on the negated
+     * side too. Via*-free leaf predicates fall back to [Predicate.matches] over the flag-scoped
+     * parent sequence (active-only child resolution is irrelevant there).
+     *
+     * Called by [executeViaPlan] only when the query carries a non-default [visibility] and
+     * [splitHybridAnd] cannot isolate a single top-level Via* arm.
+     */
+    private fun evaluateCompoundFlagScoped(
+        pred: Predicate<T>,
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility
+    ): Sequence<T> {
+        val matchingSet = collectFlagScopedMatches(pred, parentRegistry, visibility)
+        return matchingSet.asSequence()
+    }
+
+    private fun collectFlagScopedMatches(
+        pred: Predicate<T>,
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility
+    ): Set<T> =
+        when {
+            pred.isViaLeaf() -> perParentLoop(pred, parentRegistry, visibility).toHashSet()
+            pred is Predicate.And -> {
+                val left = collectFlagScopedMatches(pred.left, parentRegistry, visibility)
+                val right = collectFlagScopedMatches(pred.right, parentRegistry, visibility)
+                left.intersect(right)
+            }
+            pred is Predicate.Or -> {
+                val left = collectFlagScopedMatches(pred.left, parentRegistry, visibility)
+                val right = collectFlagScopedMatches(pred.right, parentRegistry, visibility)
+                left.union(right)
+            }
+            pred is Predicate.Not && pred.inner.containsViaNode() -> {
+                // Complement against the flag-scoped parent universe; resolving the inner Via* via
+                // [collectFlagScopedMatches] keeps child resolution flag-scoped on the negated side.
+                val universe = flagScopedParentSequence(parentRegistry, visibility).toHashSet()
+                universe - collectFlagScopedMatches(pred.inner, parentRegistry, visibility)
+            }
+            else -> {
+                // Via*-free predicate (a plain leaf or a Not over one): active-only child resolution
+                // is irrelevant since no Via* node is reached. A Via* here would be silently resolved
+                // active-only regardless of the flag — guard against that invariant violation.
+                check(!pred.containsViaNode()) {
+                    "collectFlagScopedMatches reached a Via* node through an unsupported predicate shape: ${pred::class.simpleName}"
+                }
+                flagScopedParentSequence(parentRegistry, visibility).filter { pred.matches(it) }.toHashSet()
+            }
+        }
+
+    /** Whether this predicate subtree contains any `Via*` node, recursing through `And`/`Or`/`Not`. */
+    private fun Predicate<T>.containsViaNode(): Boolean =
+        when (this) {
+            is Predicate.And -> left.containsViaNode() || right.containsViaNode()
+            is Predicate.Or -> left.containsViaNode() || right.containsViaNode()
+            is Predicate.Not -> inner.containsViaNode()
+            else -> isViaLeaf()
         }
 
     private fun <K : Comparable<K>, C : IdentifiableEntity<K>> matchingChildIds(
         registry: Registry<K, C>,
-        predicate: Predicate<C>
-    ): HashSet<K> = registry.asSequence().filter { predicate.matches(it) }.map { it.id }.toHashSet()
+        predicate: Predicate<C>,
+        visibility: Visibility
+    ): HashSet<K> = flagScopedChildSequence(registry, visibility).filter { predicate.matches(it) }.map { it.id }.toHashSet()
+
+    private fun <K : Comparable<K>, C : IdentifiableEntity<K>> childLookup(
+        registry: Registry<K, C>,
+        visibility: Visibility
+    ): Map<K, C> = flagScopedChildSequence(registry, visibility).associateBy { it.id }
 
     private fun hashJoinAnyMatch(
         v: ViaAnyMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>,
-        parentRegistry: Registry<*, T>
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility
     ): Sequence<T> {
-        val matchingIds = matchingChildIds(v.childRegistry, v.childPredicate)
+        val matchingIds = matchingChildIds(v.childRegistry, v.childPredicate, visibility)
         return sequence {
-            for (p in parentRegistry) {
+            for (p in flagScopedParentSequence(parentRegistry, visibility)) {
                 if (v.parentProp.get(p).any { it in matchingIds }) yield(p)
             }
         }
@@ -134,36 +358,44 @@ internal class ViaJoinExecutor<T : IdentifiableEntity<*>> {
 
     private fun hashJoinAllMatch(
         v: ViaAllMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>,
-        parentRegistry: Registry<*, T>
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility
     ): Sequence<T> {
-        val matchingIds = matchingChildIds(v.childRegistry, v.childPredicate)
+        val matchingIds = matchingChildIds(v.childRegistry, v.childPredicate, visibility)
+        val allChildIds = flagScopedChildSequence(v.childRegistry, visibility).map { it.id }.toHashSet()
         return sequence {
-            for (p in parentRegistry) {
+            for (p in flagScopedParentSequence(parentRegistry, visibility)) {
                 val refs = v.parentProp.get(p)
-                if (refs.isEmpty() || refs.all { it in matchingIds }) yield(p)
+                val scopedRefs = refs.filter { it in allChildIds }
+                if (scopedRefs.isEmpty() || scopedRefs.all { it in matchingIds }) yield(p)
             }
         }
     }
 
     private fun hashJoinNoneMatch(
         v: ViaNoneMatch<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>,
-        parentRegistry: Registry<*, T>
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility
     ): Sequence<T> {
-        val matchingIds = matchingChildIds(v.childRegistry, v.childPredicate)
+        val matchingIds = matchingChildIds(v.childRegistry, v.childPredicate, visibility)
+        val allChildIds = flagScopedChildSequence(v.childRegistry, visibility).map { it.id }.toHashSet()
         return sequence {
-            for (p in parentRegistry) {
-                if (v.parentProp.get(p).none { it in matchingIds }) yield(p)
+            for (p in flagScopedParentSequence(parentRegistry, visibility)) {
+                val refs = v.parentProp.get(p)
+                val scopedRefs = refs.filter { it in allChildIds }
+                if (scopedRefs.isEmpty() || scopedRefs.none { it in matchingIds }) yield(p)
             }
         }
     }
 
     private fun hashJoinWhere(
         v: ViaWhere<T, Comparable<Any>, IdentifiableEntity<Comparable<Any>>>,
-        parentRegistry: Registry<*, T>
+        parentRegistry: Registry<*, T>,
+        visibility: Visibility
     ): Sequence<T> {
-        val matchingIds = matchingChildIds(v.childRegistry, v.childPredicate)
+        val matchingIds = matchingChildIds(v.childRegistry, v.childPredicate, visibility)
         return sequence {
-            for (p in parentRegistry) {
+            for (p in flagScopedParentSequence(parentRegistry, visibility)) {
                 val id = v.parentProp.get(p)
                 if (id != null && id in matchingIds) yield(p)
             }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/LirpQueryTestFixtures.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/LirpQueryTestFixtures.kt
@@ -22,6 +22,7 @@ import net.transgressoft.lirp.entity.MutableSoftDeletable
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.persistence.Indexed
 import net.transgressoft.lirp.persistence.LirpContext
+import net.transgressoft.lirp.persistence.Registry
 import net.transgressoft.lirp.persistence.VolatileRepository
 import java.time.Instant
 
@@ -108,4 +109,128 @@ class IndexedSoftDeletableTrackRepo(context: LirpContext = LirpContext.default) 
     VolatileRepository<Int, IndexedSoftDeletableTrack>(context, "IndexedSoftDeletableTracks") {
     fun create(id: Int, genre: String): IndexedSoftDeletableTrack =
         IndexedSoftDeletableTrack(id, genre).also { add(it) }
+}
+
+/**
+ * Soft-deletable child entity referenced by [SoftDeletablePlaylist.trackIds].
+ * Used to exercise `via()` query visibility under [QueryBuilder.includeDeleted] and
+ * [QueryBuilder.onlyDeleted] across a cross-aggregate parent–child relationship.
+ */
+class SoftDeletableTrack(
+    override val id: Int,
+    title: String,
+    price: Double
+) : ReactiveEntityBase<Int, SoftDeletableTrack>(), IdentifiableEntity<Int>, MutableSoftDeletable {
+    override val uniqueId: String get() = "soft-deletable-track-$id"
+
+    var title: String by reactiveProperty(title)
+    var price: Double by reactiveProperty(price)
+
+    override var deletedAt: Instant? by reactiveProperty(null)
+
+    override fun clone(): SoftDeletableTrack =
+        SoftDeletableTrack(id, title, price).also { it.deletedAt = deletedAt }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SoftDeletableTrack) return false
+        return id == other.id && title == other.title && price == other.price && deletedAt == other.deletedAt
+    }
+
+    override fun hashCode(): Int =
+        31 * (31 * (31 * id.hashCode() + title.hashCode()) + price.hashCode()) + (deletedAt?.hashCode() ?: 0)
+
+    override fun toString(): String = "SoftDeletableTrack(id=$id, title='$title', price=$price, deletedAt=$deletedAt)"
+}
+
+/**
+ * Repository for [SoftDeletableTrack] entities.
+ */
+class SoftDeletableTrackRepo(context: LirpContext = LirpContext.default) :
+    VolatileRepository<Int, SoftDeletableTrack>(context, "SoftDeletableTracks") {
+    fun create(id: Int, title: String, price: Double): SoftDeletableTrack =
+        SoftDeletableTrack(id, title, price).also { add(it) }
+}
+
+/**
+ * Soft-deletable parent entity whose [trackIds] collection is consumed by collection `via()`
+ * queries and whose nullable [ownerTrackId] single reference is consumed by `via ... where { }`
+ * queries. Used alongside [SoftDeletableTrack] to exercise cross-aggregate `via()` visibility
+ * under [QueryBuilder.includeDeleted] and [QueryBuilder.onlyDeleted].
+ */
+class SoftDeletablePlaylist(
+    override val id: Int,
+    name: String,
+    trackIds: List<Int>,
+    ownerTrackId: Int? = null
+) : ReactiveEntityBase<Int, SoftDeletablePlaylist>(), IdentifiableEntity<Int>, MutableSoftDeletable {
+    override val uniqueId: String get() = "soft-deletable-playlist-$id"
+
+    var name: String by reactiveProperty(name)
+    var trackIds: List<Int> by reactiveProperty(trackIds)
+    var ownerTrackId: Int? by reactiveProperty(ownerTrackId)
+
+    override var deletedAt: Instant? by reactiveProperty(null)
+
+    override fun clone(): SoftDeletablePlaylist =
+        SoftDeletablePlaylist(id, name, trackIds, ownerTrackId).also { it.deletedAt = deletedAt }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SoftDeletablePlaylist) return false
+        return id == other.id &&
+            name == other.name &&
+            trackIds == other.trackIds &&
+            ownerTrackId == other.ownerTrackId &&
+            deletedAt == other.deletedAt
+    }
+
+    override fun hashCode(): Int =
+        31 * (31 * (31 * (31 * id.hashCode() + name.hashCode()) + trackIds.hashCode()) + (ownerTrackId ?: 0)) +
+            (deletedAt?.hashCode() ?: 0)
+
+    override fun toString(): String =
+        "SoftDeletablePlaylist(id=$id, name='$name', trackIds=$trackIds, ownerTrackId=$ownerTrackId, deletedAt=$deletedAt)"
+}
+
+/**
+ * Repository for [SoftDeletablePlaylist] entities.
+ */
+class SoftDeletablePlaylistRepo(context: LirpContext = LirpContext.default) :
+    VolatileRepository<Int, SoftDeletablePlaylist>(context, "SoftDeletablePlaylists") {
+    fun create(id: Int, name: String, trackIds: List<Int>, ownerTrackId: Int? = null): SoftDeletablePlaylist =
+        SoftDeletablePlaylist(id, name, trackIds, ownerTrackId).also { add(it) }
+}
+
+/**
+ * Executes [via] under both [ViaStrategy.PER_PARENT_LOOP] and [ViaStrategy.HASH_JOIN] against
+ * the same [parentRegistry] with the shared [query] visibility flags, and returns both result
+ * sets as a [Pair]. The first element is the per-parent-loop result set; the second is the
+ * hash-join result set.
+ *
+ * Pass an equality assertion on both elements of the pair to verify the strict-mirror
+ * strategy-equivalence invariant: given the same [query], both join strategies must return
+ * identical parent sets regardless of the visibility mode (active-only, includeDeleted, or
+ * onlyDeleted). Example usage:
+ *
+ * ```kotlin
+ * val (ppl, hj) = viaResultsUnderBothStrategies(via, playlists, query)
+ * ppl shouldBe hj
+ * ```
+ *
+ * @param via a normalised Via* predicate (pass a [ViaAnyMatch], [ViaAllMatch], [ViaNoneMatch], or [ViaWhere] node)
+ * @param parentRegistry the registry holding the parent entities
+ * @param query a [Query] carrying the desired visibility flags; defaults to active-only
+ * @return a [Pair] of (per-parent-loop result set, hash-join result set)
+ */
+internal fun <T : IdentifiableEntity<*>> viaResultsUnderBothStrategies(
+    via: Predicate<T>,
+    parentRegistry: Registry<*, T>,
+    query: Query<T> = activeOnlyQuery()
+): Pair<Set<T>, Set<T>> {
+    val executor = ViaJoinExecutor<T>()
+    val visibility = query.visibility()
+    val perParentLoopSet = executor.perParentLoop(via, parentRegistry, visibility).toSet()
+    val hashJoinSet = executor.hashJoin(via, parentRegistry, visibility).toSet()
+    return Pair(perParentLoopSet, hashJoinSet)
 }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/SoftDeleteQueryDslTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/SoftDeleteQueryDslTest.kt
@@ -28,7 +28,9 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 
 /**
- * Tests for the [QueryBuilder.includeDeleted] / [QueryBuilder.onlyDeleted] query DSL verbs.
+ * Tests for the [QueryBuilder.includeDeleted] / [QueryBuilder.onlyDeleted] query DSL verbs,
+ * including `via()` cross-aggregate queries that honor visibility flags on both parent
+ * enumeration and child resolution.
  *
  * The default query excludes soft-deleted entities (fail-closed). The opt-in verbs allow
  * callers to explicitly request soft-deleted entities:
@@ -37,6 +39,11 @@ import io.kotest.matchers.shouldBe
  *
  * The two verbs are mutually exclusive; combining them throws [IllegalStateException].
  * Both flags propagate through [Query] with `false` defaults and a mutual-exclusion `require`.
+ *
+ * For `via()` queries, the same visibility flag applies to both sides of the join: parent
+ * enumeration and child resolution use the same flag-scoped visible set. Under `onlyDeleted()`,
+ * a soft-deleted parent matches `allMatch` / `noneMatch` vacuously when none of its referenced
+ * children are soft-deleted (strict-mirror semantics).
  */
 @DisplayName("SoftDeleteQueryDslTest")
 internal class SoftDeleteQueryDslTest : StringSpec({
@@ -117,28 +124,390 @@ internal class SoftDeleteQueryDslTest : StringSpec({
         }
     }
 
-    "Via query combined with includeDeleted throws IllegalStateException" {
-        val tracks = TrackRepo().apply { add(Track(1, "Ghost", 10.0)) }
-        val playlists = PlaylistRepo().apply { add(Playlist(1, "PL", listOf(1), null)) }
+    "Via query with includeDeleted returns soft-deleted parents referencing active children" {
+        val trackRepo =
+            SoftDeletableTrackRepo(ctx).apply {
+                create(1, "Active Track", 10.0)
+                create(2, "Another Active Track", 20.0)
+            }
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        playlistRepo.create(1, "Active Playlist", listOf(1))
+        val deletedPl = playlistRepo.create(2, "Deleted Playlist", listOf(2))
+        playlistRepo.softDelete(deletedPl)
+        reactive.advance()
 
-        shouldThrow<IllegalStateException> {
-            playlists.query {
-                where { Playlist::trackIds via tracks anyMatch { Track::price gt 5.0 } }
+        val results =
+            playlistRepo.query {
+                where { SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 5.0 } }
                 includeDeleted()
-            }.toList()
-        }
+            }.map { it.id }.toSet()
+
+        // Both active and soft-deleted playlists referencing active tracks should be returned.
+        results shouldBe setOf(1, 2)
     }
 
-    "Via query combined with onlyDeleted throws IllegalStateException" {
-        val tracks = TrackRepo().apply { add(Track(1, "Ghost", 10.0)) }
-        val playlists = PlaylistRepo().apply { add(Playlist(1, "PL", listOf(1), null)) }
+    "Via query with onlyDeleted returns only soft-deleted parents referencing soft-deleted children (strict mirror)" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        val activeTrack = trackRepo.create(1, "Active Track", 10.0)
+        val deletedTrack = trackRepo.create(2, "Deleted Track", 20.0)
+        trackRepo.softDelete(deletedTrack)
 
-        shouldThrow<IllegalStateException> {
-            playlists.query {
-                where { Playlist::trackIds via tracks anyMatch { Track::price gt 5.0 } }
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        val deletedPlWithActiveChild = playlistRepo.create(1, "Deleted with active child", listOf(1))
+        val deletedPlWithDeletedChild = playlistRepo.create(2, "Deleted with deleted child", listOf(2))
+        val activePl = playlistRepo.create(3, "Active playlist", listOf(2))
+        playlistRepo.softDelete(deletedPlWithActiveChild)
+        playlistRepo.softDelete(deletedPlWithDeletedChild)
+        reactive.advance()
+
+        val results =
+            playlistRepo.query {
+                where { SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 5.0 } }
+                onlyDeleted()
+            }.map { it.id }.toSet()
+
+        // Only the soft-deleted playlist referencing a soft-deleted track must match.
+        // The soft-deleted playlist whose child is active must NOT match (strict mirror).
+        // The active playlist must NOT appear (onlyDeleted).
+        results shouldBe setOf(2)
+    }
+
+    "Via anyMatch with onlyDeleted — soft-deleted parent with no soft-deleted children does not match" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        trackRepo.create(1, "Active Track", 10.0)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        val deletedPl = playlistRepo.create(1, "Deleted playlist", listOf(1))
+        playlistRepo.softDelete(deletedPl)
+        reactive.advance()
+
+        val results =
+            playlistRepo.query {
+                where { SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 5.0 } }
                 onlyDeleted()
             }.toList()
-        }
+
+        // No soft-deleted children exist — anyMatch is false; parent excluded.
+        results shouldBe emptyList()
+    }
+
+    "Via allMatch with onlyDeleted — soft-deleted parent with no soft-deleted children matches vacuously" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        trackRepo.create(1, "Active Track", 10.0)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        val deletedPl = playlistRepo.create(1, "Deleted playlist", listOf(1))
+        playlistRepo.softDelete(deletedPl)
+        reactive.advance()
+
+        val results =
+            playlistRepo.query {
+                where { SoftDeletablePlaylist::trackIds via trackRepo allMatch { SoftDeletableTrack::price gt 5.0 } }
+                onlyDeleted()
+            }.map { it.id }.toList()
+
+        // The flag-scoped child set is empty (no soft-deleted children), so allMatch is vacuously true.
+        results shouldBe listOf(1)
+    }
+
+    "Via noneMatch with onlyDeleted — soft-deleted parent with no soft-deleted children matches vacuously" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        trackRepo.create(1, "Active Track", 10.0)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        val deletedPl = playlistRepo.create(1, "Deleted playlist", listOf(1))
+        playlistRepo.softDelete(deletedPl)
+        reactive.advance()
+
+        val results =
+            playlistRepo.query {
+                where { SoftDeletablePlaylist::trackIds via trackRepo noneMatch { SoftDeletableTrack::price gt 5.0 } }
+                onlyDeleted()
+            }.map { it.id }.toList()
+
+        // The flag-scoped child set is empty (no soft-deleted children), so noneMatch is vacuously true.
+        results shouldBe listOf(1)
+    }
+
+    "Via anyMatch with onlyDeleted — deleted parent referencing deleted child matches; referencing active child does not" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        val activeTrack = trackRepo.create(1, "Active Track", 10.0)
+        val deletedTrack = trackRepo.create(2, "Deleted Track", 20.0)
+        trackRepo.softDelete(deletedTrack)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        val deletedPlWithActive = playlistRepo.create(1, "Deleted, active child ref", listOf(1))
+        val deletedPlWithDeleted = playlistRepo.create(2, "Deleted, deleted child ref", listOf(2))
+        playlistRepo.softDelete(deletedPlWithActive)
+        playlistRepo.softDelete(deletedPlWithDeleted)
+        reactive.advance()
+
+        val deletedPlWithActiveResults =
+            playlistRepo.query {
+                where { SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::id eq 1 } }
+                onlyDeleted()
+            }.toList()
+
+        val deletedPlWithDeletedResults =
+            playlistRepo.query {
+                where { SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::id eq 2 } }
+                onlyDeleted()
+            }.map { it.id }.toList()
+
+        // Deleted parent referencing active child: the active child is invisible under onlyDeleted — no match.
+        deletedPlWithActiveResults shouldBe emptyList()
+        // Deleted parent referencing deleted child: the deleted child is in the visible set — matches.
+        deletedPlWithDeletedResults shouldBe listOf(2)
+    }
+
+    "Via where (single-ref) with onlyDeleted — deleted parent whose deleted owner matches is included; active owner is invisible" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        trackRepo.create(1, "Active Owner", 10.0)
+        val deletedOwner = trackRepo.create(2, "Deleted Owner", 20.0)
+        trackRepo.softDelete(deletedOwner)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        // Deleted parent whose single owner-ref points at the soft-deleted owner → in the visible set → matches.
+        val refsDeletedOwner = playlistRepo.create(1, "Refs deleted owner", emptyList(), ownerTrackId = 2)
+        // Deleted parent whose owner-ref points at an active owner → invisible under onlyDeleted → no match.
+        val refsActiveOwner = playlistRepo.create(2, "Refs active owner", emptyList(), ownerTrackId = 1)
+        // Deleted parent with no owner-ref → ViaWhere on null → no match.
+        val noOwner = playlistRepo.create(3, "No owner", emptyList(), ownerTrackId = null)
+        listOf(refsDeletedOwner, refsActiveOwner, noOwner).forEach { playlistRepo.softDelete(it) }
+        reactive.advance()
+
+        val results =
+            playlistRepo.query {
+                where { SoftDeletablePlaylist::ownerTrackId via trackRepo where { SoftDeletableTrack::price gt 5.0 } }
+                onlyDeleted()
+            }.map { it.id }.toSet()
+
+        // Only the deleted parent whose owner is also soft-deleted (and price > 5) matches.
+        results shouldBe setOf(1)
+    }
+
+    "default (no flag) via query still excludes soft-deleted parents and children (fail-closed regression guard)" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        trackRepo.create(1, "Active Track", 10.0)
+        val deletedTrack = trackRepo.create(2, "Deleted Track", 20.0)
+        trackRepo.softDelete(deletedTrack)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        playlistRepo.create(1, "Active playlist", listOf(1))
+        val deletedPl = playlistRepo.create(2, "Deleted playlist", listOf(1, 2))
+        playlistRepo.softDelete(deletedPl)
+        reactive.advance()
+
+        val results =
+            playlistRepo.query {
+                where { SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 5.0 } }
+            }.map { it.id }.toList()
+
+        // Only the active playlist referencing the active track should appear.
+        results shouldBe listOf(1)
+    }
+
+    "HASH_JOIN and PER_PARENT_LOOP return identical result sets under includeDeleted" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        trackRepo.create(1, "Active Track", 10.0)
+        val deletedTrack = trackRepo.create(2, "Deleted Track", 20.0)
+        trackRepo.softDelete(deletedTrack)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        playlistRepo.create(1, "Active playlist", listOf(1))
+        val deletedPl = playlistRepo.create(2, "Deleted playlist", listOf(2))
+        playlistRepo.softDelete(deletedPl)
+        reactive.advance()
+
+        val via = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 5.0 }
+        val query = Query<SoftDeletablePlaylist>(predicate = via, orderBy = emptyList(), limit = null, offset = 0, includeDeleted = true)
+        val (ppl, hj) = viaResultsUnderBothStrategies(via, playlistRepo, query)
+
+        ppl shouldBe hj
+    }
+
+    "HASH_JOIN and PER_PARENT_LOOP return identical result sets under onlyDeleted" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        trackRepo.create(1, "Active Track", 10.0)
+        val deletedTrack = trackRepo.create(2, "Deleted Track", 20.0)
+        trackRepo.softDelete(deletedTrack)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        playlistRepo.create(1, "Active playlist", listOf(1))
+        val deletedPl = playlistRepo.create(2, "Deleted playlist", listOf(2))
+        playlistRepo.softDelete(deletedPl)
+        reactive.advance()
+
+        val via = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 5.0 }
+        val query = Query<SoftDeletablePlaylist>(predicate = via, orderBy = emptyList(), limit = null, offset = 0, onlyDeleted = true)
+        val (ppl, hj) = viaResultsUnderBothStrategies(via, playlistRepo, query)
+
+        ppl shouldBe hj
+    }
+
+    "compound And(Via, Via) with onlyDeleted returns only deleted parents satisfying both via arms" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        // Active tracks — invisible under onlyDeleted.
+        trackRepo.create(1, "Active Low", 5.0)
+        trackRepo.create(2, "Active High", 100.0)
+        // Deleted tracks — visible under onlyDeleted.
+        val deletedLow = trackRepo.create(3, "Deleted Low", 8.0)
+        val deletedHigh = trackRepo.create(4, "Deleted High", 200.0)
+        trackRepo.softDelete(deletedLow)
+        trackRepo.softDelete(deletedHigh)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        // Deleted playlist with both deleted low-price (3) and deleted high-price (4) tracks.
+        val deletedBothArms = playlistRepo.create(1, "Deleted both arms", listOf(3, 4))
+        // Deleted playlist with only deleted high-price track (4) — satisfies both arms (200 > 5 and 200 > 150).
+        val deletedSingleTrack = playlistRepo.create(2, "Deleted single track", listOf(4))
+        // Active playlist — must not appear under onlyDeleted.
+        playlistRepo.create(3, "Active", listOf(3, 4))
+        playlistRepo.softDelete(deletedBothArms)
+        playlistRepo.softDelete(deletedSingleTrack)
+        reactive.advance()
+
+        // Compound: BOTH arms must match over the flag-scoped (deleted-only) child visible set.
+        // arm1: anyMatch price > 5.0  → matches deleted tracks 3 (8.0) and 4 (200.0)
+        // arm2: anyMatch price > 150.0 → matches only deleted track 4 (200.0)
+        val arm1 = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 5.0 }
+        val arm2 = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 150.0 }
+        val compound = arm1 and arm2
+
+        val results =
+            playlistRepo.query {
+                where { compound }
+                onlyDeleted()
+            }.map { it.id }.toSet()
+
+        // Playlist 1 ([3,4]): arm1=true (3 or 4 > 5), arm2=true (4 > 150) → included.
+        // Playlist 2 ([4]):   arm1=true (4 > 5),       arm2=true (4 > 150) → included.
+        // Active playlist 3:  not in flag-scoped parent set → excluded.
+        results shouldBe setOf(1, 2)
+    }
+
+    "compound Or(Via, Via) with onlyDeleted unions deleted parents satisfying either via arm" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        val deletedCheap = trackRepo.create(3, "Deleted Cheap", 8.0)
+        val deletedExpensive = trackRepo.create(4, "Deleted Expensive", 200.0)
+        trackRepo.softDelete(deletedCheap)
+        trackRepo.softDelete(deletedExpensive)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        // arm1 (price > 150) matches only the expensive deleted track (4).
+        val onlyArm1 = playlistRepo.create(1, "Only arm1", listOf(4))
+        // arm2 (price < 10) matches only the cheap deleted track (3) — proves the union, not intersection.
+        val onlyArm2 = playlistRepo.create(2, "Only arm2", listOf(3))
+        val bothArms = playlistRepo.create(3, "Both arms", listOf(3, 4))
+        val neither = playlistRepo.create(4, "Neither", emptyList())
+        playlistRepo.create(5, "Active", listOf(4))
+        listOf(onlyArm1, onlyArm2, bothArms, neither).forEach { playlistRepo.softDelete(it) }
+        reactive.advance()
+
+        val arm1 = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 150.0 }
+        val arm2 = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price lt 10.0 }
+
+        val results =
+            playlistRepo.query {
+                where { arm1 or arm2 }
+                onlyDeleted()
+            }.map { it.id }.toSet()
+
+        // Union: arm1-only (1), arm2-only (2), both (3); neither (4) excluded; active (5) not in the deleted universe.
+        results shouldBe setOf(1, 2, 3)
+    }
+
+    "not(Via) with onlyDeleted negates against the deleted-only child set on both sides" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        trackRepo.create(1, "Active Cheap", 5.0)
+        val deletedCheap = trackRepo.create(2, "Deleted Cheap", 8.0)
+        val deletedExpensive = trackRepo.create(3, "Deleted Expensive", 200.0)
+        trackRepo.softDelete(deletedCheap)
+        trackRepo.softDelete(deletedExpensive)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        // Deleted parent referencing the deleted expensive track — inner anyMatch{price>50} is TRUE,
+        // so the negation excludes it. (Active-only child resolution would wrongly miss track 3 and include it.)
+        val refsDeletedExpensive = playlistRepo.create(1, "Refs deleted expensive", listOf(3))
+        // Deleted parent referencing only the deleted cheap track — inner anyMatch{price>50} is FALSE → included.
+        val refsDeletedCheap = playlistRepo.create(2, "Refs deleted cheap", listOf(2))
+        // Deleted parent referencing only an ACTIVE track — invisible under onlyDeleted child resolution → included.
+        val refsActiveOnly = playlistRepo.create(3, "Refs active only", listOf(1))
+        // Deleted parent with no refs — vacuously not-any → included.
+        val noRefs = playlistRepo.create(4, "No refs", emptyList())
+        listOf(refsDeletedExpensive, refsDeletedCheap, refsActiveOnly, noRefs).forEach { playlistRepo.softDelete(it) }
+        reactive.advance()
+
+        val via = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 50.0 }
+
+        val results =
+            playlistRepo.query {
+                where { !via }
+                onlyDeleted()
+            }.map { it.id }.toSet()
+
+        // Only parent 1 references a deleted track with price > 50, so only it is negated away.
+        results shouldBe setOf(2, 3, 4)
+    }
+
+    "not(Via) with includeDeleted negates against the active-and-deleted child set" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        val activeExpensive = trackRepo.create(1, "Active Expensive", 200.0)
+        val deletedExpensive = trackRepo.create(2, "Deleted Expensive", 300.0)
+        trackRepo.softDelete(deletedExpensive)
+        val activeCheap = trackRepo.create(3, "Active Cheap", 4.0)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        // References an active expensive track — inner anyMatch{price>50} TRUE under includeDeleted → excluded.
+        val refsActiveExpensive = playlistRepo.create(1, "Refs active expensive", listOf(1))
+        // References a deleted expensive track — TRUE under includeDeleted → excluded.
+        val refsDeletedExpensive = playlistRepo.create(2, "Refs deleted expensive", listOf(2))
+        // References only a cheap active track — FALSE → included.
+        val refsCheap = playlistRepo.create(3, "Refs cheap", listOf(3))
+        playlistRepo.softDelete(refsDeletedExpensive)
+        reactive.advance()
+
+        val via = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 50.0 }
+
+        val results =
+            playlistRepo.query {
+                where { !via }
+                includeDeleted()
+            }.map { it.id }.toSet()
+
+        // Both active and deleted expensive references are visible and negated away; only the cheap one survives.
+        results shouldBe setOf(3)
+    }
+
+    "not(compound And of two via arms) with onlyDeleted complements the flag-scoped intersection" {
+        val trackRepo = SoftDeletableTrackRepo(ctx)
+        trackRepo.create(1, "Active Cheap", 5.0)
+        val deletedCheap = trackRepo.create(3, "Deleted Cheap", 8.0)
+        val deletedExpensive = trackRepo.create(4, "Deleted Expensive", 200.0)
+        trackRepo.softDelete(deletedCheap)
+        trackRepo.softDelete(deletedExpensive)
+
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        // arm1 = anyMatch price>5, arm2 = anyMatch price>150 (over the deleted-only child set).
+        val bothArms = playlistRepo.create(1, "Both arms", listOf(3, 4)) // arm1 T, arm2 T → And T → negated out
+        val arm1Only = playlistRepo.create(2, "arm1 only", listOf(3)) // arm1 T (8>5), arm2 F → And F → kept
+        val bothViaSingle = playlistRepo.create(3, "Both via single", listOf(4)) // arm1 T, arm2 T → And T → negated out
+        val neither = playlistRepo.create(4, "Neither", emptyList()) // And F → kept
+        val activeChildOnly = playlistRepo.create(5, "Active child only", listOf(1)) // active child invisible → And F → kept
+        listOf(bothArms, arm1Only, bothViaSingle, neither, activeChildOnly).forEach { playlistRepo.softDelete(it) }
+        reactive.advance()
+
+        val arm1 = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 5.0 }
+        val arm2 = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 150.0 }
+
+        val results =
+            playlistRepo.query {
+                where { !(arm1 and arm2) }
+                onlyDeleted()
+            }.map { it.id }.toSet()
+
+        // Deleted universe {1..5} minus the And-intersection {1,3} = {2,4,5}.
+        results shouldBe setOf(2, 4, 5)
     }
 
     "indexed-predicate query with onlyDeleted returns soft-deleted matches" {

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/ViaDetachIntegrationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/ViaDetachIntegrationTest.kt
@@ -42,7 +42,7 @@ import io.kotest.matchers.shouldBe
  * observe the predicate at the in-loop read boundary; only an in-flight iterator does.
  *
  * **Simulating DETACH at the in-memory layer.** In-memory cascade for collection refs is a
- * no-op (Phase 53's SQL DETACH nulls FKs at the persistence layer, observed on reload).
+ * no-op (the SQL DETACH cascade nulls FKs at the persistence layer, observed on reload).
  * To exercise the same observable post-DETACH state inside a single JVM, the tests use
  * mutable parent entities and mutate the FK-bearing property directly — clearing the
  * matching id from the collection (cases 1, 3, 4) or setting the nullable single ref to
@@ -79,7 +79,7 @@ internal class ViaDetachIntegrationTest : FunSpec({
         before shouldContain 100
 
         // Simulate DETACH: delete child Track(1) and reconcile the parent's collection
-        // (mirrors what Phase 53 SQL DETACH produces after a junction-table reconciliation).
+        // (mirrors what the SQL DETACH cascade produces after a junction-table reconciliation).
         tracks.remove(tracks.findById(1).orElseThrow())
         val parent = playlists.findById(100).orElseThrow()
         (parent.trackIds as MutableList<Int>).remove(1)
@@ -110,7 +110,7 @@ internal class ViaDetachIntegrationTest : FunSpec({
         before shouldContain 1
 
         // Simulate DETACH single-ref: deleting the referenced owner sets the FK to null
-        // (Phase 53 ON DELETE SET NULL on a nullable column).
+        // (the SQL DETACH cascade issues ON DELETE SET NULL on a nullable column).
         owners.remove(owners.findById(10).orElseThrow())
         val orphan = parents.findById(1).orElseThrow()
         orphan.ownerId = null
@@ -215,6 +215,66 @@ internal class ViaDetachIntegrationTest : FunSpec({
         // Parent 49 had id 5 cleared mid-iteration. The HASH_JOIN parent loop calls
         // parentProp.get(p).any { it in matchingIds } LIVE — so the mutated parent is dropped.
         drained shouldNotContain 49
+
+        ctx.close()
+    }
+
+    /**
+     * Proves the live-read invariant is preserved under a non-default visibility flag when
+     * [QueryPlanner.executeViaSequence] is driven with an explicit [Query] carrying
+     * [Query.includeDeleted]. Mid-iteration mutation of a parent's `trackIds` is reflected on
+     * the very next yield, identical to the active-only path.
+     *
+     * Uses [SoftDeletablePlaylist] / [SoftDeletableTrackRepo] so that both active and
+     * soft-deleted playlists are enumerated (parent side). Forces PER_PARENT_LOOP via fixture
+     * sizing (many matching children, few refs per parent).
+     */
+    test("Via anyMatch with includeDeleted — mid-iteration mutation of parentProp is still reflected (live read invariant preserved)") {
+        val ctx = LirpContext()
+        val trackRepo =
+            SoftDeletableTrackRepo(ctx).apply {
+                // 100 matching active children — forces PER_PARENT_LOOP against 5 parents × 1 ref = 5 crossover.
+                repeat(100) { add(SoftDeletableTrack(it + 1, "match", 100.0)) }
+            }
+        val playlistRepo = SoftDeletablePlaylistRepo(ctx)
+        // Build and track the 5 playlists so we can mutate them directly mid-iteration.
+        val playlists =
+            (0 until 5).map { p ->
+                val pl = SoftDeletablePlaylist(p, "p$p", mutableListOf(p + 1))
+                playlistRepo.add(pl)
+                // Soft-delete the even-indexed playlists so that includeDeleted is needed to enumerate them.
+                if (p % 2 == 0) playlistRepo.softDelete(pl)
+                pl
+            }
+
+        val via = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 50.0 }
+        val includeDeletedQuery =
+            Query<SoftDeletablePlaylist>(
+                predicate = via,
+                orderBy = emptyList(),
+                limit = null,
+                offset = 0,
+                includeDeleted = true
+            )
+        val planner = QueryPlanner<SoftDeletablePlaylist>(isIndexed = { false }, indexNameFor = { it.name })
+        planner.strategyFor(via, playlistRepo) shouldBe ViaStrategy.PER_PARENT_LOOP
+
+        val iter = planner.executeViaSequence(via, playlistRepo, includeDeletedQuery).iterator()
+
+        // Advance one element so the iterator is mid-flight.
+        val firstYielded = iter.next().id
+        // Mutate the trackIds of every not-yet-yielded parent to an empty list mid-iteration.
+        // The live-read invariant means matches() reads parentProp.get(p) at yield time, so the
+        // mutation will be picked up on the very next yield.
+        val mutated = playlists.filter { it.id != firstYielded }
+        mutated.forEach { it.trackIds = mutableListOf() }
+
+        val drained = mutableListOf<Int>()
+        while (iter.hasNext()) drained.add(iter.next().id)
+
+        // Every mutated parent's matches() now reads an empty collection live, so none of them
+        // may appear in the drained tail. This proves the live-read invariant under includeDeleted.
+        drained shouldBe emptyList()
 
         ctx.close()
     }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/ViaPlannerTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/ViaPlannerTest.kt
@@ -17,6 +17,7 @@
 
 package net.transgressoft.lirp.persistence.query
 
+import net.transgressoft.lirp.persistence.LirpContext
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -297,6 +298,126 @@ internal class ViaPlannerTest : FunSpec({
         context.viaStrategy shouldBe planner.strategyFor(via, playlists)
         // A bare via predicate has no non-via post-filter arm.
         context.postFilterCount shouldBe 0
+    }
+
+    test("HASH_JOIN and PER_PARENT_LOOP return identical result sets under includeDeleted with soft-deletable fixtures") {
+        val ctx = LirpContext()
+        val trackRepo =
+            SoftDeletableTrackRepo(ctx).apply {
+                create(1, "Active Track", 10.0)
+                create(2, "Another Active Track", 20.0)
+                val deletedTrack = create(3, "Deleted Track", 30.0)
+                softDelete(deletedTrack)
+            }
+        val playlistRepo =
+            SoftDeletablePlaylistRepo(ctx).apply {
+                create(1, "Active Playlist", listOf(1))
+                val deletedPl = create(2, "Deleted Playlist", listOf(3))
+                softDelete(deletedPl)
+            }
+
+        val via = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 5.0 }
+        val query = Query<SoftDeletablePlaylist>(predicate = via, orderBy = emptyList(), limit = null, offset = 0, includeDeleted = true)
+        val (ppl, hj) = viaResultsUnderBothStrategies(via, playlistRepo, query)
+
+        // Both strategies must produce the same result set.
+        ppl shouldBe hj
+        // Both active and soft-deleted playlists referencing matching tracks should appear.
+        ppl.map { it.id }.toSet() shouldBe setOf(1, 2)
+
+        ctx.close()
+    }
+
+    test("HASH_JOIN and PER_PARENT_LOOP return identical result sets under onlyDeleted with soft-deletable fixtures") {
+        val ctx = LirpContext()
+        val trackRepo =
+            SoftDeletableTrackRepo(ctx).apply {
+                create(1, "Active Track", 10.0)
+                val deletedTrack = create(2, "Deleted Track", 20.0)
+                softDelete(deletedTrack)
+            }
+        val playlistRepo =
+            SoftDeletablePlaylistRepo(ctx).apply {
+                // Deleted playlist referencing active child — strict-mirror: should NOT appear in onlyDeleted.
+                val deletedPlActiveChild = create(1, "Deleted with active child", listOf(1))
+                softDelete(deletedPlActiveChild)
+                // Deleted playlist referencing deleted child — strict-mirror: SHOULD appear.
+                val deletedPlDeletedChild = create(2, "Deleted with deleted child", listOf(2))
+                softDelete(deletedPlDeletedChild)
+                // Active playlist — should NOT appear under onlyDeleted.
+                create(3, "Active Playlist", listOf(2))
+            }
+
+        val via = SoftDeletablePlaylist::trackIds via trackRepo anyMatch { SoftDeletableTrack::price gt 5.0 }
+        val query = Query<SoftDeletablePlaylist>(predicate = via, orderBy = emptyList(), limit = null, offset = 0, onlyDeleted = true)
+        val (ppl, hj) = viaResultsUnderBothStrategies(via, playlistRepo, query)
+
+        // Both strategies must produce the same result set.
+        ppl shouldBe hj
+        // Only the deleted playlist whose referenced track is also deleted should appear.
+        ppl.map { it.id }.toSet() shouldBe setOf(2)
+
+        ctx.close()
+    }
+
+    test("allMatch HASH_JOIN and PER_PARENT_LOOP return identical result sets under onlyDeleted") {
+        val ctx = LirpContext()
+        val trackRepo =
+            SoftDeletableTrackRepo(ctx).apply {
+                create(1, "Active Track", 2.0)
+                val deletedCheap = create(2, "Deleted Cheap", 8.0)
+                val deletedExpensive = create(3, "Deleted Expensive", 30.0)
+                softDelete(deletedCheap)
+                softDelete(deletedExpensive)
+            }
+        val playlistRepo =
+            SoftDeletablePlaylistRepo(ctx).apply {
+                // All soft-deleted children (8, 30) are > 5 → allMatch true.
+                softDelete(create(1, "Deleted all match", listOf(2, 3)))
+                // Soft-deleted child 2 (8) > 5 but references active child 1 (invisible) → scoped {8} all match.
+                softDelete(create(2, "Deleted mixed", listOf(1, 2)))
+                // No soft-deleted children referenced (only active 1) → scoped empty → vacuously true.
+                softDelete(create(3, "Deleted vacuous", listOf(1)))
+            }
+
+        val via = SoftDeletablePlaylist::trackIds via trackRepo allMatch { SoftDeletableTrack::price gt 5.0 }
+        val query = Query<SoftDeletablePlaylist>(predicate = via, orderBy = emptyList(), limit = null, offset = 0, onlyDeleted = true)
+        val (ppl, hj) = viaResultsUnderBothStrategies(via, playlistRepo, query)
+
+        ppl shouldBe hj
+        ppl.map { it.id }.toSet() shouldBe setOf(1, 2, 3)
+
+        ctx.close()
+    }
+
+    test("noneMatch HASH_JOIN and PER_PARENT_LOOP return identical result sets under onlyDeleted") {
+        val ctx = LirpContext()
+        val trackRepo =
+            SoftDeletableTrackRepo(ctx).apply {
+                create(1, "Active Expensive", 100.0)
+                val deletedCheap = create(2, "Deleted Cheap", 8.0)
+                val deletedExpensive = create(3, "Deleted Expensive", 300.0)
+                softDelete(deletedCheap)
+                softDelete(deletedExpensive)
+            }
+        val playlistRepo =
+            SoftDeletablePlaylistRepo(ctx).apply {
+                // Soft-deleted child 3 (300) > 50 → noneMatch false → excluded.
+                softDelete(create(1, "Deleted has expensive", listOf(3)))
+                // Soft-deleted child 2 (8) not > 50 → noneMatch true → included.
+                softDelete(create(2, "Deleted cheap only", listOf(2)))
+                // References active expensive only (invisible) → scoped empty → vacuously true → included.
+                softDelete(create(3, "Deleted vacuous", listOf(1)))
+            }
+
+        val via = SoftDeletablePlaylist::trackIds via trackRepo noneMatch { SoftDeletableTrack::price gt 50.0 }
+        val query = Query<SoftDeletablePlaylist>(predicate = via, orderBy = emptyList(), limit = null, offset = 0, onlyDeleted = true)
+        val (ppl, hj) = viaResultsUnderBothStrategies(via, playlistRepo, query)
+
+        ppl shouldBe hj
+        ppl.map { it.id }.toSet() shouldBe setOf(2, 3)
+
+        ctx.close()
     }
 
     test("hybrid predicate result preserves Sequence laziness - taking only first N elements does not iterate beyond N parents") {

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SoftDeleteSqlTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SoftDeleteSqlTest.kt
@@ -75,8 +75,11 @@ internal class SoftDeleteSqlTest : StringSpec({
             repo2.softDelete(loaded)
             // The deletedAt mutation propagates to the SQL write pipeline asynchronously and is
             // persisted by the debounced background writer. Poll for the persisted version bump
-            // instead of racing a fixed sleep against async event delivery.
-            eventually(2.seconds) {
+            // instead of racing a fixed sleep against async event delivery. The window is generous
+            // because the debounced writer (max ~1s) plus container/JVM warmup can exceed a tight
+            // 2s budget under CI load; eventually returns as soon as the bump is observed, so the
+            // larger ceiling only affects the rare slow case.
+            eventually(5.seconds) {
                 val row = DatabaseTestSupport.readRow(dataSource, tableDef.tableName, 2, "version", "deleted_at")
                 row.shouldNotBeNull()
                 val dbVersion = (row["version"] as? Long) ?: (row["version"] as? Number)?.toLong()


### PR DESCRIPTION
## Summary

The Query DSL's `includeDeleted()` / `onlyDeleted()` visibility flags are now honored for
cross-aggregate `via()` queries, not just direct predicates. Previously the `via()` executor
discarded the query's visibility and hard-wired both parent enumeration and child resolution to
active-only; combining `via()` with a visibility flag fail-fast threw `IllegalStateException` as
a stopgap. That guard is removed and the combination is fully supported.

A single visibility mode now defines **one visible set** applied to **both** sides of the join —
parent enumeration and child resolution (strict mirror) — across all four operators
(`anyMatch` / `allMatch` / `noneMatch` / `where`) and multi-`via` compounds combined with
`and` / `or` / `not`. The default (no-flag) path is unchanged and remains active-only.

Closes #294.

## What changed

- **`ViaJoinExecutor`** — a single flag-scoped parent/child sequence pair (built from the
  registry's raw iterator plus the soft-delete predicate) is the sole source of the visible set
  for both the hash-join and per-parent-loop strategies and the multi-`via` compound fallback, so
  the two strategies return identical result sets under every visibility mode. The compound
  fallback evaluates each `via` arm with flag-scoped resolution and composes the boolean
  (`and`/`or`/`not`); a negated `via` arm complements against the flag-scoped parent set so child
  resolution stays flag-scoped on the negated side too.
- **`QueryPlanner`** — the query is threaded through the `via` execution path and the stopgap
  guard is removed, with no residual guard for any `via` shape.
- **Strict-mirror semantics** — under `onlyDeleted()`, `allMatch` / `noneMatch` over a parent with
  no soft-deleted children match vacuously (`true`), mirroring Kotlin stdlib collection semantics;
  documented in KDoc.
- **Internals** — a small `Visibility` value type decouples the executor (which needs only the
  mode) from the generic `Query`; a shared leaf-detection helper centralises `via` node recognition
  across the planner and executor; duplicated default-query literals collapse to one factory.

## Verification

- [x] Full `lirp-core` test suite green; multi-module compile clean.
- [x] Behavior tests cover each visibility mode, the strict-mirror vacuous-true edge cases,
      hash-join / per-parent-loop equivalence under each flag, compound `and` / `or` / `not(via)`
      cases, and a live-read-under-flag case.
- [x] Aggregate coverage held at the project baseline (line 87.80%, branch 72.93%).

## Migration / compatibility

Additive and non-breaking. The default `via()` behavior is unchanged. The only behavioral change
is that combining `via()` with `includeDeleted()` / `onlyDeleted()` — which previously threw
`IllegalStateException` — now returns the expected visibility-scoped results. Documented in
CHANGELOG.md and the wiki (Query DSL and Soft Delete pages).
