### PR TITLE
Outbox relay: publish outbox rows to Kafka with at-least-once delivery

### DIFF
--- a/lirp-kafka/api/lirp-kafka.api
+++ b/lirp-kafka/api/lirp-kafka.api
@@ -4,6 +4,32 @@ public final class net/transgressoft/lirp/kafka/KafkaEventPublisher : java/lang/
 	public final fun publish (Ljava/lang/String;Ljava/lang/String;[B)V
 }
 
+public final class net/transgressoft/lirp/kafka/KafkaOutboxConfig {
+	public static final field Companion Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig$Companion;
+	public fun <init> ()V
+	public fun <init> (JIIJJ)V
+	public synthetic fun <init> (JIIJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun copy (JIIJJ)Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;
+	public static synthetic fun copy$default (Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;JIIJJILjava/lang/Object;)Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBatchSize ()I
+	public final fun getMaxRetries ()I
+	public final fun getPollIntervalMs ()J
+	public final fun getRetryBaseDelayMs ()J
+	public final fun getRetryMaxDelayMs ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class net/transgressoft/lirp/kafka/KafkaOutboxConfig$Companion {
+	public final fun getDEFAULT ()Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;
+}
+
 public final class net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository : net/transgressoft/lirp/persistence/sql/SqlRepository {
 	public fun <init> (Ljavax/sql/DataSource;Lnet/transgressoft/lirp/persistence/sql/SqlTableDef;Z)V
 	public synthetic fun <init> (Ljavax/sql/DataSource;Lnet/transgressoft/lirp/persistence/sql/SqlTableDef;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -15,6 +41,9 @@ public final class net/transgressoft/lirp/kafka/LirpKafkaConfig : java/lang/Auto
 	public fun close ()V
 	public final fun getBootstrapServers ()Ljava/lang/String;
 	public final fun publisher ()Lnet/transgressoft/lirp/kafka/KafkaEventPublisher;
+	public final fun startRelay (Ljavax/sql/DataSource;Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;Lnet/transgressoft/lirp/event/LirpErrorHandler;)V
+	public static synthetic fun startRelay$default (Lnet/transgressoft/lirp/kafka/LirpKafkaConfig;Ljavax/sql/DataSource;Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;Lnet/transgressoft/lirp/event/LirpErrorHandler;ILjava/lang/Object;)V
+	public final fun stopRelay ()V
 }
 
 public final class net/transgressoft/lirp/kafka/LirpKafkaConfig$Companion {

--- a/lirp-kafka/build.gradle
+++ b/lirp-kafka/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation libs.hikari
     testImplementation testFixtures(project(':lirp-core'))
     testImplementation testFixtures(project(':lirp-sql'))
+    testImplementation libs.mockk
     testRuntimeOnly libs.junit.platform.launcher
 
     integrationTestImplementation platform(libs.junit.bom)

--- a/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayIT.kt
+++ b/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayIT.kt
@@ -35,12 +35,15 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.NewPartitions
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.errors.TopicExistsException
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringDeserializer
 import java.time.Duration
 import java.util.Properties
+import java.util.concurrent.ExecutionException
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -95,6 +98,7 @@ internal class OutboxRelayIT : FunSpec({
                 }
 
                 try {
+                    createMultiPartitionTopic(topic, 1)
                     KafkaConsumer<String, ByteArray>(consumerProps("relay-normal-drain-${System.currentTimeMillis()}")).use { consumer ->
                         awaitConsumerAssignment(consumer, listOf(topic))
                         lirpConfig.startRelay(dataSource, fastRelayConfig())
@@ -162,6 +166,7 @@ internal class OutboxRelayIT : FunSpec({
                 // Second relay run (crash recovery): subscribe consumer FIRST (latest offset),
                 // then start the relay. The redelivered record for key "10" must appear.
                 val lirpConfig2 = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
+                createMultiPartitionTopic(topic, 1)
                 KafkaConsumer<String, ByteArray>(consumerProps("relay-crash-recovery-${System.currentTimeMillis()}")).use { consumer ->
                     awaitConsumerAssignment(consumer, listOf(topic))
                     lirpConfig2.startRelay(dataSource, fastRelayConfig())
@@ -208,15 +213,24 @@ internal class OutboxRelayIT : FunSpec({
                 val lirpConfig1 = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
                 val lirpConfig2 = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
 
+                createMultiPartitionTopic(topic, 1)
                 KafkaConsumer<String, ByteArray>(consumerProps("relay-concurrent-${System.currentTimeMillis()}")).use { consumer ->
                     awaitConsumerAssignment(consumer, listOf(topic))
                     lirpConfig1.startRelay(pgDataSource, fastRelayConfig())
                     lirpConfig2.startRelay(pgDataSource, fastRelayConfig())
                     try {
                         val receivedKeys = mutableListOf<String>()
+                        val expectedKeys = (100 until 100 + n).map { it.toString() }.toSet()
                         eventually(30.seconds) {
                             consumer.poll(Duration.ofMillis(200)).forEach { receivedKeys.add(it.key()) }
-                            receivedKeys.size shouldBe n
+                            countUnsentOutboxRows(pgDataSource) shouldBe 0L
+                            receivedKeys.toSet() shouldBe expectedKeys
+                        }
+                        // Keep draining briefly after the outbox is empty: a duplicate published slightly
+                        // later by the peer relay would otherwise be missed, false-passing the guarantee.
+                        val quietUntil = System.currentTimeMillis() + 2_000L
+                        while (System.currentTimeMillis() < quietUntil) {
+                            consumer.poll(Duration.ofMillis(200)).forEach { receivedKeys.add(it.key()) }
                         }
                         // Each aggregate id must appear exactly once — SKIP LOCKED ensures no double-publish.
                         receivedKeys.groupBy { it }.values.forEach { group ->
@@ -267,16 +281,16 @@ internal class OutboxRelayIT : FunSpec({
                     awaitConsumerAssignment(consumer, listOf(topic))
                     lirpConfig.startRelay(dataSource, fastRelayConfig())
                     try {
-                        val receivedOffsets = mutableListOf<Long>()
+                        val receivedPayloads = mutableListOf<String>()
                         eventually(20.seconds) {
                             consumer.poll(Duration.ofMillis(200))
                                 .filter { it.key() == aggregateId }
-                                .forEach { receivedOffsets.add(it.offset()) }
-                            receivedOffsets.size shouldBe eventCount
+                                .forEach { receivedPayloads.add(String(it.value(), Charsets.UTF_8)) }
+                            receivedPayloads.size shouldBe eventCount
                         }
-                        // All records for the same key land on one partition so offsets are
-                        // monotonically increasing — proving per-aggregate in-order delivery.
-                        receivedOffsets shouldBe receivedOffsets.sorted()
+                        // Records for the same key land on one partition; asserting the decoded payload
+                        // sequence (not just increasing offsets) proves the relay published oldest-first.
+                        receivedPayloads shouldBe (0 until eventCount).map { """{"seq":$it}""" }
                     } finally {
                         lirpConfig.close()
                     }
@@ -331,6 +345,7 @@ internal class OutboxRelayIT : FunSpec({
 
                 val lirpConfig = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
                 // Valid sibling row must be published to Kafka
+                createMultiPartitionTopic(validTopic, 1)
                 KafkaConsumer<String, ByteArray>(consumerProps("relay-dead-letter-${System.currentTimeMillis()}")).use { consumer ->
                     awaitConsumerAssignment(consumer, listOf(validTopic))
                     lirpConfig.startRelay(dataSource, relayConfig)
@@ -411,8 +426,11 @@ private fun <K, V> awaitConsumerAssignment(consumer: KafkaConsumer<K, V>, topics
 }
 
 /**
- * Pre-creates a Kafka topic with [partitions] partitions via [AdminClient].
- * A no-op when the topic already exists.
+ * Ensures a Kafka topic named [topic] exists with at least [partitions] partitions via [AdminClient].
+ *
+ * When the topic already exists on the shared broker its partition count is grown to [partitions] if
+ * necessary, so an existing single-partition topic cannot silently defeat a multi-partition test.
+ * Any admin failure other than [TopicExistsException] is re-thrown rather than swallowed.
  */
 private fun createMultiPartitionTopic(topic: String, partitions: Int) {
     val adminProps =
@@ -422,8 +440,13 @@ private fun createMultiPartitionTopic(topic: String, partitions: Int) {
     AdminClient.create(adminProps).use { admin ->
         try {
             admin.createTopics(listOf(NewTopic(topic, partitions, 1.toShort()))).all().get()
-        } catch (_: Exception) {
-            // Topic may already exist — proceed without failure
+        } catch (e: ExecutionException) {
+            if (e.cause !is TopicExistsException) throw e
+            val existing = admin.describeTopics(listOf(topic)).allTopicNames().get()[topic]
+            val currentPartitions = existing?.partitions()?.size ?: 0
+            if (currentPartitions < partitions) {
+                admin.createPartitions(mapOf(topic to NewPartitions.increaseTo(partitions))).all().get()
+            }
         }
     }
 }
@@ -510,21 +533,27 @@ private fun resetSentAt(dataSource: HikariDataSource, aggregateId: String) {
 
 /**
  * Inserts [count] raw outbox rows for [aggregateType]/[aggregateId] via raw JDBC.
- * Each row gets a unique UUID, CREATE event code (100), and an empty JSON payload.
+ *
+ * Each row gets a unique UUID, CREATE event code (100), a distinguishable `{"seq":i}` payload, and a
+ * strictly increasing `created_at` (base + i ms). The distinct payloads and monotonic timestamps let
+ * a consumer assert the relay published rows in creation order, rather than merely observing that
+ * single-partition offsets increase (which they always do).
  */
 private fun insertRawOutboxRows(dataSource: HikariDataSource, aggregateType: String, aggregateId: String, count: Int) {
+    val baseCreatedAt = java.time.Instant.now()
     dataSource.connection.use { conn ->
-        repeat(count) {
+        repeat(count) { i ->
             conn.prepareStatement(
                 "INSERT INTO lirp_kafka_outbox " +
                     "(id, aggregate_type, aggregate_id, event_type_code, payload, created_at) " +
-                    "VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)"
+                    "VALUES (?, ?, ?, ?, ?, ?)"
             ).use { stmt ->
                 stmt.setObject(1, java.util.UUID.randomUUID())
                 stmt.setString(2, aggregateType)
                 stmt.setString(3, aggregateId)
                 stmt.setInt(4, 100)
-                stmt.setString(5, "{}")
+                stmt.setString(5, """{"seq":$i}""")
+                stmt.setTimestamp(6, java.sql.Timestamp.from(baseCreatedAt.plusMillis(i.toLong())))
                 stmt.executeUpdate()
             }
         }

--- a/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayIT.kt
+++ b/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayIT.kt
@@ -1,0 +1,537 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.outbox
+
+import net.transgressoft.lirp.kafka.KafkaContainerSupport
+import net.transgressoft.lirp.kafka.KafkaOutboxConfig
+import net.transgressoft.lirp.kafka.KafkaOutboxSqlRepository
+import net.transgressoft.lirp.kafka.LirpKafkaConfig
+import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.MutableAudioItem
+import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.sql.AudioItemSqlTableDef
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport
+import net.transgressoft.lirp.persistence.sql.PostgresContainerSupport
+import net.transgressoft.lirp.persistence.transaction
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.common.serialization.StringDeserializer
+import java.time.Duration
+import java.util.Properties
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Testcontainers integration tests for the outbox relay end-to-end path.
+ *
+ * Verifies the relay drains unsent rows across real SQL dialects and a real Kafka broker:
+ * rows are published as Kafka records and their `sent_at` timestamp is set atomically in the
+ * same transaction. Five scenarios are covered:
+ *
+ * 1. **Normal drain**: relay publishes all unsent rows to Kafka and sets `sent_at`.
+ * 2. **Crash/redelivery**: a row whose `sent_at` was never committed (simulating a mid-transaction
+ *    crash) is redelivered on the next relay start — proving at-least-once delivery.
+ * 3. **Concurrent no-double-publish**: two relay instances against PostgreSQL (which enforces
+ *    `FOR UPDATE SKIP LOCKED`) publish each row exactly once.
+ * 4. **Per-aggregate ordering**: rapid sequential mutations to the same aggregate id arrive at
+ *    the consumer in creation order, proving that `aggregateId` as record key + a multi-partition
+ *    topic keeps per-aggregate ordering.
+ * 5. **Dead-letter routing**: a row whose topic name is Kafka-invalid is moved atomically to the
+ *    dead-letter table and the relay continues processing sibling rows.
+ *
+ * Each test case drops and recreates the outbox/dead-letter tables for isolation so the relay's
+ * [SchemaUtils.create] call recreates the schema fresh.
+ */
+@DisplayName("OutboxRelayIT")
+internal class OutboxRelayIT : FunSpec({
+
+    afterEach {
+        RegistryBase.deregisterRepository(AudioItem::class.java)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Test 1: Normal relay path
+    // -----------------------------------------------------------------------------------------
+
+    test("OutboxRelayIT normal relay path drains all unsent rows") {
+        DatabaseTestSupport.withDatabaseTest(
+            DatabaseTestSupport.databases.first { it.name == "PostgreSQL" },
+            AudioItemSqlTableDef
+        ) { dataSource ->
+            dropOutboxTableIfExists(dataSource)
+            dropDeadLetterTableIfExists(dataSource)
+
+            val topic = "${AudioItemSqlTableDef.tableName}.events"
+
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            val lirpConfig = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
+            try {
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(1, "Bohemian Rhapsody", "A Night at the Opera") as AudioItem)
+                    r.add(MutableAudioItem(2, "Killer Queen", "Sheer Heart Attack") as AudioItem)
+                    r.add(MutableAudioItem(3, "We Will Rock You", "News of the World") as AudioItem)
+                }
+
+                try {
+                    KafkaConsumer<String, ByteArray>(consumerProps("relay-normal-drain-${System.currentTimeMillis()}")).use { consumer ->
+                        awaitConsumerAssignment(consumer, listOf(topic))
+                        lirpConfig.startRelay(dataSource, fastRelayConfig())
+                        try {
+                            val receivedKeys = mutableListOf<String>()
+                            eventually(20.seconds) {
+                                consumer.poll(Duration.ofMillis(200)).forEach { receivedKeys.add(it.key()) }
+                                receivedKeys.size shouldBe 3
+                            }
+                            receivedKeys.toSet() shouldBe setOf("1", "2", "3")
+                            eventually(10.seconds) {
+                                countUnsentOutboxRows(dataSource) shouldBe 0L
+                            }
+                        } finally {
+                            lirpConfig.stopRelay()
+                        }
+                    }
+                } finally {
+                    // no-op: consumer.use handles close
+                }
+            } finally {
+                repo.close()
+                lirpConfig.close()
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Test 2: Crash between publish and mark-sent causes redelivery
+    // -----------------------------------------------------------------------------------------
+
+    test("OutboxRelayIT crash between publish and mark-sent causes redelivery") {
+        DatabaseTestSupport.withDatabaseTest(
+            DatabaseTestSupport.databases.first { it.name == "PostgreSQL" },
+            AudioItemSqlTableDef
+        ) { dataSource ->
+            dropOutboxTableIfExists(dataSource)
+            dropDeadLetterTableIfExists(dataSource)
+
+            val topic = "${AudioItemSqlTableDef.tableName}.events"
+
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            try {
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(10, "Radio Ga Ga", "The Works") as AudioItem)
+                }
+
+                // First relay run: relay publishes the record to Kafka and sets sent_at.
+                val lirpConfig1 = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
+                lirpConfig1.startRelay(dataSource, fastRelayConfig())
+                try {
+                    eventually(15.seconds) {
+                        countUnsentOutboxRows(dataSource) shouldBe 0L
+                    }
+                } finally {
+                    lirpConfig1.close()
+                }
+
+                // Simulate crash: reset sent_at back to NULL. This models a scenario where the relay
+                // published to Kafka but the transaction containing the sent_at UPDATE was rolled back
+                // before committing (e.g. a JVM crash or JDBC connection failure mid-transaction).
+                resetSentAt(dataSource, "10")
+                countUnsentOutboxRows(dataSource) shouldBe 1L
+
+                // Second relay run (crash recovery): subscribe consumer FIRST (latest offset),
+                // then start the relay. The redelivered record for key "10" must appear.
+                val lirpConfig2 = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
+                KafkaConsumer<String, ByteArray>(consumerProps("relay-crash-recovery-${System.currentTimeMillis()}")).use { consumer ->
+                    awaitConsumerAssignment(consumer, listOf(topic))
+                    lirpConfig2.startRelay(dataSource, fastRelayConfig())
+                    try {
+                        val receivedKeys = mutableListOf<String>()
+                        eventually(20.seconds) {
+                            consumer.poll(Duration.ofMillis(200)).forEach { receivedKeys.add(it.key()) }
+                            receivedKeys.count { it == "10" } shouldNotBe 0
+                        }
+                        eventually(10.seconds) {
+                            countUnsentOutboxRows(dataSource) shouldBe 0L
+                        }
+                    } finally {
+                        lirpConfig2.close()
+                    }
+                }
+            } finally {
+                repo.close()
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Test 3: Concurrent relay instances do not double-publish (SKIP LOCKED, PostgreSQL only)
+    // -----------------------------------------------------------------------------------------
+
+    test("OutboxRelayIT concurrent relay instances do not double-publish") {
+        // FOR UPDATE SKIP LOCKED is only enforced on PostgreSQL/MySQL/MariaDB; H2 gives a false
+        // green because its SELECT does not honour the SKIP LOCKED clause.
+        val pgDataSource = PostgresContainerSupport.buildDataSource()
+        try {
+            dropOutboxTableIfExists(pgDataSource)
+            dropDeadLetterTableIfExists(pgDataSource)
+
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(pgDataSource, AudioItemSqlTableDef)
+            try {
+                val n = 6
+                transaction(repo) { r ->
+                    repeat(n) { i -> r.add(MutableAudioItem(i + 100, "Track ${i + 1}", "Album A") as AudioItem) }
+                }
+
+                val topic = "${AudioItemSqlTableDef.tableName}.events"
+
+                val lirpConfig1 = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
+                val lirpConfig2 = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
+
+                KafkaConsumer<String, ByteArray>(consumerProps("relay-concurrent-${System.currentTimeMillis()}")).use { consumer ->
+                    awaitConsumerAssignment(consumer, listOf(topic))
+                    lirpConfig1.startRelay(pgDataSource, fastRelayConfig())
+                    lirpConfig2.startRelay(pgDataSource, fastRelayConfig())
+                    try {
+                        val receivedKeys = mutableListOf<String>()
+                        eventually(30.seconds) {
+                            consumer.poll(Duration.ofMillis(200)).forEach { receivedKeys.add(it.key()) }
+                            receivedKeys.size shouldBe n
+                        }
+                        // Each aggregate id must appear exactly once — SKIP LOCKED ensures no double-publish.
+                        receivedKeys.groupBy { it }.values.forEach { group ->
+                            group.size shouldBe 1
+                        }
+                    } finally {
+                        lirpConfig1.close()
+                        lirpConfig2.close()
+                    }
+                }
+            } finally {
+                repo.close()
+            }
+        } finally {
+            pgDataSource.close()
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Test 4: Multi-partition topic preserves per-aggregate ordering
+    // -----------------------------------------------------------------------------------------
+
+    test("OutboxRelayIT multi-partition topic preserves per-aggregate ordering") {
+        DatabaseTestSupport.withDatabaseTest(
+            DatabaseTestSupport.databases.first { it.name == "PostgreSQL" },
+            AudioItemSqlTableDef
+        ) { dataSource ->
+            dropOutboxTableIfExists(dataSource)
+            dropDeadLetterTableIfExists(dataSource)
+
+            val aggregateType = AudioItemSqlTableDef.tableName
+            val topic = "$aggregateType.events"
+            // Pre-create the topic with 3 partitions. The record key (aggregate id) routes all
+            // mutations for a single aggregate to the same partition, preserving order.
+            createMultiPartitionTopic(topic, 3)
+
+            val aggregateId = "42"
+            val eventCount = 5
+
+            // Use the repository to ensure the outbox table exists, then insert additional raw rows
+            // for the same aggregate id to simulate rapid sequential mutations.
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            try {
+                insertRawOutboxRows(dataSource, aggregateType, aggregateId, eventCount)
+
+                val lirpConfig = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
+                KafkaConsumer<String, ByteArray>(consumerProps("relay-ordering-${System.currentTimeMillis()}")).use { consumer ->
+                    awaitConsumerAssignment(consumer, listOf(topic))
+                    lirpConfig.startRelay(dataSource, fastRelayConfig())
+                    try {
+                        val receivedOffsets = mutableListOf<Long>()
+                        eventually(20.seconds) {
+                            consumer.poll(Duration.ofMillis(200))
+                                .filter { it.key() == aggregateId }
+                                .forEach { receivedOffsets.add(it.offset()) }
+                            receivedOffsets.size shouldBe eventCount
+                        }
+                        // All records for the same key land on one partition so offsets are
+                        // monotonically increasing — proving per-aggregate in-order delivery.
+                        receivedOffsets shouldBe receivedOffsets.sorted()
+                    } finally {
+                        lirpConfig.close()
+                    }
+                }
+            } finally {
+                repo.close()
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Test 5: Non-retriable error moves row to dead-letter table and relay continues
+    // -----------------------------------------------------------------------------------------
+
+    test("OutboxRelayIT non-retriable error moves row to dead letter table and relay continues") {
+        DatabaseTestSupport.withDatabaseTest(
+            DatabaseTestSupport.databases.first { it.name == "PostgreSQL" },
+            AudioItemSqlTableDef
+        ) { dataSource ->
+            dropOutboxTableIfExists(dataSource)
+            dropDeadLetterTableIfExists(dataSource)
+
+            val aggregateType = AudioItemSqlTableDef.tableName
+            val validTopic = "$aggregateType.events"
+
+            // maxRetries=1: new rows (retryCount=0) attempt publishing once; a non-retriable Kafka
+            // exception (e.g. InvalidTopicException from an invalid topic name) is caught and the
+            // row is moved to the dead-letter table in the same transaction.
+            val relayConfig =
+                KafkaOutboxConfig(
+                    pollIntervalMs = 50L,
+                    batchSize = 10,
+                    maxRetries = 1,
+                    retryBaseDelayMs = 50L,
+                    retryMaxDelayMs = 100L
+                )
+
+            // Use the repository to ensure the outbox table exists (its init creates the schema).
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            try {
+                // Insert a poison row: aggregate_type contains a '#' character which produces a Kafka-
+                // invalid topic name ("invalid#topic.events"). Kafka's topic naming rules require names
+                // to match [a-zA-Z0-9._-]+; '#' is rejected with InvalidTopicException (a KafkaException
+                // subclass, not RetriableException) so the relay moves this row to the dead-letter table.
+                val poisonAggregateType = "invalid#topic"
+                insertRawOutboxRow(dataSource, poisonAggregateType, "poison-id-1")
+
+                // Insert a valid sibling row that the relay must still publish after the dead-letter move.
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(99, "Another One Bites the Dust", "The Game") as AudioItem)
+                }
+
+                val lirpConfig = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
+                // Valid sibling row must be published to Kafka
+                KafkaConsumer<String, ByteArray>(consumerProps("relay-dead-letter-${System.currentTimeMillis()}")).use { consumer ->
+                    awaitConsumerAssignment(consumer, listOf(validTopic))
+                    lirpConfig.startRelay(dataSource, relayConfig)
+                    try {
+                        val receivedKeys = mutableListOf<String>()
+                        eventually(20.seconds) {
+                            consumer.poll(Duration.ofMillis(200)).forEach { receivedKeys.add(it.key()) }
+                            receivedKeys.size shouldBe 1
+                        }
+                        receivedKeys.first() shouldBe "99"
+
+                        // Poison row must be in the dead-letter table with full failure metadata
+                        eventually(10.seconds) {
+                            countDeadLetterRows(dataSource) shouldBe 1L
+                        }
+                        val dltRow = readFirstDeadLetterRow(dataSource)
+                        dltRow shouldNotBe null
+                        dltRow!!["aggregate_type"] shouldBe poisonAggregateType
+                        (dltRow["attempt_count"] as Number).toInt() shouldBe 1
+                        dltRow["last_error"] shouldNotBe null
+                        dltRow["failed_at"] shouldNotBe null
+
+                        // Outbox must be empty — poison row removed, valid row sent
+                        countUnsentOutboxRows(dataSource) shouldBe 0L
+                    } finally {
+                        lirpConfig.close()
+                    }
+                }
+            } finally {
+                repo.close()
+            }
+        }
+    }
+})
+
+// -------------------------------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------------------------------
+
+/** [KafkaOutboxConfig] tuned for fast test turnaround. */
+private fun fastRelayConfig() =
+    KafkaOutboxConfig(
+        pollIntervalMs = 50L,
+        batchSize = 100,
+        maxRetries = 3,
+        retryBaseDelayMs = 50L,
+        retryMaxDelayMs = 200L
+    )
+
+/** Builds consumer [Properties] connected to the shared Testcontainers Kafka broker. */
+private fun consumerProps(groupId: String): Properties =
+    Properties().apply {
+        put("bootstrap.servers", KafkaContainerSupport.bootstrapServers)
+        put("group.id", groupId)
+        put("key.deserializer", StringDeserializer::class.java.name)
+        put("value.deserializer", ByteArrayDeserializer::class.java.name)
+        // latest: consume only records published AFTER this consumer subscribes,
+        // avoiding cross-test pollution when multiple tests share the same topic name.
+        put("auto.offset.reset", "latest")
+        put("request.timeout.ms", "10000")
+        put("default.api.timeout.ms", "10000")
+    }
+
+/**
+ * Subscribes [consumer] to [topics] and waits until Kafka completes the partition assignment
+ * (i.e. [KafkaConsumer.assignment] becomes non-empty). This must be done BEFORE starting the
+ * relay so that `auto.offset.reset=latest` is anchored after the current end-of-topic, ensuring
+ * the consumer sees only records published during this test run.
+ */
+private fun <K, V> awaitConsumerAssignment(consumer: KafkaConsumer<K, V>, topics: List<String>) {
+    consumer.subscribe(topics)
+    // Trigger the initial rebalance by polling; Kafka assigns partitions lazily on first poll.
+    val deadline = System.currentTimeMillis() + 15_000L
+    while (consumer.assignment().isEmpty() && System.currentTimeMillis() < deadline) {
+        consumer.poll(Duration.ofMillis(200))
+    }
+    check(consumer.assignment().isNotEmpty()) { "Consumer was not assigned any partitions within 15s for topics $topics" }
+}
+
+/**
+ * Pre-creates a Kafka topic with [partitions] partitions via [AdminClient].
+ * A no-op when the topic already exists.
+ */
+private fun createMultiPartitionTopic(topic: String, partitions: Int) {
+    val adminProps =
+        Properties().apply {
+            put("bootstrap.servers", KafkaContainerSupport.bootstrapServers)
+        }
+    AdminClient.create(adminProps).use { admin ->
+        try {
+            admin.createTopics(listOf(NewTopic(topic, partitions, 1.toShort()))).all().get()
+        } catch (_: Exception) {
+            // Topic may already exist — proceed without failure
+        }
+    }
+}
+
+/**
+ * Drops the `lirp_kafka_outbox` table if it exists.
+ * `DROP TABLE IF EXISTS` is supported by all five target dialects.
+ */
+private fun dropOutboxTableIfExists(dataSource: HikariDataSource) {
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("DROP TABLE IF EXISTS lirp_kafka_outbox").use { it.execute() }
+    }
+}
+
+/**
+ * Drops the `lirp_kafka_dead_letter` table if it exists.
+ */
+private fun dropDeadLetterTableIfExists(dataSource: HikariDataSource) {
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("DROP TABLE IF EXISTS lirp_kafka_dead_letter").use { it.execute() }
+    }
+}
+
+/** Counts outbox rows whose `sent_at` is null (pending delivery). */
+private fun countUnsentOutboxRows(dataSource: HikariDataSource): Long =
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("SELECT COUNT(*) FROM lirp_kafka_outbox WHERE sent_at IS NULL")
+            .use { stmt ->
+                stmt.executeQuery().use { rs ->
+                    rs.next()
+                    rs.getLong(1)
+                }
+            }
+    }
+
+/** Counts all rows in the dead-letter table. */
+private fun countDeadLetterRows(dataSource: HikariDataSource): Long =
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("SELECT COUNT(*) FROM lirp_kafka_dead_letter")
+            .use { stmt ->
+                stmt.executeQuery().use { rs ->
+                    rs.next()
+                    rs.getLong(1)
+                }
+            }
+    }
+
+/**
+ * Reads the first dead-letter row as a name-to-value map, or `null` when the table is empty.
+ */
+private fun readFirstDeadLetterRow(dataSource: HikariDataSource): Map<String, Any?>? =
+    dataSource.connection.use { conn ->
+        conn.prepareStatement(
+            "SELECT aggregate_type, attempt_count, last_error, failed_at FROM lirp_kafka_dead_letter LIMIT 1"
+        ).use { stmt ->
+            stmt.executeQuery().use { rs ->
+                if (!rs.next()) null
+                else mapOf(
+                    "aggregate_type" to rs.getString("aggregate_type"),
+                    "attempt_count" to rs.getInt("attempt_count"),
+                    "last_error" to rs.getString("last_error"),
+                    "failed_at" to rs.getTimestamp("failed_at")
+                )
+            }
+        }
+    }
+
+/**
+ * Resets `sent_at = NULL` for the outbox row with the given [aggregateId] via raw JDBC.
+ *
+ * This simulates a crash rollback: the relay had published the record to Kafka but the
+ * transaction containing the `sent_at` UPDATE was never committed, so the row remains pending
+ * and the next relay run redelivers it (at-least-once guarantee).
+ */
+private fun resetSentAt(dataSource: HikariDataSource, aggregateId: String) {
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("UPDATE lirp_kafka_outbox SET sent_at = NULL WHERE aggregate_id = ?")
+            .use { stmt ->
+                stmt.setString(1, aggregateId)
+                stmt.executeUpdate()
+            }
+    }
+}
+
+/**
+ * Inserts [count] raw outbox rows for [aggregateType]/[aggregateId] via raw JDBC.
+ * Each row gets a unique UUID, CREATE event code (100), and an empty JSON payload.
+ */
+private fun insertRawOutboxRows(dataSource: HikariDataSource, aggregateType: String, aggregateId: String, count: Int) {
+    dataSource.connection.use { conn ->
+        repeat(count) {
+            conn.prepareStatement(
+                "INSERT INTO lirp_kafka_outbox " +
+                    "(id, aggregate_type, aggregate_id, event_type_code, payload, created_at) " +
+                    "VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)"
+            ).use { stmt ->
+                stmt.setObject(1, java.util.UUID.randomUUID())
+                stmt.setString(2, aggregateType)
+                stmt.setString(3, aggregateId)
+                stmt.setInt(4, 100)
+                stmt.setString(5, "{}")
+                stmt.executeUpdate()
+            }
+        }
+    }
+}
+
+/** Inserts a single raw outbox row for [aggregateType]/[aggregateId] via raw JDBC. */
+private fun insertRawOutboxRow(dataSource: HikariDataSource, aggregateType: String, aggregateId: String) {
+    insertRawOutboxRows(dataSource, aggregateType, aggregateId, 1)
+}

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxConfig.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxConfig.kt
@@ -1,0 +1,67 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka
+
+/**
+ * Configuration knobs for the outbox relay process.
+ *
+ * Pass an instance to the relay when starting it. The relay requires the full outbox schema
+ * including the `next_retry_at` column; use [KafkaOutboxConfig.DEFAULT] unless you need to
+ * tune the delivery characteristics for a specific deployment.
+ *
+ * Operators tune [pollIntervalMs] and [batchSize] to balance delivery latency against
+ * database load: a lower poll interval reduces end-to-end latency but increases the number of
+ * DB round trips; a larger batch size amortises transaction overhead at the cost of longer
+ * individual poll cycles.
+ *
+ * @property pollIntervalMs Milliseconds the relay waits between poll cycles. A shorter interval
+ *   reduces delivery latency; a longer interval reduces database load. Must be positive.
+ * @property batchSize Maximum number of outbox rows fetched and processed in a single poll
+ *   cycle. Rows exceeding this limit are picked up in subsequent cycles. Must be positive.
+ * @property maxRetries Maximum number of relay delivery attempts before a row is moved to the
+ *   dead-letter table. A value of 0 moves failing rows to dead-letter on the first failure.
+ *   Must be non-negative.
+ * @property retryBaseDelayMs Base delay in milliseconds for exponential backoff after a
+ *   retriable failure. The first retry is scheduled approximately this far into the future.
+ *   Must be positive and not greater than [retryMaxDelayMs].
+ * @property retryMaxDelayMs Upper bound in milliseconds for the exponential backoff delay. The
+ *   computed retry delay is capped at this value regardless of the attempt count. Must be
+ *   greater than or equal to [retryBaseDelayMs].
+ */
+data class KafkaOutboxConfig(
+    val pollIntervalMs: Long = 500L,
+    val batchSize: Int = 100,
+    val maxRetries: Int = 5,
+    val retryBaseDelayMs: Long = 1_000L,
+    val retryMaxDelayMs: Long = 60_000L
+) {
+    init {
+        require(pollIntervalMs > 0) { "pollIntervalMs must be positive, was $pollIntervalMs" }
+        require(batchSize > 0) { "batchSize must be positive, was $batchSize" }
+        require(maxRetries >= 0) { "maxRetries must be non-negative, was $maxRetries" }
+        require(retryBaseDelayMs > 0) { "retryBaseDelayMs must be positive, was $retryBaseDelayMs" }
+        require(retryMaxDelayMs >= retryBaseDelayMs) {
+            "retryMaxDelayMs ($retryMaxDelayMs) must be >= retryBaseDelayMs ($retryBaseDelayMs)"
+        }
+    }
+
+    companion object {
+        /** Default configuration suitable for most deployments. */
+        val DEFAULT = KafkaOutboxConfig()
+    }
+}

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
@@ -17,15 +17,26 @@
 
 package net.transgressoft.lirp.kafka
 
+import net.transgressoft.lirp.event.LirpErrorHandler
+import net.transgressoft.lirp.kafka.outbox.OutboxRelay
+import org.jetbrains.exposed.v1.jdbc.Database
+import javax.sql.DataSource
+
 /**
  * Entry-point configuration for the LIRP Kafka integration.
  *
- * Construct via [LirpKafkaConfig.create] and use to obtain a [KafkaEventPublisher].
- * `bootstrapServers` must be a non-blank comma-separated list of `host:port` pairs.
+ * Construct via [LirpKafkaConfig.create] and use to obtain a [KafkaEventPublisher] or to start
+ * the outbox relay. `bootstrapServers` must be a non-blank comma-separated list of `host:port`
+ * pairs.
  *
- * This class is [AutoCloseable]: calling [close] releases the underlying broker connection
- * held by the cached [KafkaEventPublisher]. Wrap in a `use { }` block or call [close]
- * explicitly when the config is no longer needed.
+ * This class is [AutoCloseable]: calling [close] stops the relay (if running) and releases the
+ * underlying broker connection held by the cached [KafkaEventPublisher]. Wrap in a `use { }`
+ * block or call [close] explicitly when the config is no longer needed.
+ *
+ * **Relay lifecycle:** call [startRelay] with a [DataSource] to begin background outbox
+ * delivery. The relay polls the outbox table, publishes each row via the [KafkaEventPublisher],
+ * and marks it as sent only after the broker acknowledges. Call [stopRelay] to stop the relay
+ * without closing the publisher, or [close] to stop both.
  *
  * **Supported store:** only SQL-backed repositories participate in the transactional outbox.
  * [net.transgressoft.lirp.persistence.JsonFileRepository] and
@@ -36,6 +47,7 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
 
     private val publisherDelegate = lazy { KafkaEventPublisher(bootstrapServers) }
     private val _publisher: KafkaEventPublisher by publisherDelegate
+    private var relay: OutboxRelay? = null
 
     companion object {
         /**
@@ -57,8 +69,37 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
      */
     fun publisher(): KafkaEventPublisher = _publisher
 
-    /** Closes the [KafkaEventPublisher] and releases its broker connections. */
+    /**
+     * Starts the outbox relay against the given [dataSource].
+     *
+     * The relay connects to the database, creates the dead-letter table if it does not exist,
+     * and begins polling the outbox on a background coroutine. At most one relay per
+     * [LirpKafkaConfig] instance is supported; calling [startRelay] when a relay is already
+     * running throws [IllegalStateException].
+     *
+     * @param dataSource JDBC data source for the outbox and dead-letter tables.
+     * @param config Relay behaviour knobs — poll interval, batch size, retry limits, backoff.
+     * @param onDeadLetter Optional callback invoked when a row is moved to the dead-letter table.
+     */
+    fun startRelay(
+        dataSource: DataSource,
+        config: KafkaOutboxConfig = KafkaOutboxConfig.DEFAULT,
+        onDeadLetter: LirpErrorHandler? = null
+    ) {
+        val db = Database.connect(dataSource)
+        relay = OutboxRelay(db, publisher(), config, onDeadLetter).also { it.start() }
+    }
+
+    /** Stops the relay without closing the [KafkaEventPublisher]. */
+    fun stopRelay() {
+        relay?.stop()
+        relay = null
+    }
+
+    /** Stops the relay (if running) and closes the [KafkaEventPublisher]. */
     override fun close() {
+        relay?.stop()
+        relay = null
         if (publisherDelegate.isInitialized()) _publisher.close()
     }
 }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
@@ -81,22 +81,26 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
      * @param config Relay behaviour knobs — poll interval, batch size, retry limits, backoff.
      * @param onDeadLetter Optional callback invoked when a row is moved to the dead-letter table.
      */
+    @Synchronized
     fun startRelay(
         dataSource: DataSource,
         config: KafkaOutboxConfig = KafkaOutboxConfig.DEFAULT,
         onDeadLetter: LirpErrorHandler? = null
     ) {
+        check(relay == null) { "Relay is already running; call stopRelay() first" }
         val db = Database.connect(dataSource)
         relay = OutboxRelay(db, publisher(), config, onDeadLetter).also { it.start() }
     }
 
     /** Stops the relay without closing the [KafkaEventPublisher]. */
+    @Synchronized
     fun stopRelay() {
         relay?.stop()
         relay = null
     }
 
     /** Stops the relay (if running) and closes the [KafkaEventPublisher]. */
+    @Synchronized
     override fun close() {
         relay?.stop()
         relay = null

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/DeadLetterEvent.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/DeadLetterEvent.kt
@@ -21,39 +21,32 @@ import java.util.UUID
 import kotlin.time.Instant
 
 /**
- * Represents a single pending outbox record awaiting relay to Kafka.
+ * Represents a single dead-letter record that the relay could not deliver to Kafka.
  *
- * Each instance captures one entity change — create, update, or delete — together with a
- * serializer-neutral JSON field snapshot of the entity's persisted column values at the time the
- * change was committed. The relay process reads these records via [OutboxStore] and encodes
- * [payload] into the wire format before publishing to Kafka.
+ * Instances are created when the relay moves a row from the outbox to the dead-letter table —
+ * either because it exceeded the maximum retry count or because it encountered a non-retriable
+ * error. The [id] is preserved from the original outbox row for end-to-end traceability.
  *
- * The [payload] is a JSON object whose keys are SQL column names and whose values are the
- * entity's field values at capture time, matching exactly what the SQL persistence layer wrote.
- * Consumers that need field-level encryption or transformation should apply it at the persistence
- * mapping level so that both the SQL row and the outbox payload remain consistent.
+ * The [payload] is the same serializer-neutral JSON field snapshot that was captured at commit
+ * time. Consumers inspecting the dead-letter table can use it to replay or diagnose the failed
+ * delivery without referring back to the entity table.
  *
- * The [eventTypeCode] maps directly to [net.transgressoft.lirp.event.EventType.code], covering
- * standard CRUD codes (100 = Create, 300 = Update, 400 = Delete), mutation codes
- * (302 = PropertyChanged, 303 = BatchChanged), and any consumer-defined custom codes.
- *
- * Equality and hashing are based solely on [id] to guarantee stable set membership regardless
- * of relay-managed fields such as [retryCount], [lastError], and [nextRetryAt].
+ * Equality and hashing are based solely on [id], matching the identity semantics of the
+ * original [OutboxEvent].
  */
-internal data class OutboxEvent(
+internal data class DeadLetterEvent(
     val id: UUID,
     val aggregateType: String,
     val aggregateId: String,
     val eventTypeCode: Int,
     val payload: String,
     val createdAt: Instant,
-    val sentAt: Instant? = null,
-    val nextRetryAt: Instant? = null,
-    val retryCount: Int = 0,
-    val lastError: String? = null
+    val failedAt: Instant,
+    val attemptCount: Int,
+    val lastError: String
 ) {
     override fun equals(other: Any?): Boolean =
-        other is OutboxEvent && id == other.id
+        other is DeadLetterEvent && id == other.id
 
     override fun hashCode(): Int = id.hashCode()
 }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/DeadLetterTable.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/DeadLetterTable.kt
@@ -41,6 +41,11 @@ import org.jetbrains.exposed.v1.datetime.timestamp
  *
  * All failure-metadata columns (`failed_at`, `attempt_count`, `last_error`) are non-nullable
  * because rows are only inserted here after a terminal failure has been recorded.
+ *
+ * **Retention:** dead-lettered rows — including their `payload` snapshot — are retained
+ * indefinitely; the relay never purges this table. Deployments whose payloads may carry sensitive
+ * data are responsible for their own retention policy (for example a scheduled purge keyed on
+ * `failed_at`) to satisfy any applicable compliance requirements.
  */
 internal object DeadLetterTable : Table("lirp_kafka_dead_letter") {
 

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/DeadLetterTable.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/DeadLetterTable.kt
@@ -1,0 +1,58 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.outbox
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.datetime.timestamp
+
+/**
+ * Exposed table definition for the `lirp_kafka_dead_letter` table.
+ *
+ * Rows are moved here from the outbox when the relay determines that an event cannot be
+ * delivered — either because it has exceeded the maximum retry count or because it encountered
+ * a non-retriable error. The original outbox row is deleted atomically in the same transaction
+ * that inserts the dead-letter row.
+ *
+ * Column layout:
+ * - `id` — the original outbox UUID; preserved verbatim for traceability and idempotency.
+ * - `aggregate_type` — entity class name or table name identifying the aggregate type.
+ * - `aggregate_id` — string representation of the entity's primary key.
+ * - `event_type_code` — integer code identifying the event family and type.
+ * - `payload` — the original neutral JSON field snapshot captured at commit time.
+ * - `created_at` — timestamp when the original outbox row was inserted.
+ * - `failed_at` — timestamp when the relay moved the row to this table.
+ * - `attempt_count` — total number of relay delivery attempts including the final one.
+ * - `last_error` — error message from the final failed delivery attempt.
+ *
+ * All failure-metadata columns (`failed_at`, `attempt_count`, `last_error`) are non-nullable
+ * because rows are only inserted here after a terminal failure has been recorded.
+ */
+internal object DeadLetterTable : Table("lirp_kafka_dead_letter") {
+
+    val id = uuid("id")
+    val aggregateType = varchar("aggregate_type", 255)
+    val aggregateId = varchar("aggregate_id", 255)
+    val eventTypeCode = integer("event_type_code")
+    val payload = text("payload")
+    val createdAt = timestamp("created_at")
+    val failedAt = timestamp("failed_at")
+    val attemptCount = integer("attempt_count")
+    val lastError = text("last_error")
+
+    override val primaryKey = PrimaryKey(id)
+}

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxEventTable.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxEventTable.kt
@@ -18,6 +18,7 @@
 package net.transgressoft.lirp.kafka.outbox
 
 import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.datetime.timestamp
 
 /**
@@ -40,13 +41,36 @@ import org.jetbrains.exposed.v1.datetime.timestamp
  * - `sent_at` — timestamp set by the relay when the row is successfully published; `null` until then.
  * - `retry_count` — number of relay attempts; defaults to 0 and is managed exclusively by the relay.
  * - `last_error` — last relay error message; `null` until a relay attempt fails; managed by the relay.
+ * - `next_retry_at` — relay-owned retry-schedule timestamp; `null` means the row is eligible
+ *   for the next poll immediately. Set by the relay after each failed attempt using an exponential
+ *   backoff; cleared implicitly when the row is successfully published or moved to the dead-letter
+ *   table.
  *
- * `retry_count` and `last_error` are created by this DDL but written only by the relay process.
- * The capture path leaves them at their defaults.
+ * `retry_count`, `last_error`, and `next_retry_at` are created by this DDL but written only by
+ * the relay process. The capture path leaves them at their defaults.
  *
  * **Varchar(255) limit:** `aggregate_type` and `aggregate_id` are bounded to 255 characters.
  * A violation surfaces as a database error inside the enclosing transaction, rolling back both
  * entity rows and outbox rows atomically — no partial state is written.
+ *
+ * **Relay poll index:** `idx_lirp_kafka_outbox_relay` is a composite index over
+ * `(sent_at, next_retry_at, created_at)`. On PostgreSQL and SQLite it is created as a partial
+ * index with `WHERE sent_at IS NULL`, covering only unsent rows. On MySQL and MariaDB the
+ * `filterCondition` predicate is not supported and is silently dropped by Exposed, creating a
+ * plain composite index instead; the relay's WHERE clause still applies the same filter at
+ * query time.
+ *
+ * **Single-relay constraint for SQLite and H2:** SQLite and H2 do not support
+ * `FOR UPDATE SKIP LOCKED`, so the relay issues a plain `SELECT … LIMIT` without row-level
+ * locking. Running more than one relay instance against the same SQLite or H2 database will
+ * result in duplicate Kafka records. These dialects are intended for single-instance
+ * deployments and local testing only; use PostgreSQL or MySQL/MariaDB for production
+ * environments where multiple relay instances may run concurrently.
+ *
+ * **MySQL/MariaDB `FOR UPDATE SKIP LOCKED`:** MySQL 8.0+ and MariaDB 10.6+ support
+ * `FOR UPDATE SKIP LOCKED` via [SqlOutboxStore.findUnsentForRelay], so concurrent relay
+ * instances are safe on those dialects even though the index is a plain composite rather
+ * than a partial index.
  */
 internal object OutboxEventTable : Table("lirp_kafka_outbox") {
 
@@ -59,6 +83,16 @@ internal object OutboxEventTable : Table("lirp_kafka_outbox") {
     val sentAt = timestamp("sent_at").nullable()
     val retryCount = integer("retry_count").default(0)
     val lastError = text("last_error").nullable()
+    val nextRetryAt = timestamp("next_retry_at").nullable()
 
     override val primaryKey = PrimaryKey(id)
+
+    init {
+        index(
+            customIndexName = "idx_lirp_kafka_outbox_relay",
+            isUnique = false,
+            columns = arrayOf(sentAt, nextRetryAt, createdAt),
+            filterCondition = { sentAt.isNull() }
+        )
+    }
 }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
@@ -1,0 +1,173 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.outbox
+
+import net.transgressoft.lirp.event.LirpErrorContext
+import net.transgressoft.lirp.event.LirpErrorHandler
+import net.transgressoft.lirp.event.LirpOperation
+import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.kafka.KafkaEventPublisher
+import net.transgressoft.lirp.kafka.KafkaOutboxConfig
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.apache.kafka.common.errors.RetriableException
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Instant
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Background relay loop that drains the transactional outbox by publishing each unsent row to
+ * Kafka and marking it as sent only after the broker acknowledges the record.
+ *
+ * Each poll cycle executes inside a single Exposed transaction: the transaction polls unsent rows
+ * (using dialect-appropriate row locking on PostgreSQL/MySQL/MariaDB), publishes each row via
+ * [publisher], and commits [SqlOutboxStore.markSent] after a successful publish. A crash between
+ * publish and commit rolls the transaction back, leaving the row available for redelivery on the
+ * next cycle — the at-least-once guarantee.
+ *
+ * **Failure classification:** a [RetriableException] from the Kafka client increments
+ * [OutboxEvent.retryCount] and schedules the next attempt via exponential backoff. Any other
+ * exception, and any row whose [OutboxEvent.retryCount] is already at [KafkaOutboxConfig.maxRetries],
+ * is moved atomically to the dead-letter table and the [onDeadLetter] callback is invoked.
+ *
+ * **Topic routing:** each row is published to `"${row.aggregateType}.events"`. This default routing
+ * is suitable for most single-aggregate deployments; pluggable topic resolution is deferred to a
+ * later release.
+ *
+ * **Ordering:** records are keyed by [OutboxEvent.aggregateId] so the Kafka producer routes
+ * all events for a given aggregate to the same partition, preserving per-aggregate ordering.
+ *
+ * **Connection resource:** the relay holds a HikariCP connection open while waiting for Kafka
+ * broker acknowledgement inside each row's transaction. Configure the Kafka producer's
+ * `delivery.timeout.ms` and `request.timeout.ms` to bound this window; a broker outage that
+ * exceeds the connection pool's `connectionTimeout` will surface as a pool exhaustion error.
+ *
+ * @param db Exposed [Database] handle for the outbox and dead-letter tables.
+ * @param publisher Kafka publisher used to send each outbox row.
+ * @param config Relay behaviour knobs — poll interval, batch size, retry limits, backoff.
+ * @param onDeadLetter Optional callback invoked when a row is moved to the dead-letter table.
+ *   The callback receives the terminal exception and a [LirpErrorContext] describing the failure.
+ *   Exceptions thrown by the callback are swallowed.
+ */
+internal class OutboxRelay(
+    private val db: Database,
+    private val publisher: KafkaEventPublisher,
+    private val config: KafkaOutboxConfig,
+    private val onDeadLetter: LirpErrorHandler? = null
+) : AutoCloseable {
+
+    private val log = KotlinLogging.logger(javaClass.name)
+    private val store = SqlOutboxStore(db)
+    private var job: Job? = null
+
+    /**
+     * Starts the background poll loop on [ReactiveScope.ioScope].
+     *
+     * The [DeadLetterTable] schema is created idempotently before the loop starts. Calling
+     * [start] on a relay that is already running throws [IllegalStateException].
+     */
+    fun start() {
+        check(job == null || job!!.isCompleted) { "Relay is already running" }
+        transaction(db) { SchemaUtils.create(DeadLetterTable) }
+        job =
+            ReactiveScope.ioScope.launch {
+                while (isActive) {
+                    try {
+                        pollAndRelay()
+                    } catch (e: CancellationException) {
+                        throw e // cooperative cancellation — never swallow
+                    } catch (e: Exception) {
+                        log.error(e) { "Relay poll cycle failed" }
+                    }
+                    delay(config.pollIntervalMs)
+                }
+            }
+    }
+
+    /** Cancels the background poll loop. A stopped relay can be [start]ed again. */
+    fun stop() {
+        job?.cancel()
+    }
+
+    override fun close() {
+        stop()
+    }
+
+    internal fun pollAndRelay() {
+        val now = Clock.System.now()
+        transaction(db) {
+            val rows = store.findUnsentForRelay(config.batchSize, now)
+            rows.forEach { row -> processRow(row) }
+        }
+    }
+
+    internal fun processRow(row: OutboxEvent) {
+        if (row.retryCount >= config.maxRetries) {
+            val cause = RuntimeException("Max retries (${config.maxRetries}) exceeded for outbox event ${row.id}")
+            store.moveToDeadLetter(row, Clock.System.now(), cause.message!!)
+            invokeDeadLetterCallback(cause)
+            return
+        }
+
+        try {
+            publisher.publish(topicFor(row), row.aggregateId, row.payload.toByteArray())
+            store.markSent(row.id)
+        } catch (e: RetriableException) {
+            val nextRetryAt = computeNextRetryAt(row.retryCount, config)
+            store.scheduleRetry(row.id, nextRetryAt, e.message ?: e.javaClass.simpleName)
+        } catch (e: Exception) {
+            store.moveToDeadLetter(row, Clock.System.now(), e.message ?: e.javaClass.simpleName)
+            invokeDeadLetterCallback(e)
+        }
+    }
+
+    private fun invokeDeadLetterCallback(cause: Throwable) {
+        try {
+            onDeadLetter?.invoke(cause, LirpErrorContext(LirpOperation.EMIT, emptyList(), javaClass.name))
+        } catch (e: Exception) {
+            log.error(e) { "onDeadLetter callback threw an exception" }
+        }
+    }
+
+    internal companion object {
+
+        internal fun topicFor(row: OutboxEvent): String = "${row.aggregateType}.events"
+
+        /**
+         * Computes the next retry timestamp using exponential backoff with ±20% jitter.
+         *
+         * The delay doubles with each attempt (base × 2^retryCount) and is capped at
+         * [KafkaOutboxConfig.retryMaxDelayMs]. The ±20% uniform jitter is applied to reduce
+         * thundering-herd effects when many rows fail simultaneously.
+         */
+        internal fun computeNextRetryAt(retryCount: Int, config: KafkaOutboxConfig): Instant {
+            val baseMs = config.retryBaseDelayMs
+            val capMs = config.retryMaxDelayMs
+            val raw = minOf(baseMs * (1L shl retryCount), capMs)
+            val jittered = raw * (0.8 + Math.random() * 0.4)
+            return Clock.System.now() + jittered.toLong().milliseconds
+        }
+    }
+}

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
@@ -33,24 +33,31 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Instant
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 /**
  * Background relay loop that drains the transactional outbox by publishing each unsent row to
  * Kafka and marking it as sent only after the broker acknowledges the record.
  *
- * Each poll cycle executes inside a single Exposed transaction: the transaction polls unsent rows
- * (using dialect-appropriate row locking on PostgreSQL/MySQL/MariaDB), publishes each row via
- * [publisher], and commits [SqlOutboxStore.markSent] after a successful publish. A crash between
- * publish and commit rolls the transaction back, leaving the row available for redelivery on the
- * next cycle — the at-least-once guarantee.
+ * Each row is processed inside its own Exposed transaction: the transaction claims a single unsent
+ * row (using dialect-appropriate row locking on PostgreSQL/MySQL/MariaDB so concurrent relays skip
+ * it), publishes it via [publisher], and commits [SqlOutboxStore.markSent] after a successful
+ * publish. A crash between publish and commit rolls back only that row's transaction, leaving it
+ * available for redelivery on the next cycle — the at-least-once guarantee. Scoping each row to its
+ * own transaction keeps a transient persistence failure on one row from rolling back rows already
+ * published and marked in the same cycle.
  *
  * **Failure classification:** a [RetriableException] from the Kafka client increments
- * [OutboxEvent.retryCount] and schedules the next attempt via exponential backoff. Any other
- * exception, and any row whose [OutboxEvent.retryCount] is already at [KafkaOutboxConfig.maxRetries],
- * is moved atomically to the dead-letter table and the [onDeadLetter] callback is invoked.
+ * [OutboxEvent.retryCount] and schedules the next attempt via exponential backoff while retries
+ * remain; once [OutboxEvent.retryCount] reaches [KafkaOutboxConfig.maxRetries] a further retriable
+ * failure moves the row to the dead-letter table. Any non-retriable exception moves the row
+ * immediately. Delivery is always attempted at least once — a [KafkaOutboxConfig.maxRetries] of 0
+ * dead-letters a row only after its first delivery attempt fails. The [onDeadLetter] callback is
+ * invoked on every dead-letter move.
  *
  * **Topic routing:** each row is published to `"${row.aggregateType}.events"`. This default routing
  * is suitable for most single-aggregate deployments; pluggable topic resolution is deferred to a
@@ -106,9 +113,15 @@ internal class OutboxRelay(
             }
     }
 
-    /** Cancels the background poll loop. A stopped relay can be [start]ed again. */
+    /**
+     * Cancels the background poll loop and waits for it to finish before returning, so callers can
+     * safely close the underlying [DataSource][javax.sql.DataSource] afterwards. A stopped relay can
+     * be [start]ed again.
+     */
     fun stop() {
-        job?.cancel()
+        val current = job ?: return
+        runBlocking { current.cancelAndJoin() }
+        job = null
     }
 
     override fun close() {
@@ -117,26 +130,31 @@ internal class OutboxRelay(
 
     internal fun pollAndRelay() {
         val now = Clock.System.now()
-        transaction(db) {
-            val rows = store.findUnsentForRelay(config.batchSize, now)
-            rows.forEach { row -> processRow(row) }
+        var processed = 0
+        while (processed < config.batchSize) {
+            val handled =
+                transaction(db) {
+                    val row = store.findUnsentForRelay(1, now).firstOrNull() ?: return@transaction false
+                    processRow(row)
+                    true
+                }
+            if (!handled) break
+            processed++
         }
     }
 
     internal fun processRow(row: OutboxEvent) {
-        if (row.retryCount >= config.maxRetries) {
-            val cause = RuntimeException("Max retries (${config.maxRetries}) exceeded for outbox event ${row.id}")
-            store.moveToDeadLetter(row, Clock.System.now(), cause.message!!)
-            invokeDeadLetterCallback(cause)
-            return
-        }
-
         try {
             publisher.publish(topicFor(row), row.aggregateId, row.payload.toByteArray())
             store.markSent(row.id)
         } catch (e: RetriableException) {
-            val nextRetryAt = computeNextRetryAt(row.retryCount, config)
-            store.scheduleRetry(row.id, nextRetryAt, e.message ?: e.javaClass.simpleName)
+            if (row.retryCount >= config.maxRetries) {
+                store.moveToDeadLetter(row, Clock.System.now(), e.message ?: e.javaClass.simpleName)
+                invokeDeadLetterCallback(e)
+            } else {
+                val nextRetryAt = computeNextRetryAt(row.retryCount, config)
+                store.scheduleRetry(row.id, nextRetryAt, e.message ?: e.javaClass.simpleName)
+            }
         } catch (e: Exception) {
             store.moveToDeadLetter(row, Clock.System.now(), e.message ?: e.javaClass.simpleName)
             invokeDeadLetterCallback(e)
@@ -165,7 +183,10 @@ internal class OutboxRelay(
         internal fun computeNextRetryAt(retryCount: Int, config: KafkaOutboxConfig): Instant {
             val baseMs = config.retryBaseDelayMs
             val capMs = config.retryMaxDelayMs
-            val raw = minOf(baseMs * (1L shl retryCount), capMs)
+            // Clamp the shift distance: `Long shl` masks to the low 6 bits, so a retryCount >= 64
+            // would silently wrap to a small exponent instead of saturating at capMs.
+            val safeShift = minOf(retryCount, 62)
+            val raw = minOf(baseMs * (1L shl safeShift), capMs)
             val jittered = raw * (0.8 + Math.random() * 0.4)
             return Clock.System.now() + jittered.toLong().milliseconds
         }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxStore.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxStore.kt
@@ -18,6 +18,7 @@
 package net.transgressoft.lirp.kafka.outbox
 
 import java.util.UUID
+import kotlin.time.Instant
 
 /**
  * Abstraction over the outbox persistence layer.
@@ -42,4 +43,28 @@ internal interface OutboxStore {
      * Marks the event identified by [id] as sent.
      */
     fun markSent(id: UUID)
+
+    /**
+     * Returns up to [limit] outbox rows whose [OutboxEvent.sentAt] is null and whose
+     * [OutboxEvent.nextRetryAt] is null or is not later than [now], using dialect-appropriate
+     * row locking (FOR UPDATE SKIP LOCKED on PostgreSQL/MySQL/MariaDB; plain SELECT on
+     * SQLite/H2). Rows are ordered by creation time ascending so older events are delivered
+     * first. Must be called inside an active Exposed transaction.
+     */
+    fun findUnsentForRelay(limit: Int, now: Instant): List<OutboxEvent>
+
+    /**
+     * Increments [OutboxEvent.retryCount] and sets [OutboxEvent.nextRetryAt] and
+     * [OutboxEvent.lastError] for the row identified by [id]. Used by the relay after a
+     * retriable delivery failure to schedule the next attempt according to the backoff policy.
+     * Must be called inside an active Exposed transaction.
+     */
+    fun scheduleRetry(id: UUID, nextRetryAt: Instant, errorMessage: String)
+
+    /**
+     * Copies the row identified by [event.id] into the dead-letter table and deletes it from
+     * the outbox in the same transaction. Used when the row has exhausted its retries or
+     * encountered a non-retriable error. Must be called inside an active Exposed transaction.
+     */
+    fun moveToDeadLetter(event: OutboxEvent, failedAt: Instant, errorMessage: String)
 }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/SqlOutboxStore.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/SqlOutboxStore.kt
@@ -1,0 +1,146 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.outbox
+
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.core.plus
+import org.jetbrains.exposed.v1.core.vendors.ForUpdateOption
+import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
+import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.v1.core.vendors.currentDialect
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.update
+import java.util.UUID
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlin.uuid.toJavaUuid
+import kotlin.uuid.toKotlinUuid
+
+/**
+ * Exposed-backed implementation of [OutboxStore].
+ *
+ * All relay-side methods ([findUnsentForRelay], [scheduleRetry], [moveToDeadLetter]) require an
+ * active Exposed transaction opened by the caller — typically [OutboxRelay.pollAndRelay]. Holding
+ * the transaction open across the Kafka publish call means a crash between publish and
+ * [markSent] leaves the row unsent; the rolled-back transaction is the redelivery guarantee.
+ *
+ * **Dialect-aware locking:** [findUnsentForRelay] applies `FOR UPDATE SKIP LOCKED` on
+ * PostgreSQL, MySQL, and MariaDB so concurrent relay instances skip rows already claimed by a
+ * peer. On H2 and SQLite (test and single-instance deployments) the lock clause is omitted and
+ * a plain `SELECT … LIMIT` is used; for those dialects a single-relay deployment is the only
+ * supported configuration.
+ */
+internal class SqlOutboxStore(private val db: Database) : OutboxStore {
+
+    override fun findUnsent(limit: Int): List<OutboxEvent> =
+        OutboxEventTable.selectAll()
+            .where { OutboxEventTable.sentAt.isNull() }
+            .orderBy(OutboxEventTable.createdAt to SortOrder.ASC)
+            .limit(limit)
+            .map(::toOutboxEvent)
+
+    override fun markSent(id: UUID) {
+        OutboxEventTable.update({ OutboxEventTable.id eq id.toKotlinUuid() }) {
+            it[sentAt] = Clock.System.now()
+        }
+    }
+
+    /**
+     * Polls up to [limit] outbox rows eligible for delivery: [OutboxEvent.sentAt] is null and
+     * [OutboxEvent.nextRetryAt] is null or not later than [now]. Rows are ordered by creation
+     * time ascending so older events are delivered first.
+     *
+     * On PostgreSQL and MySQL/MariaDB a `FOR UPDATE SKIP LOCKED` clause prevents concurrent relay
+     * instances from claiming the same row. The lock is held for the duration of the enclosing
+     * transaction — that same transaction will either commit [markSent] or roll back, leaving the
+     * row available for the next poll cycle.
+     */
+    override fun findUnsentForRelay(limit: Int, now: Instant): List<OutboxEvent> {
+        val lockOption: ForUpdateOption? =
+            when (currentDialect) {
+                is PostgreSQLDialect ->
+                    ForUpdateOption.PostgreSQL.ForUpdate(ForUpdateOption.PostgreSQL.MODE.SKIP_LOCKED)
+                is MysqlDialect ->
+                    // MysqlDialect is the parent of MariaDBDialect — this branch covers both.
+                    ForUpdateOption.MySQL.ForUpdate(ForUpdateOption.MySQL.MODE.SKIP_LOCKED)
+                else -> null // H2, SQLite — plain SELECT; single-relay constraint is documented
+            }
+
+        val query =
+            OutboxEventTable.selectAll()
+                .where {
+                    OutboxEventTable.sentAt.isNull() and
+                        (
+                            OutboxEventTable.nextRetryAt.isNull() or
+                                (OutboxEventTable.nextRetryAt lessEq now)
+                        )
+                }
+                .orderBy(OutboxEventTable.createdAt to SortOrder.ASC)
+                .limit(limit)
+
+        lockOption?.let { query.forUpdate(it) }
+
+        return query.map(::toOutboxEvent)
+    }
+
+    override fun scheduleRetry(id: UUID, nextRetryAt: Instant, errorMessage: String) {
+        OutboxEventTable.update({ OutboxEventTable.id eq id.toKotlinUuid() }) {
+            it[retryCount] = OutboxEventTable.retryCount + 1
+            it[this.nextRetryAt] = nextRetryAt
+            it[lastError] = errorMessage
+        }
+    }
+
+    override fun moveToDeadLetter(event: OutboxEvent, failedAt: Instant, errorMessage: String) {
+        DeadLetterTable.insert {
+            it[id] = event.id.toKotlinUuid()
+            it[aggregateType] = event.aggregateType
+            it[aggregateId] = event.aggregateId
+            it[eventTypeCode] = event.eventTypeCode
+            it[payload] = event.payload
+            it[createdAt] = event.createdAt
+            it[DeadLetterTable.failedAt] = failedAt
+            it[attemptCount] = event.retryCount + 1
+            it[lastError] = errorMessage
+        }
+        OutboxEventTable.deleteWhere { OutboxEventTable.id eq event.id.toKotlinUuid() }
+    }
+
+    private fun toOutboxEvent(row: ResultRow): OutboxEvent =
+        OutboxEvent(
+            id = row[OutboxEventTable.id].toJavaUuid(),
+            aggregateType = row[OutboxEventTable.aggregateType],
+            aggregateId = row[OutboxEventTable.aggregateId],
+            eventTypeCode = row[OutboxEventTable.eventTypeCode],
+            payload = row[OutboxEventTable.payload],
+            createdAt = row[OutboxEventTable.createdAt],
+            sentAt = row[OutboxEventTable.sentAt],
+            retryCount = row[OutboxEventTable.retryCount],
+            lastError = row[OutboxEventTable.lastError],
+            nextRetryAt = row[OutboxEventTable.nextRetryAt]
+        )
+}

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
@@ -1,0 +1,338 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.outbox
+
+import net.transgressoft.lirp.event.LirpErrorContext
+import net.transgressoft.lirp.event.LirpErrorHandler
+import net.transgressoft.lirp.event.LirpOperation
+import net.transgressoft.lirp.kafka.KafkaEventPublisher
+import net.transgressoft.lirp.kafka.KafkaOutboxConfig
+import net.transgressoft.lirp.kafka.KafkaOutboxSqlRepository
+import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.MutableAudioItem
+import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.sql.AudioItemSqlTableDef
+import net.transgressoft.lirp.persistence.sql.H2ContainerSupport
+import net.transgressoft.lirp.persistence.transaction
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.apache.kafka.common.errors.NetworkException
+import org.apache.kafka.common.errors.RecordTooLargeException
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.uuid.toKotlinUuid
+
+/**
+ * H2 unit tests for the outbox relay machinery.
+ *
+ * Each test uses a fresh H2 DataSource for isolation. The relay is driven synchronously via
+ * [OutboxRelay.pollAndRelay] rather than the background loop so tests are deterministic and
+ * do not need to wait for the poll interval.
+ */
+@DisplayName("OutboxRelayTest (H2)")
+internal class OutboxRelayTest : StringSpec() {
+
+    val fastConfig =
+        KafkaOutboxConfig(
+            pollIntervalMs = 100L,
+            batchSize = 10,
+            maxRetries = 3,
+            retryBaseDelayMs = 100L,
+            retryMaxDelayMs = 1_000L
+        )
+
+    init {
+        afterEach {
+            RegistryBase.deregisterRepository(AudioItem::class.java)
+        }
+
+        "OutboxRelayTest drains the outbox by publishing rows and flipping sent_at" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            val publisher = mockk<KafkaEventPublisher>()
+            justRun { publisher.publish(any(), any(), any()) }
+
+            try {
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(1, "Bohemian Rhapsody", "A Night at the Opera") as AudioItem)
+                    r.add(MutableAudioItem(2, "Killer Queen", "Sheer Heart Attack") as AudioItem)
+                }
+
+                val db = Database.connect(dataSource)
+                val relay = OutboxRelay(db, publisher, fastConfig)
+                transaction(db) { SchemaUtils.create(DeadLetterTable) }
+                relay.pollAndRelay()
+
+                // All rows should have sent_at set after one cycle
+                val rows =
+                    transaction(db) {
+                        OutboxEventTable.selectAll()
+                            .where { OutboxEventTable.sentAt.isNull() }
+                            .count()
+                    }
+                rows shouldBe 0L
+                verify(exactly = 2) { publisher.publish(any(), any(), any()) }
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxRelayTest marks sent_at only after publish succeeds and uses aggregate id as record key" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            val capturedKeys = mutableListOf<String>()
+            val publisher = mockk<KafkaEventPublisher>()
+            every { publisher.publish(any(), capture(capturedKeys), any()) } returns Unit
+
+            try {
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(42, "We Will Rock You", "News of the World") as AudioItem)
+                }
+
+                val db = Database.connect(dataSource)
+                val relay = OutboxRelay(db, publisher, fastConfig)
+                transaction(db) { SchemaUtils.create(DeadLetterTable) }
+                relay.pollAndRelay()
+
+                val row = transaction(db) { OutboxEventTable.selectAll().single() }
+                row[OutboxEventTable.sentAt].shouldNotBeNull()
+                // Record key must equal the aggregate id
+                capturedKeys.single() shouldBe "42"
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxRelayTest retriable error leaves sent_at null, increments retry_count, sets next_retry_at" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            val publisher = mockk<KafkaEventPublisher>()
+            every { publisher.publish(any(), any(), any()) } throws NetworkException("broker unavailable")
+
+            try {
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(10, "Radio Ga Ga", "The Works") as AudioItem)
+                }
+
+                val db = Database.connect(dataSource)
+                val relay = OutboxRelay(db, publisher, fastConfig)
+                transaction(db) { SchemaUtils.create(DeadLetterTable) }
+                relay.pollAndRelay()
+
+                val row = transaction(db) { OutboxEventTable.selectAll().single() }
+                row[OutboxEventTable.sentAt].shouldBeNull()
+                row[OutboxEventTable.retryCount] shouldBe 1
+                row[OutboxEventTable.nextRetryAt].shouldNotBeNull()
+                // Dead-letter table stays empty
+                transaction(db) { DeadLetterTable.selectAll().count() } shouldBe 0L
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxRelayTest non-retriable error moves row to dead-letter table and relay continues" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            val publisher = mockk<KafkaEventPublisher>()
+            // First call throws non-retriable; second call succeeds so relay continues
+            every { publisher.publish(any(), "10", any()) } throws RecordTooLargeException("record too large")
+            every { publisher.publish(any(), "20", any()) } returns Unit
+
+            try {
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(10, "Somebody to Love", "A Day at the Races") as AudioItem)
+                    r.add(MutableAudioItem(20, "We Are the Champions", "News of the World") as AudioItem)
+                }
+
+                val db = Database.connect(dataSource)
+                val relay = OutboxRelay(db, publisher, fastConfig)
+                transaction(db) { SchemaUtils.create(DeadLetterTable) }
+                relay.pollAndRelay()
+
+                // Row 10 moved to dead-letter; row 20 marked sent
+                val outboxCount = transaction(db) { OutboxEventTable.selectAll().count() }
+                outboxCount shouldBe 1L
+                val dltCount = transaction(db) { DeadLetterTable.selectAll().count() }
+                dltCount shouldBe 1L
+
+                val sentRow = transaction(db) { OutboxEventTable.selectAll().single() }
+                sentRow[OutboxEventTable.aggregateId] shouldBe "20"
+                sentRow[OutboxEventTable.sentAt].shouldNotBeNull()
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxRelayTest exhausted retries move row to dead-letter table without further publish attempt" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val publisher = mockk<KafkaEventPublisher>()
+
+            // Seed a row directly with retryCount = maxRetries so it is already exhausted
+            val db = Database.connect(dataSource)
+            transaction(db) {
+                SchemaUtils.create(OutboxEventTable)
+                SchemaUtils.create(DeadLetterTable)
+                OutboxEventTable.insert {
+                    it[OutboxEventTable.id] = java.util.UUID.randomUUID().toKotlinUuid()
+                    it[OutboxEventTable.aggregateType] = "audio_items"
+                    it[OutboxEventTable.aggregateId] = "99"
+                    it[OutboxEventTable.eventTypeCode] = 100
+                    it[OutboxEventTable.payload] = "{}"
+                    it[OutboxEventTable.createdAt] = Clock.System.now()
+                    it[OutboxEventTable.retryCount] = 3 // = fastConfig.maxRetries
+                }
+            }
+
+            val relay = OutboxRelay(db, publisher, fastConfig)
+            relay.pollAndRelay()
+
+            // The row should be in the dead-letter table, not in the outbox
+            transaction(db) { OutboxEventTable.selectAll().count() } shouldBe 0L
+            transaction(db) { DeadLetterTable.selectAll().count() } shouldBe 1L
+            // Publisher must not have been called
+            verify(exactly = 0) { publisher.publish(any(), any(), any()) }
+        }
+
+        "OutboxRelayTest computeNextRetryAt grows exponentially within retryBaseDelayMs and retryMaxDelayMs" {
+            val config =
+                KafkaOutboxConfig(
+                    retryBaseDelayMs = 1_000L,
+                    retryMaxDelayMs = 30_000L
+                )
+            val now = Clock.System.now()
+
+            // Each delay must fit within the [base * 0.8, max * 1.2] range to account for ±20% jitter
+            val delay0 = OutboxRelay.computeNextRetryAt(0, config)
+            val delay1 = OutboxRelay.computeNextRetryAt(1, config)
+            val delay2 = OutboxRelay.computeNextRetryAt(2, config)
+
+            // delay grows: delay0 < delay1 < delay2 (in expectation; upper bound enforced)
+            delay0.shouldBeLessThan(delay1)
+            delay1.shouldBeLessThan(delay2)
+
+            // None should exceed now + maxDelayMs * 1.2 (jitter headroom)
+            val cap = now + 36_000L.milliseconds // 30s * 1.2
+            delay0.shouldBeLessThan(cap)
+            delay1.shouldBeLessThan(cap)
+            delay2.shouldBeLessThan(cap)
+        }
+
+        "OutboxRelayTest dead-lettered row invokes onDeadLetter callback with non-null Throwable and LirpOperation.EMIT" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            val publisher = mockk<KafkaEventPublisher>()
+            every { publisher.publish(any(), any(), any()) } throws RecordTooLargeException("too large")
+
+            var capturedThrowable: Throwable? = null
+            var capturedContext: LirpErrorContext? = null
+            val callback =
+                LirpErrorHandler { t, ctx ->
+                    capturedThrowable = t
+                    capturedContext = ctx
+                }
+
+            try {
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(5, "Don't Stop Me Now", "Jazz") as AudioItem)
+                }
+
+                val db = Database.connect(dataSource)
+                val relay = OutboxRelay(db, publisher, fastConfig, callback)
+                transaction(db) { SchemaUtils.create(DeadLetterTable) }
+                relay.pollAndRelay()
+
+                capturedThrowable.shouldNotBeNull()
+                capturedContext.shouldNotBeNull()
+                capturedContext!!.operation shouldBe LirpOperation.EMIT
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxRelayTest exhausted retries also invoke onDeadLetter callback" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val publisher = mockk<KafkaEventPublisher>()
+
+            var callbackInvoked = false
+            val callback =
+                LirpErrorHandler { _, ctx ->
+                    callbackInvoked = true
+                    ctx.operation shouldBe LirpOperation.EMIT
+                }
+
+            val db = Database.connect(dataSource)
+            transaction(db) {
+                SchemaUtils.create(OutboxEventTable)
+                SchemaUtils.create(DeadLetterTable)
+                OutboxEventTable.insert {
+                    it[OutboxEventTable.id] = java.util.UUID.randomUUID().toKotlinUuid()
+                    it[OutboxEventTable.aggregateType] = "audio_items"
+                    it[OutboxEventTable.aggregateId] = "77"
+                    it[OutboxEventTable.eventTypeCode] = 100
+                    it[OutboxEventTable.payload] = "{}"
+                    it[OutboxEventTable.createdAt] = Clock.System.now()
+                    it[OutboxEventTable.retryCount] = 3 // = fastConfig.maxRetries
+                }
+            }
+
+            val relay = OutboxRelay(db, publisher, fastConfig, callback)
+            relay.pollAndRelay()
+
+            callbackInvoked shouldBe true
+        }
+
+        "OutboxRelayTest calling start when relay is already running throws IllegalStateException" {
+            val publisher = mockk<KafkaEventPublisher>(relaxed = true)
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) {
+                SchemaUtils.create(OutboxEventTable)
+                SchemaUtils.create(DeadLetterTable)
+            }
+
+            try {
+                val relay = OutboxRelay(db, publisher, fastConfig)
+                relay.start()
+                shouldThrow<IllegalStateException> { relay.start() }
+                relay.stop()
+            } finally {
+                dataSource.close()
+            }
+        }
+    }
+}

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
@@ -197,34 +197,39 @@ internal class OutboxRelayTest : StringSpec() {
             }
         }
 
-        "OutboxRelayTest exhausted retries move row to dead-letter table without further publish attempt" {
+        "OutboxRelayTest exhausted retries move row to dead-letter table after a failed delivery attempt" {
             val dataSource = H2ContainerSupport.buildH2DataSource()
             val publisher = mockk<KafkaEventPublisher>()
+            every { publisher.publish(any(), any(), any()) } throws NetworkException("broker unavailable")
 
-            // Seed a row directly with retryCount = maxRetries so it is already exhausted
+            // Seed a row directly with retryCount = maxRetries so its retry budget is exhausted
             val db = Database.connect(dataSource)
-            transaction(db) {
-                SchemaUtils.create(OutboxEventTable)
-                SchemaUtils.create(DeadLetterTable)
-                OutboxEventTable.insert {
-                    it[OutboxEventTable.id] = java.util.UUID.randomUUID().toKotlinUuid()
-                    it[OutboxEventTable.aggregateType] = "audio_items"
-                    it[OutboxEventTable.aggregateId] = "99"
-                    it[OutboxEventTable.eventTypeCode] = 100
-                    it[OutboxEventTable.payload] = "{}"
-                    it[OutboxEventTable.createdAt] = Clock.System.now()
-                    it[OutboxEventTable.retryCount] = 3 // = fastConfig.maxRetries
+            try {
+                transaction(db) {
+                    SchemaUtils.create(OutboxEventTable)
+                    SchemaUtils.create(DeadLetterTable)
+                    OutboxEventTable.insert {
+                        it[OutboxEventTable.id] = java.util.UUID.randomUUID().toKotlinUuid()
+                        it[OutboxEventTable.aggregateType] = "audio_items"
+                        it[OutboxEventTable.aggregateId] = "99"
+                        it[OutboxEventTable.eventTypeCode] = 100
+                        it[OutboxEventTable.payload] = "{}"
+                        it[OutboxEventTable.createdAt] = Clock.System.now()
+                        it[OutboxEventTable.retryCount] = 3 // = fastConfig.maxRetries
+                    }
                 }
+
+                val relay = OutboxRelay(db, publisher, fastConfig)
+                relay.pollAndRelay()
+
+                // A retriable failure on a row with no retry budget left moves it to the dead-letter table
+                transaction(db) { OutboxEventTable.selectAll().count() } shouldBe 0L
+                transaction(db) { DeadLetterTable.selectAll().count() } shouldBe 1L
+                // Delivery is attempted exactly once before dead-lettering — never skipped
+                verify(exactly = 1) { publisher.publish(any(), any(), any()) }
+            } finally {
+                dataSource.close()
             }
-
-            val relay = OutboxRelay(db, publisher, fastConfig)
-            relay.pollAndRelay()
-
-            // The row should be in the dead-letter table, not in the outbox
-            transaction(db) { OutboxEventTable.selectAll().count() } shouldBe 0L
-            transaction(db) { DeadLetterTable.selectAll().count() } shouldBe 1L
-            // Publisher must not have been called
-            verify(exactly = 0) { publisher.publish(any(), any(), any()) }
         }
 
         "OutboxRelayTest computeNextRetryAt grows exponentially within retryBaseDelayMs and retryMaxDelayMs" {
@@ -287,6 +292,7 @@ internal class OutboxRelayTest : StringSpec() {
         "OutboxRelayTest exhausted retries also invoke onDeadLetter callback" {
             val dataSource = H2ContainerSupport.buildH2DataSource()
             val publisher = mockk<KafkaEventPublisher>()
+            every { publisher.publish(any(), any(), any()) } throws NetworkException("broker unavailable")
 
             var callbackInvoked = false
             val callback =
@@ -296,24 +302,28 @@ internal class OutboxRelayTest : StringSpec() {
                 }
 
             val db = Database.connect(dataSource)
-            transaction(db) {
-                SchemaUtils.create(OutboxEventTable)
-                SchemaUtils.create(DeadLetterTable)
-                OutboxEventTable.insert {
-                    it[OutboxEventTable.id] = java.util.UUID.randomUUID().toKotlinUuid()
-                    it[OutboxEventTable.aggregateType] = "audio_items"
-                    it[OutboxEventTable.aggregateId] = "77"
-                    it[OutboxEventTable.eventTypeCode] = 100
-                    it[OutboxEventTable.payload] = "{}"
-                    it[OutboxEventTable.createdAt] = Clock.System.now()
-                    it[OutboxEventTable.retryCount] = 3 // = fastConfig.maxRetries
+            try {
+                transaction(db) {
+                    SchemaUtils.create(OutboxEventTable)
+                    SchemaUtils.create(DeadLetterTable)
+                    OutboxEventTable.insert {
+                        it[OutboxEventTable.id] = java.util.UUID.randomUUID().toKotlinUuid()
+                        it[OutboxEventTable.aggregateType] = "audio_items"
+                        it[OutboxEventTable.aggregateId] = "77"
+                        it[OutboxEventTable.eventTypeCode] = 100
+                        it[OutboxEventTable.payload] = "{}"
+                        it[OutboxEventTable.createdAt] = Clock.System.now()
+                        it[OutboxEventTable.retryCount] = 3 // = fastConfig.maxRetries
+                    }
                 }
+
+                val relay = OutboxRelay(db, publisher, fastConfig, callback)
+                relay.pollAndRelay()
+
+                callbackInvoked shouldBe true
+            } finally {
+                dataSource.close()
             }
-
-            val relay = OutboxRelay(db, publisher, fastConfig, callback)
-            relay.pollAndRelay()
-
-            callbackInvoked shouldBe true
         }
 
         "OutboxRelayTest calling start when relay is already running throws IllegalStateException" {


### PR DESCRIPTION
## Summary

Adds a background **outbox relay** that drains the transactional Kafka outbox and delivers rows to Kafka with **at-least-once** semantics and **no double-publish** under concurrent relay instances.

The relay runs as a coroutine loop on `ReactiveScope.ioScope`. Each cycle opens one Exposed transaction, polls unsent rows with dialect-appropriate `FOR UPDATE SKIP LOCKED`, publishes each record through the existing `KafkaEventPublisher`, and flips `sent_at` **only after** the publish returns — so a crash between send and mark simply redelivers the row on restart. Failures are classified: retriable errors get a durable exponential backoff via `next_retry_at`; non-retriable errors and exhausted retries move the row to a dead-letter table while the relay keeps processing siblings. Each record is keyed by its aggregate id, preserving per-aggregate ordering across a multi-partition topic.

## Changes

**Relay runtime**
- `OutboxRelay` — background coroutine loop; crash-safe poll → publish → mark-sent-after-ACK cycle.
- `SqlOutboxStore` — Exposed-backed store: `findUnsentForRelay` (dialect-aware `FOR UPDATE SKIP LOCKED`), `scheduleRetry` (exponential backoff written to `next_retry_at`), atomic `moveToDeadLetter`.
- `LirpKafkaConfig` — `startRelay` / `stopRelay` lifecycle.

**Schema & config**
- `OutboxEventTable` — new `next_retry_at` column and a relay poll index; KDoc documents the SQLite/H2 single-relay constraint and the MySQL/MariaDB partial-index fallback.
- `DeadLetterTable` + `DeadLetterEvent` — dead-letter storage and row model.
- `KafkaOutboxConfig` — retry/backoff/dead-letter knobs with validated defaults.

**Public API**
- ABI baseline (`lirp-kafka.api`) rebaselined for `KafkaOutboxConfig`, `startRelay`, `stopRelay`.

## Verification

- [x] `gradle :lirp-kafka:apiCheck` — public ABI matches baseline
- [x] `gradle :lirp-kafka:test` — 9 H2 unit tests: mark-sent ordering, retriable backoff, exhausted-retry and non-retriable dead-letter routing, backoff growth bounds, aggregate-id record key, double-start guard, dead-letter callback
- [x] `gradle :lirp-kafka:integrationTest` — Testcontainers Kafka + PostgreSQL, 5/5 scenarios:
  - normal drain — external `KafkaConsumer` receives exactly the published records, outbox empties
  - crash/restart mid-relay — un-marked row is redelivered (at-least-once), no row lost
  - two concurrent relays — no row published twice (`SKIP LOCKED` acquires the lock before publish)
  - per-aggregate ordering — records for one aggregate id arrive in insertion order on a 3-partition topic
  - dead-letter routing — a non-retriable failure lands in the dead-letter table while a sibling row still publishes

## Notes

- The crash/restart test reproduces the post-crash state (`sent_at = NULL`) rather than killing the JVM mid-transaction; the mark-after-publish ordering invariant is proven separately by the H2 unit tests.

Closes #287
