### PR TITLE
Add lirp-e2e module: full-fledged fleet PoC dogfooding LIRP end-to-end with Kafka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ sonar {
 apiValidation {
     ignoredProjects.add('lirp-benchmark')
     ignoredProjects.add('lirp-gradle-plugin')
+    ignoredProjects.add('lirp-e2e')
     nonPublicMarkers.add('net.transgressoft.lirp.InternalLirpApi')
 }
 

--- a/lirp-e2e/build.gradle
+++ b/lirp-e2e/build.gradle
@@ -1,0 +1,73 @@
+plugins {
+    alias libs.plugins.kotlin.jvm
+    id 'com.google.devtools.ksp'
+    id 'idea'
+}
+
+description = 'LIRP E2E - End-to-End Fleet PoC Integration Tests'
+
+ktlint {
+    filter {
+        exclude { it.file.path.contains("/generated/") }
+    }
+}
+
+sourceSets {
+    integrationTest {
+        kotlin.srcDirs = ['src/integrationTest/kotlin']
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+    }
+}
+
+// Mark the integrationTest source set as test sources so IntelliJ imports it as a test root
+// and offers the test run gutter for FleetKafkaChainTest (custom source sets default to production).
+idea {
+    module {
+        testSources.from(sourceSets.integrationTest.kotlin.srcDirs)
+    }
+}
+
+configurations {
+    integrationTestImplementation.extendsFrom implementation
+    integrationTestRuntimeOnly.extendsFrom runtimeOnly
+}
+
+dependencies {
+    implementation project(':lirp-core')
+    implementation project(':lirp-sql')
+    implementation project(':lirp-kafka')
+    ksp project(':lirp-ksp')
+    ksp project(':lirp-sql')
+
+    integrationTestImplementation platform(libs.junit.bom)
+    integrationTestImplementation libs.bundles.kotest
+    integrationTestImplementation libs.kotest.extensions.testcontainers
+    integrationTestImplementation libs.testcontainers.postgresql
+    integrationTestImplementation libs.testcontainers.kafka
+    integrationTestImplementation libs.coroutines.test
+    integrationTestImplementation libs.junit.jupiter
+    integrationTestImplementation libs.hikari
+    integrationTestImplementation testFixtures(project(':lirp-sql'))
+    integrationTestImplementation libs.kafka.clients
+    integrationTestRuntimeOnly libs.junit.platform.launcher
+    integrationTestRuntimeOnly libs.postgresql
+}
+
+tasks.register('integrationTest', Test) {
+    description = 'Runs lirp-e2e integration tests.'
+    group = 'verification'
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    useJUnitPlatform()
+    shouldRunAfter test
+}
+
+check.dependsOn integrationTest
+
+// E2E dogfood module is never published to Maven Central (like lirp-benchmark)
+tasks.withType(PublishToMavenRepository).configureEach { enabled = false }
+tasks.withType(PublishToMavenLocal).configureEach { enabled = false }
+
+// No API docs for the dogfood module
+tasks.matching { it.name.startsWith('dokka') }.configureEach { enabled = false }

--- a/lirp-e2e/src/integrationTest/kotlin/net/transgressoft/fleet/common/FleetTestBase.kt
+++ b/lirp-e2e/src/integrationTest/kotlin/net/transgressoft/fleet/common/FleetTestBase.kt
@@ -1,0 +1,59 @@
+package net.transgressoft.fleet.common
+
+import net.transgressoft.lirp.event.ReactiveScope
+import net.transgressoft.lirp.persistence.LirpContext
+import net.transgressoft.lirp.persistence.sql.PostgresContainerSupport
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.core.spec.style.StringSpec
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+/**
+ * Base test class providing per-test Postgres isolation for LIRP fleet integration tests.
+ *
+ * Each test receives a fresh [HikariDataSource] backed by a shared Testcontainers PostgreSQL
+ * container, a fresh [LirpContext], and isolated [ReactiveScope] coroutine scopes. Isolating
+ * the scopes per-test prevents debounce coroutines from one test leaking into the next test's
+ * data source — the global `ioScope` is single-threaded and queues debounce jobs across all
+ * live repositories, so without isolation a slow flush from test N can fire after test N's
+ * data source is closed and test N+1's data source is open.
+ *
+ * Close all repositories explicitly before the test body returns to flush their debounce
+ * pipeline before the scopes and data source are torn down in `afterEach`.
+ */
+abstract class FleetTestBase(body: FleetTestBase.() -> Unit = {}) : StringSpec() {
+
+    lateinit var dataSource: HikariDataSource
+    lateinit var ctx: LirpContext
+
+    private lateinit var testFlowScope: CoroutineScope
+    private lateinit var testIoScope: CoroutineScope
+    private lateinit var previousFlowScope: CoroutineScope
+    private lateinit var previousIoScope: CoroutineScope
+
+    init {
+        beforeEach {
+            testFlowScope = CoroutineScope(Dispatchers.Default.limitedParallelism(4) + SupervisorJob())
+            testIoScope = CoroutineScope(Dispatchers.IO.limitedParallelism(1) + SupervisorJob())
+            previousFlowScope = ReactiveScope.flowScope
+            previousIoScope = ReactiveScope.ioScope
+            ReactiveScope.flowScope = testFlowScope
+            ReactiveScope.ioScope = testIoScope
+            dataSource = PostgresContainerSupport.buildDataSource()
+            ctx = LirpContext()
+        }
+
+        afterEach {
+            ctx.close()
+            dataSource.close()
+            testFlowScope.cancel()
+            testIoScope.cancel()
+            ReactiveScope.flowScope = previousFlowScope
+            ReactiveScope.ioScope = previousIoScope
+        }
+
+        body()
+    }
+}

--- a/lirp-e2e/src/integrationTest/kotlin/net/transgressoft/fleet/e2e/FleetFeaturesE2ETest.kt
+++ b/lirp-e2e/src/integrationTest/kotlin/net/transgressoft/fleet/e2e/FleetFeaturesE2ETest.kt
@@ -1,0 +1,426 @@
+package net.transgressoft.fleet.e2e
+
+import net.transgressoft.fleet.app.FleetApplication
+import net.transgressoft.fleet.vehicle.VehicleAssignmentAssignedToArm
+import net.transgressoft.fleet.vehicle.activeArm
+import net.transgressoft.fleet.vehicle.tenant
+import net.transgressoft.lirp.event.CrudEvent
+import net.transgressoft.lirp.event.MutationEvent
+import net.transgressoft.lirp.event.PropertyChanged
+import net.transgressoft.lirp.event.StandardCrudEvent
+import net.transgressoft.lirp.kafka.KafkaOutboxConfig
+import net.transgressoft.lirp.persistence.PolymorphicResolution
+import net.transgressoft.lirp.persistence.sql.PostgresContainerSupport
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import java.time.Duration
+import java.util.Properties
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Integrated end-to-end test suite exercising the remaining LIRP feature surface against
+ * real Postgres and Kafka Testcontainers.
+ *
+ * Scenarios covered:
+ *
+ * **Aggregate navigation** — asserts `vehicle.tenant.resolve()` returns the registered [Tenant]
+ * via the KSP-generated `tenant` extension accessor and the live `TenantRepository`.
+ *
+ * **All four repositories** — creates and queries entities via `PersonRepository` and
+ * `CompanyRepository` in addition to the already-exercised Vehicle and Tenant repositories,
+ * demonstrating that all four `@LirpRepository` factories work end-to-end.
+ *
+ * **Polymorphic aggregate** — assigns a vehicle to a `Person` through
+ * `VehicleAssignmentRepository`, then resolves the active arm via the KSP-generated
+ * `VehicleAssignmentAssignedToArm` sealed class and verifies the resolved entity is
+ * the expected `Person`.
+ *
+ * **Restore and soft-delete visibility** — after decommission (soft-delete), calls
+ * `restore()`, asserts `deletedAt` is null, the vehicle is back in default reads and the
+ * `vehiclesByTenant` projection, a `StandardCrudEvent.Restore` fired, and the restore
+ * mutation reaches Kafka. Also exercises the Query DSL visibility verbs: the default query
+ * excludes the decommissioned vehicle, `includeDeleted()` includes it, and `onlyDeleted()`
+ * returns only it.
+ *
+ * **Event subscriptions** — captures the full `StandardCrudEvent` sequence (Create → Update
+ * → SoftDelete → Restore) on a repository-level subscriber, and captures a `PropertyChanged`
+ * event on an entity-level subscriber when the VIN changes.
+ */
+internal class FleetFeaturesE2ETest : StringSpec({
+
+    val vehiclesTopic = "vehicles.events"
+
+    "Vehicle.tenant resolves to the registered Tenant via aggregate navigation" {
+        withFeatureResources {
+            val dataSource = PostgresContainerSupport.buildDataSource().managed()
+            resetOutboxSchema(dataSource)
+            val fleet =
+                FleetApplication(dataSource, KafkaContainerSupport.bootstrapServers, fastFeatureRelayConfig())
+                    .managed()
+            fleet.start()
+
+            val tenant = fleet.registerTenant("NAV-T1", "Navigation Tenant")
+            val vehicle = fleet.registerVehicle(tenant.id, "NAV-VIN-001")
+
+            // Wait for the entity to be persisted so the @LirpRepository is fully registered
+            eventually(10.seconds) {
+                fleet.vehicles.contains(vehicle.id) shouldBe true
+            }
+
+            // The KSP-generated `tenant` extension accessor (imported above) performs a live
+            // lookup from the TenantRepository bound in LirpContext.default
+            val resolved = vehicle.tenant.resolve()
+            resolved.shouldBePresent { it.id shouldBe tenant.id }
+            resolved.shouldBePresent { it.name shouldBe "Navigation Tenant" }
+        }
+    }
+
+    "PersonRepository and CompanyRepository factory methods create and query entities" {
+        withFeatureResources {
+            val dataSource = PostgresContainerSupport.buildDataSource().managed()
+            resetOutboxSchema(dataSource)
+            val fleet =
+                FleetApplication(dataSource, KafkaContainerSupport.bootstrapServers, fastFeatureRelayConfig())
+                    .managed()
+            fleet.start()
+
+            val tenant = fleet.registerTenant("FOUR-T1", "Four Repos Tenant")
+
+            val person = fleet.registerPerson(tenant.id, "Alice", "Driver")
+            val company = fleet.registerCompany(tenant.id, "Acme Fleet GmbH")
+
+            eventually(10.seconds) {
+                fleet.persons.contains(person.id) shouldBe true
+                fleet.companies.contains(company.id) shouldBe true
+            }
+
+            // Query DSL finders on PersonRepository
+            val personsByTenant = fleet.persons.findByTenant(tenant.id)
+            personsByTenant.map { it.id } shouldContain person.id
+
+            // Query DSL finders on CompanyRepository
+            val companiesByTenant = fleet.companies.findByTenant(tenant.id)
+            companiesByTenant.map { it.id } shouldContain company.id
+
+            val companiesByName = fleet.companies.findByName("Acme Fleet GmbH")
+            companiesByName.map { it.name } shouldContain "Acme Fleet GmbH"
+        }
+    }
+
+    "VehicleAssignment polymorphic arm resolves to the assigned Person" {
+        withFeatureResources {
+            val dataSource = PostgresContainerSupport.buildDataSource().managed()
+            resetOutboxSchema(dataSource)
+            val fleet =
+                FleetApplication(dataSource, KafkaContainerSupport.bootstrapServers, fastFeatureRelayConfig())
+                    .managed()
+            fleet.start()
+
+            val tenant = fleet.registerTenant("POLY-T1", "Polymorphic Tenant")
+            val vehicle = fleet.registerVehicle(tenant.id, "POLY-VIN-001")
+            val person = fleet.registerPerson(tenant.id, "Bob", "Driver")
+
+            eventually(10.seconds) {
+                fleet.vehicles.contains(vehicle.id) shouldBe true
+                fleet.persons.contains(person.id) shouldBe true
+            }
+
+            val assignment = fleet.assignVehicleToPerson(vehicle.id, person.id)
+
+            eventually(10.seconds) {
+                fleet.assignments.contains(assignment.id) shouldBe true
+            }
+
+            // The polymorphicAggregate delegate enforces exactly-one-non-null.
+            // resolution() returns PolymorphicResolution<*>; cast to the generated typed variant
+            // so the generated activeArm() extension (in VehicleAssignmentAssignedToArm.kt) is in scope.
+            @Suppress("UNCHECKED_CAST")
+            val typedResolution =
+                assignment.assignedTo.resolution() as PolymorphicResolution<VehicleAssignmentAssignedToArm>
+            val active = typedResolution.activeArm()
+
+            val individual = active.shouldBeInstanceOf<VehicleAssignmentAssignedToArm.Individual>()
+            individual.entity.id shouldBe person.id
+            individual.entity.firstName shouldBe "Bob"
+        }
+    }
+
+    "restore brings back a decommissioned vehicle and emits Restore event to Kafka" {
+        withFeatureResources {
+            val dataSource = PostgresContainerSupport.buildDataSource().managed()
+            resetOutboxSchema(dataSource)
+            val fleet =
+                FleetApplication(dataSource, KafkaContainerSupport.bootstrapServers, fastFeatureRelayConfig())
+                    .managed()
+
+            createFeatureTopic(vehiclesTopic, 1)
+            val consumer = subscribedFeatureConsumer("e2e-restore", vehiclesTopic)
+            fleet.start()
+
+            val tenant = fleet.registerTenant("RST-T1", "Restore Tenant")
+            val vehicle = fleet.registerVehicle(tenant.id, "RST-VIN-001")
+
+            fleet.vehiclesByTenant.size
+
+            // Confirm vehicle is active
+            eventually(10.seconds) {
+                fleet.vehicles.contains(vehicle.id) shouldBe true
+                val bucket = fleet.vehiclesByTenant[tenant.id].orEmpty()
+                bucket.map { it.id } shouldContain vehicle.id
+            }
+
+            // ── Decommission ───────────────────────────────────────────────────────
+            fleet.decommissionVehicle(vehicle)
+            vehicle.deletedAt.shouldNotBeNull()
+            fleet.vehicles.contains(vehicle.id) shouldBe false
+
+            // DSL visibility: default excludes it
+            eventually(5.seconds) {
+                fleet.findVehiclesByVin("RST-VIN-001") shouldHaveSize 0
+            }
+
+            // DSL visibility: includeDeleted() finds it
+            val withDeleted = fleet.findVehiclesByVinIncludingDeleted("RST-VIN-001")
+            withDeleted.map { it.id } shouldContain vehicle.id
+
+            // DSL visibility: onlyDeleted() returns only it
+            val onlyDecommissioned = fleet.findDecommissionedVehicles()
+            onlyDecommissioned.map { it.id } shouldContain vehicle.id
+
+            // Projection is clear
+            eventually(10.seconds) {
+                val bucket = fleet.vehiclesByTenant[tenant.id].orEmpty()
+                bucket.none { it.id == vehicle.id } shouldBe true
+            }
+
+            // ── Restore ────────────────────────────────────────────────────────────
+            fleet.restoreVehicle(vehicle)
+
+            vehicle.deletedAt.shouldBeNull()
+            fleet.vehicles.contains(vehicle.id) shouldBe true
+
+            // Default query now finds it again
+            eventually(5.seconds) {
+                fleet.findVehiclesByVin("RST-VIN-001").map { it.id } shouldContain vehicle.id
+            }
+
+            // onlyDeleted() no longer finds it
+            eventually(5.seconds) {
+                val decommissioned = fleet.findDecommissionedVehicles()
+                decommissioned.none { it.id == vehicle.id } shouldBe true
+            }
+
+            // Projection re-adds the restored vehicle
+            eventually(10.seconds) {
+                val bucket = fleet.vehiclesByTenant[tenant.id].orEmpty()
+                bucket.map { it.id } shouldContain vehicle.id
+            }
+
+            // Kafka must receive a record for the restore mutation
+            consumer.pollFeatureUntil(30.seconds) { recs ->
+                recs.map { it.key() } shouldContain vehicle.id.toString()
+            }
+        }
+    }
+
+    "repository-level CrudEvent stream captures Create, Update, SoftDelete and Restore sequence" {
+        withFeatureResources {
+            val dataSource = PostgresContainerSupport.buildDataSource().managed()
+            resetOutboxSchema(dataSource)
+            val fleet =
+                FleetApplication(dataSource, KafkaContainerSupport.bootstrapServers, fastFeatureRelayConfig())
+                    .managed()
+            fleet.start()
+
+            val tenant = fleet.registerTenant("EVT-T1", "Event Tenant")
+
+            val crudEvents = CopyOnWriteArrayList<CrudEvent<*, *>>()
+            val restoreLatch = CountDownLatch(1)
+
+            fleet.vehicles.subscribe { event ->
+                crudEvents.add(event)
+                if (event is StandardCrudEvent.Restore<*, *>) restoreLatch.countDown()
+            }
+
+            val vehicle = fleet.registerVehicle(tenant.id, "EVT-VIN-001")
+
+            eventually(10.seconds) { fleet.vehicles.contains(vehicle.id) shouldBe true }
+
+            fleet.changeVin(vehicle, "EVT-VIN-002")
+            fleet.decommissionVehicle(vehicle)
+            fleet.restoreVehicle(vehicle)
+
+            restoreLatch.await(15, TimeUnit.SECONDS) shouldBe true
+
+            // Must have received Create, SoftDelete, and Restore events in the sequence
+            val types = crudEvents.map { it.type }
+            types shouldContain CrudEvent.Type.CREATE
+            types shouldContain CrudEvent.Type.SOFT_DELETE
+            types shouldContain CrudEvent.Type.RESTORE
+        }
+    }
+
+    "entity-level subscription captures PropertyChanged when VIN changes" {
+        withFeatureResources {
+            val dataSource = PostgresContainerSupport.buildDataSource().managed()
+            resetOutboxSchema(dataSource)
+            val fleet =
+                FleetApplication(dataSource, KafkaContainerSupport.bootstrapServers, fastFeatureRelayConfig())
+                    .managed()
+            fleet.start()
+
+            val tenant = fleet.registerTenant("PROP-T1", "Property Event Tenant")
+            val vehicle = fleet.registerVehicle(tenant.id, "PROP-OLD-VIN")
+
+            eventually(10.seconds) { fleet.vehicles.contains(vehicle.id) shouldBe true }
+
+            val propertyEvents = CopyOnWriteArrayList<PropertyChanged<*, *, *>>()
+            val changeLatch = CountDownLatch(1)
+
+            vehicle.subscribe { event: MutationEvent<UUID, net.transgressoft.fleet.vehicle.Vehicle> ->
+                if (event is PropertyChanged<*, *, *> && event.property.name == "vin") {
+                    propertyEvents.add(event)
+                    changeLatch.countDown()
+                }
+            }
+
+            fleet.changeVin(vehicle, "PROP-NEW-VIN")
+
+            changeLatch.await(10, TimeUnit.SECONDS) shouldBe true
+
+            propertyEvents shouldHaveSize 1
+            val event = propertyEvents.first()
+            event.oldValue shouldBe "PROP-OLD-VIN"
+            event.newValue shouldBe "PROP-NEW-VIN"
+        }
+    }
+})
+
+// -------------------------------------------------------------------------------------------------
+// Resource management
+// -------------------------------------------------------------------------------------------------
+
+private inline fun withFeatureResources(block: FeatureResourceScope.() -> Unit) {
+    val scope = FeatureResourceScope()
+    try {
+        scope.block()
+    } finally {
+        scope.closeAll()
+    }
+}
+
+private class FeatureResourceScope {
+    private val opened = ArrayDeque<AutoCloseable>()
+
+    fun <T : AutoCloseable> T.managed(): T {
+        opened.addFirst(this)
+        return this
+    }
+
+    fun closeAll() {
+        val errors = mutableListOf<Throwable>()
+        while (opened.isNotEmpty()) {
+            runCatching { opened.removeFirst().close() }.onFailure { errors.add(it) }
+        }
+        if (errors.isNotEmpty()) {
+            val composite = errors.first()
+            errors.drop(1).forEach(composite::addSuppressed)
+            throw composite
+        }
+    }
+
+    fun subscribedFeatureConsumer(group: String, topic: String): KafkaConsumer<String, ByteArray> {
+        val consumer =
+            KafkaConsumer<String, ByteArray>(
+                featureConsumerProps("$group-${System.currentTimeMillis()}")
+            ).managed()
+        awaitFeatureConsumerAssignment(consumer, listOf(topic))
+        return consumer
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Consumer helpers
+// -------------------------------------------------------------------------------------------------
+
+private suspend fun KafkaConsumer<String, ByteArray>.pollFeatureUntil(
+    timeout: kotlin.time.Duration = 20.seconds,
+    assert: (List<ConsumerRecord<String, ByteArray>>) -> Unit
+): List<ConsumerRecord<String, ByteArray>> {
+    val received = mutableListOf<ConsumerRecord<String, ByteArray>>()
+    eventually(timeout) {
+        poll(Duration.ofMillis(200)).forEach { received.add(it) }
+        assert(received)
+    }
+    return received
+}
+
+private fun featureConsumerProps(groupId: String): Properties =
+    Properties().apply {
+        put("bootstrap.servers", KafkaContainerSupport.bootstrapServers)
+        put("group.id", groupId)
+        put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer")
+        put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer")
+        put("auto.offset.reset", "latest")
+        put("request.timeout.ms", "10000")
+        put("default.api.timeout.ms", "10000")
+    }
+
+private fun <K, V> awaitFeatureConsumerAssignment(consumer: KafkaConsumer<K, V>, topics: List<String>) {
+    consumer.subscribe(topics)
+    val deadline = System.currentTimeMillis() + 15_000L
+    while (consumer.assignment().isEmpty() && System.currentTimeMillis() < deadline) {
+        consumer.poll(Duration.ofMillis(200))
+    }
+    check(consumer.assignment().isNotEmpty()) {
+        "Consumer was not assigned any partitions within 15s for topics $topics"
+    }
+}
+
+private fun createFeatureTopic(topic: String, partitions: Int) {
+    org.apache.kafka.clients.admin.AdminClient.create(
+        Properties().apply { put("bootstrap.servers", KafkaContainerSupport.bootstrapServers) }
+    ).use { admin ->
+        try {
+            admin.createTopics(
+                listOf(org.apache.kafka.clients.admin.NewTopic(topic, partitions, 1.toShort()))
+            ).all().get()
+        } catch (e: java.util.concurrent.ExecutionException) {
+            if (e.cause !is org.apache.kafka.common.errors.TopicExistsException) throw e
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Outbox schema helper
+// -------------------------------------------------------------------------------------------------
+
+private fun resetOutboxSchema(dataSource: HikariDataSource) {
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("DROP TABLE IF EXISTS lirp_kafka_outbox").use { it.execute() }
+        conn.prepareStatement("DROP TABLE IF EXISTS lirp_kafka_dead_letter").use { it.execute() }
+    }
+}
+
+private fun fastFeatureRelayConfig() =
+    KafkaOutboxConfig(
+        pollIntervalMs = 50L,
+        batchSize = 100,
+        maxRetries = 3,
+        retryBaseDelayMs = 50L,
+        retryMaxDelayMs = 200L
+    )

--- a/lirp-e2e/src/integrationTest/kotlin/net/transgressoft/fleet/e2e/FleetLifecycleE2ETest.kt
+++ b/lirp-e2e/src/integrationTest/kotlin/net/transgressoft/fleet/e2e/FleetLifecycleE2ETest.kt
@@ -1,0 +1,433 @@
+package net.transgressoft.fleet.e2e
+
+import net.transgressoft.fleet.app.FleetApplication
+import net.transgressoft.fleet.vehicle.Vehicle
+import net.transgressoft.lirp.event.StandardCrudEvent
+import net.transgressoft.lirp.kafka.KafkaOutboxConfig
+import net.transgressoft.lirp.persistence.sql.PostgresContainerSupport
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import java.time.Duration
+import java.util.Properties
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Integrated end-to-end test suite for the fleet service, validating the complete LIRP feature
+ * surface against real Postgres and Kafka Testcontainers.
+ *
+ * Scenarios covered:
+ *
+ * **Vehicle lifecycle** — registers a tenant and vehicle, asserts Kafka receipt of the create
+ * event, projection membership, query-DSL lookup, and diagnostics; then updates the VIN and
+ * asserts Kafka receipt of the update event and query results; then soft-deletes the vehicle
+ * and asserts projection exclusion, `contains` returns false, and Kafka receipt of the resulting
+ * event.
+ *
+ * **Atomic transaction path** — `registerVehicleAtomically` commits the outbox row in the same
+ * DB transaction; Kafka receipt arrives without debounce delay.
+ *
+ * **At-least-once redelivery** — a simulated mid-transaction crash leaves the outbox row with
+ * `sent_at = NULL`; a fresh service instance redelivers it.
+ *
+ * **Optimistic locking** — an out-of-band version bump via raw JDBC causes the next in-repo
+ * mutation to surface a `StandardCrudEvent.Conflict` carrying the canonical state.
+ *
+ * The test uses a plain `KafkaConsumer<String, ByteArray>` with no LIRP or CloudEvents SDK.
+ * Receipt is verified by key, JSON value content, and `ce_*` CloudEvents binary headers.
+ */
+internal class FleetLifecycleE2ETest : StringSpec({
+
+    val vehiclesTopic = "vehicles.events"
+
+    "vehicle lifecycle covers create, update and decommission with Kafka receipt, projection and query DSL" {
+        withResources {
+            val dataSource = PostgresContainerSupport.buildDataSource().managed()
+            resetOutboxSchema(dataSource)
+            val fleet =
+                FleetApplication(dataSource, KafkaContainerSupport.bootstrapServers, fastRelayConfig())
+                    .managed()
+
+            createMultiPartitionTopic(vehiclesTopic, 1)
+            val consumer = subscribedConsumer("e2e-lifecycle", vehiclesTopic)
+            fleet.start()
+
+            // ── Create ──────────────────────────────────────────────────────────────
+            val tenant = fleet.registerTenant("E2E-T1", "E2E Tenant One")
+            val vehicle = fleet.registerVehicle(tenant.id, "E2E-VIN-001")
+
+            // Arm the projection (lazy init triggers on first size/get access)
+            fleet.vehiclesByTenant.size
+
+            val createRecords =
+                consumer.pollUntil { recs ->
+                    recs.map { it.key() } shouldContain vehicle.id.toString()
+                }
+
+            val createRecord = createRecords.first { it.key() == vehicle.id.toString() }
+            createRecord.key() shouldBe vehicle.id.toString()
+            createRecord.header("ce_subject") shouldBe vehicle.id.toString()
+            createRecord.header("ce_id").shouldNotBeNull()
+            createRecord.value().toString(Charsets.UTF_8) shouldContain "\"vin\""
+            createRecord.value().toString(Charsets.UTF_8) shouldContain "E2E-VIN-001"
+
+            // Projection should contain the vehicle under the tenant bucket after create event
+            eventually(10.seconds) {
+                val bucket = fleet.vehiclesByTenant[tenant.id].orEmpty()
+                bucket.map { it.id } shouldContain vehicle.id
+            }
+
+            // Query DSL: find-by-vin using @Indexed vin property
+            eventually(5.seconds) {
+                val byVin = fleet.findVehiclesByVin("E2E-VIN-001")
+                byVin.map { it.vin } shouldContain "E2E-VIN-001"
+            }
+
+            // Query DSL with diagnostics: @Indexed vin should report index hits
+            eventually(5.seconds) {
+                val diagnosed = fleet.diagnoseVehiclesByVin("E2E-VIN-001")
+                diagnosed.results.toList().map { it.vin } shouldContain "E2E-VIN-001"
+                diagnosed.diagnostic.indexHits.shouldNotBeEmpty()
+            }
+
+            // ── Update VIN ──────────────────────────────────────────────────────────
+            fleet.changeVin(vehicle, "E2E-VIN-002")
+
+            val allRecordsAfterUpdate =
+                consumer.pollUntil(30.seconds) { recs ->
+                    // wait for a record carrying the updated vin
+                    val updatedJson =
+                        recs
+                            .filter { it.key() == vehicle.id.toString() }
+                            .any { it.value().toString(Charsets.UTF_8).contains("E2E-VIN-002") }
+                    updatedJson shouldBe true
+                }
+
+            val updateRecord =
+                allRecordsAfterUpdate
+                    .filter { it.key() == vehicle.id.toString() }
+                    .first { it.value().toString(Charsets.UTF_8).contains("E2E-VIN-002") }
+            updateRecord.header("ce_id").shouldNotBeNull()
+            updateRecord.value().toString(Charsets.UTF_8) shouldContain "E2E-VIN-002"
+
+            // Query DSL: new VIN is findable, old VIN is gone
+            eventually(5.seconds) {
+                fleet.findVehiclesByVin("E2E-VIN-002").map { it.vin } shouldContain "E2E-VIN-002"
+            }
+
+            // ── Soft-delete (decommission) ──────────────────────────────────────────
+            fleet.decommissionVehicle(vehicle)
+
+            vehicle.deletedAt.shouldNotBeNull()
+            fleet.vehicles.contains(vehicle.id) shouldBe false
+
+            // Projection must evict soft-deleted vehicle from tenant bucket
+            eventually(10.seconds) {
+                val bucket = fleet.vehiclesByTenant[tenant.id].orEmpty()
+                bucket.none { it.id == vehicle.id } shouldBe true
+            }
+
+            // Kafka must receive the resulting event for this vehicle id after soft-delete
+            consumer.pollUntil(30.seconds) { recs ->
+                // The relay publishes the mutation produced by softDelete — a record with vehicle id key
+                recs.map { it.key() } shouldContain vehicle.id.toString()
+            }
+        }
+    }
+
+    "explicit transaction path publishes Vehicle create event without debounce delay" {
+        withResources {
+            val dataSource = PostgresContainerSupport.buildDataSource().managed()
+            resetOutboxSchema(dataSource)
+            val fleet =
+                FleetApplication(dataSource, KafkaContainerSupport.bootstrapServers, fastRelayConfig())
+                    .managed()
+
+            createMultiPartitionTopic(vehiclesTopic, 1)
+            val consumer = subscribedConsumer("e2e-txpath-lc", vehiclesTopic)
+            fleet.start()
+
+            val vehicle = fleet.registerVehicleAtomically(UUID.randomUUID(), "LC-TXPATH-001")
+            countUnsentOutboxRows(dataSource) shouldBe 1L
+
+            val records =
+                consumer.pollUntil { recs ->
+                    recs.map { it.key() } shouldContain vehicle.id.toString()
+                }
+
+            val record = records.first { it.key() == vehicle.id.toString() }
+            record.header("ce_id").shouldNotBeNull()
+            record.value().toString(Charsets.UTF_8) shouldContain "\"vin\""
+        }
+    }
+
+    "unsent outbox row is redelivered after simulated service crash" {
+        withResources {
+            val dataSource = PostgresContainerSupport.buildDataSource().managed()
+            resetOutboxSchema(dataSource)
+            createMultiPartitionTopic(vehiclesTopic, 1)
+
+            // First service run: create a vehicle, drain the outbox, then stop
+            val firstRun =
+                FleetApplication(dataSource, KafkaContainerSupport.bootstrapServers, fastRelayConfig())
+                    .managed()
+            firstRun.start()
+            val vehicle = firstRun.registerVehicleAtomically(UUID.randomUUID(), "LC-REDELIVER-001")
+            countUnsentOutboxRows(dataSource) shouldBe 1L
+            eventually(15.seconds) { countUnsentOutboxRows(dataSource) shouldBe 0L }
+            firstRun.close()
+
+            // Simulate crash: reset sent_at so the row looks un-sent
+            resetSentAt(dataSource, vehicle.id.toString())
+            countUnsentOutboxRows(dataSource) shouldBe 1L
+
+            // Subscribe before second run to avoid auto.offset.reset=latest race
+            val consumer = subscribedConsumer("e2e-redelivery-lc", vehiclesTopic)
+            val secondRun =
+                FleetApplication(dataSource, KafkaContainerSupport.bootstrapServers, fastRelayConfig())
+                    .managed()
+            secondRun.start()
+
+            val records =
+                consumer.pollUntil { recs ->
+                    recs.map { it.key() } shouldContain vehicle.id.toString()
+                }
+
+            val record = records.first { it.key() == vehicle.id.toString() }
+            record.key() shouldBe vehicle.id.toString()
+            record.header("ce_subject") shouldBe vehicle.id.toString()
+            record.header("ce_id").shouldNotBeNull()
+            record.value().toString(Charsets.UTF_8) shouldContain "\"vin\""
+
+            eventually(10.seconds) { countUnsentOutboxRows(dataSource) shouldBe 0L }
+        }
+    }
+
+    "optimistic locking conflict surfaces StandardCrudEvent.Conflict after out-of-band version bump" {
+        withResources {
+            val dataSource = PostgresContainerSupport.buildDataSource().managed()
+            resetOutboxSchema(dataSource)
+            val fleet =
+                FleetApplication(dataSource, KafkaContainerSupport.bootstrapServers, fastRelayConfig())
+                    .managed()
+            fleet.start()
+
+            val tenant = fleet.registerTenant("OL-T1", "Optimistic Tenant 1")
+            val vehicle = fleet.registerVehicle(tenant.id, "OL-INITIAL-VIN")
+
+            // Wait for the INSERT to be committed to Postgres before the out-of-band UPDATE
+            eventually(15.seconds) {
+                dataSource.connection.use { conn ->
+                    conn.prepareStatement("SELECT COUNT(*) FROM vehicles WHERE id = ?").use { stmt ->
+                        stmt.setObject(1, vehicle.id)
+                        stmt.executeQuery().use { rs ->
+                            rs.next()
+                            rs.getInt(1) shouldBe 1
+                        }
+                    }
+                }
+            }
+
+            val conflictRef = AtomicReference<StandardCrudEvent.Conflict<UUID, Vehicle>?>(null)
+            val latch = CountDownLatch(1)
+            fleet.vehicles.subscribe { event ->
+                if (event is StandardCrudEvent.Conflict<*, *>) {
+                    @Suppress("UNCHECKED_CAST")
+                    conflictRef.set(event as StandardCrudEvent.Conflict<UUID, Vehicle>)
+                    latch.countDown()
+                }
+            }
+
+            // Out-of-band writer bumps the version and vin directly via JDBC
+            dataSource.connection.use { conn ->
+                conn.prepareStatement(
+                    "UPDATE vehicles SET vin = ?, version = version + 1 WHERE id = ?"
+                ).use { stmt ->
+                    stmt.setString(1, "OL-CANONICAL-VIN")
+                    stmt.setObject(2, vehicle.id)
+                    stmt.executeUpdate() shouldBe 1
+                }
+            }
+
+            // Local mutation against the stale baseline — should surface Conflict
+            vehicle.vin = "OL-LOCAL-VIN"
+
+            latch.await(5, TimeUnit.SECONDS) shouldBe true
+
+            val conflict = conflictRef.get()
+            conflict.shouldNotBeNull()
+
+            val canonical = conflict.entities.values.single()
+            val attempted = conflict.oldEntities.values.single()
+
+            canonical.vin shouldBe "OL-CANONICAL-VIN"
+            attempted.vin shouldBe "OL-LOCAL-VIN"
+            conflict.expectedVersion shouldBe 0L
+            conflict.actualVersion shouldBe 1L
+
+            // In-memory entity is auto-reloaded to canonical state
+            fleet.vehicles.findById(vehicle.id).shouldBePresent { it.vin shouldBe "OL-CANONICAL-VIN" }
+        }
+    }
+})
+
+// -------------------------------------------------------------------------------------------------
+// Resource management
+// -------------------------------------------------------------------------------------------------
+
+private inline fun withResources(block: E2EResourceScope.() -> Unit) {
+    val scope = E2EResourceScope()
+    try {
+        scope.block()
+    } finally {
+        scope.closeAll()
+    }
+}
+
+private class E2EResourceScope {
+    private val opened = ArrayDeque<AutoCloseable>()
+
+    fun <T : AutoCloseable> T.managed(): T {
+        opened.addFirst(this)
+        return this
+    }
+
+    fun closeAll() {
+        val errors = mutableListOf<Throwable>()
+        while (opened.isNotEmpty()) {
+            runCatching { opened.removeFirst().close() }.onFailure { errors.add(it) }
+        }
+        if (errors.isNotEmpty()) {
+            val composite = errors.first()
+            errors.drop(1).forEach(composite::addSuppressed)
+            throw composite
+        }
+    }
+
+    fun subscribedConsumer(group: String, topic: String): KafkaConsumer<String, ByteArray> {
+        val consumer =
+            KafkaConsumer<String, ByteArray>(
+                consumerProps("$group-${System.currentTimeMillis()}")
+            ).managed()
+        awaitConsumerAssignment(consumer, listOf(topic))
+        return consumer
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Consumer helpers
+// -------------------------------------------------------------------------------------------------
+
+private suspend fun KafkaConsumer<String, ByteArray>.pollUntil(
+    timeout: kotlin.time.Duration = 20.seconds,
+    assert: (List<ConsumerRecord<String, ByteArray>>) -> Unit
+): List<ConsumerRecord<String, ByteArray>> {
+    val received = mutableListOf<ConsumerRecord<String, ByteArray>>()
+    eventually(timeout) {
+        poll(Duration.ofMillis(200)).forEach { received.add(it) }
+        assert(received)
+    }
+    return received
+}
+
+private fun ConsumerRecord<String, ByteArray>.header(name: String): String? =
+    headers().lastHeader(name)?.value()?.toString(Charsets.UTF_8)
+
+private fun consumerProps(groupId: String): Properties =
+    Properties().apply {
+        put("bootstrap.servers", KafkaContainerSupport.bootstrapServers)
+        put("group.id", groupId)
+        put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer")
+        put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer")
+        put("auto.offset.reset", "latest")
+        put("request.timeout.ms", "10000")
+        put("default.api.timeout.ms", "10000")
+    }
+
+private fun <K, V> awaitConsumerAssignment(consumer: KafkaConsumer<K, V>, topics: List<String>) {
+    consumer.subscribe(topics)
+    val deadline = System.currentTimeMillis() + 15_000L
+    while (consumer.assignment().isEmpty() && System.currentTimeMillis() < deadline) {
+        consumer.poll(Duration.ofMillis(200))
+    }
+    check(consumer.assignment().isNotEmpty()) {
+        "Consumer was not assigned any partitions within 15s for topics $topics"
+    }
+}
+
+private fun createMultiPartitionTopic(topic: String, partitions: Int) {
+    org.apache.kafka.clients.admin.AdminClient.create(
+        Properties().apply { put("bootstrap.servers", KafkaContainerSupport.bootstrapServers) }
+    ).use { admin ->
+        try {
+            admin.createTopics(
+                listOf(org.apache.kafka.clients.admin.NewTopic(topic, partitions, 1.toShort()))
+            ).all().get()
+        } catch (e: java.util.concurrent.ExecutionException) {
+            if (e.cause !is org.apache.kafka.common.errors.TopicExistsException) throw e
+            val existing = admin.describeTopics(listOf(topic)).allTopicNames().get()[topic]
+            val current = existing?.partitions()?.size ?: 0
+            if (current < partitions) {
+                admin.createPartitions(
+                    mapOf(topic to org.apache.kafka.clients.admin.NewPartitions.increaseTo(partitions))
+                ).all().get()
+            }
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Outbox schema / row helpers (raw JDBC — test-side observation and fault injection)
+// -------------------------------------------------------------------------------------------------
+
+private fun resetOutboxSchema(dataSource: HikariDataSource) {
+    dropTableIfExists(dataSource, "lirp_kafka_outbox")
+    dropTableIfExists(dataSource, "lirp_kafka_dead_letter")
+}
+
+private fun dropTableIfExists(dataSource: HikariDataSource, table: String) {
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("DROP TABLE IF EXISTS $table").use { it.execute() }
+    }
+}
+
+private fun countUnsentOutboxRows(dataSource: HikariDataSource): Long =
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("SELECT COUNT(*) FROM lirp_kafka_outbox WHERE sent_at IS NULL").use { stmt ->
+            stmt.executeQuery().use { rs ->
+                rs.next()
+                rs.getLong(1)
+            }
+        }
+    }
+
+private fun resetSentAt(dataSource: HikariDataSource, aggregateId: String) {
+    dataSource.connection.use { conn ->
+        conn.prepareStatement("UPDATE lirp_kafka_outbox SET sent_at = NULL WHERE aggregate_id = ?")
+            .use { stmt ->
+                stmt.setString(1, aggregateId)
+                stmt.executeUpdate()
+            }
+    }
+}
+
+private fun fastRelayConfig() =
+    KafkaOutboxConfig(
+        pollIntervalMs = 50L,
+        batchSize = 100,
+        maxRetries = 3,
+        retryBaseDelayMs = 50L,
+        retryMaxDelayMs = 200L
+    )

--- a/lirp-e2e/src/integrationTest/kotlin/net/transgressoft/fleet/e2e/KafkaContainerSupport.kt
+++ b/lirp-e2e/src/integrationTest/kotlin/net/transgressoft/fleet/e2e/KafkaContainerSupport.kt
@@ -1,0 +1,42 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.fleet.e2e
+
+import org.testcontainers.kafka.ConfluentKafkaContainer
+
+/**
+ * Shared Testcontainers Kafka broker and bootstrap-servers accessor for the fleet e2e integration tests.
+ *
+ * The container is started lazily and thread-safely on first access and reused across all
+ * integration test classes within the same JVM process. Uses KRaft mode (no ZooKeeper) via
+ * [ConfluentKafkaContainer] default behaviour in Testcontainers 2.x.
+ *
+ * A JVM shutdown hook stops the container explicitly so it is cleaned up even when Ryuk is
+ * disabled (e.g. `TESTCONTAINERS_RYUK_DISABLED=true`) or the JVM is terminated abnormally.
+ */
+internal object KafkaContainerSupport {
+    private val container: ConfluentKafkaContainer by lazy {
+        ConfluentKafkaContainer("confluentinc/cp-kafka:7.8.0").apply {
+            start()
+            Runtime.getRuntime().addShutdownHook(Thread { stop() })
+        }
+    }
+
+    /** Comma-separated `host:port` bootstrap servers for the running container. */
+    val bootstrapServers: String get() = container.bootstrapServers
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/app/FleetApplication.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/app/FleetApplication.kt
@@ -1,0 +1,211 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.fleet.app
+
+import net.transgressoft.fleet.common.AssignmentType
+import net.transgressoft.fleet.company.CompanyRepository
+import net.transgressoft.fleet.person.PersonRepository
+import net.transgressoft.fleet.tenant.TenantRepository
+import net.transgressoft.fleet.vehicle.Vehicle
+import net.transgressoft.fleet.vehicle.VehicleAssignment
+import net.transgressoft.fleet.vehicle.VehicleAssignmentRepository
+import net.transgressoft.fleet.vehicle.VehicleRepository
+import net.transgressoft.lirp.kafka.KafkaOutboxConfig
+import net.transgressoft.lirp.kafka.LirpKafkaConfig
+import net.transgressoft.lirp.persistence.projection.RegistryProjection
+import net.transgressoft.lirp.persistence.projection.registryProjection
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Composition root for the fleet service, wiring together four domain repositories, a
+ * Kafka outbox relay, and a live projection.
+ *
+ * Each repository is a `@LirpRepository`-annotated factory that auto-registers its entity type
+ * into [net.transgressoft.lirp.persistence.LirpContext.default] on construction and deregisters
+ * on [close]. Domain operations delegate to the repository factories so no raw repository
+ * constructors are needed outside this class.
+ *
+ * The service owns:
+ * - [vehicles] — Kafka-backed [VehicleRepository]; every create, update, and soft-delete is
+ *   published to Kafka via the transactional-outbox relay.
+ * - [tenants] — plain [TenantRepository]; no Kafka publishing needed for tenants.
+ * - [persons] — plain [PersonRepository].
+ * - [companies] — plain [CompanyRepository].
+ * - [assignments] — plain [VehicleAssignmentRepository] for polymorphic driver/holder references.
+ * - [vehiclesByTenant] — read-only projection grouping live (non-soft-deleted) vehicles by tenant id.
+ *
+ * Domain operations mutate through the repositories; the entity layer is unaware of Kafka — the
+ * relay captures outbox rows and publishes them transparently.
+ *
+ * The relay lifecycle belongs to this service: [start] begins draining the outbox and [close]
+ * stops the relay, closes the projection and all four repositories idempotently. Construct one
+ * instance per running process; a restart after a crash is modelled by constructing a fresh
+ * instance over the same [dataSource].
+ */
+class FleetApplication(
+    private val dataSource: DataSource,
+    bootstrapServers: String,
+    private val relayConfig: KafkaOutboxConfig = KafkaOutboxConfig.DEFAULT
+) : AutoCloseable {
+
+    val tenants = TenantRepository(dataSource)
+    val persons = PersonRepository(dataSource)
+    val companies = CompanyRepository(dataSource)
+    val vehicles = VehicleRepository(dataSource)
+    val assignments = VehicleAssignmentRepository(dataSource)
+    val vehiclesByTenant: RegistryProjection<UUID, UUID, Vehicle> =
+        registryProjection(vehicles, keyExtractor = { v: Vehicle -> v.tenantId })
+
+    private val kafka = LirpKafkaConfig.create(bootstrapServers)
+
+    @Volatile
+    private var closed = false
+
+    /**
+     * Starts the outbox relay so committed vehicle mutations are published to Kafka.
+     *
+     * Call once per instance after construction; behavior is undefined if called more than once.
+     */
+    fun start() {
+        kafka.startRelay(dataSource, relayConfig)
+    }
+
+    /**
+     * Registers a new tenant.
+     *
+     * @return the newly created tenant, already assigned to the repository.
+     */
+    fun registerTenant(code: String, name: String) = tenants.register(code, name)
+
+    /**
+     * Registers a new vehicle through the debounced write pipeline.
+     *
+     * The mutation is captured into the outbox by the write-pending hook once the debounce
+     * window elapses, then published by the relay.
+     *
+     * @return the newly created [Vehicle], already assigned a random id.
+     */
+    fun registerVehicle(tenantId: UUID, vin: String) = vehicles.register(tenantId, vin)
+
+    /**
+     * Registers a new vehicle atomically inside an explicit transaction.
+     *
+     * The outbox row is written in the same transaction as the entity, so it is visible the
+     * moment the transaction commits — no debounce delay.
+     *
+     * @return the newly created [Vehicle], already assigned a random id.
+     */
+    suspend fun registerVehicleAtomically(tenantId: UUID, vin: String) =
+        vehicles.registerAtomically(tenantId, vin)
+
+    /**
+     * Updates the VIN of an existing vehicle in-place.
+     */
+    fun changeVin(vehicle: Vehicle, newVin: String) = vehicles.changeVin(vehicle, newVin)
+
+    /**
+     * Decommissions a vehicle via soft-delete.
+     *
+     * Sets [Vehicle.deletedAt] to the current instant, removes the vehicle from default
+     * iteration and projections, and triggers a Delete event through the relay pipeline.
+     */
+    fun decommissionVehicle(vehicle: Vehicle) = vehicles.decommission(vehicle)
+
+    /**
+     * Restores a previously decommissioned vehicle.
+     *
+     * Clears [Vehicle.deletedAt], re-adds the vehicle to default iteration and projections,
+     * and emits a Restore event through the relay pipeline.
+     */
+    fun restoreVehicle(vehicle: Vehicle) = vehicles.restore(vehicle)
+
+    /**
+     * Registers a new person belonging to the given tenant.
+     *
+     * @return the newly created [net.transgressoft.fleet.person.Person].
+     */
+    fun registerPerson(tenantId: UUID, firstName: String, lastName: String) =
+        persons.register(tenantId, firstName, lastName)
+
+    /**
+     * Registers a new company belonging to the given tenant.
+     *
+     * @return the newly created [net.transgressoft.fleet.company.Company].
+     */
+    fun registerCompany(tenantId: UUID, name: String) = companies.register(tenantId, name)
+
+    /**
+     * Assigns a vehicle to a person as the primary driver.
+     *
+     * @return the newly created [VehicleAssignment].
+     */
+    fun assignVehicleToPerson(
+        vehicleId: UUID,
+        personId: UUID,
+        type: AssignmentType = AssignmentType.DRIVER
+    ): VehicleAssignment = assignments.assignToPerson(vehicleId, personId, type)
+
+    /**
+     * Finds vehicles matching the given VIN using the query DSL.
+     *
+     * [Vehicle.vin] carries `@Indexed`, so equality lookups use the index-aware planner path.
+     * Soft-deleted vehicles are excluded by default.
+     *
+     * @return a list of matching vehicles (typically zero or one for exact VIN lookups).
+     */
+    fun findVehiclesByVin(vin: String) = vehicles.findByVin(vin)
+
+    /**
+     * Finds vehicles by VIN including soft-deleted (decommissioned) vehicles.
+     */
+    fun findVehiclesByVinIncludingDeleted(vin: String) = vehicles.findByVinIncludingDeleted(vin)
+
+    /**
+     * Returns only soft-deleted (decommissioned) vehicles.
+     */
+    fun findDecommissionedVehicles() = vehicles.findDecommissioned()
+
+    /**
+     * Finds vehicles by VIN and returns diagnostic information about the query execution plan.
+     *
+     * Because [Vehicle.vin] is `@Indexed`, the planner reports index hits in the returned
+     * [net.transgressoft.lirp.persistence.query.DiagnosedQuery.diagnostic].
+     */
+    fun diagnoseVehiclesByVin(vin: String) = vehicles.diagnoseByVin(vin)
+
+    /**
+     * Closes the relay, projection, and all five repositories idempotently.
+     *
+     * Repositories are closed in reverse construction order so that foreign-key constraints are
+     * honoured: assignments (referencing vehicles) close before vehicles, and vehicles (referencing
+     * tenants) close before tenants. Each [close] deregisters the entity type from
+     * [net.transgressoft.lirp.persistence.LirpContext.default].
+     */
+    override fun close() {
+        if (closed) return
+        closed = true
+        kafka.close()
+        vehiclesByTenant.close()
+        assignments.close()
+        vehicles.close()
+        companies.close()
+        persons.close()
+        tenants.close()
+    }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/Address.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/Address.kt
@@ -1,0 +1,67 @@
+package net.transgressoft.fleet.common
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Indexed
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Physical or postal address associated with a person or company.
+ *
+ * An address may belong to a person ([personId]) or a company ([companyId]), but not both.
+ * The [addressType] categorizes the address purpose. Validity is bounded by optional
+ * [validFrom]/[validUntil] dates.
+ */
+@PersistenceMapping(name = "addresses")
+class Address(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, Address>(), Auditable {
+
+    @Indexed
+    var personId: UUID? by reactiveProperty(null)
+
+    @Indexed
+    var companyId: UUID? by reactiveProperty(null)
+
+    var addressType: AddressType by reactiveProperty(AddressType.OTHER)
+    var isPrimary: Boolean by reactiveProperty(false)
+    var street: String by reactiveProperty("")
+    var street2: String? by reactiveProperty(null)
+    var postalCode: String by reactiveProperty("")
+    var city: String by reactiveProperty("")
+    var stateProvince: String? by reactiveProperty(null)
+    var countryId: UUID? by reactiveProperty(null)
+    var validFrom: LocalDate? by reactiveProperty(null)
+    var validUntil: LocalDate? by reactiveProperty(null)
+
+    override var createdAt: LocalDateTime by reactiveProperty(LocalDateTime.now())
+    override var updatedAt: LocalDateTime by reactiveProperty(LocalDateTime.now())
+    override var createdBy: String? by reactiveProperty(null)
+    override var lastModifiedBy: String? by reactiveProperty(null)
+
+    override val uniqueId: String get() = "address-$id"
+
+    override fun clone(): Address =
+        Address(id).apply {
+            withEventsDisabled {
+                personId = this@Address.personId
+                companyId = this@Address.companyId
+                addressType = this@Address.addressType
+                isPrimary = this@Address.isPrimary
+                street = this@Address.street
+                street2 = this@Address.street2
+                postalCode = this@Address.postalCode
+                city = this@Address.city
+                stateProvince = this@Address.stateProvince
+                countryId = this@Address.countryId
+                validFrom = this@Address.validFrom
+                validUntil = this@Address.validUntil
+                createdAt = this@Address.createdAt
+                updatedAt = this@Address.updatedAt
+                createdBy = this@Address.createdBy
+                lastModifiedBy = this@Address.lastModifiedBy
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/Auditable.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/Auditable.kt
@@ -1,0 +1,16 @@
+package net.transgressoft.fleet.common
+
+import java.time.LocalDateTime
+
+/**
+ * Mixin for entities that track creation and modification metadata.
+ *
+ * LIRP has no built-in audit support, so these are manual reactive properties
+ * on each implementing entity. This interface provides the contract.
+ */
+interface Auditable {
+    var createdAt: LocalDateTime
+    var updatedAt: LocalDateTime
+    var createdBy: String?
+    var lastModifiedBy: String?
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/Contact.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/Contact.kt
@@ -1,0 +1,57 @@
+package net.transgressoft.fleet.common
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Indexed
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Contact information entry associated with a person or company.
+ *
+ * A contact may belong to a person ([personId]) or a company ([companyId]), but not both.
+ * The [contactType] classifies the communication channel (phone, email, website, etc.).
+ */
+@PersistenceMapping(name = "contacts")
+class Contact(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, Contact>(), Auditable {
+
+    @Indexed
+    var personId: UUID? by reactiveProperty(null)
+
+    @Indexed
+    var companyId: UUID? by reactiveProperty(null)
+
+    var contactType: ContactType by reactiveProperty(ContactType.OTHER)
+    var phoneNumber: String? by reactiveProperty(null)
+    var emailAddress: String? by reactiveProperty(null)
+    var websiteUrl: String? by reactiveProperty(null)
+    var label: String? by reactiveProperty(null)
+    var notes: String? by reactiveProperty(null)
+
+    override var createdAt: LocalDateTime by reactiveProperty(LocalDateTime.now())
+    override var updatedAt: LocalDateTime by reactiveProperty(LocalDateTime.now())
+    override var createdBy: String? by reactiveProperty(null)
+    override var lastModifiedBy: String? by reactiveProperty(null)
+
+    override val uniqueId: String get() = "contact-$id"
+
+    override fun clone(): Contact =
+        Contact(id).apply {
+            withEventsDisabled {
+                personId = this@Contact.personId
+                companyId = this@Contact.companyId
+                contactType = this@Contact.contactType
+                phoneNumber = this@Contact.phoneNumber
+                emailAddress = this@Contact.emailAddress
+                websiteUrl = this@Contact.websiteUrl
+                label = this@Contact.label
+                notes = this@Contact.notes
+                createdAt = this@Contact.createdAt
+                updatedAt = this@Contact.updatedAt
+                createdBy = this@Contact.createdBy
+                lastModifiedBy = this@Contact.lastModifiedBy
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/Country.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/Country.kt
@@ -1,0 +1,33 @@
+package net.transgressoft.fleet.common
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import java.util.UUID
+
+/**
+ * Reference entity representing a country with ISO code identifiers.
+ *
+ * Used as a lookup table for address country fields throughout the fleet domain.
+ */
+@PersistenceMapping(name = "countries")
+class Country(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, Country>() {
+
+    var isoCode2: String by reactiveProperty("")
+    var isoCode3: String by reactiveProperty("")
+    var plateCode: String? by reactiveProperty(null)
+    var name: String by reactiveProperty("")
+
+    override val uniqueId: String get() = "country-$id"
+
+    override fun clone(): Country =
+        Country(id).apply {
+            withEventsDisabled {
+                isoCode2 = this@Country.isoCode2
+                isoCode3 = this@Country.isoCode3
+                plateCode = this@Country.plateCode
+                name = this@Country.name
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/EngineType.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/EngineType.kt
@@ -1,0 +1,29 @@
+package net.transgressoft.fleet.common
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import java.util.UUID
+
+/**
+ * Reference entity classifying the engine type of a vehicle (e.g., combustion, electric, hybrid).
+ *
+ * Used as a lookup table for engine type assignments on [net.transgressoft.fleet.vehicle.Vehicle] instances.
+ */
+@PersistenceMapping(name = "engine_types")
+class EngineType(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, EngineType>() {
+
+    var code: String by reactiveProperty("")
+    var name: String by reactiveProperty("")
+
+    override val uniqueId: String get() = "engine-type-$id"
+
+    override fun clone(): EngineType =
+        EngineType(id).apply {
+            withEventsDisabled {
+                code = this@EngineType.code
+                name = this@EngineType.name
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/FleetEnums.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/FleetEnums.kt
@@ -1,0 +1,74 @@
+package net.transgressoft.fleet.common
+
+/** Classification of physical and postal addresses. */
+enum class AddressType {
+    PHYSICAL,
+    POSTAL,
+    BILLING,
+    SHIPPING,
+    HOME,
+    WORK,
+    OTHER
+}
+
+/** Classification of contact information entries. */
+enum class ContactType {
+    PHONE,
+    EMAIL,
+    FAX,
+    MOBILE,
+    WEBSITE,
+    OTHER
+}
+
+/** Relationship types between companies. */
+enum class RelationshipType {
+    PARENT,
+    BROKER,
+    AGENT,
+    PARTNER
+}
+
+/** Person salutation. */
+enum class Salutation {
+    MR,
+    MS,
+    DIVERSE
+}
+
+/** Academic or professional title. */
+enum class Title {
+    DR,
+    PROF,
+    PROF_DR,
+    DIPL_ING
+}
+
+/** Insurance policy type. */
+enum class PolicyType {
+    LIABILITY,
+    COMPREHENSIVE,
+    PARTIAL,
+    OTHER
+}
+
+/** Vehicle contract status. */
+enum class ContractStatus {
+    RUNNING,
+    COMPLETED
+}
+
+/** Vehicle assignment type — determines whether the target is a person or company. */
+enum class AssignmentType {
+    DRIVER,
+    USER,
+    HOLDER
+}
+
+/** Role of a person within a company. */
+enum class CompanyPersonRole {
+    EMPLOYEE,
+    DRIVER,
+    MANAGING_DIRECTOR,
+    CONTACT_PERSON
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/Manufacturer.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/Manufacturer.kt
@@ -1,0 +1,29 @@
+package net.transgressoft.fleet.common
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import java.util.UUID
+
+/**
+ * Reference entity representing a vehicle manufacturer.
+ *
+ * Used as a lookup table for manufacturer assignments on [net.transgressoft.fleet.vehicle.Vehicle] instances.
+ */
+@PersistenceMapping(name = "manufacturers")
+class Manufacturer(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, Manufacturer>() {
+
+    var code: String by reactiveProperty("")
+    var name: String by reactiveProperty("")
+
+    override val uniqueId: String get() = "manufacturer-$id"
+
+    override fun clone(): Manufacturer =
+        Manufacturer(id).apply {
+            withEventsDisabled {
+                code = this@Manufacturer.code
+                name = this@Manufacturer.name
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/PersonFeatureType.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/PersonFeatureType.kt
@@ -1,0 +1,32 @@
+package net.transgressoft.fleet.common
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import java.util.UUID
+
+/**
+ * Reference entity classifying types of person features (e.g., certifications, qualifications).
+ *
+ * Feature types are shared lookup values assigned to [net.transgressoft.fleet.person.PersonFeature]
+ * instances.
+ */
+@PersistenceMapping(name = "person_feature_types")
+class PersonFeatureType(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, PersonFeatureType>() {
+
+    var code: String by reactiveProperty("")
+    var name: String by reactiveProperty("")
+    var description: String? by reactiveProperty(null)
+
+    override val uniqueId: String get() = "person-feature-type-$id"
+
+    override fun clone(): PersonFeatureType =
+        PersonFeatureType(id).apply {
+            withEventsDisabled {
+                code = this@PersonFeatureType.code
+                name = this@PersonFeatureType.name
+                description = this@PersonFeatureType.description
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/VehicleBodyType.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/VehicleBodyType.kt
@@ -1,0 +1,29 @@
+package net.transgressoft.fleet.common
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import java.util.UUID
+
+/**
+ * Reference entity classifying the body style of a vehicle (e.g., sedan, SUV, van).
+ *
+ * Used as a lookup table for body type assignments on [net.transgressoft.fleet.vehicle.Vehicle] instances.
+ */
+@PersistenceMapping(name = "vehicle_body_types")
+class VehicleBodyType(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, VehicleBodyType>() {
+
+    var code: String by reactiveProperty("")
+    var name: String by reactiveProperty("")
+
+    override val uniqueId: String get() = "vehicle-body-type-$id"
+
+    override fun clone(): VehicleBodyType =
+        VehicleBodyType(id).apply {
+            withEventsDisabled {
+                code = this@VehicleBodyType.code
+                name = this@VehicleBodyType.name
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/VehicleUsageType.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/common/VehicleUsageType.kt
@@ -1,0 +1,29 @@
+package net.transgressoft.fleet.common
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import java.util.UUID
+
+/**
+ * Reference entity classifying the intended usage of a vehicle (e.g., pool car, company car, service vehicle).
+ *
+ * Used as a lookup table for usage type assignments on [net.transgressoft.fleet.vehicle.VehicleAssignment] instances.
+ */
+@PersistenceMapping(name = "vehicle_usage_types")
+class VehicleUsageType(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, VehicleUsageType>() {
+
+    var code: String by reactiveProperty("")
+    var name: String by reactiveProperty("")
+
+    override val uniqueId: String get() = "vehicle-usage-type-$id"
+
+    override fun clone(): VehicleUsageType =
+        VehicleUsageType(id).apply {
+            withEventsDisabled {
+                code = this@VehicleUsageType.code
+                name = this@VehicleUsageType.name
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/Company.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/Company.kt
@@ -1,0 +1,72 @@
+package net.transgressoft.fleet.company
+
+import net.transgressoft.fleet.common.Auditable
+import net.transgressoft.fleet.tenant.Tenant
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.MutableSoftDeletable
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import java.time.Instant
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Company entity representing a legal entity in the fleet domain.
+ *
+ * A company belongs to a [tenantId] and may carry financial identifiers ([taxNumber], [vatId],
+ * [debtorNumber], [creditorNumber]) along with legacy system references ([legacyGrumId], [externalId]).
+ * The [vatDeductible] flag indicates whether input tax can be reclaimed.
+ */
+@PersistenceMapping(name = "companies")
+class Company(
+    override val id: UUID,
+    tenantId: UUID
+) : ReactiveEntityBase<UUID, Company>(), Auditable, MutableSoftDeletable {
+
+    @ToOneAggregate(target = Tenant::class, onDelete = CascadeAction.RESTRICT)
+    var tenantId: UUID by reactiveProperty(tenantId)
+
+    var name: String by reactiveProperty("")
+    var additionalName: String? by reactiveProperty(null)
+    var taxNumber: String? by reactiveProperty(null)
+    var vatId: String? by reactiveProperty(null)
+    var vatDeductible: Boolean by reactiveProperty(false)
+    var debtorNumber: String? by reactiveProperty(null)
+    var creditorNumber: String? by reactiveProperty(null)
+    var notes: String? by reactiveProperty(null)
+    var companyMatch: String? by reactiveProperty(null)
+    var legacyGrumId: String? by reactiveProperty(null)
+    var externalId: String? by reactiveProperty(null)
+
+    override var createdAt: LocalDateTime by reactiveProperty(LocalDateTime.now())
+    override var updatedAt: LocalDateTime by reactiveProperty(LocalDateTime.now())
+    override var createdBy: String? by reactiveProperty(null)
+    override var lastModifiedBy: String? by reactiveProperty(null)
+
+    override var deletedAt: Instant? by reactiveProperty(null)
+
+    override val uniqueId: String get() = "company-$id"
+
+    override fun clone(): Company =
+        Company(id, tenantId).apply {
+            withEventsDisabled {
+                name = this@Company.name
+                additionalName = this@Company.additionalName
+                taxNumber = this@Company.taxNumber
+                vatId = this@Company.vatId
+                vatDeductible = this@Company.vatDeductible
+                debtorNumber = this@Company.debtorNumber
+                creditorNumber = this@Company.creditorNumber
+                notes = this@Company.notes
+                companyMatch = this@Company.companyMatch
+                legacyGrumId = this@Company.legacyGrumId
+                externalId = this@Company.externalId
+                createdAt = this@Company.createdAt
+                updatedAt = this@Company.updatedAt
+                createdBy = this@Company.createdBy
+                lastModifiedBy = this@Company.lastModifiedBy
+                deletedAt = this@Company.deletedAt
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/CompanyFeature.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/CompanyFeature.kt
@@ -1,0 +1,54 @@
+package net.transgressoft.fleet.company
+
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Indexed
+import net.transgressoft.lirp.persistence.PersistenceIgnore
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Association between a [Company] and a feature type, with optional validity period.
+ *
+ * A feature represents a qualification, certification, or attribute held by a company.
+ * The [isCurrentlyValid] computed property checks whether the feature is active today
+ * and is excluded from persistence.
+ */
+@PersistenceMapping(name = "company_features")
+class CompanyFeature(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, CompanyFeature>() {
+
+    @Indexed
+    @ToOneAggregate(target = Company::class, onDelete = CascadeAction.CASCADE)
+    var companyId: UUID by reactiveProperty(UUID(0, 0))
+
+    @ToOneAggregate(target = CompanyFeatureType::class, onDelete = CascadeAction.RESTRICT)
+    var featureTypeId: UUID by reactiveProperty(UUID(0, 0))
+
+    var validFrom: LocalDate? by reactiveProperty(null)
+    var validUntil: LocalDate? by reactiveProperty(null)
+
+    @PersistenceIgnore
+    val isCurrentlyValid: Boolean
+        get() {
+            val today = LocalDate.now()
+            val afterStart = validFrom?.let { !today.isBefore(it) } ?: true
+            val beforeEnd = validUntil?.let { !today.isAfter(it) } ?: true
+            return afterStart && beforeEnd
+        }
+
+    override val uniqueId: String get() = "company-feature-$id"
+
+    override fun clone(): CompanyFeature =
+        CompanyFeature(id).apply {
+            withEventsDisabled {
+                companyId = this@CompanyFeature.companyId
+                featureTypeId = this@CompanyFeature.featureTypeId
+                validFrom = this@CompanyFeature.validFrom
+                validUntil = this@CompanyFeature.validUntil
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/CompanyFeatureType.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/CompanyFeatureType.kt
@@ -1,0 +1,31 @@
+package net.transgressoft.fleet.company
+
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import java.util.UUID
+
+/**
+ * Reference entity classifying types of company features (e.g., certifications, accreditations).
+ *
+ * Feature types are shared lookup values assigned to [CompanyFeature] instances.
+ */
+@PersistenceMapping(name = "company_feature_types")
+class CompanyFeatureType(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, CompanyFeatureType>() {
+
+    var code: String by reactiveProperty("")
+    var name: String by reactiveProperty("")
+    var description: String? by reactiveProperty(null)
+
+    override val uniqueId: String get() = "company-feature-type-$id"
+
+    override fun clone(): CompanyFeatureType =
+        CompanyFeatureType(id).apply {
+            withEventsDisabled {
+                code = this@CompanyFeatureType.code
+                name = this@CompanyFeatureType.name
+                description = this@CompanyFeatureType.description
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/CompanyInsuranceAgreement.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/CompanyInsuranceAgreement.kt
@@ -1,0 +1,72 @@
+package net.transgressoft.fleet.company
+
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Indexed
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Insurance agreement held by a [Company], covering liability, comprehensive, and partial policies.
+ *
+ * An agreement may reference a [parentAgreementId] for hierarchical structures (e.g. consortium
+ * arrangements). Deductible amounts ([deductibleComprehensive], [deductiblePartial]) are stored
+ * with up to 10 significant digits and 2 decimal places. The [isOwnCoverage] and
+ * [isConsortiumPolicyholder] flags further classify the coverage arrangement.
+ */
+@PersistenceMapping(name = "company_insurance_agreements")
+class CompanyInsuranceAgreement(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, CompanyInsuranceAgreement>() {
+
+    @Indexed
+    @ToOneAggregate(target = Company::class, onDelete = CascadeAction.CASCADE)
+    var companyId: UUID by reactiveProperty(UUID(0, 0))
+
+    @ToOneAggregate(target = CompanyInsuranceAgreement::class, onDelete = CascadeAction.DETACH)
+    var parentAgreementId: UUID? by reactiveProperty(null)
+
+    @ToOneAggregate(target = Company::class, onDelete = CascadeAction.DETACH)
+    var liabilityInsuranceCompanyId: UUID? by reactiveProperty(null)
+
+    @ToOneAggregate(target = Company::class, onDelete = CascadeAction.DETACH)
+    var comprehensiveInsuranceCompanyId: UUID? by reactiveProperty(null)
+
+    @ToOneAggregate(target = Company::class, onDelete = CascadeAction.DETACH)
+    var partialInsuranceCompanyId: UUID? by reactiveProperty(null)
+
+    var deductibleComprehensive: BigDecimal? by reactiveProperty(null)
+    var deductiblePartial: BigDecimal? by reactiveProperty(null)
+    var defaultPolicyNumberLiability: String? by reactiveProperty(null)
+    var defaultPolicyNumberComprehensive: String? by reactiveProperty(null)
+    var defaultPolicyNumberPartial: String? by reactiveProperty(null)
+    var isOwnCoverage: Boolean by reactiveProperty(false)
+    var isConsortiumPolicyholder: Boolean by reactiveProperty(false)
+    var validFrom: LocalDate? by reactiveProperty(null)
+    var validUntil: LocalDate? by reactiveProperty(null)
+
+    override val uniqueId: String get() = "company-insurance-agreement-$id"
+
+    override fun clone(): CompanyInsuranceAgreement =
+        CompanyInsuranceAgreement(id).apply {
+            withEventsDisabled {
+                companyId = this@CompanyInsuranceAgreement.companyId
+                parentAgreementId = this@CompanyInsuranceAgreement.parentAgreementId
+                liabilityInsuranceCompanyId = this@CompanyInsuranceAgreement.liabilityInsuranceCompanyId
+                comprehensiveInsuranceCompanyId = this@CompanyInsuranceAgreement.comprehensiveInsuranceCompanyId
+                partialInsuranceCompanyId = this@CompanyInsuranceAgreement.partialInsuranceCompanyId
+                deductibleComprehensive = this@CompanyInsuranceAgreement.deductibleComprehensive
+                deductiblePartial = this@CompanyInsuranceAgreement.deductiblePartial
+                defaultPolicyNumberLiability = this@CompanyInsuranceAgreement.defaultPolicyNumberLiability
+                defaultPolicyNumberComprehensive = this@CompanyInsuranceAgreement.defaultPolicyNumberComprehensive
+                defaultPolicyNumberPartial = this@CompanyInsuranceAgreement.defaultPolicyNumberPartial
+                isOwnCoverage = this@CompanyInsuranceAgreement.isOwnCoverage
+                isConsortiumPolicyholder = this@CompanyInsuranceAgreement.isConsortiumPolicyholder
+                validFrom = this@CompanyInsuranceAgreement.validFrom
+                validUntil = this@CompanyInsuranceAgreement.validUntil
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/CompanyPerson.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/CompanyPerson.kt
@@ -1,0 +1,50 @@
+package net.transgressoft.fleet.company
+
+import net.transgressoft.fleet.common.CompanyPersonRole
+import net.transgressoft.fleet.person.Person
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Indexed
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Association between a [Company] and a person, defining the person's [role] within the company.
+ *
+ * An optional validity period ([validFrom], [validUntil]) constrains the active timeframe of
+ * the assignment. The [notes] field allows free-text remarks about the relationship.
+ */
+@PersistenceMapping(name = "company_persons")
+class CompanyPerson(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, CompanyPerson>() {
+
+    @Indexed
+    @ToOneAggregate(target = Company::class, onDelete = CascadeAction.CASCADE)
+    var companyId: UUID by reactiveProperty(UUID(0, 0))
+
+    @Indexed
+    @ToOneAggregate(target = Person::class, onDelete = CascadeAction.CASCADE)
+    var personId: UUID by reactiveProperty(UUID(0, 0))
+
+    var role: CompanyPersonRole by reactiveProperty(CompanyPersonRole.EMPLOYEE)
+    var validFrom: LocalDate? by reactiveProperty(null)
+    var validUntil: LocalDate? by reactiveProperty(null)
+    var notes: String? by reactiveProperty(null)
+
+    override val uniqueId: String get() = "company-person-$id"
+
+    override fun clone(): CompanyPerson =
+        CompanyPerson(id).apply {
+            withEventsDisabled {
+                companyId = this@CompanyPerson.companyId
+                personId = this@CompanyPerson.personId
+                role = this@CompanyPerson.role
+                validFrom = this@CompanyPerson.validFrom
+                validUntil = this@CompanyPerson.validUntil
+                notes = this@CompanyPerson.notes
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/CompanyRelationship.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/CompanyRelationship.kt
@@ -1,0 +1,58 @@
+package net.transgressoft.fleet.company
+
+import net.transgressoft.fleet.common.RelationshipType
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Indexed
+import net.transgressoft.lirp.persistence.PersistenceIgnore
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Directed relationship between two companies with a typed [relationshipType] and optional validity period.
+ *
+ * The [sourceCompanyId] is the originating party and [targetCompanyId] is the related party.
+ * The [isCurrentlyValid] computed property checks whether the relationship is active today
+ * and is excluded from persistence.
+ */
+@PersistenceMapping(name = "company_relationships")
+class CompanyRelationship(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, CompanyRelationship>() {
+
+    @Indexed
+    @ToOneAggregate(target = Company::class, onDelete = CascadeAction.CASCADE)
+    var sourceCompanyId: UUID by reactiveProperty(UUID(0, 0))
+
+    @Indexed
+    @ToOneAggregate(target = Company::class, onDelete = CascadeAction.CASCADE)
+    var targetCompanyId: UUID by reactiveProperty(UUID(0, 0))
+
+    var relationshipType: RelationshipType by reactiveProperty(RelationshipType.PARTNER)
+    var validFrom: LocalDate? by reactiveProperty(null)
+    var validUntil: LocalDate? by reactiveProperty(null)
+
+    @PersistenceIgnore
+    val isCurrentlyValid: Boolean
+        get() {
+            val today = LocalDate.now()
+            val afterStart = validFrom?.let { !today.isBefore(it) } ?: true
+            val beforeEnd = validUntil?.let { !today.isAfter(it) } ?: true
+            return afterStart && beforeEnd
+        }
+
+    override val uniqueId: String get() = "company-relationship-$id"
+
+    override fun clone(): CompanyRelationship =
+        CompanyRelationship(id).apply {
+            withEventsDisabled {
+                sourceCompanyId = this@CompanyRelationship.sourceCompanyId
+                targetCompanyId = this@CompanyRelationship.targetCompanyId
+                relationshipType = this@CompanyRelationship.relationshipType
+                validFrom = this@CompanyRelationship.validFrom
+                validUntil = this@CompanyRelationship.validUntil
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/CompanyRepository.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/company/CompanyRepository.kt
@@ -1,0 +1,64 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.fleet.company
+
+import net.transgressoft.lirp.persistence.LirpRepository
+import net.transgressoft.lirp.persistence.query.eq
+import net.transgressoft.lirp.persistence.query.query
+import net.transgressoft.lirp.persistence.sql.SqlRepository
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Factory and query surface for the [Company] aggregate.
+ *
+ * Auto-registers in [net.transgressoft.lirp.persistence.LirpContext.default] on construction
+ * and deregisters on [close].
+ *
+ * Factory methods build entities and add them to the repository in one call.
+ */
+@LirpRepository
+class CompanyRepository(dataSource: DataSource) :
+    SqlRepository<UUID, Company>(dataSource, Company_LirpTableDef) {
+
+    /**
+     * Creates a new company belonging to [tenantId] and adds it to the repository.
+     *
+     * @return the newly created [Company], already assigned a random id.
+     */
+    fun register(tenantId: UUID, name: String): Company =
+        Company(UUID.randomUUID(), tenantId).apply {
+            this.name = name
+        }.also(::add)
+
+    /**
+     * Returns all companies belonging to the given tenant.
+     */
+    fun findByTenant(tenantId: UUID): List<Company> =
+        query<UUID, Company> {
+            where { Company::tenantId eq tenantId }
+        }.toList()
+
+    /**
+     * Returns all companies whose [Company.name] matches [name] exactly.
+     */
+    fun findByName(name: String): List<Company> =
+        query<UUID, Company> {
+            where { Company::name eq name }
+        }.toList()
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/person/Person.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/person/Person.kt
@@ -1,0 +1,79 @@
+package net.transgressoft.fleet.person
+
+import net.transgressoft.fleet.common.Auditable
+import net.transgressoft.fleet.common.Salutation
+import net.transgressoft.fleet.common.Title
+import net.transgressoft.fleet.tenant.Tenant
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.MutableSoftDeletable
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.PersistenceIgnore
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Person entity representing an individual in the fleet domain.
+ *
+ * A person belongs to a [tenantId] and may have optional identity attributes such as
+ * [salutation], [title], and [birthDate]. Debtor/creditor numbers link to financial systems.
+ * The computed [fullName] property is excluded from persistence.
+ */
+@PersistenceMapping(name = "persons")
+class Person(
+    override val id: UUID,
+    tenantId: UUID
+) : ReactiveEntityBase<UUID, Person>(), Auditable, MutableSoftDeletable {
+
+    @ToOneAggregate(target = Tenant::class, onDelete = CascadeAction.RESTRICT)
+    var tenantId: UUID by reactiveProperty(tenantId)
+
+    var firstName: String by reactiveProperty("")
+    var lastName: String by reactiveProperty("")
+    var salutation: Salutation? by reactiveProperty(null)
+    var title: Title? by reactiveProperty(null)
+    var birthDate: LocalDate? by reactiveProperty(null)
+    var debtorNumber: String? by reactiveProperty(null)
+    var creditorNumber: String? by reactiveProperty(null)
+    var isVip: Boolean by reactiveProperty(false)
+    var notes: String? by reactiveProperty(null)
+    var legacyGrumId: String? by reactiveProperty(null)
+    var externalId: String? by reactiveProperty(null)
+
+    override var createdAt: LocalDateTime by reactiveProperty(LocalDateTime.now())
+    override var updatedAt: LocalDateTime by reactiveProperty(LocalDateTime.now())
+    override var createdBy: String? by reactiveProperty(null)
+    override var lastModifiedBy: String? by reactiveProperty(null)
+
+    override var deletedAt: Instant? by reactiveProperty(null)
+
+    @PersistenceIgnore
+    val fullName: String get() = "$firstName $lastName".trim()
+
+    override val uniqueId: String get() = "person-$id"
+
+    override fun clone(): Person =
+        Person(id, tenantId).apply {
+            withEventsDisabled {
+                firstName = this@Person.firstName
+                lastName = this@Person.lastName
+                salutation = this@Person.salutation
+                title = this@Person.title
+                birthDate = this@Person.birthDate
+                debtorNumber = this@Person.debtorNumber
+                creditorNumber = this@Person.creditorNumber
+                isVip = this@Person.isVip
+                notes = this@Person.notes
+                legacyGrumId = this@Person.legacyGrumId
+                externalId = this@Person.externalId
+                createdAt = this@Person.createdAt
+                updatedAt = this@Person.updatedAt
+                createdBy = this@Person.createdBy
+                lastModifiedBy = this@Person.lastModifiedBy
+                deletedAt = this@Person.deletedAt
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/person/PersonFeature.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/person/PersonFeature.kt
@@ -1,0 +1,55 @@
+package net.transgressoft.fleet.person
+
+import net.transgressoft.fleet.common.PersonFeatureType
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Indexed
+import net.transgressoft.lirp.persistence.PersistenceIgnore
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Association between a [Person] and a feature type, with optional validity period.
+ *
+ * A feature represents a qualification, certification, or attribute held by a person.
+ * The [isCurrentlyValid] computed property checks whether the feature is active today
+ * and is excluded from persistence.
+ */
+@PersistenceMapping(name = "person_features")
+class PersonFeature(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, PersonFeature>() {
+
+    @Indexed
+    @ToOneAggregate(target = Person::class, onDelete = CascadeAction.CASCADE)
+    var personId: UUID by reactiveProperty(UUID(0, 0))
+
+    @ToOneAggregate(target = PersonFeatureType::class, onDelete = CascadeAction.RESTRICT)
+    var featureTypeId: UUID by reactiveProperty(UUID(0, 0))
+
+    var validFrom: LocalDate? by reactiveProperty(null)
+    var validUntil: LocalDate? by reactiveProperty(null)
+
+    @PersistenceIgnore
+    val isCurrentlyValid: Boolean
+        get() {
+            val today = LocalDate.now()
+            val afterStart = validFrom?.let { !today.isBefore(it) } ?: true
+            val beforeEnd = validUntil?.let { !today.isAfter(it) } ?: true
+            return afterStart && beforeEnd
+        }
+
+    override val uniqueId: String get() = "person-feature-$id"
+
+    override fun clone(): PersonFeature =
+        PersonFeature(id).apply {
+            withEventsDisabled {
+                personId = this@PersonFeature.personId
+                featureTypeId = this@PersonFeature.featureTypeId
+                validFrom = this@PersonFeature.validFrom
+                validUntil = this@PersonFeature.validUntil
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/person/PersonRepository.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/person/PersonRepository.kt
@@ -1,0 +1,57 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.fleet.person
+
+import net.transgressoft.lirp.persistence.LirpRepository
+import net.transgressoft.lirp.persistence.query.eq
+import net.transgressoft.lirp.persistence.query.query
+import net.transgressoft.lirp.persistence.sql.SqlRepository
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Factory and query surface for the [Person] aggregate.
+ *
+ * Auto-registers in [net.transgressoft.lirp.persistence.LirpContext.default] on construction
+ * and deregisters on [close].
+ *
+ * Factory methods build entities and add them to the repository in one call.
+ */
+@LirpRepository
+class PersonRepository(dataSource: DataSource) :
+    SqlRepository<UUID, Person>(dataSource, Person_LirpTableDef) {
+
+    /**
+     * Creates a new person belonging to [tenantId] and adds them to the repository.
+     *
+     * @return the newly created [Person], already assigned a random id.
+     */
+    fun register(tenantId: UUID, firstName: String, lastName: String): Person =
+        Person(UUID.randomUUID(), tenantId).apply {
+            this.firstName = firstName
+            this.lastName = lastName
+        }.also(::add)
+
+    /**
+     * Returns all persons belonging to the given tenant.
+     */
+    fun findByTenant(tenantId: UUID): List<Person> =
+        query<UUID, Person> {
+            where { Person::tenantId eq tenantId }
+        }.toList()
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/tenant/Tenant.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/tenant/Tenant.kt
@@ -1,0 +1,69 @@
+package net.transgressoft.fleet.tenant
+
+import net.transgressoft.fleet.common.Auditable
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.MutableSoftDeletable
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import java.time.Instant
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Root tenant entity representing an organization in a multi-tenant hierarchy.
+ *
+ * Tenants can form a parent-child tree via [parentTenantId]. Root tenants have
+ * a null parent. The nullable [parentTenantId] produces an optional reference via
+ * the KSP-generated extension accessor.
+ */
+@PersistenceMapping(name = "tenants")
+class Tenant(
+    override val id: UUID,
+    parentTenantId: UUID? = null
+) : ReactiveEntityBase<UUID, Tenant>(), Auditable, MutableSoftDeletable {
+
+    var code: String by reactiveProperty("")
+    var name: String by reactiveProperty("")
+    var displayName: String? by reactiveProperty(null)
+    var shortName: String? by reactiveProperty(null)
+    var color: String? by reactiveProperty(null)
+    var logoUrl: String? by reactiveProperty(null)
+    var isSelectable: Boolean by reactiveProperty(true)
+    var isMainTenant: Boolean by reactiveProperty(false)
+    var sortOrder: Int? by reactiveProperty(null)
+    var legacyId: String? by reactiveProperty(null)
+
+    @ToOneAggregate(target = Tenant::class, onDelete = CascadeAction.DETACH)
+    var parentTenantId: UUID? by reactiveProperty(parentTenantId)
+
+    override var createdAt: LocalDateTime by reactiveProperty(LocalDateTime.now())
+    override var updatedAt: LocalDateTime by reactiveProperty(LocalDateTime.now())
+    override var createdBy: String? by reactiveProperty(null)
+    override var lastModifiedBy: String? by reactiveProperty(null)
+
+    override var deletedAt: Instant? by reactiveProperty(null)
+
+    override val uniqueId: String get() = "tenant-$id"
+
+    override fun clone(): Tenant =
+        Tenant(id, parentTenantId).apply {
+            withEventsDisabled {
+                code = this@Tenant.code
+                name = this@Tenant.name
+                displayName = this@Tenant.displayName
+                shortName = this@Tenant.shortName
+                color = this@Tenant.color
+                logoUrl = this@Tenant.logoUrl
+                isSelectable = this@Tenant.isSelectable
+                isMainTenant = this@Tenant.isMainTenant
+                sortOrder = this@Tenant.sortOrder
+                legacyId = this@Tenant.legacyId
+                createdAt = this@Tenant.createdAt
+                updatedAt = this@Tenant.updatedAt
+                createdBy = this@Tenant.createdBy
+                lastModifiedBy = this@Tenant.lastModifiedBy
+                deletedAt = this@Tenant.deletedAt
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/tenant/TenantRepository.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/tenant/TenantRepository.kt
@@ -1,0 +1,58 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.fleet.tenant
+
+import net.transgressoft.lirp.persistence.LirpRepository
+import net.transgressoft.lirp.persistence.query.eq
+import net.transgressoft.lirp.persistence.query.query
+import net.transgressoft.lirp.persistence.sql.SqlRepository
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Factory and query surface for the [Tenant] aggregate.
+ *
+ * Auto-registers in [net.transgressoft.lirp.persistence.LirpContext.default] on construction
+ * and deregisters on [close]. Tenants do not publish to Kafka — a plain [SqlRepository] is
+ * sufficient.
+ *
+ * Factory methods build entities and add them to the repository in one call.
+ */
+@LirpRepository
+class TenantRepository(dataSource: DataSource) :
+    SqlRepository<UUID, Tenant>(dataSource, Tenant_LirpTableDef) {
+
+    /**
+     * Creates a new tenant with the given [code] and [name] and adds it to the repository.
+     *
+     * @return the newly created [Tenant], already assigned a random id.
+     */
+    fun register(code: String, name: String): Tenant =
+        Tenant(UUID.randomUUID()).apply {
+            this.code = code
+            this.name = name
+        }.also(::add)
+
+    /**
+     * Returns all tenants whose [Tenant.code] matches [code] exactly.
+     */
+    fun findByCode(code: String): List<Tenant> =
+        query<UUID, Tenant> {
+            where { Tenant::code eq code }
+        }.toList()
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/Vehicle.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/Vehicle.kt
@@ -1,0 +1,93 @@
+package net.transgressoft.fleet.vehicle
+
+import net.transgressoft.fleet.common.Auditable
+import net.transgressoft.fleet.common.ContractStatus
+import net.transgressoft.fleet.common.EngineType
+import net.transgressoft.fleet.common.Manufacturer
+import net.transgressoft.fleet.common.VehicleBodyType
+import net.transgressoft.fleet.tenant.Tenant
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.MutableSoftDeletable
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Indexed
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import net.transgressoft.lirp.persistence.Version
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Core vehicle entity representing a physical vehicle in the fleet.
+ *
+ * A vehicle belongs to a [tenantId] and is uniquely identified by its [vin] (Vehicle Identification Number).
+ * The [contractStatus] tracks whether the vehicle is currently under an active contract or completed.
+ * Financial data such as [listenpreis] (list price) supports cost-center reporting via [costCenterCode].
+ */
+@PersistenceMapping(name = "vehicles")
+class Vehicle(
+    override val id: UUID,
+    tenantId: UUID
+) : ReactiveEntityBase<UUID, Vehicle>(), Auditable, MutableSoftDeletable {
+
+    @ToOneAggregate(target = Tenant::class, onDelete = CascadeAction.NONE)
+    var tenantId: UUID by reactiveProperty(tenantId)
+
+    @Indexed(name = "vin")
+    var vin: String by reactiveProperty("")
+
+    @ToOneAggregate(target = Manufacturer::class, onDelete = CascadeAction.DETACH)
+    var manufacturerId: UUID? by reactiveProperty(null)
+
+    var modelName: String by reactiveProperty("")
+
+    @ToOneAggregate(target = VehicleBodyType::class, onDelete = CascadeAction.DETACH)
+    var bodyTypeId: UUID? by reactiveProperty(null)
+
+    @ToOneAggregate(target = EngineType::class, onDelete = CascadeAction.DETACH)
+    var engineTypeId: UUID? by reactiveProperty(null)
+
+    var contractStatus: ContractStatus by reactiveProperty(ContractStatus.RUNNING)
+    var costCenterCode: String? by reactiveProperty(null)
+    var firstRegistrationDate: LocalDate? by reactiveProperty(null)
+    var listenpreis: BigDecimal? by reactiveProperty(null)
+    var legacyGrumId: String? by reactiveProperty(null)
+    var externalId: String? by reactiveProperty(null)
+
+    override var createdAt: LocalDateTime by reactiveProperty(LocalDateTime.now())
+    override var updatedAt: LocalDateTime by reactiveProperty(LocalDateTime.now())
+    override var createdBy: String? by reactiveProperty(null)
+    override var lastModifiedBy: String? by reactiveProperty(null)
+
+    override var deletedAt: Instant? by reactiveProperty(null)
+
+    @Version
+    var version: Long by reactiveProperty(0L)
+
+    override val uniqueId: String get() = "vehicle-$id"
+
+    override fun clone(): Vehicle =
+        Vehicle(id, tenantId).apply {
+            withEventsDisabled {
+                vin = this@Vehicle.vin
+                manufacturerId = this@Vehicle.manufacturerId
+                modelName = this@Vehicle.modelName
+                bodyTypeId = this@Vehicle.bodyTypeId
+                engineTypeId = this@Vehicle.engineTypeId
+                contractStatus = this@Vehicle.contractStatus
+                costCenterCode = this@Vehicle.costCenterCode
+                firstRegistrationDate = this@Vehicle.firstRegistrationDate
+                listenpreis = this@Vehicle.listenpreis
+                legacyGrumId = this@Vehicle.legacyGrumId
+                externalId = this@Vehicle.externalId
+                createdAt = this@Vehicle.createdAt
+                updatedAt = this@Vehicle.updatedAt
+                createdBy = this@Vehicle.createdBy
+                lastModifiedBy = this@Vehicle.lastModifiedBy
+                deletedAt = this@Vehicle.deletedAt
+                version = this@Vehicle.version
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/VehicleAssignment.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/VehicleAssignment.kt
@@ -1,0 +1,83 @@
+package net.transgressoft.fleet.vehicle
+
+import net.transgressoft.fleet.common.AssignmentType
+import net.transgressoft.fleet.common.VehicleUsageType
+import net.transgressoft.fleet.company.Company
+import net.transgressoft.fleet.person.Person
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Indexed
+import net.transgressoft.lirp.persistence.PersistenceIgnore
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import net.transgressoft.lirp.persistence.arm
+import net.transgressoft.lirp.persistence.polymorphicAggregate
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Assignment of a [Vehicle] to a person or company for a given period.
+ *
+ * The [assignmentType] determines whether the target is a driver, user, or holder.
+ * Exactly one of [personId] or [companyId] should be populated depending on the assignment target.
+ * The computed [isCurrentlyValid] property checks whether the assignment is active today and is
+ * excluded from persistence.
+ */
+@PersistenceMapping(name = "vehicle_assignments")
+class VehicleAssignment(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, VehicleAssignment>() {
+
+    @Indexed(name = "vehicleId")
+    @ToOneAggregate(target = Vehicle::class, onDelete = CascadeAction.CASCADE)
+    var vehicleId: UUID by reactiveProperty(UUID(0, 0))
+
+    var assignmentType: AssignmentType by reactiveProperty(AssignmentType.DRIVER)
+
+    @Indexed(name = "personId")
+    var personId: UUID? by reactiveProperty(null)
+
+    @Indexed(name = "companyId")
+    var companyId: UUID? by reactiveProperty(null)
+
+    /**
+     * Polymorphic assignment target: exactly one of [personId] or [companyId] must be set.
+     * The exactly-one invariant is enforced before persistence, and each arm keeps its own
+     * `SET NULL` foreign key. Resolve the active target with the generated typed accessor:
+     * `(assignedTo.resolution() as PolymorphicResolution<VehicleAssignmentAssignedToArm>).activeArm()`.
+     */
+    val assignedTo by polymorphicAggregate(
+        arm<UUID, Person>("individual", onDelete = CascadeAction.DETACH) { personId },
+        arm<UUID, Company>("organization", onDelete = CascadeAction.DETACH) { companyId }
+    )
+
+    @ToOneAggregate(target = VehicleUsageType::class, onDelete = CascadeAction.DETACH)
+    var usageTypeId: UUID? by reactiveProperty(null)
+
+    var validFrom: LocalDate? by reactiveProperty(null)
+    var validUntil: LocalDate? by reactiveProperty(null)
+
+    @PersistenceIgnore
+    val isCurrentlyValid: Boolean
+        get() {
+            val today = LocalDate.now()
+            val afterStart = validFrom?.let { !today.isBefore(it) } ?: true
+            val beforeEnd = validUntil?.let { !today.isAfter(it) } ?: true
+            return afterStart && beforeEnd
+        }
+
+    override val uniqueId: String get() = "vehicle-assignment-$id"
+
+    override fun clone(): VehicleAssignment =
+        VehicleAssignment(id).apply {
+            withEventsDisabled {
+                vehicleId = this@VehicleAssignment.vehicleId
+                assignmentType = this@VehicleAssignment.assignmentType
+                personId = this@VehicleAssignment.personId
+                companyId = this@VehicleAssignment.companyId
+                usageTypeId = this@VehicleAssignment.usageTypeId
+                validFrom = this@VehicleAssignment.validFrom
+                validUntil = this@VehicleAssignment.validUntil
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/VehicleAssignmentRepository.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/VehicleAssignmentRepository.kt
@@ -1,0 +1,96 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.fleet.vehicle
+
+import net.transgressoft.fleet.common.AssignmentType
+import net.transgressoft.lirp.persistence.LirpRepository
+import net.transgressoft.lirp.persistence.query.eq
+import net.transgressoft.lirp.persistence.query.query
+import net.transgressoft.lirp.persistence.sql.SqlRepository
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Factory and query surface for the [VehicleAssignment] aggregate.
+ *
+ * Auto-registers in [net.transgressoft.lirp.persistence.LirpContext.default] on construction
+ * and deregisters on [close]. Vehicle assignments are not Kafka-backed — a plain
+ * [SqlRepository] is sufficient for this PoC.
+ *
+ * Factory methods build entities and add them to the repository in one call. The
+ * `polymorphicAggregate` invariant (exactly one of [personId] / [companyId] set) is
+ * enforced by LIRP before persistence.
+ */
+@LirpRepository
+class VehicleAssignmentRepository(dataSource: DataSource) :
+    SqlRepository<UUID, VehicleAssignment>(dataSource, VehicleAssignment_LirpTableDef) {
+
+    /**
+     * Assigns a vehicle to a person (individual driver/user).
+     *
+     * Sets [VehicleAssignment.personId] and leaves [VehicleAssignment.companyId] null, satisfying
+     * the polymorphic `assignedTo` exactly-one invariant for the `individual` arm.
+     *
+     * @return the newly created [VehicleAssignment], already added to the repository.
+     */
+    fun assignToPerson(
+        vehicleId: UUID,
+        personId: UUID,
+        type: AssignmentType = AssignmentType.DRIVER
+    ): VehicleAssignment =
+        VehicleAssignment(UUID.randomUUID()).apply {
+            this.vehicleId = vehicleId
+            this.personId = personId
+            this.assignmentType = type
+        }.also(::add)
+
+    /**
+     * Assigns a vehicle to a company (organizational holder/user).
+     *
+     * Sets [VehicleAssignment.companyId] and leaves [VehicleAssignment.personId] null, satisfying
+     * the polymorphic `assignedTo` exactly-one invariant for the `organization` arm.
+     *
+     * @return the newly created [VehicleAssignment], already added to the repository.
+     */
+    fun assignToCompany(
+        vehicleId: UUID,
+        companyId: UUID,
+        type: AssignmentType = AssignmentType.USER
+    ): VehicleAssignment =
+        VehicleAssignment(UUID.randomUUID()).apply {
+            this.vehicleId = vehicleId
+            this.companyId = companyId
+            this.assignmentType = type
+        }.also(::add)
+
+    /**
+     * Returns all assignments for the given vehicle.
+     */
+    fun findByVehicle(vehicleId: UUID): List<VehicleAssignment> =
+        query<UUID, VehicleAssignment> {
+            where { VehicleAssignment::vehicleId eq vehicleId }
+        }.toList()
+
+    /**
+     * Returns all assignments for the given person.
+     */
+    fun findByPerson(personId: UUID): List<VehicleAssignment> =
+        query<UUID, VehicleAssignment> {
+            where { VehicleAssignment::personId eq personId }
+        }.toList()
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/VehicleInsurance.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/VehicleInsurance.kt
@@ -1,0 +1,82 @@
+package net.transgressoft.fleet.vehicle
+
+import net.transgressoft.fleet.common.PolicyType
+import net.transgressoft.fleet.company.Company
+import net.transgressoft.fleet.company.CompanyInsuranceAgreement
+import net.transgressoft.fleet.person.Person
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Indexed
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import net.transgressoft.lirp.persistence.arm
+import net.transgressoft.lirp.persistence.polymorphicAggregate
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Insurance policy attached to a [Vehicle], covering a specific [policyType] and validity period.
+ *
+ * The policyholder may be either a person ([policyholderPersonId]) or a company ([policyholderCompanyId]).
+ * Financial terms including [deductible], [coverageLimit], and [annualPremium] are stored with
+ * high-precision decimal types to support accurate premium calculations.
+ */
+@PersistenceMapping(name = "vehicle_insurances")
+class VehicleInsurance(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, VehicleInsurance>() {
+
+    @Indexed(name = "vehicleId")
+    @ToOneAggregate(target = Vehicle::class, onDelete = CascadeAction.CASCADE)
+    var vehicleId: UUID by reactiveProperty(UUID(0, 0))
+
+    @ToOneAggregate(target = Company::class, onDelete = CascadeAction.DETACH)
+    var insuranceCompanyId: UUID? by reactiveProperty(null)
+
+    var policyholderPersonId: UUID? by reactiveProperty(null)
+
+    var policyholderCompanyId: UUID? by reactiveProperty(null)
+
+    /**
+     * Polymorphic policyholder: exactly one of [policyholderPersonId] or [policyholderCompanyId]
+     * must be set. The exactly-one invariant is enforced before persistence, and each arm keeps
+     * its own `SET NULL` foreign key. Resolve the active policyholder with the generated typed
+     * accessor: `(policyholder.resolution() as PolymorphicResolution<VehicleInsurancePolicyholderArm>).activeArm()`.
+     */
+    val policyholder by polymorphicAggregate(
+        arm<UUID, Person>("individual", onDelete = CascadeAction.DETACH) { policyholderPersonId },
+        arm<UUID, Company>("organization", onDelete = CascadeAction.DETACH) { policyholderCompanyId }
+    )
+
+    @ToOneAggregate(target = CompanyInsuranceAgreement::class, onDelete = CascadeAction.DETACH)
+    var companyInsuranceAgreementId: UUID? by reactiveProperty(null)
+
+    var policyNumber: String by reactiveProperty("")
+    var policyType: PolicyType by reactiveProperty(PolicyType.LIABILITY)
+    var coverageStartDate: LocalDate? by reactiveProperty(null)
+    var coverageEndDate: LocalDate? by reactiveProperty(null)
+    var deductible: BigDecimal? by reactiveProperty(null)
+    var coverageLimit: BigDecimal? by reactiveProperty(null)
+    var annualPremium: BigDecimal? by reactiveProperty(null)
+
+    override val uniqueId: String get() = "vehicle-insurance-$id"
+
+    override fun clone(): VehicleInsurance =
+        VehicleInsurance(id).apply {
+            withEventsDisabled {
+                vehicleId = this@VehicleInsurance.vehicleId
+                insuranceCompanyId = this@VehicleInsurance.insuranceCompanyId
+                policyholderPersonId = this@VehicleInsurance.policyholderPersonId
+                policyholderCompanyId = this@VehicleInsurance.policyholderCompanyId
+                companyInsuranceAgreementId = this@VehicleInsurance.companyInsuranceAgreementId
+                policyNumber = this@VehicleInsurance.policyNumber
+                policyType = this@VehicleInsurance.policyType
+                coverageStartDate = this@VehicleInsurance.coverageStartDate
+                coverageEndDate = this@VehicleInsurance.coverageEndDate
+                deductible = this@VehicleInsurance.deductible
+                coverageLimit = this@VehicleInsurance.coverageLimit
+                annualPremium = this@VehicleInsurance.annualPremium
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/VehicleLease.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/VehicleLease.kt
@@ -1,0 +1,54 @@
+package net.transgressoft.fleet.vehicle
+
+import net.transgressoft.fleet.company.Company
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Indexed
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Lease contract associated with a [Vehicle], capturing both contractual and actual date ranges.
+ *
+ * The [contractStartDate] and [contractEndDate] reflect the agreed-upon lease period, while
+ * [actualStartDate] and [actualEndDate] record when the lease was physically active.
+ */
+@PersistenceMapping(name = "vehicle_leases")
+class VehicleLease(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, VehicleLease>() {
+
+    @Indexed(name = "vehicleId")
+    @ToOneAggregate(target = Vehicle::class, onDelete = CascadeAction.CASCADE)
+    var vehicleId: UUID by reactiveProperty(UUID(0, 0))
+
+    @ToOneAggregate(target = Company::class, onDelete = CascadeAction.DETACH)
+    var leasingCompanyId: UUID? by reactiveProperty(null)
+
+    var contractNumber: String by reactiveProperty("")
+
+    // contractTypeId has no domain entity in this model yet — no @ToOneAggregate emitted.
+    var contractTypeId: UUID? by reactiveProperty(null)
+    var contractStartDate: LocalDate? by reactiveProperty(null)
+    var contractEndDate: LocalDate? by reactiveProperty(null)
+    var actualStartDate: LocalDate? by reactiveProperty(null)
+    var actualEndDate: LocalDate? by reactiveProperty(null)
+
+    override val uniqueId: String get() = "vehicle-lease-$id"
+
+    override fun clone(): VehicleLease =
+        VehicleLease(id).apply {
+            withEventsDisabled {
+                vehicleId = this@VehicleLease.vehicleId
+                leasingCompanyId = this@VehicleLease.leasingCompanyId
+                contractNumber = this@VehicleLease.contractNumber
+                contractTypeId = this@VehicleLease.contractTypeId
+                contractStartDate = this@VehicleLease.contractStartDate
+                contractEndDate = this@VehicleLease.contractEndDate
+                actualStartDate = this@VehicleLease.actualStartDate
+                actualEndDate = this@VehicleLease.actualEndDate
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/VehicleLicensePlate.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/VehicleLicensePlate.kt
@@ -1,0 +1,58 @@
+package net.transgressoft.fleet.vehicle
+
+import net.transgressoft.fleet.common.Country
+import net.transgressoft.lirp.entity.CascadeAction
+import net.transgressoft.lirp.entity.ReactiveEntityBase
+import net.transgressoft.lirp.persistence.Indexed
+import net.transgressoft.lirp.persistence.PersistenceIgnore
+import net.transgressoft.lirp.persistence.PersistenceMapping
+import net.transgressoft.lirp.persistence.ToOneAggregate
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * License plate associated with a [Vehicle], supporting historical plate tracking via validity dates.
+ *
+ * Multiple plates may exist for a vehicle over time. The computed [isCurrentlyValid] property indicates
+ * whether the plate is active today and is excluded from persistence.
+ */
+@PersistenceMapping(name = "vehicle_license_plates")
+class VehicleLicensePlate(
+    override val id: UUID
+) : ReactiveEntityBase<UUID, VehicleLicensePlate>() {
+
+    @Indexed(name = "vehicleId")
+    @ToOneAggregate(target = Vehicle::class, onDelete = CascadeAction.CASCADE)
+    var vehicleId: UUID by reactiveProperty(UUID(0, 0))
+
+    @Indexed(name = "plateNumber")
+    var plateNumber: String by reactiveProperty("")
+
+    @ToOneAggregate(target = Country::class, onDelete = CascadeAction.DETACH)
+    var countryId: UUID? by reactiveProperty(null)
+
+    var validFrom: LocalDate? by reactiveProperty(null)
+    var validUntil: LocalDate? by reactiveProperty(null)
+
+    @PersistenceIgnore
+    val isCurrentlyValid: Boolean
+        get() {
+            val today = LocalDate.now()
+            val afterStart = validFrom?.let { !today.isBefore(it) } ?: true
+            val beforeEnd = validUntil?.let { !today.isAfter(it) } ?: true
+            return afterStart && beforeEnd
+        }
+
+    override val uniqueId: String get() = "vehicle-license-plate-$id"
+
+    override fun clone(): VehicleLicensePlate =
+        VehicleLicensePlate(id).apply {
+            withEventsDisabled {
+                vehicleId = this@VehicleLicensePlate.vehicleId
+                plateNumber = this@VehicleLicensePlate.plateNumber
+                countryId = this@VehicleLicensePlate.countryId
+                validFrom = this@VehicleLicensePlate.validFrom
+                validUntil = this@VehicleLicensePlate.validUntil
+            }
+        }
+}

--- a/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/VehicleRepository.kt
+++ b/lirp-e2e/src/main/kotlin/net/transgressoft/fleet/vehicle/VehicleRepository.kt
@@ -1,0 +1,139 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.fleet.vehicle
+
+import net.transgressoft.lirp.kafka.KafkaOutboxSqlRepository
+import net.transgressoft.lirp.persistence.LirpRepository
+import net.transgressoft.lirp.persistence.query.DiagnosedQuery
+import net.transgressoft.lirp.persistence.query.eq
+import net.transgressoft.lirp.persistence.query.query
+import net.transgressoft.lirp.persistence.query.queryWithDiagnostics
+import net.transgressoft.lirp.persistence.transaction
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * Kafka-backed factory and query surface for the [Vehicle] aggregate.
+ *
+ * Extends [KafkaOutboxSqlRepository] so every create, update, and soft-delete mutation is
+ * captured into the transactional outbox and published to Kafka by the relay. Auto-registers
+ * in [net.transgressoft.lirp.persistence.LirpContext.default] on construction and deregisters
+ * on [close].
+ *
+ * Factory methods build entities and add them to the repository in one call. Query methods
+ * use the LIRP query DSL; [Vehicle.vin] carries `@Indexed`, so equality lookups on VIN take the
+ * index-aware planner path.
+ */
+@LirpRepository
+class VehicleRepository(dataSource: DataSource) :
+    KafkaOutboxSqlRepository<UUID, Vehicle>(dataSource, Vehicle_LirpTableDef) {
+
+    /**
+     * Creates a new vehicle and adds it to the repository via the debounced write pipeline.
+     *
+     * The outbox row is captured when the debounce window elapses and then published by the relay.
+     *
+     * @return the newly created [Vehicle], already assigned a random id.
+     */
+    fun register(tenantId: UUID, vin: String): Vehicle =
+        Vehicle(UUID.randomUUID(), tenantId).apply { this.vin = vin }.also(::add)
+
+    /**
+     * Creates a new vehicle atomically inside an explicit transaction.
+     *
+     * The outbox row is written in the same transaction as the entity row, so Kafka receipt
+     * arrives without debounce delay.
+     *
+     * @return the newly created [Vehicle], already assigned a random id.
+     */
+    suspend fun registerAtomically(tenantId: UUID, vin: String): Vehicle {
+        val vehicle = Vehicle(UUID.randomUUID(), tenantId).apply { this.vin = vin }
+        transaction(this) { repo -> repo.add(vehicle) }
+        return vehicle
+    }
+
+    /**
+     * Updates the VIN of an existing vehicle in-place.
+     *
+     * The assignment triggers a reactive property mutation that is debounced and flushed to
+     * the backing store; the relay then publishes the resulting Update event to Kafka.
+     */
+    fun changeVin(vehicle: Vehicle, newVin: String) {
+        vehicle.vin = newVin
+    }
+
+    /**
+     * Soft-deletes a vehicle, marking it as decommissioned.
+     *
+     * Sets [Vehicle.deletedAt] to the current instant, removes the vehicle from default
+     * iteration and projections, and triggers a Delete event through the relay pipeline.
+     */
+    fun decommission(vehicle: Vehicle) {
+        softDelete(vehicle)
+    }
+
+    /**
+     * Returns all vehicles whose VIN matches [vin] exactly.
+     *
+     * Because [Vehicle.vin] carries `@Indexed`, the query planner resolves this lookup via
+     * the index, reporting an index hit in [diagnoseByVin].
+     */
+    fun findByVin(vin: String): List<Vehicle> =
+        query<UUID, Vehicle> {
+            where { Vehicle::vin eq vin }
+        }.toList()
+
+    /**
+     * Returns all vehicles belonging to the given tenant.
+     */
+    fun findByTenant(tenantId: UUID): List<Vehicle> =
+        query<UUID, Vehicle> {
+            where { Vehicle::tenantId eq tenantId }
+        }.toList()
+
+    /**
+     * Executes a VIN lookup and returns results together with query-planner diagnostics.
+     *
+     * The [DiagnosedQuery.diagnostic] reports index hits because [Vehicle.vin] is `@Indexed`.
+     */
+    fun diagnoseByVin(vin: String): DiagnosedQuery<Vehicle> =
+        queryWithDiagnostics<UUID, Vehicle> {
+            where { Vehicle::vin eq vin }
+        }
+
+    /**
+     * Returns all vehicles with the given VIN, including soft-deleted (decommissioned) vehicles.
+     *
+     * Useful for auditing or checking whether a VIN was previously registered.
+     */
+    fun findByVinIncludingDeleted(vin: String): List<Vehicle> =
+        query<UUID, Vehicle> {
+            where { Vehicle::vin eq vin }
+            includeDeleted()
+        }.toList()
+
+    /**
+     * Returns only soft-deleted (decommissioned) vehicles.
+     *
+     * Excludes active vehicles from the result set.
+     */
+    fun findDecommissioned(): List<Vehicle> =
+        query<UUID, Vehicle> {
+            onlyDeleted()
+        }.toList()
+}

--- a/lirp-kafka/api/lirp-kafka.api
+++ b/lirp-kafka/api/lirp-kafka.api
@@ -46,9 +46,11 @@ public final class net/transgressoft/lirp/kafka/KafkaOutboxConfig$Companion {
 	public final fun getDEFAULT ()Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;
 }
 
-public final class net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository : net/transgressoft/lirp/persistence/sql/SqlRepository {
+public class net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository : net/transgressoft/lirp/persistence/sql/SqlRepository {
 	public fun <init> (Ljavax/sql/DataSource;Lnet/transgressoft/lirp/persistence/sql/SqlTableDef;Z)V
 	public synthetic fun <init> (Ljavax/sql/DataSource;Lnet/transgressoft/lirp/persistence/sql/SqlTableDef;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected fun onAfterEntityWritesInTransaction (Lnet/transgressoft/lirp/persistence/TransactionBuffer;)V
+	protected fun onAfterEntityWritesInWritePending (Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
 }
 
 public final class net/transgressoft/lirp/kafka/LirpKafkaConfig : java/lang/AutoCloseable {

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository.kt
@@ -70,7 +70,7 @@ import kotlinx.serialization.json.put
  * @param loadOnInit When `true` (default), rows are loaded from the database immediately during
  *   construction.
  */
-class KafkaOutboxSqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
+open class KafkaOutboxSqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
     dataSource: DataSource,
     private val tableDef: SqlTableDef<R>,
     loadOnInit: Boolean = true

--- a/lirp-ksp/build.gradle
+++ b/lirp-ksp/build.gradle
@@ -10,6 +10,7 @@ dependencies {
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-gradle-plugin-api'
     }
     testImplementation(project(path: ':lirp-sql'))
+    testImplementation(project(path: ':lirp-kafka'))
     testImplementation(libs.kctfork.ksp)
     testImplementation platform(libs.junit.bom)
     testImplementation libs.bundles.kotest

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessor.kt
@@ -35,7 +35,9 @@ private val REPOSITORY_BASE_FQN_SET =
         "net.transgressoft.lirp.persistence.VolatileRepository",
         "net.transgressoft.lirp.persistence.PersistentRepositoryBase",
         "net.transgressoft.lirp.persistence.json.JsonFileRepository",
-        "net.transgressoft.lirp.persistence.json.FlexibleJsonFileRepository"
+        "net.transgressoft.lirp.persistence.json.FlexibleJsonFileRepository",
+        "net.transgressoft.lirp.persistence.sql.SqlRepository",
+        "net.transgressoft.lirp.kafka.KafkaOutboxSqlRepository"
     )
 
 /**

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/LirpRepositoryProcessorTest.kt
@@ -257,6 +257,70 @@ internal class LirpRepositoryProcessorTest : FunSpec({
         result.messages shouldContain "must have exactly one Repository-typed constructor parameter"
     }
 
+    test("generates _LirpRegistryInfo for repository extending SqlRepository directly") {
+        val result =
+            KspTestSupport.compile(
+                LirpRepositoryProcessorProvider(),
+                SourceFile.kotlin(
+                    "ItemSqlRepo.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.LirpRepository
+                    import net.transgressoft.lirp.persistence.sql.SqlRepository
+                    import net.transgressoft.lirp.persistence.sql.SqlTableDef
+                    import javax.sql.DataSource
+
+                    data class ItemEntity(override val id: Int) : ReactiveEntityBase<Int, ItemEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+
+                    @LirpRepository
+                    class ItemSqlRepo(dataSource: DataSource, tableDef: SqlTableDef<ItemEntity>) :
+                        SqlRepository<Int, ItemEntity>(dataSource, tableDef)
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("ItemSqlRepo_LirpRegistryInfo.kt")
+        content shouldContain "`ItemSqlRepo_LirpRegistryInfo`"
+        content shouldContain "ItemEntity::class.java"
+    }
+
+    test("generates _LirpRegistryInfo for repository extending KafkaOutboxSqlRepository") {
+        val result =
+            KspTestSupport.compile(
+                LirpRepositoryProcessorProvider(),
+                SourceFile.kotlin(
+                    "EventSqlRepo.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.LirpRepository
+                    import net.transgressoft.lirp.kafka.KafkaOutboxSqlRepository
+                    import net.transgressoft.lirp.persistence.sql.SqlTableDef
+                    import javax.sql.DataSource
+
+                    data class EventEntity(override val id: Int) : ReactiveEntityBase<Int, EventEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                    }
+
+                    @LirpRepository
+                    class EventSqlRepo(dataSource: DataSource, tableDef: SqlTableDef<EventEntity>) :
+                        KafkaOutboxSqlRepository<Int, EventEntity>(dataSource, tableDef)
+                    """
+                )
+            )
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        val content = result.generatedFileContent("EventSqlRepo_LirpRegistryInfo.kt")
+        content shouldContain "`EventSqlRepo_LirpRegistryInfo`"
+        content shouldContain "EventEntity::class.java"
+    }
+
     test("class annotated with @LirpRepository that neither extends base nor delegates gets warn-and-skip") {
         val result =
             KspTestSupport.compile(

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = 'lirp'
-include 'lirp-api', 'lirp-core', 'lirp-ksp', 'lirp-sql-api', 'lirp-sql', 'lirp-fx', 'lirp-benchmark', 'lirp-gradle-plugin', 'lirp-kafka'
+include 'lirp-api', 'lirp-core', 'lirp-ksp', 'lirp-sql-api', 'lirp-sql', 'lirp-fx', 'lirp-benchmark', 'lirp-gradle-plugin', 'lirp-kafka', 'lirp-e2e'


### PR DESCRIPTION
Closes #299.

## Summary

Adds a new `lirp-e2e` Gradle module in which a **full-fledged fleet application consumes LIRP as a real component** — via the `@LirpRepository` repository-as-factory pattern — and validates the full transactional-outbox chain end-to-end against **Kafka + Postgres Testcontainers**, where receipt of messages from Kafka is the assertion. It doubles as a dogfooding harness for the library.

## What changed

### New `lirp-e2e` module
- Vendors a fleet domain (24 entity/model files: tenants, vehicles, persons, companies and their value objects), migrated to the built-in `MutableSoftDeletable` (`deletedAt: Instant?`).
- Registered in the multi-module build with an `integrationTest` source set; KSP table-def codegen wired via `ksp project(':lirp-ksp')` + `ksp project(':lirp-sql')`. `check.dependsOn integrationTest` wires the suite into `gradle build` for CI. The module is excluded from the binary-compatibility-validator and from Maven publishing (it is a non-published dogfood module), and its integration sources are marked as test sources for IDE support.

### Fleet application — repository-as-factory pattern
- Five `@LirpRepository` factory classes, each exposing typed factory methods and query-DSL finders, auto-registered in `LirpContext.default`: `VehicleRepository` (Kafka-backed `KafkaOutboxSqlRepository`), `TenantRepository`, `PersonRepository`, `CompanyRepository`, `VehicleAssignmentRepository`.
- `FleetApplication` composes the repositories, the outbox relay, and a `registryProjection` bucketing vehicles by tenant; it owns the relay lifecycle (idempotent `close()` deregisters the repositories).

### Integration test suite (10 tests, Postgres + Kafka Testcontainers)
Each feature is exercised through the application and — where a mutation occurs — asserted against a plain, non-LIRP `KafkaConsumer` (raw JSON value + `ce_*` CloudEvents headers, key = aggregate id):

- Vehicle lifecycle: create / update / soft-delete each reaching Kafka, while the projection map and Query DSL reflect state.
- Transactional and debounced capture paths; at-least-once redelivery after a simulated service crash.
- Optimistic locking → `StandardCrudEvent.Conflict`.
- Aggregate navigation (`vehicle.tenant.resolve()`) and a `polymorphicAggregate` assignment (a vehicle assigned to a person).
- `restore()` plus `includeDeleted()` / `onlyDeleted()` soft-delete visibility.
- Repository-level `CrudEvent` and entity-level `PropertyChanged` subscriptions.

## Library changes surfaced by the dogfooding (please review)

Building a real consumer surfaced genuine gaps in the published library, fixed here:

- **`lirp-ksp`** — the `@LirpRepository` processor did not recognise `SqlRepository` or `KafkaOutboxSqlRepository` as repository base classes, so it could not resolve the entity type for SQL/Kafka-backed repositories (even though `@LirpRepository` on `SqlRepository` is documented in the README). Both are now in the base-class set, with tests. Additive, non-breaking.
- **`lirp-kafka`** — `KafkaOutboxSqlRepository` is now `open` so it can be subclassed with `@LirpRepository` (`SqlRepository` was already `open`). Additive, non-breaking.
- **`lirp-e2e`** — `Vehicle.tenantId` aggregate cascade changed `RESTRICT → NONE`. Cascade fires when the *referencing* entity is soft-deleted, so `RESTRICT` there blocks a vehicle's own decommission while its tenant is active — not the intent. `NONE` is correct for a non-null child→parent reference (the docs' own `Tenant.parentTenantId` example uses `DETACH` for a nullable one).

## How it was tested

- `gradle :lirp-e2e:integrationTest` — 10 tests, 0 failures (Postgres + Kafka Testcontainers; requires Docker on the runner).
- `gradle build` — full build green: all module unit tests, ktlint, `apiCheck`, and the `lirp-e2e` integration suite via `check.dependsOn integrationTest`.

## Notes

- The new integration suite requires a Docker daemon on the CI runner (Testcontainers spins up Postgres + Kafka).
