### PR TITLE
Transactional outbox capture (lirp-kafka)

### DIFF
--- a/lirp-kafka/api/lirp-kafka.api
+++ b/lirp-kafka/api/lirp-kafka.api
@@ -4,6 +4,11 @@ public final class net/transgressoft/lirp/kafka/KafkaEventPublisher : java/lang/
 	public final fun publish (Ljava/lang/String;Ljava/lang/String;[B)V
 }
 
+public final class net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository : net/transgressoft/lirp/persistence/sql/SqlRepository {
+	public fun <init> (Ljavax/sql/DataSource;Lnet/transgressoft/lirp/persistence/sql/SqlTableDef;Z)V
+	public synthetic fun <init> (Ljavax/sql/DataSource;Lnet/transgressoft/lirp/persistence/sql/SqlTableDef;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class net/transgressoft/lirp/kafka/LirpKafkaConfig : java/lang/AutoCloseable {
 	public static final field Companion Lnet/transgressoft/lirp/kafka/LirpKafkaConfig$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/lirp-kafka/build.gradle
+++ b/lirp-kafka/build.gradle
@@ -18,6 +18,9 @@ dependencies {
     api project(':lirp-api')
     implementation project(':lirp-sql')             // brings lirp-core + lirp-sql-api transitively
 
+    implementation platform(libs.exposed.bom)
+    implementation libs.exposed.jdbc               // exposed-jdbc is implementation in lirp-sql, so not transitive
+
     implementation libs.kafka.clients
     implementation libs.coroutines.core
     implementation libs.kotlin.logging
@@ -27,6 +30,10 @@ dependencies {
     testImplementation libs.bundles.kotest
     testImplementation libs.coroutines.test
     testImplementation libs.junit.jupiter
+    testImplementation libs.h2
+    testImplementation libs.hikari
+    testImplementation testFixtures(project(':lirp-core'))
+    testImplementation testFixtures(project(':lirp-sql'))
     testRuntimeOnly libs.junit.platform.launcher
 
     integrationTestImplementation platform(libs.junit.bom)
@@ -37,6 +44,8 @@ dependencies {
     integrationTestImplementation libs.junit.jupiter
     integrationTestRuntimeOnly libs.junit.platform.launcher
 
+    integrationTestImplementation libs.hikari
+    integrationTestImplementation libs.h2
     integrationTestImplementation testFixtures(project(':lirp-core'))
     integrationTestImplementation testFixtures(project(':lirp-sql'))
 }

--- a/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxAtomicityIntegrationTest.kt
+++ b/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxAtomicityIntegrationTest.kt
@@ -1,0 +1,139 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.outbox
+
+import net.transgressoft.lirp.event.CrudEvent
+import net.transgressoft.lirp.kafka.KafkaOutboxSqlRepository
+import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.LirpTransactionException
+import net.transgressoft.lirp.persistence.MutableAudioItem
+import net.transgressoft.lirp.persistence.sql.AudioItemSqlTableDef
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.withDatabaseTest
+import net.transgressoft.lirp.persistence.transaction
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withTests
+import io.kotest.matchers.shouldBe
+
+/**
+ * Multi-dialect integration tests for [KafkaOutboxSqlRepository] transactional outbox capture.
+ *
+ * Verifies commit and rollback atomicity across all five supported SQL dialects
+ * (PostgreSQL, MySQL, MariaDB, SQLite, H2). For each dialect:
+ * - A committed `transaction { r.add(item) }` produces exactly one outbox row with the
+ *   correct aggregate id and CREATE code.
+ * - A block-throw rollback leaves zero additional outbox rows.
+ *
+ * The `uuid` and `timestamp` columns on the outbox table are exercised implicitly —
+ * a dialect-specific DDL or type-mapping mismatch would surface as a DDL or read error
+ * inside [withDatabaseTest].
+ */
+@DisplayName("OutboxAtomicityIntegrationTest")
+internal class OutboxAtomicityIntegrationTest : FunSpec({
+
+    context("outbox atomicity across dialects") {
+        withTests(databases) { db ->
+            withDatabaseTest(db, AudioItemSqlTableDef) { dataSource ->
+
+                // Drop the outbox table before each dialect run so KafkaOutboxSqlRepository.init
+                // recreates it fresh via SchemaUtils.create — same isolation guarantee as the
+                // entity table drop performed by withDatabaseTest for AudioItemSqlTableDef.
+                dropOutboxTableIfExists(dataSource)
+
+                val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+
+                try {
+                    // Commit path: one outbox row with matching aggregate id and CREATE code.
+                    val item = MutableAudioItem(1, "Bohemian Rhapsody", "A Night at the Opera") as AudioItem
+                    transaction(repo) { r -> r.add(item) }
+
+                    countOutboxRows(dataSource) shouldBe 1L
+
+                    val row = readFirstOutboxRow(dataSource)!!
+                    row["aggregate_id"] shouldBe "1"
+                    row["event_type_code"] shouldBe CrudEvent.Type.CREATE.code
+
+                    // Rollback path: block-throw leaves zero additional outbox rows.
+                    val outboxCountBeforeRollback = countOutboxRows(dataSource)
+                    shouldThrow<LirpTransactionException> {
+                        transaction(repo) { r ->
+                            r.add(MutableAudioItem(2, "Killer Queen", "Sheer Heart Attack") as AudioItem)
+                            throw RuntimeException("injected failure — both entity and outbox rows must roll back")
+                        }
+                    }
+
+                    countOutboxRows(dataSource) shouldBe outboxCountBeforeRollback
+                } finally {
+                    repo.close()
+                }
+            }
+        }
+    }
+})
+
+/**
+ * Counts the rows in the `lirp_kafka_outbox` table using raw JDBC, independent of the
+ * Exposed table object which is internal to the main source set.
+ */
+private fun countOutboxRows(dataSource: HikariDataSource): Long =
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("SELECT COUNT(*) FROM lirp_kafka_outbox").use { stmt ->
+            stmt.executeQuery().use { rs ->
+                rs.next()
+                rs.getLong(1)
+            }
+        }
+    }
+
+/**
+ * Reads the first row from `lirp_kafka_outbox` as a name-to-value map using raw JDBC.
+ * Returns `null` when the table is empty.
+ */
+private fun readFirstOutboxRow(dataSource: HikariDataSource): Map<String, Any?>? =
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("SELECT aggregate_id, event_type_code FROM lirp_kafka_outbox LIMIT 1")
+            .use { stmt ->
+                stmt.executeQuery().use { rs ->
+                    if (!rs.next()) null
+                    else {
+                        mapOf(
+                            "aggregate_id" to rs.getString("aggregate_id"),
+                            "event_type_code" to rs.getInt("event_type_code")
+                        )
+                    }
+                }
+            }
+    }
+
+/**
+ * Drops the `lirp_kafka_outbox` table if it exists, swallowing the "table not found" dialect
+ * variants across PostgreSQL/MySQL/MariaDB/SQLite/H2.
+ */
+private fun dropOutboxTableIfExists(dataSource: HikariDataSource) {
+    try {
+        dataSource.connection.use { conn ->
+            conn.prepareStatement("DROP TABLE IF EXISTS lirp_kafka_outbox").use { it.execute() }
+        }
+    } catch (_: Exception) {
+        // Some drivers throw on DROP TABLE IF EXISTS even when the table doesn't exist;
+        // ignore and let KafkaOutboxSqlRepository.init create it fresh.
+    }
+}

--- a/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxAtomicityIntegrationTest.kt
+++ b/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxAtomicityIntegrationTest.kt
@@ -124,16 +124,12 @@ private fun readFirstOutboxRow(dataSource: HikariDataSource): Map<String, Any?>?
     }
 
 /**
- * Drops the `lirp_kafka_outbox` table if it exists, swallowing the "table not found" dialect
- * variants across PostgreSQL/MySQL/MariaDB/SQLite/H2.
+ * Drops the `lirp_kafka_outbox` table if it exists. `DROP TABLE IF EXISTS` is supported by all five
+ * target dialects (PostgreSQL/MySQL/MariaDB/SQLite/H2), so a thrown exception indicates a real
+ * setup or driver failure and is allowed to surface rather than be swallowed.
  */
 private fun dropOutboxTableIfExists(dataSource: HikariDataSource) {
-    try {
-        dataSource.connection.use { conn ->
-            conn.prepareStatement("DROP TABLE IF EXISTS lirp_kafka_outbox").use { it.execute() }
-        }
-    } catch (_: Exception) {
-        // Some drivers throw on DROP TABLE IF EXISTS even when the table doesn't exist;
-        // ignore and let KafkaOutboxSqlRepository.init create it fresh.
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("DROP TABLE IF EXISTS lirp_kafka_outbox").use { it.execute() }
     }
 }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository.kt
@@ -136,17 +136,7 @@ class KafkaOutboxSqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
         val updateRows = updates.map { buildRow(it.entity, CrudEvent.Type.UPDATE.code) }
         // On the writePending path, deleted entities are already removed from in-memory state.
         // Only the key is available; payload is recorded as an empty JSON object.
-        val deleteRows =
-            deletes.map { (key, _) ->
-                OutboxEvent(
-                    id = UUID.randomUUID(),
-                    aggregateType = tableDef.tableName,
-                    aggregateId = key.toString(),
-                    eventTypeCode = CrudEvent.Type.DELETE.code,
-                    payload = "{}",
-                    createdAt = Clock.System.now()
-                )
-            }
+        val deleteRows = deletes.map { (key, _) -> buildRow(key.toString(), CrudEvent.Type.DELETE.code, "{}") }
         insertRows(insertRows + updateRows + deleteRows)
     }
 
@@ -177,15 +167,18 @@ class KafkaOutboxSqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
         )
     }
 
