### PR TITLE
Publisher, Serialization SPI & Topic Resolver

### DIFF
--- a/lirp-core/api/lirp-core.api
+++ b/lirp-core/api/lirp-core.api
@@ -1017,6 +1017,8 @@ public class net/transgressoft/lirp/persistence/VolatileRepository : net/transgr
 	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
 	public fun <init> (Ljava/lang/String;Ljava/util/Map;Lnet/transgressoft/lirp/event/LirpErrorHandler;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Lnet/transgressoft/lirp/event/LirpErrorHandler;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Lnet/transgressoft/lirp/event/LirpEventPublisher;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Lnet/transgressoft/lirp/event/LirpEventPublisher;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun add (Lnet/transgressoft/lirp/entity/IdentifiableEntity;)Z
 	public fun clear ()V
 	public fun equals (Ljava/lang/Object;)Z

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/VolatileRepository.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/VolatileRepository.kt
@@ -19,12 +19,14 @@ package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import net.transgressoft.lirp.entity.MutableSoftDeletable
+import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.CrudEvent.Type.CREATE
 import net.transgressoft.lirp.event.CrudEvent.Type.DELETE
 import net.transgressoft.lirp.event.CrudEvent.Type.RESTORE
 import net.transgressoft.lirp.event.CrudEvent.Type.SOFT_DELETE
 import net.transgressoft.lirp.event.FlowEventPublisher
 import net.transgressoft.lirp.event.LirpErrorHandler
+import net.transgressoft.lirp.event.LirpEventPublisher
 import net.transgressoft.lirp.event.StandardCrudEvent.Create
 import net.transgressoft.lirp.event.StandardCrudEvent.Delete
 import net.transgressoft.lirp.event.StandardCrudEvent.Restore
@@ -55,13 +57,20 @@ open class VolatileRepository<K : Comparable<K>, T : IdentifiableEntity<K>>
         context: LirpContext,
         name: String,
         initialEntities: MutableMap<K, T>,
-        onError: LirpErrorHandler? = null
-    ) : RegistryBase<K, T>(context, initialEntities, FlowEventPublisher(name, onError = onError)), Repository<K, T> {
+        publisher: LirpEventPublisher<CrudEvent.Type, CrudEvent<K, T>>
+    ) : RegistryBase<K, T>(context, initialEntities, publisher), Repository<K, T> {
+
+        internal constructor(
+            context: LirpContext,
+            name: String,
+            initialEntities: MutableMap<K, T>,
+            onError: LirpErrorHandler? = null
+        ) : this(context, name, initialEntities, FlowEventPublisher(name, onError = onError))
 
         internal constructor(
             context: LirpContext,
             name: String
-        ) : this(context, name, ConcurrentHashMap())
+        ) : this(context, name, ConcurrentHashMap(), null as LirpErrorHandler?)
 
         @JvmOverloads
         constructor(
@@ -74,6 +83,25 @@ open class VolatileRepository<K : Comparable<K>, T : IdentifiableEntity<K>>
              */
             onError: LirpErrorHandler? = null
         ) : this(LirpContext.default, name, initialEntities, onError)
+
+        /**
+         * Creates a [VolatileRepository] that routes CRUD events to the supplied [publisher]
+         * instead of the default [FlowEventPublisher].
+         *
+         * This constructor allows injecting any [LirpEventPublisher] implementation
+         * interchangeably with the default in-process publisher, enabling transparent
+         * Kafka publishing of CRUD events when paired with a
+         * [net.transgressoft.lirp.kafka.KafkaEventPublisher].
+         *
+         * @param name A descriptive name for this repository, used in logging
+         * @param initialEntities Optional map of entities to initialize the repository with
+         * @param publisher The event publisher that will receive all CRUD events emitted by this repository
+         */
+        constructor(
+            name: String = "Repository",
+            initialEntities: MutableMap<K, T> = ConcurrentHashMap(),
+            publisher: LirpEventPublisher<CrudEvent.Type, CrudEvent<K, T>>
+        ) : this(LirpContext.default, name, initialEntities, publisher)
 
         private val log = KotlinLogging.logger(javaClass.name)
 

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/VolatileRepository.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/VolatileRepository.kt
@@ -93,6 +93,10 @@ open class VolatileRepository<K : Comparable<K>, T : IdentifiableEntity<K>>
          * Kafka publishing of CRUD events when paired with a
          * [net.transgressoft.lirp.kafka.KafkaEventPublisher].
          *
+         * **Ownership:** the repository takes ownership of [publisher] and closes it when the
+         * repository is closed. Do not share a single publisher instance across repositories —
+         * closing one repository would shut down publishing for the others.
+         *
          * @param name A descriptive name for this repository, used in logging
          * @param initialEntities Optional map of entities to initialize the repository with
          * @param publisher The event publisher that will receive all CRUD events emitted by this repository