-    private fun buildRow(entity: R, eventTypeCode: Int): OutboxEvent =
+    private fun buildRow(aggregateId: String, eventTypeCode: Int, payload: String): OutboxEvent =
         OutboxEvent(
             id = UUID.randomUUID(),
             aggregateType = tableDef.tableName,
-            aggregateId = entity.id.toString(),
+            aggregateId = aggregateId,
             eventTypeCode = eventTypeCode,
-            payload = buildPayload(entity),
+            payload = payload,
             createdAt = Clock.System.now()
         )
+
+    private fun buildRow(entity: R, eventTypeCode: Int): OutboxEvent =
+        buildRow(entity.id.toString(), eventTypeCode, buildPayload(entity))
 
     private fun buildCrudOutboxRows(
         inserts: List<Pair<R, CrudEvent.Type>>,

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository.kt
@@ -1,0 +1,208 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka
+
+import net.transgressoft.lirp.entity.ReactiveEntity
+import net.transgressoft.lirp.event.CrudEvent
+import net.transgressoft.lirp.event.EventType
+import net.transgressoft.lirp.kafka.outbox.OutboxEvent
+import net.transgressoft.lirp.kafka.outbox.OutboxEventTable
+import net.transgressoft.lirp.persistence.PendingUpdate
+import net.transgressoft.lirp.persistence.TransactionBuffer
+import net.transgressoft.lirp.persistence.sql.SqlRepository
+import net.transgressoft.lirp.persistence.sql.SqlTableDef
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.batchInsert
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.UUID
+import javax.sql.DataSource
+import kotlin.time.Clock
+import kotlin.uuid.toKotlinUuid
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * A [SqlRepository] subclass that co-inserts one outbox row per entity change into the
+ * `lirp_kafka_outbox` table, atomically inside the same JDBC commit that persists the entity rows.
+ *
+ * Outbox rows are inserted on two paths:
+ * - The explicit `transaction { }` path via [onAfterEntityWritesInTransaction], which also
+ *   captures the mutation events buffered during the block (property-changed, batch-changed).
+ * - The debounced write-pending path via [onAfterEntityWritesInWritePending], which captures
+ *   CRUD codes only (no deferred events are available on this path).
+ *
+ * Both overrides run inside the parent's already-open Exposed transaction block. They use bare
+ * Exposed DSL without opening a new `transaction { }` — any new transaction call from inside an
+ * active transaction would start a separate JDBC commit and break the atomicity guarantee.
+ *
+ * The outbox payload is a serializer-neutral JSON field snapshot built by calling
+ * [SqlTableDef.toParams] on each entity — the same field mapping the SQL persistence layer
+ * uses for INSERT/UPDATE. Consumers needing field-level encryption or transformation should
+ * apply it at the [SqlTableDef] mapping level so both the SQL row and the outbox payload remain
+ * consistent.
+ *
+ * The `lirp_kafka_outbox` table is created at construction time via [SchemaUtils.create].
+ *
+ * @param K The type of entity identifier, must be [Comparable].
+ * @param R The type of reactive entity stored in this repository.
+ * @param dataSource JDBC data source shared with the parent [SqlRepository]; owning the same
+ *   pool ensures all writes land on the same JDBC connection and share the same transaction.
+ * @param tableDef SQL table definition for the entity. Stored locally because the parent's
+ *   [SqlTableDef] field is `private` and the payload builder needs it for [SqlTableDef.toParams].
+ * @param loadOnInit When `true` (default), rows are loaded from the database immediately during
+ *   construction.
+ */
+class KafkaOutboxSqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
+    dataSource: DataSource,
+    private val tableDef: SqlTableDef<R>,
+    loadOnInit: Boolean = true
+) : SqlRepository<K, R>(dataSource, tableDef, loadOnInit) {
+
+    init {
+        // Create the outbox table at construction time, mirroring the entity-table creation in
+        // SqlRepository.init. Reuses the parent's connection registration so no second one is
+        // opened. SchemaUtils.create is a no-op when the table already exists.
+        transaction(db) {
+            SchemaUtils.create(OutboxEventTable)
+        }
+    }
+
+    /**
+     * Called inside the `transaction(db) { }` block of [commitTransactionBuffer], after all entity
+     * writes and before the transaction closes. Inserts one outbox row per entity change using bare
+     * Exposed DSL — no new transaction is opened here.
+     *
+     * Covers the event families reachable inside the entity-state flush. CRUD codes are derived
+     * from the buffer's insert/update/delete partitions; mutation codes come from the events the
+     * entities buffered during the block:
+     * - Inserts → CrudEvent.Type.CREATE (code 100)
+     * - Updates → CrudEvent.Type.UPDATE (code 300)
+     * - Deletes → CrudEvent.Type.DELETE (code 400)
+     * - Deferred mutation events → each event's [EventType.code] (302 for PropertyChanged,
+     *   303 for BatchChanged)
+     *
+     * The mapping reads [EventType.code] verbatim rather than switching on a fixed set, so any
+     * code an event carries is recorded faithfully. Events a consumer publishes through the event
+     * publisher outside the flush are not visible here; those are captured by the publisher-backed
+     * outbox path.
+     */
+    override fun onAfterEntityWritesInTransaction(buffer: TransactionBuffer<K, R>) {
+        val rows =
+            buildCrudOutboxRows(
+                buffer.inserts.map { it to CrudEvent.Type.CREATE },
+                buffer.updates.map { it.entity to CrudEvent.Type.UPDATE },
+                buffer.deletes.map { it.entity to CrudEvent.Type.DELETE }
+            ) +
+                buffer.deferredEvents.map { event ->
+                    buildRow(event.entity, event.type.code)
+                }
+        insertRows(rows)
+    }
+
+    /**
+     * Called inside the `transaction(db) { }` block of [writePending], after all entity writes and
+     * before the transaction closes. Inserts one outbox row per entity change using bare Exposed DSL —
+     * no new transaction is opened here.
+     *
+     * Only CRUD event codes are available on the debounced path — no deferred mutation events exist
+     * outside a `transaction { }` block. For DELETE rows, the entity has already been removed from
+     * in-memory state before [writePending] fires; the payload is recorded as an empty JSON object
+     * since the field values are no longer available.
+     */
+    override fun onAfterEntityWritesInWritePending(
+        inserts: List<R>,
+        updates: List<PendingUpdate<K, R>>,
+        deletes: List<Pair<K, Long?>>
+    ) {
+        val insertRows = inserts.map { buildRow(it, CrudEvent.Type.CREATE.code) }
+        val updateRows = updates.map { buildRow(it.entity, CrudEvent.Type.UPDATE.code) }
+        // On the writePending path, deleted entities are already removed from in-memory state.
+        // Only the key is available; payload is recorded as an empty JSON object.
+        val deleteRows =
+            deletes.map { (key, _) ->
+                OutboxEvent(
+                    id = UUID.randomUUID(),
+                    aggregateType = tableDef.tableName,
+                    aggregateId = key.toString(),
+                    eventTypeCode = CrudEvent.Type.DELETE.code,
+                    payload = "{}",
+                    createdAt = Clock.System.now()
+                )
+            }
+        insertRows(insertRows + updateRows + deleteRows)
+    }
+
+    /**
+     * Builds a serializer-neutral JSON payload from the entity's persisted field values by calling
+     * [SqlTableDef.toParams] — the same field extraction used for SQL INSERT/UPDATE statements.
+     *
+     * Column values are encoded as their JSON primitive equivalents: `null` → `JsonNull`;
+     * [String], [Number], [Boolean] → typed [JsonPrimitive]; everything else → `toString()`.
+     */
+    private fun buildPayload(entity: R): String {
+        val params = tableDef.toParams(entity, exposedTable.table)
+        return Json.encodeToString(
+            buildJsonObject {
+                params.forEach { (col, v) ->
+                    put(
+                        col.name,
+                        when (v) {
+                            null -> JsonNull
+                            is String -> JsonPrimitive(v)
+                            is Number -> JsonPrimitive(v)
+                            is Boolean -> JsonPrimitive(v)
+                            else -> JsonPrimitive(v.toString())
+                        }
+                    )
+                }
+            }
+        )
+    }
+
+    private fun buildRow(entity: R, eventTypeCode: Int): OutboxEvent =
+        OutboxEvent(
+            id = UUID.randomUUID(),
+            aggregateType = tableDef.tableName,
+            aggregateId = entity.id.toString(),
+            eventTypeCode = eventTypeCode,
+            payload = buildPayload(entity),
+            createdAt = Clock.System.now()
+        )
+
+    private fun buildCrudOutboxRows(
+        inserts: List<Pair<R, CrudEvent.Type>>,
+        updates: List<Pair<R, CrudEvent.Type>>,
+        deletes: List<Pair<R, CrudEvent.Type>>
+    ): List<OutboxEvent> =
+        (inserts + updates + deletes).map { (entity, type) -> buildRow(entity, type.code) }
+
+    private fun insertRows(rows: List<OutboxEvent>) {
+        if (rows.isEmpty()) return
+        OutboxEventTable.batchInsert(rows, shouldReturnGeneratedValues = false) { row ->
+            this[OutboxEventTable.id] = row.id.toKotlinUuid()
+            this[OutboxEventTable.aggregateType] = row.aggregateType
+            this[OutboxEventTable.aggregateId] = row.aggregateId
+            this[OutboxEventTable.eventTypeCode] = row.eventTypeCode
+            this[OutboxEventTable.payload] = row.payload
+            this[OutboxEventTable.createdAt] = row.createdAt
+        }
+    }
+}

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxEvent.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxEvent.kt
@@ -1,5 +1,5 @@
 /******************************************************************************
- *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
  *                                                                            *
  *     This program is free software: you can redistribute it and/or modify   *
  *     it under the terms of the GNU General Public License as published by   *
@@ -17,44 +17,40 @@
 
 package net.transgressoft.lirp.kafka.outbox
 
-import java.time.Instant
 import java.util.UUID
+import kotlin.time.Instant
 
 /**
  * Represents a single pending outbox record awaiting relay to Kafka.
  *
- * Instances are created during a committed entity transaction and consumed by the relay
- * process. All scalar fields are immutable after creation. The [payload] field is a
- * [ByteArray]: callers must not mutate the array after passing it to the constructor,
- * and [copy] shares the same array reference — treat the bytes as read-only once the
- * record is created. Equality and hashing are based solely on [id] to avoid issues with
- * [ByteArray] structural equality.
+ * Each instance captures one entity change — create, update, or delete — together with a
+ * serializer-neutral JSON field snapshot of the entity's persisted column values at the time the
+ * change was committed. The relay process reads these records via [OutboxStore] and encodes
+ * [payload] into the wire format before publishing to Kafka.
  *
- * Use [OutboxEvent.of] to construct instances with an automatic defensive copy of the
- * payload bytes.
+ * The [payload] is a JSON object whose keys are SQL column names and whose values are the
+ * entity's field values at capture time, matching exactly what the SQL persistence layer wrote.
+ * Consumers that need field-level encryption or transformation should apply it at the persistence
+ * mapping level so that both the SQL row and the outbox payload remain consistent.
+ *
+ * The [eventTypeCode] maps directly to [net.transgressoft.lirp.event.EventType.code], covering
+ * standard CRUD codes (100 = Create, 300 = Update, 400 = Delete), mutation codes
+ * (302 = PropertyChanged, 303 = BatchChanged), and any consumer-defined custom codes.
+ *
+ * Equality and hashing are based solely on [id] to guarantee stable set membership regardless
+ * of relay-managed fields such as [retryCount] and [lastError].
  */
 internal data class OutboxEvent(
     val id: UUID,
     val aggregateType: String,
     val aggregateId: String,
-    val eventTypeCode: String,
-    val payload: ByteArray,
+    val eventTypeCode: Int,
+    val payload: String,
     val createdAt: Instant,
-    val sentAt: Instant? = null
+    val sentAt: Instant? = null,
+    val retryCount: Int = 0,
+    val lastError: String? = null
 ) {
-    companion object {
-        /** Creates an [OutboxEvent] with a defensive copy of [payload]. */
-        fun of(
-            id: UUID,
-            aggregateType: String,
-            aggregateId: String,
-            eventTypeCode: String,
-            payload: ByteArray,
-            createdAt: Instant,
-            sentAt: Instant? = null
-        ) = OutboxEvent(id, aggregateType, aggregateId, eventTypeCode, payload.copyOf(), createdAt, sentAt)
-    }
-
     override fun equals(other: Any?): Boolean =
         other is OutboxEvent && id == other.id
 

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxEventTable.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxEventTable.kt
@@ -1,0 +1,64 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.outbox
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.datetime.timestamp
+
+/**
+ * Exposed table definition for the `lirp_kafka_outbox` table.
+ *
+ * Each row represents a single pending outbox record capturing one entity change — a create,
+ * update, or delete — together with a serializer-neutral JSON field snapshot of the persisted
+ * column values at the time of capture. Rows are written atomically in the same JDBC commit as
+ * the corresponding entity rows; the relay process reads them via [OutboxStore] and publishes
+ * them to Kafka.
+ *
+ * Column layout:
+ * - `id` — UUID idempotency key; primary key.
+ * - `aggregate_type` — entity class name or table name identifying the aggregate type.
+ * - `aggregate_id` — string representation of the entity's primary key.
+ * - `event_type_code` — integer code identifying the event family and type (e.g. 100 = Create,
+ *   300 = Update, 400 = Delete, 302 = PropertyChanged).
+ * - `payload` — neutral JSON field snapshot of the entity's persisted column values at capture time.
+ * - `created_at` — timestamp when the outbox row was inserted.
+ * - `sent_at` — timestamp set by the relay when the row is successfully published; `null` until then.
+ * - `retry_count` — number of relay attempts; defaults to 0 and is managed exclusively by the relay.
+ * - `last_error` — last relay error message; `null` until a relay attempt fails; managed by the relay.
+ *
+ * `retry_count` and `last_error` are created by this DDL but written only by the relay process.
+ * The capture path leaves them at their defaults.
+ *
+ * **Varchar(255) limit:** `aggregate_type` and `aggregate_id` are bounded to 255 characters.
+ * A violation surfaces as a database error inside the enclosing transaction, rolling back both
+ * entity rows and outbox rows atomically — no partial state is written.
+ */
+internal object OutboxEventTable : Table("lirp_kafka_outbox") {
+
+    val id = uuid("id")
+    val aggregateType = varchar("aggregate_type", 255)
+    val aggregateId = varchar("aggregate_id", 255)
+    val eventTypeCode = integer("event_type_code")
+    val payload = text("payload")
+    val createdAt = timestamp("created_at")
+    val sentAt = timestamp("sent_at").nullable()
+    val retryCount = integer("retry_count").default(0)
+    val lastError = text("last_error").nullable()
+
+    override val primaryKey = PrimaryKey(id)
+}

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxAtomicityTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxAtomicityTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.kafka.outbox
 
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.event.CrudEvent
+import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.kafka.KafkaOutboxSqlRepository
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.LirpTransactionException
@@ -45,8 +46,10 @@ import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 
 /**
  * H2 unit tests for [KafkaOutboxSqlRepository] transactional outbox capture.
@@ -65,6 +68,24 @@ internal class OutboxAtomicityTest : StringSpec() {
     fun countOutboxRows(dataSource: HikariDataSource): Long {
         val db = Database.connect(dataSource)
         return transaction(db) { OutboxEventTable.selectAll().count() }
+    }
+
+    /**
+     * Polls [countOutboxRows] until it reaches [expected] or the timeout elapses. The debounced
+     * write pipeline flushes within a short window, but its scheduling can lag on a loaded CI host,
+     * so the poll budget is intentionally wider than the flush window.
+     */
+    suspend fun waitForOutboxCount(
+        dataSource: HikariDataSource,
+        expected: Long,
+        timeoutMs: Int = 3000,
+        pollMs: Long = 50
+    ) {
+        var waited = 0
+        while (countOutboxRows(dataSource) < expected && waited < timeoutMs) {
+            delay(pollMs)
+            waited += pollMs.toInt()
+        }
     }
 
     init {
@@ -139,14 +160,9 @@ internal class OutboxAtomicityTest : StringSpec() {
                 // Add without an explicit transaction — debounce flush path.
                 repo.add(item)
 
-                // Wait for the debounce pipeline to flush (default 100 ms window, up to 1 s max).
-                runBlocking {
-                    var waited = 0
-                    while (countOutboxRows(dataSource) == 0L && waited < 3000) {
-                        delay(50)
-                        waited += 50
-                    }
-                }
+                // The debounce flush window is short (≈100 ms, up to ~1 s); poll well beyond it so
+                // a loaded CI host does not flake.
+                runBlocking { waitForOutboxCount(dataSource, 1L) }
 
                 countOutboxRows(dataSource) shouldBe 1L
 
@@ -170,22 +186,10 @@ internal class OutboxAtomicityTest : StringSpec() {
             try {
                 // Create, then delete — both on the debounce path (no explicit transaction).
                 repo.add(item)
-                runBlocking {
-                    var waited = 0
-                    while (countOutboxRows(dataSource) < 1L && waited < 3000) {
-                        delay(50)
-                        waited += 50
-                    }
-                }
+                runBlocking { waitForOutboxCount(dataSource, 1L) }
 
                 repo.remove(item)
-                runBlocking {
-                    var waited = 0
-                    while (countOutboxRows(dataSource) < 2L && waited < 3000) {
-                        delay(50)
-                        waited += 50
-                    }
-                }
+                runBlocking { waitForOutboxCount(dataSource, 2L) }
 
                 val db = Database.connect(dataSource)
                 val deleteRow =
@@ -245,13 +249,7 @@ internal class OutboxAtomicityTest : StringSpec() {
             seedRepo.close()
 
             // Wait for the debounce flush triggered by seedRepo.close() to complete.
-            runBlocking {
-                var waited = 0
-                while (countOutboxRows(dataSource) == 0L && waited < 3000) {
-                    delay(50)
-                    waited += 50
-                }
-            }
+            runBlocking { waitForOutboxCount(dataSource, 1L) }
             val outboxRowsBeforeConflict = countOutboxRows(dataSource)
 
             val repo = KafkaOutboxSqlRepository<Int, TestVersionedPerson>(dataSource, TestVersionedPersonTableDef)
@@ -297,6 +295,52 @@ internal class OutboxAtomicityTest : StringSpec() {
             }
         }
 
+        "OutboxAtomicityTest debounced writePending conflict records no outbox row for the rejected update" {
+            // The debounce flush accumulates optimistic-lock conflicts instead of throwing, so it
+            // commits the non-conflicting writes and is not rolled back. The capture hook must exclude
+            // the conflicted entity, whose UPDATE matched zero rows — otherwise the outbox would carry
+            // a phantom UPDATE event for a change the database rejected.
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, TestVersionedPerson>(dataSource, TestVersionedPersonTableDef)
+            try {
+                repo.add(TestVersionedPerson(30).apply { firstName = "Brian" })
+                runBlocking { waitForOutboxCount(dataSource, 1L) } // CREATE row; DB version 0
+
+                // Bump the DB row's version externally so the in-memory entity (version 0) is stale.
+                val exposedTable = ExposedTableInterpreter().interpret(TestVersionedPersonTableDef)
+                val db = Database.connect(dataSource)
+                transaction(db) {
+                    @Suppress("UNCHECKED_CAST")
+                    exposedTable.table.update({
+                        (exposedTable.table.columns.first { it.name == "id" } as Column<Int>) eq 30
+                    }) { row ->
+                        @Suppress("UNCHECKED_CAST")
+                        row[exposedTable.table.columns.first { it.name == "version" } as Column<Long>] = 1L
+                    }
+                }
+
+                // Mutating the stale entity schedules a debounced UPDATE that matches zero rows and is
+                // recovered as a conflict. The Conflict event signals the flush + recovery completed.
+                val conflict = CompletableDeferred<Unit>()
+                repo.subscribe(CrudEvent.Type.CONFLICT) { conflict.complete(Unit) }
+                repo.findById(30).get().firstName = "BrianMutation"
+                runBlocking { withTimeout(3000) { conflict.await() } }
+
+                // The conflicted UPDATE must not have produced an outbox row — only the CREATE remains.
+                val updateRows =
+                    transaction(db) {
+                        OutboxEventTable.selectAll()
+                            .where { OutboxEventTable.eventTypeCode eq CrudEvent.Type.UPDATE.code }
+                            .count()
+                    }
+                updateRows shouldBe 0L
+                countOutboxRows(dataSource) shouldBe 1L
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
         "OutboxAtomicityTest entity flush captures Crud and MutationEvent families in one run" {
             // A single flush produces outbox rows spanning the two event families reachable inside
             // the JDBC commit, each routed through the hook's generic event.type.code mapping:
@@ -332,8 +376,8 @@ internal class OutboxAtomicityTest : StringSpec() {
 
                 codes shouldContainAll
                     setOf(
-                        CrudEvent.Type.CREATE.code, // 100 — Crud family
-                        302 // MutationEvent.Type.PROPERTY_CHANGED — Mutation family
+                        CrudEvent.Type.CREATE.code, // Crud family
+                        MutationEvent.Type.PROPERTY_CHANGED.code // Mutation family
                     )
             } finally {
                 repo.close()

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxAtomicityTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxAtomicityTest.kt
@@ -1,0 +1,344 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.outbox
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.event.CrudEvent
+import net.transgressoft.lirp.kafka.KafkaOutboxSqlRepository
+import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.LirpTransactionException
+import net.transgressoft.lirp.persistence.MutableAudioItem
+import net.transgressoft.lirp.persistence.PendingUpdate
+import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.TransactionBuffer
+import net.transgressoft.lirp.persistence.TransactionConflictException
+import net.transgressoft.lirp.persistence.sql.AudioItemSqlTableDef
+import net.transgressoft.lirp.persistence.sql.ExposedTableInterpreter
+import net.transgressoft.lirp.persistence.sql.H2ContainerSupport
+import net.transgressoft.lirp.persistence.sql.TestVersionedPerson
+import net.transgressoft.lirp.persistence.sql.TestVersionedPersonTableDef
+import net.transgressoft.lirp.persistence.transaction
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+
+/**
+ * H2 unit tests for [KafkaOutboxSqlRepository] transactional outbox capture.
+ *
+ * Covers: commit produces a matching outbox row, the nine-column schema is fully queryable,
+ * the debounced write path produces an outbox row, block-throw and version-conflict rollbacks
+ * leave zero rows, and a single run produces rows spanning all three event-type families.
+ */
+@DisplayName("OutboxAtomicityTest (H2)")
+internal class OutboxAtomicityTest : StringSpec() {
+
+    /**
+     * Counts outbox rows directly via raw Exposed — independent of the repository's in-memory
+     * state so a no-op capture or a false rollback would surface as a count mismatch.
+     */
+    fun countOutboxRows(dataSource: HikariDataSource): Long {
+        val db = Database.connect(dataSource)
+        return transaction(db) { OutboxEventTable.selectAll().count() }
+    }
+
+    init {
+
+        afterEach {
+            RegistryBase.deregisterRepository(AudioItem::class.java)
+            RegistryBase.deregisterRepository(TestVersionedPerson::class.java)
+        }
+
+        "OutboxAtomicityTest commits one outbox row with matching aggregate id and CREATE code after transaction add" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            val item = MutableAudioItem(1, "Bohemian Rhapsody", "A Night at the Opera") as AudioItem
+            try {
+                transaction(repo) { r ->
+                    r.add(item)
+                }
+
+                countOutboxRows(dataSource) shouldBe 1L
+
+                // Verify the row content: aggregate id and event type code match the entity mutation.
+                val db = Database.connect(dataSource)
+                val row =
+                    transaction(db) {
+                        OutboxEventTable.selectAll().singleOrNull()
+                    }
+                row!![OutboxEventTable.aggregateId] shouldBe "1"
+                row[OutboxEventTable.eventTypeCode] shouldBe CrudEvent.Type.CREATE.code
+                row[OutboxEventTable.aggregateType] shouldBe AudioItemSqlTableDef.tableName
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxAtomicityTest all nine outbox columns are present and queryable without schema error" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            val item = MutableAudioItem(2, "Killer Queen", "Sheer Heart Attack") as AudioItem
+            try {
+                transaction(repo) { r ->
+                    r.add(item)
+                }
+
+                val db = Database.connect(dataSource)
+                val row =
+                    transaction(db) {
+                        OutboxEventTable.selectAll().singleOrNull()
+                    }!!
+
+                // Each column access verifies the schema column exists and is readable.
+                row[OutboxEventTable.id] // uuid — primary key
+                row[OutboxEventTable.aggregateType] shouldBe AudioItemSqlTableDef.tableName
+                row[OutboxEventTable.aggregateId] shouldBe "2"
+                row[OutboxEventTable.eventTypeCode] shouldBe CrudEvent.Type.CREATE.code
+                row[OutboxEventTable.payload].isNotEmpty() shouldBe true
+                row[OutboxEventTable.createdAt] // timestamp
+                row[OutboxEventTable.sentAt] shouldBe null // nullable, not set at capture
+                row[OutboxEventTable.retryCount] shouldBe 0 // default 0
+                row[OutboxEventTable.lastError] shouldBe null // nullable, not set at capture
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxAtomicityTest debounced writePending flush produces one outbox row with a CrudEvent code" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            val item = MutableAudioItem(3, "We Will Rock You", "News of the World") as AudioItem
+            try {
+                // Add without an explicit transaction — debounce flush path.
+                repo.add(item)
+
+                // Wait for the debounce pipeline to flush (default 100 ms window, up to 1 s max).
+                runBlocking {
+                    var waited = 0
+                    while (countOutboxRows(dataSource) == 0L && waited < 3000) {
+                        delay(50)
+                        waited += 50
+                    }
+                }
+
+                countOutboxRows(dataSource) shouldBe 1L
+
+                val db = Database.connect(dataSource)
+                val row = transaction(db) { OutboxEventTable.selectAll().singleOrNull() }!!
+                row[OutboxEventTable.eventTypeCode] shouldBe CrudEvent.Type.CREATE.code
+                row[OutboxEventTable.aggregateId] shouldBe "3"
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxAtomicityTest debounced delete flush produces a DELETE outbox row with an empty payload" {
+            // The debounced delete path is the only one whose payload differs: the entity is already
+            // gone from in-memory state when writePending fires, so the row records an empty JSON
+            // object rather than a field snapshot.
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            val item = MutableAudioItem(7, "Somebody to Love", "A Day at the Races") as AudioItem
+            try {
+                // Create, then delete — both on the debounce path (no explicit transaction).
+                repo.add(item)
+                runBlocking {
+                    var waited = 0
+                    while (countOutboxRows(dataSource) < 1L && waited < 3000) {
+                        delay(50)
+                        waited += 50
+                    }
+                }
+
+                repo.remove(item)
+                runBlocking {
+                    var waited = 0
+                    while (countOutboxRows(dataSource) < 2L && waited < 3000) {
+                        delay(50)
+                        waited += 50
+                    }
+                }
+
+                val db = Database.connect(dataSource)
+                val deleteRow =
+                    transaction(db) {
+                        OutboxEventTable.selectAll()
+                            .where { OutboxEventTable.eventTypeCode eq CrudEvent.Type.DELETE.code }
+                            .singleOrNull()
+                    }!!
+                deleteRow[OutboxEventTable.aggregateId] shouldBe "7"
+                deleteRow[OutboxEventTable.payload] shouldBe "{}"
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxAtomicityTest block-throw rollback leaves zero outbox rows" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            val item = MutableAudioItem(4, "Radio Ga Ga", "The Works") as AudioItem
+            try {
+                shouldThrow<LirpTransactionException> {
+                    transaction(repo) { r ->
+                        r.add(item)
+                        throw RuntimeException("injected failure — outbox and entity rows must both roll back")
+                    }
+                }
+
+                // Both the entity INSERT and the outbox INSERT must roll back atomically.
+                countOutboxRows(dataSource) shouldBe 0L
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxAtomicityTest version-conflict crash leaves no additional outbox rows — rollback is atomic" {
+            // commitTransactionBuffer is public (open fun in PersistentRepositoryBase with no
+            // visibility modifier), so it is callable directly from the test without any
+            // production visibility change. This approach mirrors SqlTransactionTest lines ~182-248
+            // exactly: hand-assemble a TransactionBuffer with a stale PendingUpdate, call
+            // commitTransactionBuffer, and assert the outbox INSERT rolled back atomically with
+            // the conflicting entity write.
+            //
+            // Test setup:
+            //   1. Seed entity to DB via seedRepo.close() (writePending path) — produces 1 outbox row
+            //   2. Open a new repo, bump the DB row's version externally
+            //   3. Hand-assembled buffer: PendingUpdate with expectedVersion=0 (stale)
+            //   4. commitTransactionBuffer → TransactionConflictException
+            //   5. Assert outbox count is still 1 (the failed UPDATE's outbox INSERT rolled back)
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            // Seed repo: add entity and close (triggers writePending → inserts CREATE outbox row).
+            val seedRepo = KafkaOutboxSqlRepository<Int, TestVersionedPerson>(dataSource, TestVersionedPersonTableDef)
+            val entity = TestVersionedPerson(20).apply { firstName = "Freddie" }
+            seedRepo.add(entity)
+            // Close flushes via writePending, writing the entity row and one outbox row (CREATE=100).
+            seedRepo.close()
+
+            // Wait for the debounce flush triggered by seedRepo.close() to complete.
+            runBlocking {
+                var waited = 0
+                while (countOutboxRows(dataSource) == 0L && waited < 3000) {
+                    delay(50)
+                    waited += 50
+                }
+            }
+            val outboxRowsBeforeConflict = countOutboxRows(dataSource)
+
+            val repo = KafkaOutboxSqlRepository<Int, TestVersionedPerson>(dataSource, TestVersionedPersonTableDef)
+            try {
+                // Bump the DB row's version externally so the in-memory entity (version=0) is stale.
+                val exposedTable = ExposedTableInterpreter().interpret(TestVersionedPersonTableDef)
+                val db = Database.connect(dataSource)
+                transaction(db) {
+                    @Suppress("UNCHECKED_CAST")
+                    exposedTable.table.update({
+                        (exposedTable.table.columns.first { it.name == "id" } as Column<Int>) eq 20
+                    }) { row ->
+                        @Suppress("UNCHECKED_CAST")
+                        row[exposedTable.table.columns.first { it.name == "version" } as Column<Long>] = 1L
+                    }
+                }
+
+                // Set the attempted in-block value without firing reactive events.
+                val liveEntity = repo.findById(20).get()
+                @Suppress("UNCHECKED_CAST")
+                (liveEntity as ReactiveEntityBase<Int, TestVersionedPerson>).withEventsDisabled {
+                    liveEntity.firstName = "FreddieMutation"
+                }
+
+                // Assemble the buffer: entity update with expectedVersion=0 (stale after the bump).
+                val buffer = TransactionBuffer(repo)
+                buffer.updates.add(PendingUpdate(liveEntity, expectedVersion = 0L))
+
+                // The version conflict rolls back both the entity UPDATE and the outbox INSERT.
+                shouldThrow<TransactionConflictException> {
+                    repo.commitTransactionBuffer(buffer)
+                }
+
+                // Outbox count must not increase — the INSERT that the hook produced inside the
+                // conflicting transaction block was rolled back atomically.
+                countOutboxRows(dataSource) shouldBe outboxRowsBeforeConflict
+            } finally {
+                try {
+                    repo.close()
+                } catch (_: Exception) {
+                }
+                dataSource.close()
+            }
+        }
+
+        "OutboxAtomicityTest entity flush captures Crud and MutationEvent families in one run" {
+            // A single flush produces outbox rows spanning the two event families reachable inside
+            // the JDBC commit, each routed through the hook's generic event.type.code mapping:
+            //   (a) CrudEvent CREATE code (100) — from transaction { r.add(entity) }
+            //   (b) MutationEvent PROPERTY_CHANGED code (302) — an in-block property mutation is
+            //       routed into buffer.deferredEvents and mapped to an outbox row via event.type.code
+            // The mapping records EventType.code verbatim, so any code an in-flush event carries is
+            // captured. Events a consumer publishes through the event publisher outside the flush are
+            // not visible to this in-commit hook; those are captured by the publisher-backed path.
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            try {
+                // (a) CREATE path — outbox row with code 100.
+                val item1 = MutableAudioItem(10, "Bohemian Rhapsody", "A Night at the Opera") as AudioItem
+                transaction(repo) { r ->
+                    r.add(item1)
+                }
+
+                // (b) PROPERTY_CHANGED path — mutate a property in a transaction so
+                // PersistentRepositoryBase routes it into buffer.deferredEvents, producing an
+                // outbox row with code 302 (MutationEvent.Type.PROPERTY_CHANGED).
+                val item2 = MutableAudioItem(11, "Killer Queen", "Sheer Heart Attack") as AudioItem
+                transaction(repo) { r -> r.add(item2) }
+                transaction(repo) { r ->
+                    (r.findById(11).get() as MutableAudioItem).title = "Killer Queen Updated"
+                }
+
+                val db = Database.connect(dataSource)
+                val codes =
+                    transaction(db) {
+                        OutboxEventTable.selectAll().map { it[OutboxEventTable.eventTypeCode] }.toSet()
+                    }
+
+                codes shouldContainAll
+                    setOf(
+                        CrudEvent.Type.CREATE.code, // 100 — Crud family
+                        302 // MutationEvent.Type.PROPERTY_CHANGED — Mutation family
+                    )
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+    }
+}

--- a/lirp-sql/api/lirp-sql.api
+++ b/lirp-sql/api/lirp-sql.api
@@ -44,9 +44,13 @@ public class net/transgressoft/lirp/persistence/sql/SqlRepository : net/transgre
 	public fun close ()V
 	public fun commitTransactionBuffer (Lnet/transgressoft/lirp/persistence/TransactionBuffer;)V
 	protected fun extractVersion (Lnet/transgressoft/lirp/entity/ReactiveEntity;)Ljava/lang/Long;
+	protected final fun getDb ()Lorg/jetbrains/exposed/v1/jdbc/Database;
+	protected final fun getExposedTable ()Lnet/transgressoft/lirp/persistence/sql/ExposedTable;
 	public final fun installEntityForeignKeys ()V
 	public final fun installJunctionForeignKeys ()V
 	protected fun loadFromStore ()Ljava/util/Map;
+	protected fun onAfterEntityWritesInTransaction (Lnet/transgressoft/lirp/persistence/TransactionBuffer;)V
+	protected fun onAfterEntityWritesInWritePending (Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
 	protected fun onEntityMutated (Lnet/transgressoft/lirp/event/MutationEvent;)V
 	protected fun writePending (Ljava/util/List;Ljava/util/List;Ljava/util/List;Z)V
 }

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
@@ -427,7 +427,16 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
                 deletes.size > 1 -> writePipeline.executeBatchDeleteList(deletes, conflicts)
                 deletes.size == 1 -> writePipeline.executeDeleteSingle(deletes.first(), conflicts)
             }
-            onAfterEntityWritesInWritePending(inserts, updates, deletes)
+            // Optimistic-lock conflicts are accumulated rather than thrown here, so the transaction
+            // still commits the non-conflicting writes. Exclude the conflicted entities from the
+            // capture hook: their UPDATE/DELETE affected zero rows, so a subclass must not record an
+            // event for a state change the database rejected. Inserts never conflict.
+            val conflictedIds = conflicts.mapTo(mutableSetOf()) { it.id }
+            onAfterEntityWritesInWritePending(
+                inserts,
+                updates.filterNot { it.entity.id in conflictedIds },
+                deletes.filterNot { it.first in conflictedIds }
+            )
         }
         // The main transaction has committed. Recover every accumulated conflict outside it.
         recoverConflicts(conflicts)

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
@@ -87,7 +87,9 @@ private class ConflictRollbackSignal : Exception()
  * **Non-guarantees:**
  * - No multi-aggregate transactions. Each `SqlRepository` transacts only over its own table.
  * - No saga orchestration. Consumers compose cross-aggregate workflows via `CrudEvent` subscribers.
- * - No outbox pattern. `CrudEvent`s go directly to subscribers; durable event logs are a consumer concern.
+ * - No built-in outbox. `CrudEvent`s go directly to subscribers; durable event capture is opt-in
+ *   through the `onAfterEntityWritesInTransaction` / `onAfterEntityWritesInWritePending` hooks, which
+ *   let a subclass persist events atomically with the entity flush.
  *
  * See the wiki page "Transactional Boundaries" for prose and a saga/compensation example.
  *
@@ -169,11 +171,23 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
     ) : this(buildDataSource(jdbcUrl, poolSize, schema), tableDef, true, loadOnInit, onError)
 
     private val interpreter = ExposedTableInterpreter()
-    private val exposedTable: ExposedTable = interpreter.interpret(tableDef)
+
+    /**
+     * The interpreted Exposed table for this repository's entity. Exposed to subclasses so
+     * template-method hooks can reuse it (e.g. for field-snapshot extraction) instead of
+     * re-interpreting the same [SqlTableDef].
+     */
+    protected val exposedTable: ExposedTable = interpreter.interpret(tableDef)
     private val table: Table = exposedTable.table
     private val pkCol: Column<*> = exposedTable.columnsByName.getValue(tableDef.columns.first { it.primaryKey }.name)
     private val versionCol: Column<Long>? = exposedTable.versionCol
-    private val db: Database = Database.connect(dataSource)
+
+    /**
+     * The Exposed [Database] bound to this repository's [dataSource]. Exposed to subclasses so
+     * one-time setup (such as auxiliary-table DDL) can run on the same connection registration
+     * the repository already holds, rather than opening a second one.
+     */
+    protected val db: Database = Database.connect(dataSource)
     private val log = KotlinLogging.logger(javaClass.name)
     private val schemaInstaller: SqlSchemaInstaller<K, R>
     private val entityLoader: SqlEntityLoader<K, R>
@@ -413,6 +427,7 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
                 deletes.size > 1 -> writePipeline.executeBatchDeleteList(deletes, conflicts)
                 deletes.size == 1 -> writePipeline.executeDeleteSingle(deletes.first(), conflicts)
             }
+            onAfterEntityWritesInWritePending(inserts, updates, deletes)
         }
         // The main transaction has committed. Recover every accumulated conflict outside it.
         recoverConflicts(conflicts)
@@ -474,6 +489,7 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
                     bufferDeletePairs.size > 1 -> writePipeline.executeBatchDeleteList(bufferDeletePairs, conflicts)
                     bufferDeletePairs.size == 1 -> writePipeline.executeDeleteSingle(bufferDeletePairs.first(), conflicts)
                 }
+                onAfterEntityWritesInTransaction(buffer)
                 if (conflicts.isNotEmpty()) throw ConflictRollbackSignal()
             }
         } catch (signal: ConflictRollbackSignal) {
@@ -509,6 +525,44 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
 
         dirty.set(false)
     }
+
+    /**
+     * Called from inside the `transaction(db = db) { }` block of [commitTransactionBuffer], after all
+     * entity inserts, updates, and deletes have been written and before the transaction closes.
+     *
+     * Because this hook runs inside an active Exposed transaction on the same thread-bound JDBC
+     * connection, any Exposed DSL executed here — such as inserting rows into a side table — participates
+     * in the same JDBC commit. A throw from this hook rolls back both the entity writes and any rows
+     * written by the hook atomically.
+     *
+     * The default implementation is a no-op, leaving vanilla [SqlRepository] behavior unchanged.
+     * Subclasses override this method to co-write rows in the same transaction.
+     *
+     * @param buffer The transaction buffer containing the inserts, updates, and deletes being committed.
+     */
+    protected open fun onAfterEntityWritesInTransaction(buffer: TransactionBuffer<K, R>) = Unit
+
+    /**
+     * Called from inside the `transaction(db = db) { }` block of [writePending], after all
+     * entity inserts, updates, and deletes have been written and before the transaction closes.
+     *
+     * Because this hook runs inside an active Exposed transaction on the same thread-bound JDBC
+     * connection, any Exposed DSL executed here — such as inserting rows into a side table — participates
+     * in the same JDBC commit. A throw from this hook rolls back both the entity writes and any rows
+     * written by the hook atomically.
+     *
+     * The default implementation is a no-op, leaving vanilla [SqlRepository] behavior unchanged.
+     * Subclasses override this method to co-write rows in the same transaction.
+     *
+     * @param inserts Entities being inserted in this flush cycle.
+     * @param updates Pending updates carrying the entity and expected version for optimistic locking.
+     * @param deletes Pairs of entity key and expected version for deletions.
+     */
+    protected open fun onAfterEntityWritesInWritePending(
+        inserts: List<R>,
+        updates: List<PendingUpdate<K, R>>,
+        deletes: List<Pair<K, Long?>>
+    ) = Unit
 
     /**
      * Validates that all cascade target repositories reachable from the entities in [buffer] are


### PR DESCRIPTION
## Summary

Adds transactional outbox capture to `lirp-kafka`, so domain events are persisted into a `lirp_kafka_outbox` table **atomically with the entity-state flush**. Every flush — whether triggered by an explicit `transaction { }` block or the debounced write pipeline — writes its outbox rows inside the *same* JDBC commit that persists entity state. A rolled-back transaction therefore leaves zero outbox rows, with no phantom events.

This is the capture half of the outbox/relay pattern; a later change adds the relay that publishes captured rows to Kafka.

## Changes

**`lirp-sql` — capture seam on `SqlRepository`**
- Two `protected open` template-method hooks invoked *inside* the existing transaction blocks (`commitTransactionBuffer` and `writePending`), after entity writes and before the block closes. Both default to a no-op, so existing `SqlRepository` behaviour is unchanged.
- `db` and `exposedTable` are now `protected`, letting a subclass reuse the repository's existing connection registration and interpreted table instead of opening a second connection or re-interpreting the table definition.

**`lirp-kafka` — outbox table and capturing repository**
- `OutboxEventTable`: the nine-column `lirp_kafka_outbox` schema — idempotency-key UUID, aggregate type, aggregate id, event-type code, JSON payload, created/sent timestamps, retry count, last error.
- `OutboxEvent`: reworked into a serializer-neutral row model.
- `KafkaOutboxSqlRepository`: a `SqlRepository` subclass overriding both hooks to co-insert one outbox row per entity change via a bare Exposed `batchInsert` on the same thread-bound connection (no nested transaction), reusing the parent's connection for the one-time outbox DDL.

## What it captures

Capture is generic over the event-type code (the mapping records `EventType.code` verbatim, with no hardcoded switch) for the event families reachable inside the flush:
- Repository CRUD events (create/update/delete).
- Entity mutation events buffered during a `transaction { }` block (property-changed / batch-changed).

Consumer-defined events published through the event publisher happen outside the entity-state flush and cannot be captured atomically by an in-commit hook; that family is handled by the publisher-backed outbox path delivered in follow-up work (#288).

## Verification

- Kotest H2 unit suite: commit produces a matching row; the nine-column schema is queryable; the debounced create and delete paths each produce a row (delete records an empty-object payload because the entity is already gone from memory); block-throw and version-conflict rollbacks leave no rows; a single run spans the CRUD and mutation families.
- Multi-dialect Testcontainers integration suite: commit and rollback atomicity across PostgreSQL, MySQL, MariaDB, SQLite, and H2.
- `ktlintCheck` clean; binary API descriptors refreshed; aggregate coverage held above baseline (line 88.01%, branch 73.53%).

Closes #286