--- a/lirp-kafka/api/lirp-kafka.api
+++ b/lirp-kafka/api/lirp-kafka.api
@@ -1,7 +1,23 @@
-public final class net/transgressoft/lirp/kafka/KafkaEventPublisher : java/lang/AutoCloseable {
-	public fun <init> (Ljava/lang/String;)V
+public final class net/transgressoft/lirp/kafka/KafkaEventPublisher : net/transgressoft/lirp/event/LirpEventPublisher {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/v1/jdbc/Database;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/jetbrains/exposed/v1/jdbc/Database;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun activateEvents ([Lnet/transgressoft/lirp/event/EventType;)V
 	public fun close ()V
-	public final fun publish (Ljava/lang/String;Ljava/lang/String;[B)V
+	public fun disableEvents ([Lnet/transgressoft/lirp/event/EventType;)V
+	public fun emitAsync (Lnet/transgressoft/lirp/event/LirpEvent;)V
+	public fun getChanges ()Lkotlinx/coroutines/flow/SharedFlow;
+	public fun getSubscriberCount ()I
+	public fun isClosed ()Z
+	public fun isEventActive (Lnet/transgressoft/lirp/event/EventType;)Z
+	public final fun publish (Ljava/lang/String;Ljava/lang/String;[BLjava/lang/Iterable;)V
+	public static synthetic fun publish$default (Lnet/transgressoft/lirp/kafka/KafkaEventPublisher;Ljava/lang/String;Ljava/lang/String;[BLjava/lang/Iterable;ILjava/lang/Object;)V
+	public fun subscribe (Ljava/util/concurrent/Flow$Subscriber;)V
+	public fun subscribe (Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribe ([Lnet/transgressoft/lirp/event/EventType;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync (Ljava/util/function/Consumer;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync (Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync (Lkotlin/jvm/functions/Function2;Lnet/transgressoft/lirp/event/LirpErrorHandler;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
+	public fun subscribeAsync ([Lnet/transgressoft/lirp/event/EventType;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/event/LirpEventSubscription;
 }
 
 public final class net/transgressoft/lirp/kafka/KafkaOutboxConfig {
@@ -41,12 +57,82 @@ public final class net/transgressoft/lirp/kafka/LirpKafkaConfig : java/lang/Auto
 	public fun close ()V
 	public final fun getBootstrapServers ()Ljava/lang/String;
 	public final fun publisher ()Lnet/transgressoft/lirp/kafka/KafkaEventPublisher;
-	public final fun startRelay (Ljavax/sql/DataSource;Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;Lnet/transgressoft/lirp/event/LirpErrorHandler;)V
-	public static synthetic fun startRelay$default (Lnet/transgressoft/lirp/kafka/LirpKafkaConfig;Ljavax/sql/DataSource;Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;Lnet/transgressoft/lirp/event/LirpErrorHandler;ILjava/lang/Object;)V
+	public final fun startRelay (Ljavax/sql/DataSource;Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;Ljava/util/Map;Lnet/transgressoft/lirp/kafka/spi/LirpEventSerializer;Lnet/transgressoft/lirp/kafka/spi/TopicResolver;Lnet/transgressoft/lirp/event/LirpErrorHandler;)V
+	public static synthetic fun startRelay$default (Lnet/transgressoft/lirp/kafka/LirpKafkaConfig;Ljavax/sql/DataSource;Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;Ljava/util/Map;Lnet/transgressoft/lirp/kafka/spi/LirpEventSerializer;Lnet/transgressoft/lirp/kafka/spi/TopicResolver;Lnet/transgressoft/lirp/event/LirpErrorHandler;ILjava/lang/Object;)V
 	public final fun stopRelay ()V
 }
 
 public final class net/transgressoft/lirp/kafka/LirpKafkaConfig$Companion {
 	public final fun create (Ljava/lang/String;)Lnet/transgressoft/lirp/kafka/LirpKafkaConfig;
+}
+
+public final class net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer : net/transgressoft/lirp/kafka/spi/LirpEventSerializer {
+	public fun <init> ()V
+	public fun deserialize ([BLjava/util/Map;)Lnet/transgressoft/lirp/kafka/spi/LirpEventEnvelope;
+	public fun serialize (Lnet/transgressoft/lirp/kafka/spi/LirpEventEnvelope;)Lnet/transgressoft/lirp/kafka/spi/SerializedEvent;
+}
+
+public final class net/transgressoft/lirp/kafka/spi/LirpEventEnvelope {
+	public static final field Companion Lnet/transgressoft/lirp/kafka/spi/LirpEventEnvelope$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)Lnet/transgressoft/lirp/kafka/spi/LirpEventEnvelope;
+	public static synthetic fun copy$default (Lnet/transgressoft/lirp/kafka/spi/LirpEventEnvelope;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lnet/transgressoft/lirp/kafka/spi/LirpEventEnvelope;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAggregateId ()Ljava/lang/String;
+	public final fun getAggregateType ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/lang/String;
+	public final fun getEventId ()Ljava/lang/String;
+	public final fun getEventTypeCode ()I
+	public final fun getPayload ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class net/transgressoft/lirp/kafka/spi/LirpEventEnvelope$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lnet/transgressoft/lirp/kafka/spi/LirpEventEnvelope$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lnet/transgressoft/lirp/kafka/spi/LirpEventEnvelope;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/transgressoft/lirp/kafka/spi/LirpEventEnvelope;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class net/transgressoft/lirp/kafka/spi/LirpEventEnvelope$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class net/transgressoft/lirp/kafka/spi/LirpEventSerializer {
+	public abstract fun deserialize ([BLjava/util/Map;)Lnet/transgressoft/lirp/kafka/spi/LirpEventEnvelope;
+	public abstract fun serialize (Lnet/transgressoft/lirp/kafka/spi/LirpEventEnvelope;)Lnet/transgressoft/lirp/kafka/spi/SerializedEvent;
+}
+
+public abstract interface class net/transgressoft/lirp/kafka/spi/OutboxRoutableEvent : net/transgressoft/lirp/event/LirpEvent {
+	public abstract fun getAggregateId ()Ljava/lang/String;
+	public abstract fun getPayload ()Ljava/lang/String;
+}
+
+public final class net/transgressoft/lirp/kafka/spi/SerializedEvent {
+	public fun <init> ([BLjava/util/Map;)V
+	public final fun component1 ()[B
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy ([BLjava/util/Map;)Lnet/transgressoft/lirp/kafka/spi/SerializedEvent;
+	public static synthetic fun copy$default (Lnet/transgressoft/lirp/kafka/spi/SerializedEvent;[BLjava/util/Map;ILjava/lang/Object;)Lnet/transgressoft/lirp/kafka/spi/SerializedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getValue ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class net/transgressoft/lirp/kafka/spi/TopicResolver {
+	public abstract fun resolve (Lnet/transgressoft/lirp/kafka/spi/LirpEventEnvelope;)Ljava/lang/String;
 }
 

--- a/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/KafkaPublishSkeletonIT.kt
+++ b/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/KafkaPublishSkeletonIT.kt
@@ -17,6 +17,7 @@
 
 package net.transgressoft.lirp.kafka
 
+import net.transgressoft.lirp.persistence.sql.PostgresContainerSupport
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -44,8 +45,14 @@ internal class KafkaPublishSkeletonIT : StringSpec({
                 put("auto.offset.reset", "earliest")
             }
 
-        KafkaEventPublisher(bootstrapServers).use { publisher ->
-            publisher.publish(topic, "aggregate-1", "skeleton-payload".toByteArray())
+        val dataSource = PostgresContainerSupport.buildDataSource()
+        val lirpConfig = LirpKafkaConfig.create(bootstrapServers)
+        try {
+            lirpConfig.startRelay(dataSource)
+            lirpConfig.publisher().publish(topic, "aggregate-1", "skeleton-payload".toByteArray())
+        } finally {
+            lirpConfig.close()
+            dataSource.close()
         }
 
         KafkaConsumer<String, ByteArray>(consumerProps).use { consumer ->

--- a/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/KafkaPublishSkeletonIT.kt
+++ b/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/KafkaPublishSkeletonIT.kt
@@ -24,6 +24,7 @@ import io.kotest.matchers.shouldBe
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringDeserializer
+import org.jetbrains.exposed.v1.jdbc.Database
 import org.junit.jupiter.api.DisplayName
 import java.time.Duration
 import java.util.Properties
@@ -45,13 +46,16 @@ internal class KafkaPublishSkeletonIT : StringSpec({
                 put("auto.offset.reset", "earliest")
             }
 
+        // This test exercises the direct synchronous publish path only, so it constructs the
+        // publisher directly rather than starting the relay — starting the relay would launch a
+        // poll loop against an outbox table this test never creates.
         val dataSource = PostgresContainerSupport.buildDataSource()
-        val lirpConfig = LirpKafkaConfig.create(bootstrapServers)
+        val db = Database.connect(dataSource)
+        val publisher = KafkaEventPublisher<Nothing, Nothing>("lirp-skeleton", bootstrapServers, db)
         try {
-            lirpConfig.startRelay(dataSource)
-            lirpConfig.publisher().publish(topic, "aggregate-1", "skeleton-payload".toByteArray())
+            publisher.publish(topic, "aggregate-1", "skeleton-payload".toByteArray())
         } finally {
-            lirpConfig.close()
+            publisher.close()
             dataSource.close()
         }
 

--- a/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayIT.kt
+++ b/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayIT.kt
@@ -17,10 +17,14 @@
 
 package net.transgressoft.lirp.kafka.outbox
 
+import net.transgressoft.lirp.event.EventType
 import net.transgressoft.lirp.kafka.KafkaContainerSupport
+import net.transgressoft.lirp.kafka.KafkaEventPublisher
 import net.transgressoft.lirp.kafka.KafkaOutboxConfig
 import net.transgressoft.lirp.kafka.KafkaOutboxSqlRepository
 import net.transgressoft.lirp.kafka.LirpKafkaConfig
+import net.transgressoft.lirp.kafka.spi.CloudEventsBinarySerializer
+import net.transgressoft.lirp.kafka.spi.OutboxRoutableEvent
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.RegistryBase
@@ -32,15 +36,22 @@ import com.zaxxer.hikari.HikariDataSource
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.NewPartitions
 import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.errors.TopicExistsException
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringDeserializer
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.time.Duration
 import java.util.Properties
 import java.util.concurrent.ExecutionException
@@ -49,23 +60,29 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * Testcontainers integration tests for the outbox relay end-to-end path.
  *
- * Verifies the relay drains unsent rows across real SQL dialects and a real Kafka broker:
- * rows are published as Kafka records and their `sent_at` timestamp is set atomically in the
- * same transaction. Five scenarios are covered:
+ * Verifies the relay drains unsent rows against a real SQL dialect and a real Kafka broker: rows
+ * are published as Kafka records and their `sent_at` timestamp is set atomically in the same
+ * transaction. Scenarios covered:
  *
  * 1. **Normal drain**: relay publishes all unsent rows to Kafka and sets `sent_at`.
  * 2. **Crash/redelivery**: a row whose `sent_at` was never committed (simulating a mid-transaction
  *    crash) is redelivered on the next relay start — proving at-least-once delivery.
  * 3. **Concurrent no-double-publish**: two relay instances against PostgreSQL (which enforces
  *    `FOR UPDATE SKIP LOCKED`) publish each row exactly once.
- * 4. **Per-aggregate ordering**: rapid sequential mutations to the same aggregate id arrive at
- *    the consumer in creation order, proving that `aggregateId` as record key + a multi-partition
- *    topic keeps per-aggregate ordering.
- * 5. **Dead-letter routing**: a row whose topic name is Kafka-invalid is moved atomically to the
+ * 4. **Per-aggregate ordering**: rapid sequential mutations to the same aggregate id arrive at the
+ *    consumer in creation order, proving that `aggregateId` as record key + a multi-partition topic
+ *    keeps per-aggregate ordering.
+ * 5. **CloudEvents headers**: every relayed record carries `ce_id` equal to the outbox row UUID and
+ *    a record key/`ce_subject` equal to the aggregate id.
+ * 6. **Custom-event round-trip**: an [OutboxRoutableEvent] emitted via `emitAsync` inside a
+ *    transaction is captured, relayed, and deserialized back without data loss.
+ * 7. **Dead-letter routing**: a row whose topic name is Kafka-invalid is moved atomically to the
  *    dead-letter table and the relay continues processing sibling rows.
  *
- * Each test case drops and recreates the outbox/dead-letter tables for isolation so the relay's
- * [SchemaUtils.create] call recreates the schema fresh.
+ * Each test resets the outbox/dead-letter tables for isolation so the relay's [SchemaUtils.create]
+ * call recreates the schema fresh. The shared `try/finally` resource choreography (repo, publisher,
+ * relay config, consumer) is handled by [withResources]; the repeated poll-collect-assert loop is
+ * handled by [pollUntil].
  */
 @DisplayName("OutboxRelayIT")
 internal class OutboxRelayIT : FunSpec({
@@ -74,326 +91,406 @@ internal class OutboxRelayIT : FunSpec({
         RegistryBase.deregisterRepository(AudioItem::class.java)
     }
 
-    // -----------------------------------------------------------------------------------------
-    // Test 1: Normal relay path
-    // -----------------------------------------------------------------------------------------
-
-    test("OutboxRelayIT normal relay path drains all unsent rows") {
-        DatabaseTestSupport.withDatabaseTest(
-            DatabaseTestSupport.databases.first { it.name == "PostgreSQL" },
-            AudioItemSqlTableDef
-        ) { dataSource ->
-            dropOutboxTableIfExists(dataSource)
-            dropDeadLetterTableIfExists(dataSource)
-
-            val topic = "${AudioItemSqlTableDef.tableName}.events"
-
-            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
-            val lirpConfig = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
-            try {
+    test("normal relay path drains all unsent rows") {
+        DatabaseTestSupport.withDatabaseTest(postgres, AudioItemSqlTableDef) { dataSource ->
+            withResources {
+                resetOutboxSchema(dataSource)
+                val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef).managed()
                 transaction(repo) { r ->
                     r.add(MutableAudioItem(1, "Bohemian Rhapsody", "A Night at the Opera") as AudioItem)
                     r.add(MutableAudioItem(2, "Killer Queen", "Sheer Heart Attack") as AudioItem)
                     r.add(MutableAudioItem(3, "We Will Rock You", "News of the World") as AudioItem)
                 }
 
-                try {
-                    createMultiPartitionTopic(topic, 1)
-                    KafkaConsumer<String, ByteArray>(consumerProps("relay-normal-drain-${System.currentTimeMillis()}")).use { consumer ->
-                        awaitConsumerAssignment(consumer, listOf(topic))
-                        lirpConfig.startRelay(dataSource, fastRelayConfig())
-                        try {
-                            val receivedKeys = mutableListOf<String>()
-                            eventually(20.seconds) {
-                                consumer.poll(Duration.ofMillis(200)).forEach { receivedKeys.add(it.key()) }
-                                receivedKeys.size shouldBe 3
-                            }
-                            receivedKeys.toSet() shouldBe setOf("1", "2", "3")
-                            eventually(10.seconds) {
-                                countUnsentOutboxRows(dataSource) shouldBe 0L
-                            }
-                        } finally {
-                            lirpConfig.stopRelay()
-                        }
-                    }
-                } finally {
-                    // no-op: consumer.use handles close
+                createMultiPartitionTopic(audioItemsTopic, 1)
+                val consumer = subscribedConsumer("relay-normal-drain", audioItemsTopic)
+                lirpKafkaConfig().startRelay(dataSource, fastRelayConfig())
+
+                consumer.pollUntil { records ->
+                    records.map { it.key() } shouldContainExactlyInAnyOrder listOf("1", "2", "3")
                 }
-            } finally {
-                repo.close()
-                lirpConfig.close()
+                eventually(10.seconds) {
+                    countUnsentOutboxRows(dataSource) shouldBe 0L
+                }
             }
         }
     }
 
-    // -----------------------------------------------------------------------------------------
-    // Test 2: Crash between publish and mark-sent causes redelivery
-    // -----------------------------------------------------------------------------------------
-
-    test("OutboxRelayIT crash between publish and mark-sent causes redelivery") {
-        DatabaseTestSupport.withDatabaseTest(
-            DatabaseTestSupport.databases.first { it.name == "PostgreSQL" },
-            AudioItemSqlTableDef
-        ) { dataSource ->
-            dropOutboxTableIfExists(dataSource)
-            dropDeadLetterTableIfExists(dataSource)
-
-            val topic = "${AudioItemSqlTableDef.tableName}.events"
-
-            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
-            try {
+    test("crash between publish and mark-sent causes redelivery") {
+        DatabaseTestSupport.withDatabaseTest(postgres, AudioItemSqlTableDef) { dataSource ->
+            withResources {
+                resetOutboxSchema(dataSource)
+                val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef).managed()
                 transaction(repo) { r ->
                     r.add(MutableAudioItem(10, "Radio Ga Ga", "The Works") as AudioItem)
                 }
 
-                // First relay run: relay publishes the record to Kafka and sets sent_at.
-                val lirpConfig1 = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
-                lirpConfig1.startRelay(dataSource, fastRelayConfig())
-                try {
+                // First relay run: publish the record to Kafka and set sent_at.
+                LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers).use { firstRelay ->
+                    firstRelay.startRelay(dataSource, fastRelayConfig())
                     eventually(15.seconds) {
                         countUnsentOutboxRows(dataSource) shouldBe 0L
                     }
-                } finally {
-                    lirpConfig1.close()
                 }
 
-                // Simulate crash: reset sent_at back to NULL. This models a scenario where the relay
-                // published to Kafka but the transaction containing the sent_at UPDATE was rolled back
-                // before committing (e.g. a JVM crash or JDBC connection failure mid-transaction).
+                // Simulate crash: reset sent_at back to NULL — the relay published to Kafka but the
+                // transaction carrying the sent_at UPDATE rolled back before committing (e.g. a JVM
+                // crash or JDBC connection failure mid-transaction).
                 resetSentAt(dataSource, "10")
                 countUnsentOutboxRows(dataSource) shouldBe 1L
 
-                // Second relay run (crash recovery): subscribe consumer FIRST (latest offset),
-                // then start the relay. The redelivered record for key "10" must appear.
-                val lirpConfig2 = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
-                createMultiPartitionTopic(topic, 1)
-                KafkaConsumer<String, ByteArray>(consumerProps("relay-crash-recovery-${System.currentTimeMillis()}")).use { consumer ->
-                    awaitConsumerAssignment(consumer, listOf(topic))
-                    lirpConfig2.startRelay(dataSource, fastRelayConfig())
-                    try {
-                        val receivedKeys = mutableListOf<String>()
-                        eventually(20.seconds) {
-                            consumer.poll(Duration.ofMillis(200)).forEach { receivedKeys.add(it.key()) }
-                            receivedKeys.count { it == "10" } shouldNotBe 0
-                        }
-                        eventually(10.seconds) {
-                            countUnsentOutboxRows(dataSource) shouldBe 0L
-                        }
-                    } finally {
-                        lirpConfig2.close()
-                    }
+                // Second relay run (crash recovery): subscribe the consumer FIRST (latest offset),
+                // then start the relay so the redelivered record for key "10" must appear.
+                createMultiPartitionTopic(audioItemsTopic, 1)
+                val consumer = subscribedConsumer("relay-crash-recovery", audioItemsTopic)
+                lirpKafkaConfig().startRelay(dataSource, fastRelayConfig())
+
+                consumer.pollUntil { records ->
+                    records.map { it.key() } shouldContain "10"
                 }
-            } finally {
-                repo.close()
+                eventually(10.seconds) {
+                    countUnsentOutboxRows(dataSource) shouldBe 0L
+                }
             }
         }
     }
 
-    // -----------------------------------------------------------------------------------------
-    // Test 3: Concurrent relay instances do not double-publish (SKIP LOCKED, PostgreSQL only)
-    // -----------------------------------------------------------------------------------------
-
-    test("OutboxRelayIT concurrent relay instances do not double-publish") {
-        // FOR UPDATE SKIP LOCKED is only enforced on PostgreSQL/MySQL/MariaDB; H2 gives a false
-        // green because its SELECT does not honour the SKIP LOCKED clause.
-        val pgDataSource = PostgresContainerSupport.buildDataSource()
-        try {
-            dropOutboxTableIfExists(pgDataSource)
-            dropDeadLetterTableIfExists(pgDataSource)
-
-            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(pgDataSource, AudioItemSqlTableDef)
-            try {
-                val n = 6
-                transaction(repo) { r ->
-                    repeat(n) { i -> r.add(MutableAudioItem(i + 100, "Track ${i + 1}", "Album A") as AudioItem) }
-                }
-
-                val topic = "${AudioItemSqlTableDef.tableName}.events"
-
-                val lirpConfig1 = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
-                val lirpConfig2 = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
-
-                createMultiPartitionTopic(topic, 1)
-                KafkaConsumer<String, ByteArray>(consumerProps("relay-concurrent-${System.currentTimeMillis()}")).use { consumer ->
-                    awaitConsumerAssignment(consumer, listOf(topic))
-                    lirpConfig1.startRelay(pgDataSource, fastRelayConfig())
-                    lirpConfig2.startRelay(pgDataSource, fastRelayConfig())
-                    try {
-                        val receivedKeys = mutableListOf<String>()
-                        val expectedKeys = (100 until 100 + n).map { it.toString() }.toSet()
-                        eventually(30.seconds) {
-                            consumer.poll(Duration.ofMillis(200)).forEach { receivedKeys.add(it.key()) }
-                            countUnsentOutboxRows(pgDataSource) shouldBe 0L
-                            receivedKeys.toSet() shouldBe expectedKeys
-                        }
-                        // Keep draining briefly after the outbox is empty: a duplicate published slightly
-                        // later by the peer relay would otherwise be missed, false-passing the guarantee.
-                        val quietUntil = System.currentTimeMillis() + 2_000L
-                        while (System.currentTimeMillis() < quietUntil) {
-                            consumer.poll(Duration.ofMillis(200)).forEach { receivedKeys.add(it.key()) }
-                        }
-                        // Each aggregate id must appear exactly once — SKIP LOCKED ensures no double-publish.
-                        receivedKeys.groupBy { it }.values.forEach { group ->
-                            group.size shouldBe 1
-                        }
-                    } finally {
-                        lirpConfig1.close()
-                        lirpConfig2.close()
-                    }
-                }
-            } finally {
-                repo.close()
+    test("concurrent relay instances do not double-publish") {
+        // FOR UPDATE SKIP LOCKED is only enforced on PostgreSQL/MySQL/MariaDB; H2 gives a false green
+        // because its SELECT does not honour the SKIP LOCKED clause.
+        withResources {
+            val dataSource = PostgresContainerSupport.buildDataSource().managed()
+            resetOutboxSchema(dataSource)
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef).managed()
+            val n = 6
+            transaction(repo) { r ->
+                repeat(n) { i -> r.add(MutableAudioItem(i + 100, "Track ${i + 1}", "Album A") as AudioItem) }
             }
-        } finally {
-            pgDataSource.close()
+            val expectedKeys = (100 until 100 + n).map { it.toString() }
+
+            createMultiPartitionTopic(audioItemsTopic, 1)
+            val consumer = subscribedConsumer("relay-concurrent", audioItemsTopic)
+            lirpKafkaConfig().startRelay(dataSource, fastRelayConfig())
+            lirpKafkaConfig().startRelay(dataSource, fastRelayConfig())
+
+            val received =
+                consumer.pollUntil(30.seconds) { records ->
+                    countUnsentOutboxRows(dataSource) shouldBe 0L
+                    records.map { it.key() } shouldContainAll expectedKeys
+                }.toMutableList()
+
+            // Keep draining briefly after the outbox is empty: a duplicate published slightly later by
+            // the peer relay would otherwise be missed, false-passing the guarantee.
+            consumer.drainFor(2.seconds) { received.add(it) }
+
+            // Exactly-once: multiset equality against the unique expected keys fails if any key was
+            // published more than once, so SKIP LOCKED prevented double-publishing.
+            received.map { it.key() } shouldContainExactlyInAnyOrder expectedKeys
         }
     }
 
-    // -----------------------------------------------------------------------------------------
-    // Test 4: Multi-partition topic preserves per-aggregate ordering
-    // -----------------------------------------------------------------------------------------
+    test("multi-partition topic preserves per-aggregate ordering") {
+        DatabaseTestSupport.withDatabaseTest(postgres, AudioItemSqlTableDef) { dataSource ->
+            withResources {
+                resetOutboxSchema(dataSource)
+                val aggregateType = AudioItemSqlTableDef.tableName
+                val topic = "$aggregateType.events"
+                // Pre-create the topic with 3 partitions. The record key (aggregate id) routes all
+                // mutations for a single aggregate to the same partition, preserving order.
+                createMultiPartitionTopic(topic, 3)
 
-    test("OutboxRelayIT multi-partition topic preserves per-aggregate ordering") {
-        DatabaseTestSupport.withDatabaseTest(
-            DatabaseTestSupport.databases.first { it.name == "PostgreSQL" },
-            AudioItemSqlTableDef
-        ) { dataSource ->
-            dropOutboxTableIfExists(dataSource)
-            dropDeadLetterTableIfExists(dataSource)
+                val aggregateId = "42"
+                val eventCount = 5
 
-            val aggregateType = AudioItemSqlTableDef.tableName
-            val topic = "$aggregateType.events"
-            // Pre-create the topic with 3 partitions. The record key (aggregate id) routes all
-            // mutations for a single aggregate to the same partition, preserving order.
-            createMultiPartitionTopic(topic, 3)
-
-            val aggregateId = "42"
-            val eventCount = 5
-
-            // Use the repository to ensure the outbox table exists, then insert additional raw rows
-            // for the same aggregate id to simulate rapid sequential mutations.
-            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
-            try {
+                // Use the repository to ensure the outbox table exists, then insert additional raw rows
+                // for the same aggregate id to simulate rapid sequential mutations.
+                KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef).managed()
                 insertRawOutboxRows(dataSource, aggregateType, aggregateId, eventCount)
 
-                val lirpConfig = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
-                KafkaConsumer<String, ByteArray>(consumerProps("relay-ordering-${System.currentTimeMillis()}")).use { consumer ->
-                    awaitConsumerAssignment(consumer, listOf(topic))
-                    lirpConfig.startRelay(dataSource, fastRelayConfig())
-                    try {
-                        val receivedPayloads = mutableListOf<String>()
-                        eventually(20.seconds) {
-                            consumer.poll(Duration.ofMillis(200))
-                                .filter { it.key() == aggregateId }
-                                .forEach { receivedPayloads.add(String(it.value(), Charsets.UTF_8)) }
-                            receivedPayloads.size shouldBe eventCount
-                        }
-                        // Records for the same key land on one partition; asserting the decoded payload
-                        // sequence (not just increasing offsets) proves the relay published oldest-first.
-                        receivedPayloads shouldBe (0 until eventCount).map { """{"seq":$it}""" }
-                    } finally {
-                        lirpConfig.close()
+                val consumer = subscribedConsumer("relay-ordering", topic)
+                lirpKafkaConfig().startRelay(dataSource, fastRelayConfig())
+
+                val records =
+                    consumer.pollUntil { records ->
+                        records.count { it.key() == aggregateId } shouldBe eventCount
                     }
-                }
-            } finally {
-                repo.close()
+
+                // Records for the same key land on one partition; asserting the decoded payload
+                // sequence (not just increasing offsets) proves the relay published oldest-first.
+                records.filter { it.key() == aggregateId }.map { it.payloadText() } shouldBe
+                    (0 until eventCount).map { """{"seq":$it}""" }
             }
         }
     }
 
-    // -----------------------------------------------------------------------------------------
-    // Test 5: Non-retriable error moves row to dead-letter table and relay continues
-    // -----------------------------------------------------------------------------------------
+    test("relayed record carries ce_id header equal to outbox row UUID") {
+        DatabaseTestSupport.withDatabaseTest(postgres, AudioItemSqlTableDef) { dataSource ->
+            withResources {
+                resetOutboxSchema(dataSource)
+                val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef).managed()
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(201, "Killer Queen", "Sheer Heart Attack") as AudioItem)
+                }
 
-    test("OutboxRelayIT non-retriable error moves row to dead letter table and relay continues") {
-        DatabaseTestSupport.withDatabaseTest(
-            DatabaseTestSupport.databases.first { it.name == "PostgreSQL" },
-            AudioItemSqlTableDef
-        ) { dataSource ->
-            dropOutboxTableIfExists(dataSource)
-            dropDeadLetterTableIfExists(dataSource)
+                // Capture the outbox row UUID before the relay starts.
+                val outboxRowId = firstOutboxRowId(dataSource)
 
-            val aggregateType = AudioItemSqlTableDef.tableName
-            val validTopic = "$aggregateType.events"
+                createMultiPartitionTopic(audioItemsTopic, 1)
+                val consumer = subscribedConsumer("relay-ce-id", audioItemsTopic)
+                lirpKafkaConfig().startRelay(dataSource, fastRelayConfig())
 
-            // maxRetries=1: new rows (retryCount=0) attempt publishing once; a non-retriable Kafka
-            // exception (e.g. InvalidTopicException from an invalid topic name) is caught and the
-            // row is moved to the dead-letter table in the same transaction.
-            val relayConfig =
-                KafkaOutboxConfig(
-                    pollIntervalMs = 50L,
-                    batchSize = 10,
-                    maxRetries = 1,
-                    retryBaseDelayMs = 50L,
-                    retryMaxDelayMs = 100L
-                )
+                val record = consumer.pollUntil { it.shouldNotBeEmpty() }.first()
+                record.header("ce_id") shouldBe outboxRowId
+            }
+        }
+    }
 
-            // Use the repository to ensure the outbox table exists (its init creates the schema).
-            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
-            try {
-                // Insert a poison row: aggregate_type contains a '#' character which produces a Kafka-
-                // invalid topic name ("invalid#topic.events"). Kafka's topic naming rules require names
-                // to match [a-zA-Z0-9._-]+; '#' is rejected with InvalidTopicException (a KafkaException
-                // subclass, not RetriableException) so the relay moves this row to the dead-letter table.
+    test("relayed record key equals aggregate id and ce_subject header") {
+        DatabaseTestSupport.withDatabaseTest(postgres, AudioItemSqlTableDef) { dataSource ->
+            withResources {
+                resetOutboxSchema(dataSource)
+                val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef).managed()
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(202, "We Will Rock You", "News of the World") as AudioItem)
+                }
+
+                createMultiPartitionTopic(audioItemsTopic, 1)
+                val consumer = subscribedConsumer("relay-key-subject", audioItemsTopic)
+                lirpKafkaConfig().startRelay(dataSource, fastRelayConfig())
+
+                val record = consumer.pollUntil { it.shouldNotBeEmpty() }.first()
+                // Record key equals the aggregate id, which in turn equals the ce_subject header.
+                record.key() shouldBe "202"
+                record.header("ce_subject") shouldBe "202"
+            }
+        }
+    }
+
+    test("custom event emitted via emitAsync inside transaction round-trips through relay") {
+        withResources {
+            val dataSource = PostgresContainerSupport.buildDataSource().managed()
+            resetOutboxSchema(dataSource)
+
+            // KafkaOutboxSqlRepository creates the outbox schema (idempotent).
+            KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef).managed()
+
+            val db = Database.connect(dataSource)
+            val bootstrapServers = KafkaContainerSupport.bootstrapServers
+            val publisher =
+                KafkaEventPublisher<PlaybackEventType, PlaybackEvent>("relay-custom-event-it", bootstrapServers, db).managed()
+            publisher.activateEvents(PlaybackEventType.STARTED)
+
+            // Emit a custom event inside a transaction — the outbox row must be captured atomically.
+            transaction(db) {
+                publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 77))
+            }
+            countOutboxRows(dataSource) shouldBe 1L
+            val rowId = firstOutboxRowId(dataSource)
+
+            val topic = "$playbackAggregateType.events"
+            createMultiPartitionTopic(topic, 1)
+            val consumer = subscribedConsumer("relay-custom-rt", topic)
+            lirpKafkaConfig().startRelay(dataSource, fastRelayConfig())
+
+            val record = consumer.pollUntil { it.shouldNotBeEmpty() }.first()
+            val restoredEnvelope = CloudEventsBinarySerializer().deserialize(record.value(), record.headerBytes())
+
+            restoredEnvelope.eventId shouldBe rowId
+            restoredEnvelope.eventTypeCode shouldBe PlaybackEventType.STARTED.code
+            restoredEnvelope.aggregateType shouldBe playbackAggregateType
+            // ce_id header must equal the outbox row UUID verbatim.
+            record.header("ce_id") shouldBe rowId
+            // Record key, envelope aggregate id, and payload must carry the original event data
+            // (trackId), not "unknown"/"{}" — the OutboxRoutableEvent capture path.
+            record.key() shouldBe "77"
+            restoredEnvelope.aggregateId shouldBe "77"
+            restoredEnvelope.payload shouldBe """{"trackId":77}"""
+        }
+    }
+
+    test("non-retriable error moves row to dead letter table and relay continues") {
+        DatabaseTestSupport.withDatabaseTest(postgres, AudioItemSqlTableDef) { dataSource ->
+            withResources {
+                resetOutboxSchema(dataSource)
+
+                // maxRetries=1: new rows (retryCount=0) attempt publishing once; a non-retriable Kafka
+                // exception (InvalidTopicException from an invalid topic name) is caught and the row is
+                // moved to the dead-letter table in the same transaction.
+                val relayConfig =
+                    KafkaOutboxConfig(
+                        pollIntervalMs = 50L,
+                        batchSize = 10,
+                        maxRetries = 1,
+                        retryBaseDelayMs = 50L,
+                        retryMaxDelayMs = 100L
+                    )
+
+                val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef).managed()
+
+                // Poison row: aggregate_type contains '#', producing a Kafka-invalid topic name
+                // ("invalid#topic.events"). Kafka topic names must match [a-zA-Z0-9._-]+; '#' is rejected
+                // with InvalidTopicException (a KafkaException subclass, not RetriableException), so the
+                // relay moves this row to the dead-letter table.
                 val poisonAggregateType = "invalid#topic"
                 insertRawOutboxRow(dataSource, poisonAggregateType, "poison-id-1")
 
-                // Insert a valid sibling row that the relay must still publish after the dead-letter move.
+                // Valid sibling row the relay must still publish after the dead-letter move.
                 transaction(repo) { r ->
                     r.add(MutableAudioItem(99, "Another One Bites the Dust", "The Game") as AudioItem)
                 }
 
-                val lirpConfig = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers)
-                // Valid sibling row must be published to Kafka
-                createMultiPartitionTopic(validTopic, 1)
-                KafkaConsumer<String, ByteArray>(consumerProps("relay-dead-letter-${System.currentTimeMillis()}")).use { consumer ->
-                    awaitConsumerAssignment(consumer, listOf(validTopic))
-                    lirpConfig.startRelay(dataSource, relayConfig)
-                    try {
-                        val receivedKeys = mutableListOf<String>()
-                        eventually(20.seconds) {
-                            consumer.poll(Duration.ofMillis(200)).forEach { receivedKeys.add(it.key()) }
-                            receivedKeys.size shouldBe 1
-                        }
-                        receivedKeys.first() shouldBe "99"
+                createMultiPartitionTopic(audioItemsTopic, 1)
+                val consumer = subscribedConsumer("relay-dead-letter", audioItemsTopic)
+                lirpKafkaConfig().startRelay(dataSource, relayConfig)
 
-                        // Poison row must be in the dead-letter table with full failure metadata
-                        eventually(10.seconds) {
-                            countDeadLetterRows(dataSource) shouldBe 1L
-                        }
-                        val dltRow = readFirstDeadLetterRow(dataSource)
-                        dltRow shouldNotBe null
-                        dltRow!!["aggregate_type"] shouldBe poisonAggregateType
-                        (dltRow["attempt_count"] as Number).toInt() shouldBe 1
-                        dltRow["last_error"] shouldNotBe null
-                        dltRow["failed_at"] shouldNotBe null
-
-                        // Outbox must be empty — poison row removed, valid row sent
-                        countUnsentOutboxRows(dataSource) shouldBe 0L
-                    } finally {
-                        lirpConfig.close()
-                    }
+                consumer.pollUntil { records ->
+                    records.map { it.key() } shouldContainExactlyInAnyOrder listOf("99")
                 }
-            } finally {
-                repo.close()
+
+                // Poison row must be in the dead-letter table with full failure metadata.
+                eventually(10.seconds) {
+                    countDeadLetterRows(dataSource) shouldBe 1L
+                }
+                val dltRow = readFirstDeadLetterRow(dataSource).shouldNotBeNull()
+                dltRow["aggregate_type"] shouldBe poisonAggregateType
+                (dltRow["attempt_count"] as Number).toInt() shouldBe 1
+                dltRow["last_error"].shouldNotBeNull()
+                dltRow["failed_at"].shouldNotBeNull()
+
+                // Outbox must be empty — poison row removed, valid row sent.
+                countUnsentOutboxRows(dataSource) shouldBe 0L
             }
         }
     }
 })
 
 // -------------------------------------------------------------------------------------------------
-// Helpers
+// Custom event types for the custom-event round-trip test
 // -------------------------------------------------------------------------------------------------
 
-/** [KafkaOutboxConfig] tuned for fast test turnaround. */
-private fun fastRelayConfig() =
-    KafkaOutboxConfig(
-        pollIntervalMs = 50L,
-        batchSize = 100,
-        maxRetries = 3,
-        retryBaseDelayMs = 50L,
-        retryMaxDelayMs = 200L
-    )
+/** Consumer-defined event type with a code outside the flush-managed set {100, 300, 400, ...}. */
+private enum class PlaybackEventType(override val code: Int) : EventType {
+    STARTED(998)
+}
+
+/**
+ * Consumer-defined event implementing [OutboxRoutableEvent] so the relay can capture
+ * [aggregateId] and [payload] into the outbox row rather than discarding them.
+ */
+private data class PlaybackEvent(
+    override val type: PlaybackEventType,
+    val trackId: Int
+) : OutboxRoutableEvent<PlaybackEventType> {
+    override val aggregateId: String get() = trackId.toString()
+    override val payload: String get() = """{"trackId":$trackId}"""
+}
+
+// -------------------------------------------------------------------------------------------------
+// Shared fixtures
+// -------------------------------------------------------------------------------------------------
+
+/** The single dialect these broker-level tests run against. */
+private val postgres = DatabaseTestSupport.databases.first { it.name == "PostgreSQL" }
+
+/** Default topic for `AudioItem` events, per [net.transgressoft.lirp.kafka.spi.DefaultTopicResolver]. */
+private val audioItemsTopic = "${AudioItemSqlTableDef.tableName}.events"
+
+/** Aggregate type the publisher derives by reflection for [PlaybackEventType] events. */
+private val playbackAggregateType: String =
+    PlaybackEventType.STARTED::class.java.declaringClass?.simpleName
+        ?: PlaybackEventType.STARTED::class.java.simpleName
+        ?: "unknown"
+
+/**
+ * Runs [block] with a [ResourceScope] that closes every [ResourceScope.managed] resource in reverse
+ * registration order when the block completes, replacing the nested `try/finally` choreography each
+ * test would otherwise repeat. Closing a [LirpKafkaConfig] stops its relay and closes its publisher,
+ * so a running relay needs no explicit stop.
+ */
+private inline fun withResources(block: ResourceScope.() -> Unit) {
+    val scope = ResourceScope()
+    try {
+        scope.block()
+    } finally {
+        scope.closeAll()
+    }
+}
+
+/**
+ * Tracks per-test [AutoCloseable]s and provides the two factories the relay tests always need: a
+ * consumer already subscribed and assigned to a topic, and a relay config wired to the shared broker.
+ */
+private class ResourceScope {
+    private val opened = ArrayDeque<AutoCloseable>()
+
+    fun <T : AutoCloseable> T.managed(): T {
+        opened.addFirst(this)
+        return this
+    }
+
+    fun closeAll() {
+        while (opened.isNotEmpty()) {
+            runCatching { opened.removeFirst().close() }
+        }
+    }
+
+    /**
+     * Creates a managed [KafkaConsumer] with a unique group id derived from [group], subscribes it to
+     * [topic], and waits for partition assignment before returning — assignment must complete before
+     * the relay starts so `auto.offset.reset=latest` anchors after the current end-of-topic.
+     */
+    fun subscribedConsumer(group: String, topic: String): KafkaConsumer<String, ByteArray> {
+        val consumer = KafkaConsumer<String, ByteArray>(consumerProps("$group-${System.currentTimeMillis()}")).managed()
+        awaitConsumerAssignment(consumer, listOf(topic))
+        return consumer
+    }
+
+    /** Creates a managed [LirpKafkaConfig] connected to the shared Testcontainers broker. */
+    fun lirpKafkaConfig(): LirpKafkaConfig = LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers).managed()
+}
+
+// -------------------------------------------------------------------------------------------------
+// Consumer helpers
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Polls the consumer, accumulating every record, and re-runs [assert] against the growing list until
+ * it passes or the [timeout] elapses. Returns the collected records for further assertions. Keeping
+ * [assert] as the loop condition preserves Kotest's descriptive failure message on timeout.
+ */
+private suspend fun KafkaConsumer<String, ByteArray>.pollUntil(
+    timeout: kotlin.time.Duration = 20.seconds,
+    assert: (List<ConsumerRecord<String, ByteArray>>) -> Unit
+): List<ConsumerRecord<String, ByteArray>> {
+    val received = mutableListOf<ConsumerRecord<String, ByteArray>>()
+    eventually(timeout) {
+        poll(Duration.ofMillis(200)).forEach { received.add(it) }
+        assert(received)
+    }
+    return received
+}
+
+/** Polls the consumer for [duration], passing every record to [action]. Used for quiet-period drains. */
+private inline fun KafkaConsumer<String, ByteArray>.drainFor(
+    duration: kotlin.time.Duration,
+    action: (ConsumerRecord<String, ByteArray>) -> Unit
+) {
+    val deadline = System.currentTimeMillis() + duration.inWholeMilliseconds
+    while (System.currentTimeMillis() < deadline) {
+        poll(Duration.ofMillis(200)).forEach(action)
+    }
+}
+
+/** Returns the UTF-8 string value of the last header named [name], or `null` when absent. */
+private fun ConsumerRecord<String, ByteArray>.header(name: String): String? =
+    headers().lastHeader(name)?.value()?.toString(Charsets.UTF_8)
+
+/** Returns every header as a name-to-bytes map, matching the [CloudEventsBinarySerializer] input shape. */
+private fun ConsumerRecord<String, ByteArray>.headerBytes(): Map<String, ByteArray> =
+    headers().associate { it.key() to it.value() }
+
+/** Decodes the record value as a UTF-8 string. */
+private fun ConsumerRecord<String, ByteArray>.payloadText(): String = value().toString(Charsets.UTF_8)
 
 /** Builds consumer [Properties] connected to the shared Testcontainers Kafka broker. */
 private fun consumerProps(groupId: String): Properties =
@@ -451,47 +548,54 @@ private fun createMultiPartitionTopic(topic: String, partitions: Int) {
     }
 }
 
-/**
- * Drops the `lirp_kafka_outbox` table if it exists.
- * `DROP TABLE IF EXISTS` is supported by all five target dialects.
- */
-private fun dropOutboxTableIfExists(dataSource: HikariDataSource) {
-    dataSource.connection.use { conn ->
-        conn.prepareStatement("DROP TABLE IF EXISTS lirp_kafka_outbox").use { it.execute() }
-    }
+// -------------------------------------------------------------------------------------------------
+// Outbox schema / row helpers (raw JDBC to avoid referencing internal Exposed tables)
+// -------------------------------------------------------------------------------------------------
+
+/** Drops the outbox and dead-letter tables so the relay's `SchemaUtils.create` recreates them fresh. */
+private fun resetOutboxSchema(dataSource: HikariDataSource) {
+    dropTableIfExists(dataSource, "lirp_kafka_outbox")
+    dropTableIfExists(dataSource, "lirp_kafka_dead_letter")
 }
 
-/**
- * Drops the `lirp_kafka_dead_letter` table if it exists.
- */
-private fun dropDeadLetterTableIfExists(dataSource: HikariDataSource) {
+/** `DROP TABLE IF EXISTS` is supported by all five target dialects. */
+private fun dropTableIfExists(dataSource: HikariDataSource, table: String) {
     dataSource.connection.use { conn ->
-        conn.prepareStatement("DROP TABLE IF EXISTS lirp_kafka_dead_letter").use { it.execute() }
+        conn.prepareStatement("DROP TABLE IF EXISTS $table").use { it.execute() }
     }
 }
 
 /** Counts outbox rows whose `sent_at` is null (pending delivery). */
 private fun countUnsentOutboxRows(dataSource: HikariDataSource): Long =
-    dataSource.connection.use { conn ->
-        conn.prepareStatement("SELECT COUNT(*) FROM lirp_kafka_outbox WHERE sent_at IS NULL")
-            .use { stmt ->
-                stmt.executeQuery().use { rs ->
-                    rs.next()
-                    rs.getLong(1)
-                }
-            }
-    }
+    queryLong(dataSource, "SELECT COUNT(*) FROM lirp_kafka_outbox WHERE sent_at IS NULL")
+
+/** Counts all outbox rows, sent or pending. */
+private fun countOutboxRows(dataSource: HikariDataSource): Long =
+    queryLong(dataSource, "SELECT COUNT(*) FROM lirp_kafka_outbox")
 
 /** Counts all rows in the dead-letter table. */
 private fun countDeadLetterRows(dataSource: HikariDataSource): Long =
+    queryLong(dataSource, "SELECT COUNT(*) FROM lirp_kafka_dead_letter")
+
+private fun queryLong(dataSource: HikariDataSource, sql: String): Long =
     dataSource.connection.use { conn ->
-        conn.prepareStatement("SELECT COUNT(*) FROM lirp_kafka_dead_letter")
-            .use { stmt ->
-                stmt.executeQuery().use { rs ->
-                    rs.next()
-                    rs.getLong(1)
-                }
+        conn.prepareStatement(sql).use { stmt ->
+            stmt.executeQuery().use { rs ->
+                rs.next()
+                rs.getLong(1)
             }
+        }
+    }
+
+/** Reads the id of the first outbox row, failing if the table is empty. */
+private fun firstOutboxRowId(dataSource: HikariDataSource): String =
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("SELECT id FROM lirp_kafka_outbox LIMIT 1").use { stmt ->
+            stmt.executeQuery().use { rs ->
+                check(rs.next()) { "Expected an outbox row but found none" }
+                rs.getString("id")
+            }
+        }
     }
 
 /**
@@ -503,13 +607,16 @@ private fun readFirstDeadLetterRow(dataSource: HikariDataSource): Map<String, An
             "SELECT aggregate_type, attempt_count, last_error, failed_at FROM lirp_kafka_dead_letter LIMIT 1"
         ).use { stmt ->
             stmt.executeQuery().use { rs ->
-                if (!rs.next()) null
-                else mapOf(
-                    "aggregate_type" to rs.getString("aggregate_type"),
-                    "attempt_count" to rs.getInt("attempt_count"),
-                    "last_error" to rs.getString("last_error"),
-                    "failed_at" to rs.getTimestamp("failed_at")
-                )
+                if (!rs.next()) {
+                    null
+                } else {
+                    mapOf(
+                        "aggregate_type" to rs.getString("aggregate_type"),
+                        "attempt_count" to rs.getInt("attempt_count"),
+                        "last_error" to rs.getString("last_error"),
+                        "failed_at" to rs.getTimestamp("failed_at")
+                    )
+                }
             }
         }
     }
@@ -564,3 +671,13 @@ private fun insertRawOutboxRows(dataSource: HikariDataSource, aggregateType: Str
 private fun insertRawOutboxRow(dataSource: HikariDataSource, aggregateType: String, aggregateId: String) {
     insertRawOutboxRows(dataSource, aggregateType, aggregateId, 1)
 }
+
+/** [KafkaOutboxConfig] tuned for fast test turnaround. */
+private fun fastRelayConfig() =
+    KafkaOutboxConfig(
+        pollIntervalMs = 50L,
+        batchSize = 100,
+        maxRetries = 3,
+        retryBaseDelayMs = 50L,
+        retryMaxDelayMs = 200L
+    )

--- a/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayIT.kt
+++ b/lirp-kafka/src/integrationTest/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayIT.kt
@@ -125,7 +125,9 @@ internal class OutboxRelayIT : FunSpec({
                     r.add(MutableAudioItem(10, "Radio Ga Ga", "The Works") as AudioItem)
                 }
 
-                // First relay run: publish the record to Kafka and set sent_at.
+                // First relay run: publish the record to Kafka and set sent_at. Pre-create the topic
+                // so this run does not depend on broker auto-topic creation, matching the later runs.
+                createMultiPartitionTopic(audioItemsTopic, 1)
                 LirpKafkaConfig.create(KafkaContainerSupport.bootstrapServers).use { firstRelay ->
                     firstRelay.startRelay(dataSource, fastRelayConfig())
                     eventually(15.seconds) {

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisher.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisher.kt
@@ -18,11 +18,13 @@
 package net.transgressoft.lirp.kafka
 
 import net.transgressoft.lirp.entity.LirpEntity
+import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.EventType
 import net.transgressoft.lirp.event.FlowEventPublisher
 import net.transgressoft.lirp.event.LirpEvent
 import net.transgressoft.lirp.event.LirpEventPublisher
 import net.transgressoft.lirp.event.LirpEventSubscription
+import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.kafka.outbox.OutboxEvent
 import net.transgressoft.lirp.kafka.outbox.OutboxStore
 import net.transgressoft.lirp.kafka.outbox.SqlOutboxStore
@@ -48,10 +50,10 @@ import kotlinx.coroutines.flow.SharedFlow
  * [FlowEventPublisher], preserving in-process reactive delivery when this publisher is
  * injected in place of [FlowEventPublisher].
  *
- * [emitAsync] captures custom (non-flush-managed) events into the transactional outbox
- * **before** delivering them to local in-process subscribers, so a capture failure leaves
- * neither the outbox nor local subscribers in an inconsistent state. Standard CRUD and mutation
- * codes are already captured by the flush hook in [KafkaOutboxSqlRepository] and are only
+ * [emitAsync] captures custom events into the transactional outbox **before** delivering them to
+ * local in-process subscribers, so a capture failure leaves neither the outbox nor local
+ * subscribers in an inconsistent state. Framework-owned [CrudEvent.Type] and [MutationEvent.Type]
+ * events are already captured by the flush hook in [KafkaOutboxSqlRepository] and are only
  * delivered locally here.
  *
  * Custom events emitted via [emitAsync] must implement [OutboxRoutableEvent] to supply an
@@ -125,13 +127,6 @@ class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
                 }
             )
 
-        // Event type codes that are already captured by the in-commit flush hook
-        // (KafkaOutboxSqlRepository) and must NOT be re-captured via emitAsync to
-        // prevent duplicate outbox rows. These cover all standard CRUD and mutation codes:
-        // CREATE(100), UPDATE(300), DELETE(400), PROPERTY_CHANGED(302), BATCH_CHANGED(303),
-        // SOFT_DELETE(410), RESTORE(420), CONFLICT(950).
-        private val flushManagedCodes = setOf(100, 300, 400, 302, 303, 410, 420, 950)
-
         override val changes: SharedFlow<E> get() = delegate.changes
 
         override val isClosed: Boolean get() = delegate.isClosed
@@ -159,29 +154,33 @@ class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
         override fun subscribe(subscriber: Flow.Subscriber<in E>) = delegate.subscribe(subscriber)
 
         /**
-         * Emits [event] to local in-process subscribers and, when the event type code is not in the
-         * flush-managed set, inserts an outbox row to ensure at-least-once Kafka delivery.
+         * Emits [event] to local in-process subscribers and, when the event is not a framework-owned
+         * [CrudEvent.Type] or [MutationEvent.Type], inserts an outbox row to ensure at-least-once
+         * Kafka delivery.
          *
          * Outbox capture happens **before** local delivery so that a capture failure leaves
-         * neither the outbox nor local subscribers with an inconsistent view. Standard CRUD/mutation
-         * codes (flush-managed) are captured by the [KafkaOutboxSqlRepository] flush hook; for
-         * those, only local delivery is performed here.
+         * neither the outbox nor local subscribers with an inconsistent view. Framework-owned
+         * CRUD/mutation events are captured by the [KafkaOutboxSqlRepository] flush hook; for those,
+         * only local delivery is performed here. The gate keys off the framework event-type classes
+         * rather than their numeric codes, so a consumer-defined [EventType] that happens to reuse a
+         * framework code (e.g. `100`) is still captured into the outbox.
          *
          * If the event type is currently disabled, both local delivery and outbox capture are suppressed.
-         * When an active Exposed transaction is detected the outbox INSERT joins that transaction;
-         * otherwise a fresh single-row transaction is opened.
+         * When an active Exposed transaction bound to this publisher's [db] is detected the outbox
+         * INSERT joins that transaction; otherwise a fresh single-row transaction on [db] is opened.
          *
          * Custom events must implement [OutboxRoutableEvent]; emitting a non-routable custom event
          * throws immediately so the misconfiguration is surfaced as a bug.
          */
         override fun emitAsync(event: E) {
             if (!delegate.isEventActive(event.type)) return
-            if (flushManagedCodes.contains(event.type.code)) {
+            if (event.type is CrudEvent.Type || event.type is MutationEvent.Type) {
                 delegate.emitAsync(event)
                 return
             }
             val outboxEvent = buildOutboxEvent(event)
-            if (TransactionManager.currentOrNull() != null) {
+            val currentTransaction = TransactionManager.currentOrNull()
+            if (currentTransaction != null && currentTransaction.db == db) {
                 outboxStore.insert(outboxEvent)
             } else {
                 transaction(db) {

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisher.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisher.kt
@@ -17,57 +17,236 @@
 
 package net.transgressoft.lirp.kafka
 
+import net.transgressoft.lirp.entity.LirpEntity
+import net.transgressoft.lirp.event.EventType
+import net.transgressoft.lirp.event.FlowEventPublisher
+import net.transgressoft.lirp.event.LirpEvent
+import net.transgressoft.lirp.event.LirpEventPublisher
+import net.transgressoft.lirp.event.LirpEventSubscription
+import net.transgressoft.lirp.kafka.outbox.OutboxEvent
+import net.transgressoft.lirp.kafka.outbox.OutboxStore
+import net.transgressoft.lirp.kafka.outbox.SqlOutboxStore
+import net.transgressoft.lirp.kafka.spi.OutboxRoutableEvent
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.header.Header
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.Properties
+import java.util.UUID
 import java.util.concurrent.ExecutionException
+import java.util.concurrent.Flow
+import kotlin.time.Clock
+import kotlinx.coroutines.flow.SharedFlow
 
 /**
- * Publishes domain event payloads to a Kafka topic via a [KafkaProducer].
+ * A full [LirpEventPublisher] implementation that publishes domain events to Kafka.
  *
- * [publish] is a direct synchronous send (acks=all) that blocks until the broker
- * acknowledges the record. Future releases will drive publish through the transactional
- * outbox relay instead.
+ * All subscribe/activation/changes operations delegate to an internally composed
+ * [FlowEventPublisher], preserving in-process reactive delivery when this publisher is
+ * injected in place of [FlowEventPublisher].
  *
- * [bootstrapServers] must be a non-blank comma-separated list of `host:port` pairs;
- * validated at construction.
+ * [emitAsync] captures custom (non-flush-managed) events into the transactional outbox
+ * **before** delivering them to local in-process subscribers, so a capture failure leaves
+ * neither the outbox nor local subscribers in an inconsistent state. Standard CRUD and mutation
+ * codes are already captured by the flush hook in [KafkaOutboxSqlRepository] and are only
+ * delivered locally here.
+ *
+ * Custom events emitted via [emitAsync] must implement [OutboxRoutableEvent] to supply an
+ * [OutboxRoutableEvent.aggregateId] and [OutboxRoutableEvent.payload]; emitting a non-routable
+ * custom event will throw to surface the misconfiguration immediately.
+ *
+ * [publish] is a direct synchronous send (acks=all) used by the outbox relay. It accepts
+ * an optional [headers] iterable to carry CloudEvents binary-mode attributes.
+ *
+ * Closing this publisher stops in-process subscriptions and releases the broker connection.
+ * It does **not** stop the outbox relay, whose lifecycle is owned by [LirpKafkaConfig].
+ *
+ * @param ET The specific [EventType] this publisher emits
+ * @param E  The specific [LirpEvent] type this publisher emits
+ * @param id Logical identifier, used to name the internal [FlowEventPublisher]
+ * @param bootstrapServers Comma-separated list of `host:port` Kafka broker addresses; must be non-blank
+ * @param db Exposed [Database] handle used when opening a fresh single-row transaction in [emitAsync]
+ * @param outboxStore Internal store used to persist custom event outbox rows in [emitAsync]
+ * @param producerConfig Optional producer properties overlaid on the defaults (delivery.timeout.ms,
+ *   request.timeout.ms, max.block.ms). Use this to tune or override any producer property; entries
+ *   are applied after the defaults, so any key present in [producerConfig] wins.
  */
-class KafkaEventPublisher(bootstrapServers: String) : AutoCloseable {
+class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
+    internal constructor(
+        id: String,
+        bootstrapServers: String,
+        private val db: Database,
+        private val outboxStore: OutboxStore,
+        producerConfig: Map<String, String> = emptyMap()
+    ) : LirpEventPublisher<ET, E> {
 
-    init {
-        require(bootstrapServers.isNotBlank()) { "bootstrapServers must not be blank" }
-    }
+        /**
+         * Creates a [KafkaEventPublisher] connected to the given [bootstrapServers] and [db].
+         *
+         * The internal [OutboxStore] is created automatically from [db].
+         *
+         * @param id Logical identifier for this publisher, used for logging and the delegate [FlowEventPublisher]
+         * @param bootstrapServers Comma-separated `host:port` list of Kafka broker addresses; must be non-blank
+         * @param db Exposed [Database] handle for outbox row persistence
+         * @param producerConfig Optional producer properties overlaid on the defaults (delivery.timeout.ms,
+         *   request.timeout.ms, max.block.ms). Entries are applied after defaults so any key present here wins.
+         */
+        constructor(
+            id: String,
+            bootstrapServers: String,
+            db: Database,
+            producerConfig: Map<String, String> = emptyMap()
+        ) : this(id, bootstrapServers, db, SqlOutboxStore(db), producerConfig)
 
-    private val log = KotlinLogging.logger(javaClass.name)
+        init {
+            require(bootstrapServers.isNotBlank()) { "bootstrapServers must not be blank" }
+        }
 
-    private val producer: KafkaProducer<String, ByteArray> =
-        KafkaProducer(
-            Properties().apply {
-                put("bootstrap.servers", bootstrapServers)
-                put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
-                put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer")
-                put("acks", "all")
+        private val log = KotlinLogging.logger(javaClass.name)
+
+        private val delegate: FlowEventPublisher<ET, E> = FlowEventPublisher(id)
+
+        private val producer: KafkaProducer<String, ByteArray> =
+            KafkaProducer(
+                Properties().apply {
+                    put("bootstrap.servers", bootstrapServers)
+                    put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+                    put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer")
+                    put("acks", "all")
+                    // Safe defaults that bound the publish window so a broker outage does not hold
+                    // a HikariCP connection open indefinitely inside the relay's per-row transaction.
+                    put("delivery.timeout.ms", "30000")
+                    put("request.timeout.ms", "10000")
+                    put("max.block.ms", "10000")
+                    putAll(producerConfig)
+                }
+            )
+
+        // Event type codes that are already captured by the in-commit flush hook
+        // (KafkaOutboxSqlRepository) and must NOT be re-captured via emitAsync to
+        // prevent duplicate outbox rows. These cover all standard CRUD and mutation codes:
+        // CREATE(100), UPDATE(300), DELETE(400), PROPERTY_CHANGED(302), BATCH_CHANGED(303),
+        // SOFT_DELETE(410), RESTORE(420), CONFLICT(950).
+        private val flushManagedCodes = setOf(100, 300, 400, 302, 303, 410, 420, 950)
+
+        override val changes: SharedFlow<E> get() = delegate.changes
+
+        override val isClosed: Boolean get() = delegate.isClosed
+
+        override val subscriberCount: Int get() = delegate.subscriberCount
+
+        override fun subscribe(callback: (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, E> = delegate.subscribe(callback)
+
+        override fun subscribe(vararg eventTypes: ET, callback: (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, E> =
+            delegate.subscribe(*eventTypes, callback = callback)
+
+        override fun subscribeAsync(action: suspend (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, E> = delegate.subscribeAsync(action)
+
+        override fun subscribeAsync(
+            vararg eventTypes: ET,
+            action: suspend (E) -> Unit
+        ): LirpEventSubscription<in LirpEntity, ET, E> = delegate.subscribeAsync(*eventTypes, action = action)
+
+        override fun activateEvents(vararg types: ET) = delegate.activateEvents(*types)
+
+        override fun disableEvents(vararg types: ET) = delegate.disableEvents(*types)
+
+        override fun isEventActive(type: ET): Boolean = delegate.isEventActive(type)
+
+        override fun subscribe(subscriber: Flow.Subscriber<in E>) = delegate.subscribe(subscriber)
+
+        /**
+         * Emits [event] to local in-process subscribers and, when the event type code is not in the
+         * flush-managed set, inserts an outbox row to ensure at-least-once Kafka delivery.
+         *
+         * Outbox capture happens **before** local delivery so that a capture failure leaves
+         * neither the outbox nor local subscribers with an inconsistent view. Standard CRUD/mutation
+         * codes (flush-managed) are captured by the [KafkaOutboxSqlRepository] flush hook; for
+         * those, only local delivery is performed here.
+         *
+         * If the event type is currently disabled, both local delivery and outbox capture are suppressed.
+         * When an active Exposed transaction is detected the outbox INSERT joins that transaction;
+         * otherwise a fresh single-row transaction is opened.
+         *
+         * Custom events must implement [OutboxRoutableEvent]; emitting a non-routable custom event
+         * throws immediately so the misconfiguration is surfaced as a bug.
+         */
+        override fun emitAsync(event: E) {
+            if (!delegate.isEventActive(event.type)) return
+            if (flushManagedCodes.contains(event.type.code)) {
+                delegate.emitAsync(event)
+                return
             }
-        )
+            val outboxEvent = buildOutboxEvent(event)
+            if (TransactionManager.currentOrNull() != null) {
+                outboxStore.insert(outboxEvent)
+            } else {
+                transaction(db) {
+                    outboxStore.insert(outboxEvent)
+                }
+            }
+            delegate.emitAsync(event)
+        }
 
-    /**
-     * Sends [value] to [topic] with [key] as the partition key.
-     *
-     * Blocks until the broker acknowledges the record (acks=all). The underlying Kafka exception
-     * is unwrapped from [ExecutionException] so callers can distinguish retriable network faults
-     * from permanent failures such as authorization or serialization errors.
-     */
-    fun publish(topic: String, key: String, value: ByteArray) {
-        log.debug { "publish: topic=$topic key=$key bytes=${value.size}" }
-        try {
-            producer.send(ProducerRecord(topic, key, value)).get()
-        } catch (e: ExecutionException) {
-            throw e.cause ?: e
+        /**
+         * Sends [value] to [topic] with [key] as the partition key.
+         *
+         * Blocks until the broker acknowledges the record (acks=all). The underlying Kafka exception
+         * is unwrapped from [ExecutionException] so callers can distinguish retriable network faults
+         * from permanent failures. [headers] are attached to the [ProducerRecord] to carry
+         * CloudEvents binary-mode attributes.
+         *
+         * @param headers Optional record headers; defaults to empty for backwards compatibility
+         */
+        fun publish(
+            topic: String,
+            key: String,
+            value: ByteArray,
+            headers: Iterable<Header> = emptyList()
+        ) {
+            log.debug { "publish: topic=$topic key=$key bytes=${value.size}" }
+            try {
+                val record = ProducerRecord<String, ByteArray>(topic, null, null, key, value, headers)
+                producer.send(record).get()
+            } catch (e: ExecutionException) {
+                throw e.cause ?: e
+            }
+        }
+
+        /**
+         * Closes the internal [FlowEventPublisher] and the [KafkaProducer].
+         *
+         * This does not stop the outbox relay; relay lifecycle is owned by [LirpKafkaConfig].
+         */
+        override fun close() {
+            delegate.close()
+            producer.close()
+        }
+
+        private fun buildOutboxEvent(event: E): OutboxEvent {
+            // Derive aggregateType from the EventType's enclosing class (e.g. MyEntity.EventType → MyEntity),
+            // falling back to the EventType class name if no enclosing class is declared.
+            val aggregateType =
+                event.type::class.java.declaringClass?.simpleName
+                    ?: event.type::class.java.simpleName
+                    ?: "unknown"
+            val routable =
+                event as? OutboxRoutableEvent<*>
+                    ?: error(
+                        "Custom event ${event.type} emitted through KafkaEventPublisher must implement " +
+                            "OutboxRoutableEvent to be relayed to Kafka; implement aggregateId and payload " +
+                            "or use FlowEventPublisher for local-only delivery"
+                    )
+            return OutboxEvent(
+                id = UUID.randomUUID(),
+                aggregateType = aggregateType,
+                aggregateId = routable.aggregateId,
+                eventTypeCode = event.type.code,
+                payload = routable.payload,
+                createdAt = Clock.System.now()
+            )
         }
     }
-
-    override fun close() {
-        producer.close()
-    }
-}

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxConfig.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxConfig.kt
@@ -24,6 +24,10 @@ package net.transgressoft.lirp.kafka
  * including the `next_retry_at` column; use [KafkaOutboxConfig.DEFAULT] unless you need to
  * tune the delivery characteristics for a specific deployment.
  *
+ * **Defaults:** poll interval 500 ms, batch size 100, max retries 5. Invalid values (non-positive
+ * poll interval or batch size, negative max retries, or max delay less than base delay) are
+ * rejected at construction with an [IllegalArgumentException].
+ *
  * Operators tune [pollIntervalMs] and [batchSize] to balance delivery latency against
  * database load: a lower poll interval reduces end-to-end latency but increases the number of
  * DB round trips; a larger batch size amortises transaction overhead at the cost of longer

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
@@ -19,6 +19,10 @@ package net.transgressoft.lirp.kafka
 
 import net.transgressoft.lirp.event.LirpErrorHandler
 import net.transgressoft.lirp.kafka.outbox.OutboxRelay
+import net.transgressoft.lirp.kafka.spi.CloudEventsBinarySerializer
+import net.transgressoft.lirp.kafka.spi.DefaultTopicResolver
+import net.transgressoft.lirp.kafka.spi.LirpEventSerializer
+import net.transgressoft.lirp.kafka.spi.TopicResolver
 import org.jetbrains.exposed.v1.jdbc.Database
 import javax.sql.DataSource
 
@@ -45,8 +49,7 @@ import javax.sql.DataSource
  */
 class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCloseable {
 
-    private val publisherDelegate = lazy { KafkaEventPublisher(bootstrapServers) }
-    private val _publisher: KafkaEventPublisher by publisherDelegate
+    private var _publisher: KafkaEventPublisher<*, *>? = null
     private var relay: OutboxRelay? = null
 
     companion object {
@@ -64,10 +67,12 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
     /**
      * Returns the [KafkaEventPublisher] owned by this config.
      *
-     * The publisher is created lazily on first call and reused on subsequent calls.
+     * The publisher is initialized when [startRelay] is called and reused on subsequent calls.
      * Its lifecycle is tied to this config — call [close] to release broker connections.
+     *
+     * @throws IllegalStateException if called before [startRelay]
      */
-    fun publisher(): KafkaEventPublisher = _publisher
+    fun publisher(): KafkaEventPublisher<*, *> = checkNotNull(_publisher) { "Publisher not initialized — call startRelay first" }
 
     /**
      * Starts the outbox relay against the given [dataSource].
@@ -79,17 +84,32 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
      *
      * @param dataSource JDBC data source for the outbox and dead-letter tables.
      * @param config Relay behaviour knobs — poll interval, batch size, retry limits, backoff.
+     * @param producerConfig Optional producer properties overlaid on the safe defaults
+     *   (`delivery.timeout.ms=30000`, `request.timeout.ms=10000`, `max.block.ms=10000`). These
+     *   defaults bound the window the relay holds a HikariCP connection open while waiting for
+     *   broker acknowledgement; pass overrides here to tighten or relax the bounds.
+     * @param serializer Strategy for serializing each [net.transgressoft.lirp.kafka.spi.LirpEventEnvelope]
+     *   to wire bytes and CloudEvents `ce_*` headers before publishing. Defaults to
+     *   [CloudEventsBinarySerializer].
+     * @param topicResolver Strategy for resolving the Kafka topic name from each
+     *   [net.transgressoft.lirp.kafka.spi.LirpEventEnvelope]. Defaults to [DefaultTopicResolver],
+     *   which returns `"${aggregateType}.events"`.
      * @param onDeadLetter Optional callback invoked when a row is moved to the dead-letter table.
      */
     @Synchronized
     fun startRelay(
         dataSource: DataSource,
         config: KafkaOutboxConfig = KafkaOutboxConfig.DEFAULT,
+        producerConfig: Map<String, String> = emptyMap(),
+        serializer: LirpEventSerializer = CloudEventsBinarySerializer(),
+        topicResolver: TopicResolver = DefaultTopicResolver,
         onDeadLetter: LirpErrorHandler? = null
     ) {
         check(relay == null) { "Relay is already running; call stopRelay() first" }
         val db = Database.connect(dataSource)
-        relay = OutboxRelay(db, publisher(), config, onDeadLetter).also { it.start() }
+        val publisher = KafkaEventPublisher<Nothing, Nothing>("lirp-kafka", bootstrapServers, db, producerConfig)
+        _publisher = publisher
+        relay = OutboxRelay(db, publisher, config, serializer, topicResolver, onDeadLetter).also { it.start() }
     }
 
     /** Stops the relay without closing the [KafkaEventPublisher]. */
@@ -104,6 +124,7 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
     override fun close() {
         relay?.stop()
         relay = null
-        if (publisherDelegate.isInitialized()) _publisher.close()
+        _publisher?.close()
+        _publisher = null
     }
 }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
@@ -107,8 +107,12 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
     ) {
         check(relay == null) { "Relay is already running; call stopRelay() first" }
         val db = Database.connect(dataSource)
-        val publisher = KafkaEventPublisher<Nothing, Nothing>("lirp-kafka", bootstrapServers, db, producerConfig)
-        _publisher = publisher
+        // Reuse the cached publisher across relay restarts so a prior stopRelay() does not leave the
+        // previous producer/broker connection open when a new relay is started.
+        val publisher =
+            _publisher
+                ?: KafkaEventPublisher<Nothing, Nothing>("lirp-kafka", bootstrapServers, db, producerConfig)
+                    .also { _publisher = it }
         relay = OutboxRelay(db, publisher, config, serializer, topicResolver, onDeadLetter).also { it.start() }
     }
 

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
@@ -23,8 +23,14 @@ import net.transgressoft.lirp.event.LirpOperation
 import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.kafka.KafkaEventPublisher
 import net.transgressoft.lirp.kafka.KafkaOutboxConfig
+import net.transgressoft.lirp.kafka.spi.CloudEventsBinarySerializer
+import net.transgressoft.lirp.kafka.spi.DefaultTopicResolver
+import net.transgressoft.lirp.kafka.spi.LirpEventEnvelope
+import net.transgressoft.lirp.kafka.spi.LirpEventSerializer
+import net.transgressoft.lirp.kafka.spi.TopicResolver
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.kafka.common.errors.RetriableException
+import org.apache.kafka.common.header.internals.RecordHeaders
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -59,9 +65,10 @@ import kotlinx.coroutines.runBlocking
  * dead-letters a row only after its first delivery attempt fails. The [onDeadLetter] callback is
  * invoked on every dead-letter move.
  *
- * **Topic routing:** each row is published to `"${row.aggregateType}.events"`. This default routing
- * is suitable for most single-aggregate deployments; pluggable topic resolution is deferred to a
- * later release.
+ * **Topic routing:** each row's topic is resolved via the pluggable [TopicResolver]. The default
+ * resolver returns `"${aggregateType}.events"`, which is suitable for most single-aggregate
+ * deployments. Pass a custom [TopicResolver] to [net.transgressoft.lirp.kafka.LirpKafkaConfig.startRelay]
+ * to override routing for specific aggregate types or event-type codes.
  *
  * **Ordering:** records are keyed by [OutboxEvent.aggregateId] so the Kafka producer routes
  * all events for a given aggregate to the same partition, preserving per-aggregate ordering.
@@ -74,14 +81,20 @@ import kotlinx.coroutines.runBlocking
  * @param db Exposed [Database] handle for the outbox and dead-letter tables.
  * @param publisher Kafka publisher used to send each outbox row.
  * @param config Relay behaviour knobs — poll interval, batch size, retry limits, backoff.
+ * @param serializer Strategy for serializing a [LirpEventEnvelope] to wire bytes and CloudEvents
+ *   `ce_*` headers. Defaults to [CloudEventsBinarySerializer].
+ * @param topicResolver Strategy for resolving the Kafka topic name from a [LirpEventEnvelope].
+ *   Defaults to [DefaultTopicResolver] which returns `"${aggregateType}.events"`.
  * @param onDeadLetter Optional callback invoked when a row is moved to the dead-letter table.
  *   The callback receives the terminal exception and a [LirpErrorContext] describing the failure.
  *   Exceptions thrown by the callback are swallowed.
  */
 internal class OutboxRelay(
     private val db: Database,
-    private val publisher: KafkaEventPublisher,
+    private val publisher: KafkaEventPublisher<*, *>,
     private val config: KafkaOutboxConfig,
+    private val serializer: LirpEventSerializer = CloudEventsBinarySerializer(),
+    private val topicResolver: TopicResolver = DefaultTopicResolver,
     private val onDeadLetter: LirpErrorHandler? = null
 ) : AutoCloseable {
 
@@ -114,9 +127,25 @@ internal class OutboxRelay(
     }
 
     /**
-     * Cancels the background poll loop and waits for it to finish before returning, so callers can
-     * safely close the underlying [DataSource][javax.sql.DataSource] afterwards. A stopped relay can
-     * be [start]ed again.
+     * Cancels the background poll loop and suspends until it finishes, then clears the job.
+     *
+     * Prefer this over [stop] when calling from a coroutine context to avoid blocking a thread.
+     * A stopped relay can be [start]ed again.
+     */
+    suspend fun stopAndJoin() {
+        job?.cancelAndJoin()
+        job = null
+    }
+
+    /**
+     * Cancels the background poll loop and blocks the calling thread until it finishes, so callers
+     * can safely close the underlying [DataSource][javax.sql.DataSource] afterwards. A stopped relay
+     * can be [start]ed again.
+     *
+     * **Precondition:** this method must NOT be called from a thread running on
+     * [ReactiveScope.ioScope] (the relay's own dispatcher). Doing so will deadlock because
+     * [runBlocking] cannot complete the [kotlinx.coroutines.cancelAndJoin] suspension while the
+     * calling thread is occupied. Coroutine callers must use [stopAndJoin] instead.
      */
     fun stop() {
         val current = job ?: return
@@ -145,14 +174,22 @@ internal class OutboxRelay(
 
     internal fun processRow(row: OutboxEvent) {
         try {
-            publisher.publish(topicFor(row), row.aggregateId, row.payload.toByteArray())
+            val envelope = LirpEventEnvelope.from(row)
+            val topic = topicResolver.resolve(envelope)
+            require(topic.isNotBlank()) {
+                "TopicResolver returned a blank topic for aggregateType='${envelope.aggregateType}'"
+            }
+            val serialized = serializer.serialize(envelope)
+            val recordHeaders = RecordHeaders()
+            serialized.headers.forEach { (k, v) -> recordHeaders.add(k, v) }
+            publisher.publish(topic, row.aggregateId, serialized.value, recordHeaders)
             store.markSent(row.id)
         } catch (e: RetriableException) {
             if (row.retryCount >= config.maxRetries) {
                 store.moveToDeadLetter(row, Clock.System.now(), e.message ?: e.javaClass.simpleName)
                 invokeDeadLetterCallback(e)
             } else {
-                val nextRetryAt = computeNextRetryAt(row.retryCount, config)
+                val nextRetryAt = computeNextRetryAt(row.retryCount + 1, config)
                 store.scheduleRetry(row.id, nextRetryAt, e.message ?: e.javaClass.simpleName)
             }
         } catch (e: Exception) {
@@ -170,8 +207,6 @@ internal class OutboxRelay(
     }
 
     internal companion object {
-
-        internal fun topicFor(row: OutboxEvent): String = "${row.aggregateType}.events"
 
         /**
          * Computes the next retry timestamp using exponential backoff with ±20% jitter.

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxStore.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxStore.kt
@@ -67,4 +67,14 @@ internal interface OutboxStore {
      * encountered a non-retriable error. Must be called inside an active Exposed transaction.
      */
     fun moveToDeadLetter(event: OutboxEvent, failedAt: Instant, errorMessage: String)
+
+    /**
+     * Inserts a single outbox row using bare Exposed DSL.
+     *
+     * Intended for use by [net.transgressoft.lirp.kafka.KafkaEventPublisher.emitAsync] to capture
+     * custom events that do not flow through the transactional flush hook. When called inside an
+     * active Exposed transaction the INSERT joins that transaction atomically; when no transaction
+     * is active the caller is responsible for opening one.
+     */
+    fun insert(event: OutboxEvent)
 }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/SqlOutboxStore.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/SqlOutboxStore.kt
@@ -115,6 +115,17 @@ internal class SqlOutboxStore(private val db: Database) : OutboxStore {
         }
     }
 
+    override fun insert(event: OutboxEvent) {
+        OutboxEventTable.insert {
+            it[OutboxEventTable.id] = event.id.toKotlinUuid()
+            it[OutboxEventTable.aggregateType] = event.aggregateType
+            it[OutboxEventTable.aggregateId] = event.aggregateId
+            it[OutboxEventTable.eventTypeCode] = event.eventTypeCode
+            it[OutboxEventTable.payload] = event.payload
+            it[OutboxEventTable.createdAt] = event.createdAt
+        }
+    }
+
     override fun moveToDeadLetter(event: OutboxEvent, failedAt: Instant, errorMessage: String) {
         DeadLetterTable.insert {
             it[id] = event.id.toKotlinUuid()

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer.kt
@@ -1,0 +1,71 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.spi
+
+/**
+ * Default [LirpEventSerializer] that encodes events using the CloudEvents v1.0 Kafka binary
+ * content mode specification.
+ *
+ * In binary content mode, CloudEvents attributes are carried as Kafka record headers with the
+ * `ce_` prefix, and the event payload is transmitted as the raw record value. This allows
+ * non-LIRP consumers to read the payload as plain JSON without a CloudEvents SDK, while
+ * retaining full CloudEvents envelope metadata in the headers.
+ *
+ * Headers produced on [serialize]:
+ * - `ce_specversion`: CloudEvents specification version, always `"1.0"`.
+ * - `ce_id`: The outbox row UUID, used as the idempotency key for consumer-side deduplication.
+ * - `ce_source`: URI-reference identifying the event origin as `"lirp/{aggregateType}"`.
+ * - `ce_type`: Event type encoded as `"{aggregateType}.{eventTypeCode}"`.
+ * - `ce_subject`: The aggregate instance identifier (`aggregateId`).
+ * - `ce_time`: ISO-8601 UTC capture timestamp (`createdAt`).
+ * - `content-type`: Always `"application/json"` — the record value is a JSON string.
+ *
+ * All header values are encoded as UTF-8 bytes. Missing required headers on [deserialize] cause
+ * an `error()` invocation (bug detector — do not downgrade to logging).
+ *
+ * No external CloudEvents SDK is required. Hand-rolled with kotlinx-serialization only.
+ */
+class CloudEventsBinarySerializer : LirpEventSerializer {
+
+    override fun serialize(envelope: LirpEventEnvelope): SerializedEvent {
+        val headers = mutableMapOf<String, ByteArray>()
+        headers["ce_specversion"] = "1.0".toByteArray(Charsets.UTF_8)
+        headers["ce_id"] = envelope.eventId.toByteArray(Charsets.UTF_8)
+        headers["ce_source"] = "lirp/${envelope.aggregateType}".toByteArray(Charsets.UTF_8)
+        headers["ce_type"] = "${envelope.aggregateType}.${envelope.eventTypeCode}".toByteArray(Charsets.UTF_8)
+        headers["ce_subject"] = envelope.aggregateId.toByteArray(Charsets.UTF_8)
+        headers["ce_time"] = envelope.createdAt.toByteArray(Charsets.UTF_8)
+        headers["content-type"] = "application/json".toByteArray(Charsets.UTF_8)
+        val value = envelope.payload.toByteArray(Charsets.UTF_8)
+        return SerializedEvent(value, headers)
+    }
+
+    override fun deserialize(value: ByteArray, headers: Map<String, ByteArray>): LirpEventEnvelope {
+        val payload = value.toString(Charsets.UTF_8)
+        val eventId = headers["ce_id"]?.toString(Charsets.UTF_8) ?: error("missing required ce_id header")
+        val source = headers["ce_source"]?.toString(Charsets.UTF_8) ?: error("missing required ce_source header")
+        val aggregateType = source.removePrefix("lirp/")
+        val ceType = headers["ce_type"]?.toString(Charsets.UTF_8) ?: error("missing required ce_type header")
+        val eventTypeCode =
+            ceType.substringAfterLast('.').toIntOrNull()
+                ?: error("ce_type '$ceType' does not end in a numeric event-type code")
+        val aggregateId = headers["ce_subject"]?.toString(Charsets.UTF_8) ?: error("missing required ce_subject header")
+        val createdAt = headers["ce_time"]?.toString(Charsets.UTF_8) ?: error("missing required ce_time header")
+        return LirpEventEnvelope(eventId, aggregateType, aggregateId, eventTypeCode, payload, createdAt)
+    }
+}

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer.kt
@@ -35,8 +35,10 @@ package net.transgressoft.lirp.kafka.spi
  * - `ce_time`: ISO-8601 UTC capture timestamp (`createdAt`).
  * - `content-type`: Always `"application/json"` — the record value is a JSON string.
  *
- * All header values are encoded as UTF-8 bytes. Missing required headers on [deserialize] cause
- * an `error()` invocation (bug detector — do not downgrade to logging).
+ * All header values are encoded as UTF-8 bytes. [deserialize] fails fast on any record that does
+ * not honour this contract: a missing required header, an unsupported `ce_specversion` or
+ * `content-type`, or a `ce_source` that is not in the `lirp/{aggregateType}` form all raise an
+ * exception rather than yield a bogus envelope (bug detector — do not downgrade to logging).
  *
  * No external CloudEvents SDK is required. Hand-rolled with kotlinx-serialization only.
  */
@@ -57,8 +59,11 @@ class CloudEventsBinarySerializer : LirpEventSerializer {
 
     override fun deserialize(value: ByteArray, headers: Map<String, ByteArray>): LirpEventEnvelope {
         val payload = value.toString(Charsets.UTF_8)
+        val specVersion = headers["ce_specversion"]?.toString(Charsets.UTF_8) ?: error("missing required ce_specversion header")
+        require(specVersion == "1.0") { "unsupported ce_specversion '$specVersion'" }
         val eventId = headers["ce_id"]?.toString(Charsets.UTF_8) ?: error("missing required ce_id header")
         val source = headers["ce_source"]?.toString(Charsets.UTF_8) ?: error("missing required ce_source header")
+        require(source.startsWith("lirp/")) { "ce_source '$source' does not use the expected lirp/{aggregateType} format" }
         val aggregateType = source.removePrefix("lirp/")
         val ceType = headers["ce_type"]?.toString(Charsets.UTF_8) ?: error("missing required ce_type header")
         val eventTypeCode =
@@ -66,6 +71,8 @@ class CloudEventsBinarySerializer : LirpEventSerializer {
                 ?: error("ce_type '$ceType' does not end in a numeric event-type code")
         val aggregateId = headers["ce_subject"]?.toString(Charsets.UTF_8) ?: error("missing required ce_subject header")
         val createdAt = headers["ce_time"]?.toString(Charsets.UTF_8) ?: error("missing required ce_time header")
+        val contentType = headers["content-type"]?.toString(Charsets.UTF_8) ?: error("missing required content-type header")
+        require(contentType == "application/json") { "unsupported content-type '$contentType'" }
         return LirpEventEnvelope(eventId, aggregateType, aggregateId, eventTypeCode, payload, createdAt)
     }
 }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/LirpEventEnvelope.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/LirpEventEnvelope.kt
@@ -1,0 +1,74 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.spi
+
+import net.transgressoft.lirp.kafka.outbox.OutboxEvent
+import kotlinx.serialization.Serializable
+
+/**
+ * Public wire envelope that the [LirpEventSerializer] SPI serializes to and deserializes from.
+ *
+ * Each instance represents a single domain event as captured by the transactional outbox.
+ * The [payload] field carries a serializer-neutral JSON field snapshot produced by the SQL
+ * persistence layer at capture time. Consumer serializer plugins (Avro, Protobuf, etc.) receive
+ * a structured [LirpEventEnvelope] rather than an opaque byte array, so they can map from a
+ * well-defined public contract.
+ *
+ * The [createdAt] field is stored as an ISO-8601 UTC string rather than a timestamp type so
+ * the envelope remains directly serializable with kotlinx-serialization without a custom
+ * serializer.
+ *
+ * @property eventId Unique identifier of the outbox row (UUID string). Used as the CloudEvents
+ *   `ce_id` header and as the idempotency key for consumer-side deduplication.
+ * @property aggregateType Logical aggregate type name (e.g. table name or class name) used to
+ *   route events to the appropriate Kafka topic via [TopicResolver] and to derive the CloudEvents
+ *   `ce_source` and `ce_type` headers.
+ * @property aggregateId String identifier of the specific aggregate instance; used as the Kafka
+ *   record key for per-aggregate ordering and as the CloudEvents `ce_subject` header.
+ * @property eventTypeCode Numeric event-type code mapping directly to
+ *   [net.transgressoft.lirp.event.EventType.code].
+ * @property payload Serializer-neutral JSON field snapshot of the entity at capture time.
+ * @property createdAt ISO-8601 UTC timestamp of when the outbox row was captured. Used as the
+ *   CloudEvents `ce_time` header.
+ */
+@Serializable
+data class LirpEventEnvelope(
+    val eventId: String,
+    val aggregateType: String,
+    val aggregateId: String,
+    val eventTypeCode: Int,
+    val payload: String,
+    val createdAt: String
+) {
+    companion object {
+        /**
+         * Builds a [LirpEventEnvelope] from an internal outbox row.
+         *
+         * @param row The outbox row to convert.
+         */
+        internal fun from(row: OutboxEvent): LirpEventEnvelope =
+            LirpEventEnvelope(
+                eventId = row.id.toString(),
+                aggregateType = row.aggregateType,
+                aggregateId = row.aggregateId,
+                eventTypeCode = row.eventTypeCode,
+                payload = row.payload,
+                createdAt = row.createdAt.toString()
+            )
+    }
+}

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/LirpEventSerializer.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/LirpEventSerializer.kt
@@ -1,0 +1,73 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.spi
+
+/**
+ * Symmetric serialization SPI for converting [LirpEventEnvelope] instances to and from wire format.
+ *
+ * The relay calls [serialize] before publishing each outbox row to Kafka, and consumer-side
+ * infrastructure calls [deserialize] to reconstruct the envelope from the received record.
+ * Implementing this interface allows consumers to substitute alternative wire encodings
+ * (Avro, Protobuf, etc.) without modifying any LIRP class.
+ *
+ * The default implementation is [CloudEventsBinarySerializer], which encodes the envelope as
+ * CloudEvents v1.0 binary content mode — `ce_*` Kafka record headers carrying CloudEvents
+ * attributes and the neutral JSON field snapshot as the raw record value.
+ *
+ * Because this interface declares two abstract methods, it is a regular interface and not a
+ * `fun interface`. Callers that need a lambda-friendly single-method abstraction should use
+ * [TopicResolver] instead.
+ */
+interface LirpEventSerializer {
+
+    /**
+     * Serializes [envelope] to the wire representation.
+     *
+     * @param envelope The event envelope to serialize.
+     * @return A [SerializedEvent] containing the Kafka record value bytes and the associated
+     *   header map (header name to UTF-8 encoded bytes).
+     */
+    fun serialize(envelope: LirpEventEnvelope): SerializedEvent
+
+    /**
+     * Deserializes a Kafka record back to a [LirpEventEnvelope].
+     *
+     * Implementations must use `error(...)` for any missing required header rather than returning
+     * a partial envelope — missing headers indicate a serialization bug and must surface
+     * immediately rather than silently producing corrupt data.
+     *
+     * @param value Raw Kafka record value bytes.
+     * @param headers Raw header map from the Kafka record (header name to raw bytes).
+     * @return The reconstructed [LirpEventEnvelope].
+     */
+    fun deserialize(value: ByteArray, headers: Map<String, ByteArray>): LirpEventEnvelope
+}
+
+/**
+ * Wire representation of a serialized [LirpEventEnvelope].
+ *
+ * @property value Raw Kafka record value bytes (typically a JSON payload).
+ * @property headers Kafka record headers as a map from header name to raw bytes.
+ *   All header values are expected to be UTF-8 encoded strings.
+ */
+data class SerializedEvent(val value: ByteArray, val headers: Map<String, ByteArray>) {
+    override fun equals(other: Any?): Boolean =
+        other is SerializedEvent && value.contentEquals(other.value) && headers == other.headers
+
+    override fun hashCode(): Int = 31 * value.contentHashCode() + headers.hashCode()
+}

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/OutboxRoutableEvent.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/OutboxRoutableEvent.kt
@@ -1,0 +1,64 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.spi
+
+import net.transgressoft.lirp.event.EventType
+import net.transgressoft.lirp.event.LirpEvent
+
+/**
+ * Opt-in SPI marker for custom (non-CRUD) [LirpEvent] implementations that need to be relayed
+ * through [net.transgressoft.lirp.kafka.KafkaEventPublisher.emitAsync] to the transactional
+ * outbox and ultimately to Kafka.
+ *
+ * Standard CRUD and mutation events are captured automatically by the flush hook in
+ * [net.transgressoft.lirp.kafka.KafkaOutboxSqlRepository]; custom events emitted through
+ * [net.transgressoft.lirp.kafka.KafkaEventPublisher.emitAsync] must supply their own aggregate
+ * identity and JSON payload, because the generic [LirpEvent] interface only exposes [type].
+ *
+ * Implementing this interface makes a custom event relayable:
+ * - [aggregateId] becomes the Kafka record key, routing all events for the same aggregate to
+ *   the same partition and preserving per-aggregate delivery order.
+ * - [payload] is stored as the JSON body of the outbox row and delivered as the CloudEvents
+ *   `data` field to downstream consumers.
+ *
+ * Events that do **not** implement [OutboxRoutableEvent] and are emitted through
+ * [net.transgressoft.lirp.kafka.KafkaEventPublisher.emitAsync] will cause the publisher to
+ * throw at the point of emission, surfacing the misconfiguration as a bug rather than silently
+ * losing event data.
+ */
+interface OutboxRoutableEvent<out T : EventType> : LirpEvent<T> {
+
+    /**
+     * Stable string key identifying the aggregate instance this event belongs to.
+     *
+     * Used as the Kafka record key to route all events for the same aggregate to the same
+     * partition, preserving per-aggregate ordering. Must be non-blank and stable across retries
+     * so the relay can redeliver the row with the same key after a transient failure.
+     */
+    val aggregateId: String
+
+    /**
+     * JSON-encoded body of the event, serialized into the outbox row and delivered as the
+     * CloudEvents `data` field.
+     *
+     * The format is left to the implementing event type; the relay transmits it verbatim.
+     * Consumers that need strong schema guarantees should encode a versioned schema identifier
+     * inside the payload or use a custom [net.transgressoft.lirp.kafka.spi.LirpEventSerializer].
+     */
+    val payload: String
+}

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/TopicResolver.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/TopicResolver.kt
@@ -1,0 +1,57 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.spi
+
+/**
+ * Resolves the Kafka topic name for a given [LirpEventEnvelope].
+ *
+ * Pass a custom implementation to
+ * [net.transgressoft.lirp.kafka.LirpKafkaConfig.startRelay] to override the default
+ * per-aggregate-type routing. Because this is a `fun interface`, a Kotlin lambda is accepted
+ * directly at the call site:
+ *
+ * ```kotlin
+ * lirpConfig.startRelay(dataSource, topicResolver = TopicResolver { env -> "custom.${env.aggregateType}" })
+ * ```
+ *
+ * The default behaviour is provided by [DefaultTopicResolver], which returns
+ * `"${aggregateType}.events"`.
+ */
+fun interface TopicResolver {
+
+    /**
+     * Returns the Kafka topic name for the given [envelope].
+     *
+     * The returned string must be a valid Kafka topic name (non-blank).
+     *
+     * @param envelope The event envelope to resolve a topic for.
+     */
+    fun resolve(envelope: LirpEventEnvelope): String
+}
+
+/**
+ * Default [TopicResolver] that routes each event to a topic named `"${aggregateType}.events"`.
+ *
+ * This matches the default routing used by the outbox relay prior to the introduction of the
+ * pluggable [TopicResolver] SPI, and is the recommended starting point for new deployments.
+ * Consumers that need per-event-type or per-aggregate-instance routing can supply a custom
+ * [TopicResolver] lambda at relay startup.
+ */
+internal object DefaultTopicResolver : TopicResolver {
+    override fun resolve(envelope: LirpEventEnvelope): String = "${envelope.aggregateType}.events"
+}

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisherTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisherTest.kt
@@ -49,9 +49,26 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 @DisplayName("KafkaEventPublisherTest")
 internal class KafkaEventPublisherTest : StringSpec() {
 
-    /** A consumer-defined custom event type with a code outside the flush-managed set. */
+    /** A consumer-defined custom event type with a code outside the framework CRUD/mutation range. */
     enum class PlaybackEventType(override val code: Int) : EventType {
         STARTED(999)
+    }
+
+    /**
+     * A consumer-defined event type that deliberately reuses the framework CREATE code (`100`),
+     * used to prove the outbox gate keys off the event-type class rather than its numeric code.
+     */
+    enum class CollidingEventType(override val code: Int) : EventType {
+        RENAMED(100)
+    }
+
+    /** Custom routable event carrying [CollidingEventType] so it can be captured into the outbox. */
+    data class CollidingEvent(
+        override val type: CollidingEventType,
+        val trackId: Int
+    ) : OutboxRoutableEvent<CollidingEventType> {
+        override val aggregateId: String get() = trackId.toString()
+        override val payload: String get() = """{"trackId":$trackId}"""
     }
 
     /**
@@ -141,6 +158,27 @@ internal class KafkaEventPublisherTest : StringSpec() {
                 rowCount shouldBe 0L
             } finally {
                 kafkaPublisher.close()
+                dataSource.close()
+            }
+        }
+
+        "KafkaEventPublisherTest custom event reusing a framework code is still captured to the outbox" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) { SchemaUtils.create(OutboxEventTable) }
+            val publisher = KafkaEventPublisher<CollidingEventType, CollidingEvent>("test-collision", "localhost:9092", db)
+            publisher.activateEvents(CollidingEventType.RENAMED)
+
+            try {
+                // RENAMED reuses CREATE's code (100) but is not a framework CrudEvent.Type, so the
+                // gate must NOT treat it as flush-managed — the row has to reach the outbox.
+                publisher.emitAsync(CollidingEvent(CollidingEventType.RENAMED, trackId = 100))
+                val rows = transaction(db) { OutboxEventTable.selectAll().toList() }
+                rows.size shouldBe 1
+                rows.single()[OutboxEventTable.eventTypeCode] shouldBe 100
+                rows.single()[OutboxEventTable.aggregateId] shouldBe "100"
+            } finally {
+                publisher.close()
                 dataSource.close()
             }
         }

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisherTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisherTest.kt
@@ -1,0 +1,267 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka
+
+import net.transgressoft.lirp.event.CrudEvent
+import net.transgressoft.lirp.event.EventType
+import net.transgressoft.lirp.event.LirpEvent
+import net.transgressoft.lirp.event.StandardCrudEvent
+import net.transgressoft.lirp.kafka.outbox.OutboxEventTable
+import net.transgressoft.lirp.kafka.spi.OutboxRoutableEvent
+import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.MutableAudioItem
+import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.VolatileRepository
+import net.transgressoft.lirp.persistence.sql.H2ContainerSupport
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+/**
+ * H2 unit tests for [KafkaEventPublisher] injection and gating behaviour.
+ *
+ * Covers: local subscriber fires on custom emitAsync, VolatileRepository publisher overload
+ * routes CRUD events, flush-managed codes do not write outbox rows, disableEvents
+ * fully suppresses both local delivery and outbox capture, OutboxRoutableEvent carries correct
+ * aggregateId and payload into the outbox row, capture happens before local delivery, and
+ * non-routable custom events throw immediately.
+ */
+@DisplayName("KafkaEventPublisherTest")
+internal class KafkaEventPublisherTest : StringSpec() {
+
+    /** A consumer-defined custom event type with a code outside the flush-managed set. */
+    enum class PlaybackEventType(override val code: Int) : EventType {
+        STARTED(999)
+    }
+
+    /**
+     * Consumer-defined event implementing [OutboxRoutableEvent] so it can be relayed through
+     * [KafkaEventPublisher.emitAsync] to the transactional outbox.
+     */
+    data class PlaybackEvent(
+        override val type: PlaybackEventType,
+        val trackId: Int
+    ) : OutboxRoutableEvent<PlaybackEventType> {
+        override val aggregateId: String get() = trackId.toString()
+        override val payload: String get() = """{"trackId":$trackId}"""
+    }
+
+    /**
+     * A custom event that intentionally does NOT implement [OutboxRoutableEvent], used to verify
+     * that emitting it through [KafkaEventPublisher.emitAsync] throws.
+     */
+    data class NonRoutableEvent(
+        override val type: PlaybackEventType,
+        val trackId: Int
+    ) : LirpEvent<PlaybackEventType>
+
+    init {
+        afterEach {
+            RegistryBase.deregisterRepository(AudioItem::class.java)
+        }
+
+        "KafkaEventPublisherTest injected publisher fires local subscriber on emitAsync of custom event" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) { SchemaUtils.create(OutboxEventTable) }
+            val publisher = KafkaEventPublisher<PlaybackEventType, PlaybackEvent>("test", "localhost:9092", db)
+            publisher.activateEvents(PlaybackEventType.STARTED)
+            var received: PlaybackEvent? = null
+            publisher.subscribe { received = it }
+
+            try {
+                publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 1))
+                received?.trackId shouldBe 1
+            } finally {
+                publisher.close()
+                dataSource.close()
+            }
+        }
+
+        "KafkaEventPublisherTest VolatileRepository publisher overload routes CRUD events to supplied publisher" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) { SchemaUtils.create(OutboxEventTable) }
+            val kafkaPublisher =
+                KafkaEventPublisher<CrudEvent.Type, CrudEvent<Int, AudioItem>>("test-repo", "localhost:9092", db)
+            kafkaPublisher.activateEvents(*CrudEvent.Type.entries.toTypedArray())
+            val repo =
+                VolatileRepository<Int, AudioItem>(
+                    name = "audio-items",
+                    publisher = kafkaPublisher
+                )
+
+            val received = mutableListOf<CrudEvent<Int, AudioItem>>()
+            kafkaPublisher.subscribe { received.add(it) }
+            val item = MutableAudioItem(1, "Bohemian Rhapsody", "A Night at the Opera") as AudioItem
+
+            try {
+                repo.add(item)
+                received.size shouldBe 1
+                (received.single() as StandardCrudEvent.Create<Int, AudioItem>).entities.values.single() shouldBe item
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "KafkaEventPublisherTest emitAsync with flush-managed CREATE code does not write outbox row" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) { SchemaUtils.create(OutboxEventTable) }
+            val kafkaPublisher =
+                KafkaEventPublisher<CrudEvent.Type, CrudEvent<Int, AudioItem>>("test-flush-gate", "localhost:9092", db)
+            kafkaPublisher.activateEvents(*CrudEvent.Type.entries.toTypedArray())
+
+            val item = MutableAudioItem(2, "Killer Queen", "Sheer Heart Attack") as AudioItem
+
+            try {
+                kafkaPublisher.emitAsync(StandardCrudEvent.Create(item))
+                val rowCount = transaction(db) { OutboxEventTable.selectAll().count() }
+                rowCount shouldBe 0L
+            } finally {
+                kafkaPublisher.close()
+                dataSource.close()
+            }
+        }
+
+        "KafkaEventPublisherTest disableEvents gates both local delivery and outbox capture" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) { SchemaUtils.create(OutboxEventTable) }
+            val publisher = KafkaEventPublisher<PlaybackEventType, PlaybackEvent>("test-disable", "localhost:9092", db)
+            publisher.activateEvents(PlaybackEventType.STARTED)
+            publisher.disableEvents(PlaybackEventType.STARTED)
+
+            var received: PlaybackEvent? = null
+            publisher.subscribe { received = it }
+
+            try {
+                publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 3))
+                received shouldBe null
+                val rowCount = transaction(db) { OutboxEventTable.selectAll().count() }
+                rowCount shouldBe 0L
+            } finally {
+                publisher.close()
+                dataSource.close()
+            }
+        }
+
+        "KafkaEventPublisherTest OutboxRoutableEvent emitAsync writes outbox row with correct aggregateId and payload" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) { SchemaUtils.create(OutboxEventTable) }
+            val publisher = KafkaEventPublisher<PlaybackEventType, PlaybackEvent>("test-routable", "localhost:9092", db)
+            publisher.activateEvents(PlaybackEventType.STARTED)
+
+            try {
+                publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 42))
+
+                val rows = transaction(db) { OutboxEventTable.selectAll().toList() }
+                rows.size shouldBe 1
+                rows.single()[OutboxEventTable.aggregateId] shouldBe "42"
+                rows.single()[OutboxEventTable.payload] shouldBe """{"trackId":42}"""
+                rows.single()[OutboxEventTable.eventTypeCode] shouldBe PlaybackEventType.STARTED.code
+            } finally {
+                publisher.close()
+                dataSource.close()
+            }
+        }
+
+        "KafkaEventPublisherTest capture happens before local delivery so insert failure suppresses subscriber" {
+            // Simulate a capture failure by checking that: when the outbox INSERT succeeds, the subscriber
+            // is notified after it; and that the subscriber count is zero before emitting when disabled,
+            // confirming the order. We verify ordering by asserting that local delivery only fires when
+            // the outbox row already exists — i.e. the row is present before the subscriber callback runs.
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) { SchemaUtils.create(OutboxEventTable) }
+            val publisher = KafkaEventPublisher<PlaybackEventType, PlaybackEvent>("test-order", "localhost:9092", db)
+            publisher.activateEvents(PlaybackEventType.STARTED)
+
+            var rowCountAtDelivery = -1L
+            publisher.subscribe {
+                // When this callback fires the outbox row must already exist
+                rowCountAtDelivery = transaction(db) { OutboxEventTable.selectAll().count() }
+            }
+
+            try {
+                publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 7))
+                // Subscriber was called with the row already present (capture-before-delivery)
+                rowCountAtDelivery shouldBe 1L
+            } finally {
+                publisher.close()
+                dataSource.close()
+            }
+        }
+
+        "KafkaEventPublisherTest emitting non-routable custom LirpEvent throws rather than silently persisting unknown data" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) { SchemaUtils.create(OutboxEventTable) }
+            @Suppress("UNCHECKED_CAST")
+            val publisher =
+                KafkaEventPublisher<PlaybackEventType, LirpEvent<PlaybackEventType>>(
+                    "test-non-routable", "localhost:9092", db
+                )
+            publisher.activateEvents(PlaybackEventType.STARTED)
+
+            try {
+                shouldThrow<IllegalStateException> {
+                    publisher.emitAsync(NonRoutableEvent(PlaybackEventType.STARTED, trackId = 5))
+                }
+                // No outbox row must have been written
+                val rowCount = transaction(db) { OutboxEventTable.selectAll().count() }
+                rowCount shouldBe 0L
+            } finally {
+                publisher.close()
+                dataSource.close()
+            }
+        }
+
+        "KafkaEventPublisherTest flush-managed codes tee to local subscribers without writing outbox row" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) { SchemaUtils.create(OutboxEventTable) }
+            val kafkaPublisher =
+                KafkaEventPublisher<CrudEvent.Type, CrudEvent<Int, AudioItem>>("test-flush-local", "localhost:9092", db)
+            kafkaPublisher.activateEvents(*CrudEvent.Type.entries.toTypedArray())
+
+            val received = mutableListOf<CrudEvent<Int, AudioItem>>()
+            kafkaPublisher.subscribe { received.add(it) }
+            val item = MutableAudioItem(9, "Somebody to Love", "A Day at the Races") as AudioItem
+
+            try {
+                kafkaPublisher.emitAsync(StandardCrudEvent.Create(item))
+                // Local subscriber must have received the event
+                received.size shouldBe 1
+                // No outbox row — flush-managed codes are captured by the flush hook, not emitAsync
+                val rowCount = transaction(db) { OutboxEventTable.selectAll().count() }
+                rowCount shouldBe 0L
+            } finally {
+                kafkaPublisher.close()
+                dataSource.close()
+            }
+        }
+    }
+}

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxConfigTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxConfigTest.kt
@@ -1,0 +1,75 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests verifying that [KafkaOutboxConfig] exposes the documented defaults and rejects
+ * invalid construction arguments.
+ */
+@DisplayName("KafkaOutboxConfigTest")
+internal class KafkaOutboxConfigTest : StringSpec() {
+
+    init {
+        "KafkaOutboxConfigTest DEFAULT has pollIntervalMs of 500" {
+            KafkaOutboxConfig.DEFAULT.pollIntervalMs shouldBe 500L
+        }
+
+        "KafkaOutboxConfigTest DEFAULT has batchSize of 100" {
+            KafkaOutboxConfig.DEFAULT.batchSize shouldBe 100
+        }
+
+        "KafkaOutboxConfigTest DEFAULT has maxRetries of 5" {
+            KafkaOutboxConfig.DEFAULT.maxRetries shouldBe 5
+        }
+
+        "KafkaOutboxConfigTest construction rejects pollIntervalMs of zero" {
+            shouldThrow<IllegalArgumentException> {
+                KafkaOutboxConfig(pollIntervalMs = 0)
+            }
+        }
+
+        "KafkaOutboxConfigTest construction rejects batchSize of zero" {
+            shouldThrow<IllegalArgumentException> {
+                KafkaOutboxConfig(batchSize = 0)
+            }
+        }
+
+        "KafkaOutboxConfigTest construction rejects negative maxRetries" {
+            shouldThrow<IllegalArgumentException> {
+                KafkaOutboxConfig(maxRetries = -1)
+            }
+        }
+
+        "KafkaOutboxConfigTest construction rejects retryMaxDelayMs less than retryBaseDelayMs" {
+            shouldThrow<IllegalArgumentException> {
+                KafkaOutboxConfig(retryBaseDelayMs = 5000L, retryMaxDelayMs = 1000L)
+            }
+        }
+
+        "KafkaOutboxConfigTest LirpKafkaConfig.create rejects blank bootstrapServers" {
+            shouldThrow<IllegalArgumentException> {
+                LirpKafkaConfig.create("")
+            }
+        }
+    }
+}

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxEnlistmentTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxEnlistmentTest.kt
@@ -1,0 +1,104 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.outbox
+
+import net.transgressoft.lirp.event.EventType
+import net.transgressoft.lirp.kafka.KafkaEventPublisher
+import net.transgressoft.lirp.kafka.spi.OutboxRoutableEvent
+import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.sql.H2ContainerSupport
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+
+/**
+ * H2 unit tests for [KafkaEventPublisher.emitAsync] transaction enlistment behaviour.
+ *
+ * Covers: emitAsync inside an active transaction writes the outbox row atomically
+ * on the same connection (row visible before commit), and emitAsync outside any
+ * transaction opens its own single-row transaction producing exactly one committed row.
+ */
+@DisplayName("OutboxEnlistmentTest")
+internal class OutboxEnlistmentTest : StringSpec() {
+
+    /** A consumer-defined custom event type with a code outside the flush-managed set. */
+    enum class PlaybackEventType(override val code: Int) : EventType {
+        STARTED(998)
+    }
+
+    data class PlaybackEvent(
+        override val type: PlaybackEventType,
+        val trackId: Int
+    ) : OutboxRoutableEvent<PlaybackEventType> {
+        override val aggregateId: String get() = trackId.toString()
+        override val payload: String get() = """{"trackId":$trackId}"""
+    }
+
+    init {
+        afterEach {
+            RegistryBase.deregisterRepository(AudioItem::class.java)
+        }
+
+        "OutboxEnlistmentTest emitAsync inside active transaction writes row visible before commit on same connection" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) { SchemaUtils.create(OutboxEventTable) }
+            val publisher =
+                KafkaEventPublisher<PlaybackEventType, PlaybackEvent>("enlistment-in-tx", "localhost:9092", db)
+            publisher.activateEvents(PlaybackEventType.STARTED)
+
+            try {
+                var rowCountInTx = 0L
+                transaction(db) {
+                    publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 10))
+                    rowCountInTx = OutboxEventTable.selectAll().count()
+                }
+                rowCountInTx shouldBe 1L
+                // Committed row is also visible after transaction commit
+                val rowCountAfter = transaction(db) { OutboxEventTable.selectAll().count() }
+                rowCountAfter shouldBe 1L
+            } finally {
+                publisher.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxEnlistmentTest emitAsync without active transaction opens own single-row transaction and commits one row" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) { SchemaUtils.create(OutboxEventTable) }
+            val publisher =
+                KafkaEventPublisher<PlaybackEventType, PlaybackEvent>("enlistment-no-tx", "localhost:9092", db)
+            publisher.activateEvents(PlaybackEventType.STARTED)
+
+            try {
+                publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 20))
+                val rowCount = transaction(db) { OutboxEventTable.selectAll().count() }
+                rowCount shouldBe 1L
+            } finally {
+                publisher.close()
+                dataSource.close()
+            }
+        }
+    }
+}

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
@@ -29,6 +29,7 @@ import net.transgressoft.lirp.persistence.RegistryBase
 import net.transgressoft.lirp.persistence.sql.AudioItemSqlTableDef
 import net.transgressoft.lirp.persistence.sql.H2ContainerSupport
 import net.transgressoft.lirp.persistence.transaction
+import com.zaxxer.hikari.HikariDataSource
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -42,6 +43,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.apache.kafka.common.errors.NetworkException
 import org.apache.kafka.common.errors.RecordTooLargeException
+import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
@@ -57,7 +59,9 @@ import kotlin.uuid.toKotlinUuid
  *
  * Each test uses a fresh H2 DataSource for isolation. The relay is driven synchronously via
  * [OutboxRelay.pollAndRelay] rather than the background loop so tests are deterministic and
- * do not need to wait for the poll interval.
+ * do not need to wait for the poll interval. Datasource/schema setup and teardown are handled by
+ * [withOutboxDb]/[withOutboxRepo]; outbox and dead-letter assertions read through the [Database]
+ * count/row helpers.
  */
 @DisplayName("OutboxRelayTest (H2)")
 internal class OutboxRelayTest : StringSpec() {
@@ -76,163 +80,104 @@ internal class OutboxRelayTest : StringSpec() {
             RegistryBase.deregisterRepository(AudioItem::class.java)
         }
 
-        "OutboxRelayTest drains the outbox by publishing rows and flipping sent_at" {
-            val dataSource = H2ContainerSupport.buildH2DataSource()
-            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
-            val publisher = mockk<KafkaEventPublisher>()
-            justRun { publisher.publish(any(), any(), any()) }
+        "drains the outbox by publishing rows and flipping sent_at" {
+            withOutboxRepo { db, repo ->
+                val publisher = mockk<KafkaEventPublisher<*, *>>()
+                justRun { publisher.publish(any(), any(), any(), any()) }
 
-            try {
                 transaction(repo) { r ->
                     r.add(MutableAudioItem(1, "Bohemian Rhapsody", "A Night at the Opera") as AudioItem)
                     r.add(MutableAudioItem(2, "Killer Queen", "Sheer Heart Attack") as AudioItem)
                 }
 
-                val db = Database.connect(dataSource)
-                val relay = OutboxRelay(db, publisher, fastConfig)
-                transaction(db) { SchemaUtils.create(DeadLetterTable) }
-                relay.pollAndRelay()
+                OutboxRelay(db, publisher, fastConfig).pollAndRelay()
 
-                // All rows should have sent_at set after one cycle
-                val rows =
-                    transaction(db) {
-                        OutboxEventTable.selectAll()
-                            .where { OutboxEventTable.sentAt.isNull() }
-                            .count()
-                    }
-                rows shouldBe 0L
-                verify(exactly = 2) { publisher.publish(any(), any(), any()) }
-            } finally {
-                repo.close()
-                dataSource.close()
+                // All rows should have sent_at set after one cycle.
+                db.unsentOutboxCount() shouldBe 0L
+                verify(exactly = 2) { publisher.publish(any(), any(), any(), any()) }
             }
         }
 
-        "OutboxRelayTest marks sent_at only after publish succeeds and uses aggregate id as record key" {
-            val dataSource = H2ContainerSupport.buildH2DataSource()
-            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
-            val capturedKeys = mutableListOf<String>()
-            val publisher = mockk<KafkaEventPublisher>()
-            every { publisher.publish(any(), capture(capturedKeys), any()) } returns Unit
+        "marks sent_at only after publish succeeds and uses aggregate id as record key" {
+            withOutboxRepo { db, repo ->
+                val capturedKeys = mutableListOf<String>()
+                val publisher = mockk<KafkaEventPublisher<*, *>>()
+                every { publisher.publish(any(), capture(capturedKeys), any(), any()) } returns Unit
 
-            try {
                 transaction(repo) { r ->
                     r.add(MutableAudioItem(42, "We Will Rock You", "News of the World") as AudioItem)
                 }
 
-                val db = Database.connect(dataSource)
-                val relay = OutboxRelay(db, publisher, fastConfig)
-                transaction(db) { SchemaUtils.create(DeadLetterTable) }
-                relay.pollAndRelay()
+                OutboxRelay(db, publisher, fastConfig).pollAndRelay()
 
-                val row = transaction(db) { OutboxEventTable.selectAll().single() }
-                row[OutboxEventTable.sentAt].shouldNotBeNull()
-                // Record key must equal the aggregate id
+                db.singleOutboxRow()[OutboxEventTable.sentAt].shouldNotBeNull()
+                // Record key must equal the aggregate id.
                 capturedKeys.single() shouldBe "42"
-            } finally {
-                repo.close()
-                dataSource.close()
             }
         }
 
-        "OutboxRelayTest retriable error leaves sent_at null, increments retry_count, sets next_retry_at" {
-            val dataSource = H2ContainerSupport.buildH2DataSource()
-            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
-            val publisher = mockk<KafkaEventPublisher>()
-            every { publisher.publish(any(), any(), any()) } throws NetworkException("broker unavailable")
+        "retriable error leaves sent_at null, increments retry_count, sets next_retry_at" {
+            withOutboxRepo { db, repo ->
+                val publisher = mockk<KafkaEventPublisher<*, *>>()
+                every { publisher.publish(any(), any(), any(), any()) } throws NetworkException("broker unavailable")
 
-            try {
                 transaction(repo) { r ->
                     r.add(MutableAudioItem(10, "Radio Ga Ga", "The Works") as AudioItem)
                 }
 
-                val db = Database.connect(dataSource)
-                val relay = OutboxRelay(db, publisher, fastConfig)
-                transaction(db) { SchemaUtils.create(DeadLetterTable) }
-                relay.pollAndRelay()
+                OutboxRelay(db, publisher, fastConfig).pollAndRelay()
 
-                val row = transaction(db) { OutboxEventTable.selectAll().single() }
+                val row = db.singleOutboxRow()
                 row[OutboxEventTable.sentAt].shouldBeNull()
                 row[OutboxEventTable.retryCount] shouldBe 1
                 row[OutboxEventTable.nextRetryAt].shouldNotBeNull()
-                // Dead-letter table stays empty
-                transaction(db) { DeadLetterTable.selectAll().count() } shouldBe 0L
-            } finally {
-                repo.close()
-                dataSource.close()
+                // Dead-letter table stays empty.
+                db.deadLetterCount() shouldBe 0L
             }
         }
 
-        "OutboxRelayTest non-retriable error moves row to dead-letter table and relay continues" {
-            val dataSource = H2ContainerSupport.buildH2DataSource()
-            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
-            val publisher = mockk<KafkaEventPublisher>()
-            // First call throws non-retriable; second call succeeds so relay continues
-            every { publisher.publish(any(), "10", any()) } throws RecordTooLargeException("record too large")
-            every { publisher.publish(any(), "20", any()) } returns Unit
+        "non-retriable error moves row to dead-letter table and relay continues" {
+            withOutboxRepo { db, repo ->
+                val publisher = mockk<KafkaEventPublisher<*, *>>()
+                // First call throws non-retriable; second call succeeds so the relay continues.
+                every { publisher.publish(any(), "10", any(), any()) } throws RecordTooLargeException("record too large")
+                every { publisher.publish(any(), "20", any(), any()) } returns Unit
 
-            try {
                 transaction(repo) { r ->
                     r.add(MutableAudioItem(10, "Somebody to Love", "A Day at the Races") as AudioItem)
                     r.add(MutableAudioItem(20, "We Are the Champions", "News of the World") as AudioItem)
                 }
 
-                val db = Database.connect(dataSource)
-                val relay = OutboxRelay(db, publisher, fastConfig)
-                transaction(db) { SchemaUtils.create(DeadLetterTable) }
-                relay.pollAndRelay()
+                OutboxRelay(db, publisher, fastConfig).pollAndRelay()
 
-                // Row 10 moved to dead-letter; row 20 marked sent
-                val outboxCount = transaction(db) { OutboxEventTable.selectAll().count() }
-                outboxCount shouldBe 1L
-                val dltCount = transaction(db) { DeadLetterTable.selectAll().count() }
-                dltCount shouldBe 1L
-
-                val sentRow = transaction(db) { OutboxEventTable.selectAll().single() }
+                // Row 10 moved to dead-letter; row 20 marked sent.
+                db.outboxCount() shouldBe 1L
+                db.deadLetterCount() shouldBe 1L
+                val sentRow = db.singleOutboxRow()
                 sentRow[OutboxEventTable.aggregateId] shouldBe "20"
                 sentRow[OutboxEventTable.sentAt].shouldNotBeNull()
-            } finally {
-                repo.close()
-                dataSource.close()
             }
         }
 
-        "OutboxRelayTest exhausted retries move row to dead-letter table after a failed delivery attempt" {
-            val dataSource = H2ContainerSupport.buildH2DataSource()
-            val publisher = mockk<KafkaEventPublisher>()
-            every { publisher.publish(any(), any(), any()) } throws NetworkException("broker unavailable")
+        "exhausted retries move row to dead-letter table after a failed delivery attempt" {
+            withOutboxDb { _, db ->
+                val publisher = mockk<KafkaEventPublisher<*, *>>()
+                every { publisher.publish(any(), any(), any(), any()) } throws NetworkException("broker unavailable")
 
-            // Seed a row directly with retryCount = maxRetries so its retry budget is exhausted
-            val db = Database.connect(dataSource)
-            try {
-                transaction(db) {
-                    SchemaUtils.create(OutboxEventTable)
-                    SchemaUtils.create(DeadLetterTable)
-                    OutboxEventTable.insert {
-                        it[OutboxEventTable.id] = java.util.UUID.randomUUID().toKotlinUuid()
-                        it[OutboxEventTable.aggregateType] = "audio_items"
-                        it[OutboxEventTable.aggregateId] = "99"
-                        it[OutboxEventTable.eventTypeCode] = 100
-                        it[OutboxEventTable.payload] = "{}"
-                        it[OutboxEventTable.createdAt] = Clock.System.now()
-                        it[OutboxEventTable.retryCount] = 3 // = fastConfig.maxRetries
-                    }
-                }
+                // Seed a row whose retry budget is already exhausted.
+                db.seedExhaustedRow("99", fastConfig.maxRetries)
 
-                val relay = OutboxRelay(db, publisher, fastConfig)
-                relay.pollAndRelay()
+                OutboxRelay(db, publisher, fastConfig).pollAndRelay()
 
-                // A retriable failure on a row with no retry budget left moves it to the dead-letter table
-                transaction(db) { OutboxEventTable.selectAll().count() } shouldBe 0L
-                transaction(db) { DeadLetterTable.selectAll().count() } shouldBe 1L
-                // Delivery is attempted exactly once before dead-lettering — never skipped
-                verify(exactly = 1) { publisher.publish(any(), any(), any()) }
-            } finally {
-                dataSource.close()
+                // A retriable failure on a row with no retry budget left moves it to the dead-letter table.
+                db.outboxCount() shouldBe 0L
+                db.deadLetterCount() shouldBe 1L
+                // Delivery is attempted exactly once before dead-lettering — never skipped.
+                verify(exactly = 1) { publisher.publish(any(), any(), any(), any()) }
             }
         }
 
-        "OutboxRelayTest computeNextRetryAt grows exponentially within retryBaseDelayMs and retryMaxDelayMs" {
+        "computeNextRetryAt grows exponentially within retryBaseDelayMs and retryMaxDelayMs" {
             val config =
                 KafkaOutboxConfig(
                     retryBaseDelayMs = 1_000L,
@@ -240,109 +185,146 @@ internal class OutboxRelayTest : StringSpec() {
                 )
             val now = Clock.System.now()
 
-            // Each delay must fit within the [base * 0.8, max * 1.2] range to account for ±20% jitter
+            // Each delay must fit within the [base * 0.8, max * 1.2] range to account for ±20% jitter.
             val delay0 = OutboxRelay.computeNextRetryAt(0, config)
             val delay1 = OutboxRelay.computeNextRetryAt(1, config)
             val delay2 = OutboxRelay.computeNextRetryAt(2, config)
 
-            // delay grows: delay0 < delay1 < delay2 (in expectation; upper bound enforced)
+            // Delay grows: delay0 < delay1 < delay2 (in expectation; upper bound enforced).
             delay0.shouldBeLessThan(delay1)
             delay1.shouldBeLessThan(delay2)
 
-            // None should exceed now + maxDelayMs * 1.2 (jitter headroom)
+            // None should exceed now + maxDelayMs * 1.2 (jitter headroom).
             val cap = now + 36_000L.milliseconds // 30s * 1.2
             delay0.shouldBeLessThan(cap)
             delay1.shouldBeLessThan(cap)
             delay2.shouldBeLessThan(cap)
         }
 
-        "OutboxRelayTest dead-lettered row invokes onDeadLetter callback with non-null Throwable and LirpOperation.EMIT" {
-            val dataSource = H2ContainerSupport.buildH2DataSource()
-            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
-            val publisher = mockk<KafkaEventPublisher>()
-            every { publisher.publish(any(), any(), any()) } throws RecordTooLargeException("too large")
+        "dead-lettered row invokes onDeadLetter callback with non-null Throwable and LirpOperation.EMIT" {
+            withOutboxRepo { db, repo ->
+                val publisher = mockk<KafkaEventPublisher<*, *>>()
+                every { publisher.publish(any(), any(), any(), any()) } throws RecordTooLargeException("too large")
 
-            var capturedThrowable: Throwable? = null
-            var capturedContext: LirpErrorContext? = null
-            val callback =
-                LirpErrorHandler { t, ctx ->
-                    capturedThrowable = t
-                    capturedContext = ctx
-                }
+                var capturedThrowable: Throwable? = null
+                var capturedContext: LirpErrorContext? = null
+                val callback =
+                    LirpErrorHandler { t, ctx ->
+                        capturedThrowable = t
+                        capturedContext = ctx
+                    }
 
-            try {
                 transaction(repo) { r ->
                     r.add(MutableAudioItem(5, "Don't Stop Me Now", "Jazz") as AudioItem)
                 }
 
-                val db = Database.connect(dataSource)
-                val relay = OutboxRelay(db, publisher, fastConfig, callback)
-                transaction(db) { SchemaUtils.create(DeadLetterTable) }
-                relay.pollAndRelay()
+                OutboxRelay(db, publisher, fastConfig, onDeadLetter = callback).pollAndRelay()
 
                 capturedThrowable.shouldNotBeNull()
-                capturedContext.shouldNotBeNull()
-                capturedContext!!.operation shouldBe LirpOperation.EMIT
-            } finally {
-                repo.close()
-                dataSource.close()
+                capturedContext.shouldNotBeNull().operation shouldBe LirpOperation.EMIT
             }
         }
 
-        "OutboxRelayTest exhausted retries also invoke onDeadLetter callback" {
-            val dataSource = H2ContainerSupport.buildH2DataSource()
-            val publisher = mockk<KafkaEventPublisher>()
-            every { publisher.publish(any(), any(), any()) } throws NetworkException("broker unavailable")
+        "exhausted retries also invoke onDeadLetter callback" {
+            withOutboxDb { _, db ->
+                val publisher = mockk<KafkaEventPublisher<*, *>>()
+                every { publisher.publish(any(), any(), any(), any()) } throws NetworkException("broker unavailable")
 
-            var callbackInvoked = false
-            val callback =
-                LirpErrorHandler { _, ctx ->
-                    callbackInvoked = true
-                    ctx.operation shouldBe LirpOperation.EMIT
-                }
-
-            val db = Database.connect(dataSource)
-            try {
-                transaction(db) {
-                    SchemaUtils.create(OutboxEventTable)
-                    SchemaUtils.create(DeadLetterTable)
-                    OutboxEventTable.insert {
-                        it[OutboxEventTable.id] = java.util.UUID.randomUUID().toKotlinUuid()
-                        it[OutboxEventTable.aggregateType] = "audio_items"
-                        it[OutboxEventTable.aggregateId] = "77"
-                        it[OutboxEventTable.eventTypeCode] = 100
-                        it[OutboxEventTable.payload] = "{}"
-                        it[OutboxEventTable.createdAt] = Clock.System.now()
-                        it[OutboxEventTable.retryCount] = 3 // = fastConfig.maxRetries
+                var callbackInvoked = false
+                val callback =
+                    LirpErrorHandler { _, ctx ->
+                        callbackInvoked = true
+                        ctx.operation shouldBe LirpOperation.EMIT
                     }
-                }
 
-                val relay = OutboxRelay(db, publisher, fastConfig, callback)
-                relay.pollAndRelay()
+                db.seedExhaustedRow("77", fastConfig.maxRetries)
+
+                OutboxRelay(db, publisher, fastConfig, onDeadLetter = callback).pollAndRelay()
 
                 callbackInvoked shouldBe true
-            } finally {
-                dataSource.close()
             }
         }
 
-        "OutboxRelayTest calling start when relay is already running throws IllegalStateException" {
-            val publisher = mockk<KafkaEventPublisher>(relaxed = true)
-            val dataSource = H2ContainerSupport.buildH2DataSource()
-            val db = Database.connect(dataSource)
-            transaction(db) {
-                SchemaUtils.create(OutboxEventTable)
-                SchemaUtils.create(DeadLetterTable)
-            }
-
-            try {
+        "calling start when relay is already running throws IllegalStateException" {
+            withOutboxDb { _, db ->
+                val publisher = mockk<KafkaEventPublisher<*, *>>(relaxed = true)
                 val relay = OutboxRelay(db, publisher, fastConfig)
                 relay.start()
                 shouldThrow<IllegalStateException> { relay.start() }
                 relay.stop()
-            } finally {
-                dataSource.close()
             }
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Fixtures & helpers
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Runs [block] with a fresh H2 [Database] whose outbox and dead-letter tables already exist, closing
+ * the datasource afterwards. Suits tests that seed rows directly rather than through a repository.
+ */
+private inline fun withOutboxDb(block: (HikariDataSource, Database) -> Unit) {
+    val dataSource = H2ContainerSupport.buildH2DataSource()
+    try {
+        val db = Database.connect(dataSource)
+        transaction(db) {
+            SchemaUtils.create(OutboxEventTable)
+            SchemaUtils.create(DeadLetterTable)
+        }
+        block(dataSource, db)
+    } finally {
+        dataSource.close()
+    }
+}
+
+/**
+ * Runs [block] with a fresh H2 [Database] plus a [KafkaOutboxSqlRepository] over [AudioItem], closing
+ * the repository and datasource afterwards. Suits tests that seed rows through the transactional
+ * flush hook.
+ */
+private inline fun withOutboxRepo(block: (Database, KafkaOutboxSqlRepository<Int, AudioItem>) -> Unit) {
+    withOutboxDb { dataSource, db ->
+        val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+        try {
+            block(db, repo)
+        } finally {
+            repo.close()
+        }
+    }
+}
+
+/** Counts outbox rows whose `sent_at` is null (pending delivery). */
+private fun Database.unsentOutboxCount(): Long =
+    transaction(this) {
+        OutboxEventTable.selectAll().where { OutboxEventTable.sentAt.isNull() }.count()
+    }
+
+/** Counts all outbox rows, sent or pending. */
+private fun Database.outboxCount(): Long = transaction(this) { OutboxEventTable.selectAll().count() }
+
+/** Counts all rows in the dead-letter table. */
+private fun Database.deadLetterCount(): Long = transaction(this) { DeadLetterTable.selectAll().count() }
+
+/** Returns the single outbox row, failing if there is not exactly one. */
+private fun Database.singleOutboxRow(): ResultRow = transaction(this) { OutboxEventTable.selectAll().single() }
+
+/**
+ * Seeds one outbox row for [aggregateId] with the given [retryCount] via bare Exposed DSL, bypassing
+ * the flush hook. Used to exercise the exhausted-retry path where the persisted attempt count already
+ * equals the configured maximum.
+ */
+private fun Database.seedExhaustedRow(aggregateId: String, retryCount: Int) {
+    transaction(this) {
+        OutboxEventTable.insert {
+            it[OutboxEventTable.id] = java.util.UUID.randomUUID().toKotlinUuid()
+            it[OutboxEventTable.aggregateType] = "audio_items"
+            it[OutboxEventTable.aggregateId] = aggregateId
+            it[OutboxEventTable.eventTypeCode] = 100
+            it[OutboxEventTable.payload] = "{}"
+            it[OutboxEventTable.createdAt] = Clock.System.now()
+            it[OutboxEventTable.retryCount] = retryCount
         }
     }
 }

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
@@ -249,9 +249,12 @@ internal class OutboxRelayTest : StringSpec() {
             withOutboxDb { _, db ->
                 val publisher = mockk<KafkaEventPublisher<*, *>>(relaxed = true)
                 val relay = OutboxRelay(db, publisher, fastConfig)
-                relay.start()
-                shouldThrow<IllegalStateException> { relay.start() }
-                relay.stop()
+                try {
+                    relay.start()
+                    shouldThrow<IllegalStateException> { relay.start() }
+                } finally {
+                    relay.stop()
+                }
             }
         }
     }

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializerTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializerTest.kt
@@ -1,0 +1,76 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.spi
+
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for [CloudEventsBinarySerializer] header and record-value production.
+ */
+@DisplayName("CloudEventsBinarySerializerTest")
+internal class CloudEventsBinarySerializerTest : StringSpec() {
+
+    val envelope =
+        LirpEventEnvelope(
+            eventId = "550e8400-e29b-41d4-a716-446655440000",
+            aggregateType = "audio_items",
+            aggregateId = "42",
+            eventTypeCode = 100,
+            payload = """{"title":"Bohemian Rhapsody"}""",
+            createdAt = "2026-07-01T10:30:00Z"
+        )
+
+    val serializer = CloudEventsBinarySerializer()
+    val serialized = serializer.serialize(envelope)
+
+    init {
+        "CloudEventsBinarySerializerTest ce_specversion header decodes to 1.0" {
+            serialized.headers["ce_specversion"]!!.toString(Charsets.UTF_8) shouldBe "1.0"
+        }
+
+        "CloudEventsBinarySerializerTest ce_id header equals the envelope eventId" {
+            serialized.headers["ce_id"]!!.toString(Charsets.UTF_8) shouldBe envelope.eventId
+        }
+
+        "CloudEventsBinarySerializerTest ce_source header encodes the aggregateType" {
+            serialized.headers["ce_source"]!!.toString(Charsets.UTF_8) shouldBe "lirp/${envelope.aggregateType}"
+        }
+
+        "CloudEventsBinarySerializerTest ce_type header encodes aggregateType and eventTypeCode" {
+            serialized.headers["ce_type"]!!.toString(Charsets.UTF_8) shouldBe "${envelope.aggregateType}.${envelope.eventTypeCode}"
+        }
+
+        "CloudEventsBinarySerializerTest ce_subject header equals the envelope aggregateId" {
+            serialized.headers["ce_subject"]!!.toString(Charsets.UTF_8) shouldBe envelope.aggregateId
+        }
+
+        "CloudEventsBinarySerializerTest ce_time header equals the envelope createdAt" {
+            serialized.headers["ce_time"]!!.toString(Charsets.UTF_8) shouldBe envelope.createdAt
+        }
+
+        "CloudEventsBinarySerializerTest content-type header is application/json" {
+            serialized.headers["content-type"]!!.toString(Charsets.UTF_8) shouldBe "application/json"
+        }
+
+        "CloudEventsBinarySerializerTest record value UTF-8-decodes to the envelope payload" {
+            serialized.value.toString(Charsets.UTF_8) shouldBe envelope.payload
+        }
+    }
+}

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializerTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializerTest.kt
@@ -17,6 +17,7 @@
 
 package net.transgressoft.lirp.kafka.spi
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -71,6 +72,37 @@ internal class CloudEventsBinarySerializerTest : StringSpec() {
 
         "CloudEventsBinarySerializerTest record value UTF-8-decodes to the envelope payload" {
             serialized.value.toString(Charsets.UTF_8) shouldBe envelope.payload
+        }
+
+        "CloudEventsBinarySerializerTest deserialize round-trips a serialized envelope without loss" {
+            serializer.deserialize(serialized.value, serialized.headers) shouldBe envelope
+        }
+
+        "CloudEventsBinarySerializerTest deserialize rejects a missing ce_specversion header" {
+            shouldThrow<IllegalStateException> {
+                serializer.deserialize(serialized.value, serialized.headers - "ce_specversion")
+            }
+        }
+
+        "CloudEventsBinarySerializerTest deserialize rejects an unsupported ce_specversion" {
+            val headers = serialized.headers + ("ce_specversion" to "0.3".toByteArray(Charsets.UTF_8))
+            shouldThrow<IllegalArgumentException> { serializer.deserialize(serialized.value, headers) }
+        }
+
+        "CloudEventsBinarySerializerTest deserialize rejects a ce_source not in lirp format" {
+            val headers = serialized.headers + ("ce_source" to "other/audio_items".toByteArray(Charsets.UTF_8))
+            shouldThrow<IllegalArgumentException> { serializer.deserialize(serialized.value, headers) }
+        }
+
+        "CloudEventsBinarySerializerTest deserialize rejects a missing content-type header" {
+            shouldThrow<IllegalStateException> {
+                serializer.deserialize(serialized.value, serialized.headers - "content-type")
+            }
+        }
+
+        "CloudEventsBinarySerializerTest deserialize rejects an unsupported content-type" {
+            val headers = serialized.headers + ("content-type" to "application/xml".toByteArray(Charsets.UTF_8))
+            shouldThrow<IllegalArgumentException> { serializer.deserialize(serialized.value, headers) }
         }
     }
 }

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/LirpEventSerializerTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/LirpEventSerializerTest.kt
@@ -1,0 +1,61 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.spi
+
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for the [LirpEventSerializer] round-trip contract.
+ */
+@DisplayName("LirpEventSerializerTest")
+internal class LirpEventSerializerTest : StringSpec() {
+
+    val envelope =
+        LirpEventEnvelope(
+            eventId = "550e8400-e29b-41d4-a716-446655440000",
+            aggregateType = "audio_items",
+            aggregateId = "42",
+            eventTypeCode = 100,
+            payload = """{"title":"Bohemian Rhapsody","album":"A Night at the Opera"}""",
+            createdAt = "2026-07-01T10:30:00Z"
+        )
+
+    init {
+        "LirpEventSerializerTest serialize then deserialize round-trips LirpEventEnvelope without data loss" {
+            val serializer = CloudEventsBinarySerializer()
+            val serialized = serializer.serialize(envelope)
+            val restored = serializer.deserialize(serialized.value, serialized.headers)
+            restored shouldBe envelope
+        }
+
+        "LirpEventSerializerTest a no-op stub LirpEventSerializer can be constructed and used without modifying any LIRP class" {
+            // Proves PUBLISH-02: a consumer can supply an alternative LirpEventSerializer
+            val fixedEvent = SerializedEvent("test".toByteArray(Charsets.UTF_8), emptyMap())
+            val stub =
+                object : LirpEventSerializer {
+                    override fun serialize(envelope: LirpEventEnvelope): SerializedEvent = fixedEvent
+
+                    override fun deserialize(value: ByteArray, headers: Map<String, ByteArray>): LirpEventEnvelope = envelope
+                }
+            stub.serialize(envelope) shouldBe fixedEvent
+            stub.deserialize(fixedEvent.value, fixedEvent.headers) shouldBe envelope
+        }
+    }
+}

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/TopicResolverTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/TopicResolverTest.kt
@@ -1,0 +1,42 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.kafka.spi
+
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for [TopicResolver] and [DefaultTopicResolver].
+ */
+@DisplayName("TopicResolverTest")
+internal class TopicResolverTest : StringSpec() {
+
+    init {
+        "TopicResolverTest DefaultTopicResolver returns aggregateType.events" {
+            val envelope = LirpEventEnvelope("id", "audio_items", "42", 100, "{}", "2026-07-01T00:00:00Z")
+            DefaultTopicResolver.resolve(envelope) shouldBe "audio_items.events"
+        }
+
+        "TopicResolverTest custom TopicResolver lambda overrides default routing" {
+            val envelope = LirpEventEnvelope("id", "audio_items", "42", 100, "{}", "2026-07-01T00:00:00Z")
+            val custom = TopicResolver { e -> "custom.${e.aggregateType}" }
+            custom.resolve(envelope) shouldBe "custom.audio_items"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Goal:** `KafkaEventPublisher` maps any LIRP event to a `ProducerRecord` via pluggable serialization and topic-resolution SPIs; every delivery carries an idempotency-key header; consumers can supply their own serializer or topic resolver with no framework coupling. The publisher implements `LirpEventPublisher<ET, E>`, so it is injectable interchangeably with `FlowEventPublisher`, and its `emitAsync` routes events through the transactional outbox (capture → relay) rather than a fire-and-forget direct send.

**Status:** Verified ✓

This change completes the publish path for `lirp-kafka`: a CloudEvents v1.0 binary-mode serialization SPI, a pluggable topic resolver, an injectable `KafkaEventPublisher` that tees local subscribers while capturing custom events into the outbox within the active `transaction { }`, and a relay that routes each outbox row through the SPIs to build CloudEvents headers before publishing. All public surface is ABI-baselined.

## Changes

### Serialization SPI + Topic Resolver (`net.transgressoft.lirp.kafka.spi`)
CloudEvents v1.0 binary-mode serialization SPI and pluggable topic resolution.

- `LirpEventEnvelope` — `@Serializable` transport record (6 fields; `createdAt` as ISO-8601 string) with an internal `from(OutboxEvent)` factory.
- `LirpEventSerializer` — SPI with `serialize`/`deserialize`; `SerializedEvent` uses content-based `equals`/`hashCode` to avoid the `ByteArray` identity trap.
- `CloudEventsBinarySerializer` — default serializer: seven `ce_*`/`content-type` headers as UTF-8 bytes, neutral JSON payload as the record value; missing required headers surface as bug detectors on deserialize.
- `TopicResolver` (`fun interface`) + `DefaultTopicResolver` returning `"${aggregateType}.events"`.
- `KafkaOutboxConfig` — documented and construction-validated defaults (bootstrap servers required, poll 500 ms, batch 100, retries 5).

**Key files:** `spi/LirpEventEnvelope.kt`, `spi/LirpEventSerializer.kt`, `spi/TopicResolver.kt`, `spi/CloudEventsBinarySerializer.kt`, `KafkaOutboxConfig.kt`

### `KafkaEventPublisher` as injectable `LirpEventPublisher` with outbox routing
`KafkaEventPublisher<ET, E>` composes a `FlowEventPublisher` via manual delegation; `emitAsync` tees local subscribers and routes custom events to the outbox.

- `emitAsync` captures the outbox row **before** local delivery; flush-managed codes skip capture (deny-list) to avoid double-capture with the in-commit hook; disabled types suppress both paths.
- Outbox insert joins the caller's active JDBC transaction via `TransactionManager.currentOrNull()`, else opens its own.
- Public constructor takes only a `Database` (creates `SqlOutboxStore` internally); the internal-type constructor stays internal.
- `VolatileRepository` gains a publisher-injection constructor accepting `LirpEventPublisher`, interchangeable with `FlowEventPublisher`.

**Key files:** `KafkaEventPublisher.kt`, `outbox/OutboxStore.kt`, `outbox/SqlOutboxStore.kt`, `LirpKafkaConfig.kt`, `outbox/OutboxRelay.kt`, `lirp-core/.../VolatileRepository.kt`

### Wire SPIs into the relay + ABI rebaseline
`OutboxRelay` routes each outbox row through `TopicResolver` + `LirpEventSerializer` before publishing.

- `processRow` builds the envelope, resolves the topic, serializes, builds `RecordHeaders`, and publishes with the aggregate id as the record key. Serialization failures fall into the dead-letter branch.
- `startRelay` exposes `serializer` and `topicResolver` as defaulted parameters.
- ABI rebaselined additively for `lirp-kafka.api` and `lirp-core.api`.

**Key files:** `outbox/OutboxRelay.kt`, `LirpKafkaConfig.kt`, `api/lirp-kafka.api`, `api/lirp-core.api`

## Requirements Addressed

- Event round-trips through serialize/deserialize without data loss
- Default kotlinx-serialization JSON serializer, replaceable without changing any LIRP class
- Default topic resolver `"${aggregateType}.events"`, overridable by a supplied resolver
- Every `ProducerRecord` carries the aggregate id as key and the outbox row UUID as the idempotency-key header verbatim
- `KafkaOutboxConfig` documents and enforces its defaults, validated at startup
- Consumer-defined custom event types round-trip via the default serializer (tested + documented)
- `KafkaEventPublisher` implements `LirpEventPublisher<ET, E>`, injectable via `publisherFactory` and a repository overload
- `emitAsync` captures atomically within `transaction { }` and the relay delivers at-least-once — never fire-and-forget

## Verification

- [x] Automated verification: **passed** (9/9 goal truths verified)
- [x] `gradle :lirp-kafka:test` — BUILD SUCCESSFUL
- [x] `gradle :lirp-kafka:integrationTest` — BUILD SUCCESSFUL (Testcontainers; `OutboxRelayIT` round-trip, `ce_id` header, and record-key assertions green against a real broker)
- [x] `gradle :lirp-kafka:apiCheck :lirp-core:apiCheck` — BUILD SUCCESSFUL
- [x] Full `gradle test` green apart from a known pre-existing flaky `lirp-sql` test unrelated to this change (passes deterministically in module isolation)

## Key Decisions

- **CloudEvents binary mode hand-rolled** with kotlinx-serialization — no new dependency introduced.
- **`createdAt` stored as ISO-8601 string** — kotlinx-serialization 1.11.0 has no built-in serializer for `kotlin.time.Instant`.
- **`FlowEventPublisher` composed via manual delegation** (not Kotlin `by`) because `emitAsync` must be overridden for outbox routing.
- **Flush-managed code deny-list** (CRUD/Mutation codes) prevents `emitAsync` from double-capturing events already handled by the in-commit hook.
- **`VolatileRepository` primary constructor** refactored to accept `LirpEventPublisher` directly; `FlowEventPublisher` creation moved to internal secondary constructors.

Closes #288
