### PR TITLE
Kafka integration documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,76 @@
 All notable changes to **LIRP (Lightweight Reactive Persistence)** are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
-project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Detailed release
+notes begin with 3.0.0; for earlier releases (including SQLite as a fourth SQL dialect in 2.5.0)
+see the [GitHub releases](https://github.com/octaviospain/lirp/releases).
+
+## [Unreleased]
+
+## [3.2.0] - 2026-07-02
+
+Version 3.2.0 introduces the new `lirp-kafka` module, which adds transactional-outbox Kafka
+publishing of domain events. All changes in this release are additive and non-breaking — no
+migration steps are required. The module is published to Maven Central under the `net.transgressoft`
+group and scopes `kafka-clients` exclusively as an implementation dependency (see
+[#289](https://github.com/octaviospain/lirp/issues/289)).
+
+### Added
+
+- **`lirp-kafka` module — transactional-outbox Kafka publishing.** A repository extends
+  `KafkaOutboxSqlRepository<K, R>` (a `SqlRepository` subclass) so every create, update, and
+  soft-delete co-inserts an outbox row into the `lirp_kafka_outbox` table atomically inside the same
+  JDBC commit that persists the entity — no dual-write window exists. Capture covers both the explicit
+  `transaction { }` path (including buffered `PropertyChanged` / `BatchChanged` mutation events) and
+  the debounced write-pending path. Only SQL-backed repositories participate; `JsonFileRepository` and
+  `VolatileRepository` are unsupported for atomic outbox writes.
+  See [#285](https://github.com/octaviospain/lirp/issues/285),
+  [#286](https://github.com/octaviospain/lirp/issues/286).
+
+- **Outbox relay.** `LirpKafkaConfig.create(bootstrapServers)` builds the entry-point configuration,
+  and `startRelay(dataSource, config)` launches a background coroutine that polls unsent outbox rows,
+  publishes each to Kafka, and marks it sent only after the broker acknowledges — at-least-once
+  delivery with no loss. The Kafka record key is the aggregate id (per-aggregate ordering). Rows that
+  exhaust the configured retry limit (default 5) or encounter a non-retriable error are moved to a
+  dead-letter table. `LirpKafkaConfig` is `AutoCloseable`; calling `close()` stops the relay and
+  releases broker connections.
+  See [#287](https://github.com/octaviospain/lirp/issues/287).
+
+- **`KafkaEventPublisher`.** Implements `LirpEventPublisher<ET, E>` so it is injectable
+  interchangeably with `FlowEventPublisher`. All `subscribe` / `subscribeAsync` / `changes`
+  operations delegate to an internal `FlowEventPublisher`, preserving in-process reactive delivery.
+  `emitAsync` routes custom events through the transactional outbox before delivering them to local
+  subscribers. Framework-owned `CrudEvent.Type` and `MutationEvent.Type` events are captured by
+  the `KafkaOutboxSqlRepository` flush hook and only delivered locally by this publisher. Custom
+  events must implement `OutboxRoutableEvent` to supply an `aggregateId` and `payload`; emitting a
+  non-routable event throws immediately to surface the misconfiguration.
+  See [#288](https://github.com/octaviospain/lirp/issues/288).
+
+- **Pluggable serialization and topic SPIs.** `LirpEventSerializer` serializes and deserializes
+  `LirpEventEnvelope` instances to and from wire bytes. The default implementation,
+  `CloudEventsBinarySerializer`, encodes events as CloudEvents v1.0 binary content mode: `ce_*`
+  Kafka record headers carry CloudEvents attributes (`ce_specversion`, `ce_id`, `ce_source`,
+  `ce_type`, `ce_subject`, `ce_time`, `content-type`) and the neutral JSON field snapshot is the raw
+  record value, readable by non-LIRP consumers without a CloudEvents SDK. The `ce_id` header carries
+  the outbox row UUID and serves as an idempotency key for consumer-side deduplication.
+  `TopicResolver` is a `fun interface` that resolves the Kafka topic name from an envelope; the
+  default `DefaultTopicResolver` returns `"${aggregateType}.events"`. Consumers can substitute
+  alternative wire encodings (Avro, Protobuf) and routing strategies by passing custom
+  implementations to `startRelay`.
+  See [#288](https://github.com/octaviospain/lirp/issues/288).
+
+- **`KafkaOutboxConfig` relay knobs.** A `data class` with documented, startup-validated defaults:
+  poll interval 500 ms, batch size 100, max retries 5, retry base delay 1 000 ms, retry max delay
+  60 000 ms. Invalid values (non-positive poll interval or batch size, negative max retries, max
+  delay less than base delay) are rejected at construction with `IllegalArgumentException`.
+  `KafkaOutboxConfig.DEFAULT` covers most deployments without tuning.
+
+- **Additive `@LirpRepository` and `KafkaOutboxSqlRepository` changes (dogfooding).** The KSP
+  processor now resolves `@LirpRepository` annotations on `SqlRepository` and
+  `KafkaOutboxSqlRepository` subclasses, so Kafka-backed repositories participate in `LirpContext`
+  wiring without any extra configuration. `KafkaOutboxSqlRepository` is now `open`, allowing
+  consumers to subclass it further. Both changes are additive and backward compatible.
+  See [#299](https://github.com/octaviospain/lirp/issues/299).
 
 ## [3.1.0] - 2026-06-29
 
@@ -396,14 +465,14 @@ These are **breaking changes**; see [Migration from 2.x to 3.0.0](#migration-fro
   `@ToManyAggregates`. The annotation's parameters (`bubbleUp`, `onDelete`) are unchanged.
   `@ToManyAggregates` is now **collection-only**: applying it to a single (non-collection) reference
   is a compile error directing you to `@ToOneAggregate`, making the to-one/to-many split
-  self-enforcing. See [Migration](#migration-aggregate-to-tomanyaggregates) below.
+  self-enforcing. See [Migration](#aggregate-renamed-to-tomanyaggregates) below.
 
 ### Removed
 
 - **Single-entity `@Aggregate` (to-one) removed** — the two-declaration pattern (`var xId` scalar
   + `@Aggregate @PersistenceIgnore val x by optionalAggregate { xId }`) is replaced entirely by
   `@ToOneAggregate` placed directly on the persisted FK scalar. All single-entity `@Aggregate`
-  usages must be migrated to `@ToOneAggregate`. See [Migration](#migration-toone-aggregate) below.
+  usages must be migrated to `@ToOneAggregate`. See [Migration](#single-entity-aggregate-replaced-by-tooneaggregate) below.
 
 - **Core projection package** — all projection types moved from `net.transgressoft.lirp.persistence`
   to `net.transgressoft.lirp.persistence.projection`, and the `CoreFactories` file was renamed to
@@ -437,7 +506,7 @@ These are **breaking changes**; see [Migration from 2.x to 3.0.0](#migration-fro
 
 ## Migration from 2.x to 3.0
 
-### Single-entity `@Aggregate` replaced by `@ToOneAggregate` {#migration-toone-aggregate}
+### Single-entity `@Aggregate` replaced by `@ToOneAggregate`
 
 The two-declaration pattern for single-entity FK references is replaced by a single annotation on
 the persisted FK scalar. The `@Aggregate` annotation is removed; use `@ToOneAggregate` instead. The
@@ -517,7 +586,7 @@ reference — `resolve()` returns `Optional.empty()` when the FK is null. A non-
 
 See [GitHub #255](https://github.com/octaviospain/lirp/issues/255) for background.
 
-### `@Aggregate` renamed to `@ToManyAggregates` {#migration-aggregate-to-tomanyaggregates}
+### `@Aggregate` renamed to `@ToManyAggregates`
 
 All `@Aggregate` annotations on collection-typed properties must be renamed to `@ToManyAggregates`.
 The parameters are identical:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A Kotlin/Java library where domain entities own their reactivity — property ch
 - [Quick Start](#quick-start)
 - [SQL Persistence](#sql-persistence)
 - [Query DSL](#query-dsl)
+- [Kafka Integration](#kafka-integration)
 - [Features](#features)
 - [Limitations and Design Trade-offs](#limitations-and-design-trade-offs)
 - [Performance](#performance)
@@ -63,7 +64,7 @@ reactive entity + in-memory / JSON repository surface; add `lirp-sql` for the SQ
 `lirp-fx` for the JavaFX bridge. The `net.transgressoft.lirp.sql` Gradle plugin wires up the KSP
 processor for you so generated accessors are produced at build time.
 
-**Requirements:** JVM 21 toolchain (JVM 17+ runtime), Kotlin 2.3.10.
+**Requirements:** JVM 21 toolchain (JVM 17+ runtime), Kotlin 2.4.0.
 
 Gradle (Kotlin DSL):
 ```kotlin
@@ -318,6 +319,59 @@ The returned `Sequence<T>` is lazy — no evaluation occurs until a terminal ope
 
 Deep coverage of the write pipeline, collapse algorithm, transactional guarantees, `@Version` optimistic locking, aggregate references, cascade semantics, collection delegates, JSON persistence, and JavaFX integration lives on the wiki — see [Documentation](#documentation) below.
 
+## Kafka Integration
+
+`lirp-kafka` publishes domain mutations to Kafka using the **transactional outbox** pattern: the
+outbox row and the entity row are written in the same JDBC commit, eliminating the dual-write /
+lost-event window. A background relay polls the outbox and delivers each row to the broker.
+
+### Zero per-event wiring
+
+Extend `KafkaOutboxSqlRepository<K, R>` instead of `SqlRepository<K, R>`. Every create, update, and
+soft-delete co-inserts an outbox row in the same transaction that persists the entity — no manual
+event emission needed:
+
+```kotlin
+@LirpRepository
+class VehicleRepository(dataSource: DataSource) :
+    KafkaOutboxSqlRepository<UUID, Vehicle>(dataSource, Vehicle_LirpTableDef)
+```
+
+### Starting the relay
+
+Create a `LirpKafkaConfig` with the broker address, then call `startRelay` with the shared
+`DataSource`. The relay runs on a background coroutine and stops when `close` is called:
+
+```kotlin
+val kafka = LirpKafkaConfig.create(bootstrapServers)
+kafka.startRelay(dataSource, KafkaOutboxConfig.DEFAULT)
+
+// ...
+
+kafka.close()  // stops the relay and releases the broker connection
+```
+
+`KafkaOutboxConfig` exposes relay tuning knobs: `pollIntervalMs` (default 500 ms), `batchSize`
+(default 100), `maxRetries` (default 5), and exponential `retryBaseDelayMs` / `retryMaxDelayMs`.
+Pass `KafkaOutboxConfig.DEFAULT` or a custom instance to `startRelay`.
+
+### Delivery semantics
+
+Publishing is **at-least-once**: if the relay crashes after sending a record but before marking it sent, the row is eligible for redelivery on the next polling cycle.
+Each Kafka record carries the aggregate id as the
+key (preserving per-aggregate ordering) and a `ce_id` CloudEvents header set to the outbox row's
+UUID — consumers use it as an idempotency key for dedup. Rows that exhaust all retries move to a
+dead-letter table.
+
+### Supported store
+
+Only SQL-backed repositories participate in the transactional outbox. `JsonFileRepository` and
+`VolatileRepository` cannot guarantee atomic outbox writes and are explicitly unsupported.
+
+For architecture details, the serialization (`LirpEventSerializer` / CloudEvents default) and topic
+(`TopicResolver`) SPIs, redelivery behaviour, and the inbound-consumption DIY pattern see
+[Kafka Integration](https://github.com/octaviospain/lirp/wiki/Kafka-Integration) on the wiki.
+
 ## Features
 
 - **Transparent SQL persistence** — add an entity, change a property, the database stays in sync automatically
@@ -338,6 +392,7 @@ Deep coverage of the write pipeline, collapse algorithm, transactional guarantee
 - **Repository-as-factory** — typed `create()` methods with automatic `@LirpRepository` registration
 - **JavaFX integration** (`lirp-fx`) — `fxAggregateList`/`fxAggregateSet` bridging lirp collections with `ObservableList`/`ObservableSet`, scalar delegates (`fxString`, `fxInteger`, etc.), read-only `ObservableMap` projections
 - **Non-FX projection maps** — `projection` (aggregate source) and `registryProjection` (whole-registry source) in `lirp-core` group entities into a `Map<PK, List<E>>` with no JavaFX dependency. An optional value-transform (`{ pk, items -> V }`) maps each bucket to a derived value, recomputed only for affected buckets, and a multi-key extractor (`multiKeyProjection`) places one entity in every bucket its key set yields. Registry-backed projections are `AutoCloseable`
+- **Kafka event publishing** (`lirp-kafka`) — domain mutations are published to Kafka through a transactional outbox with zero per-event wiring; a repository extends `KafkaOutboxSqlRepository` and a background relay delivers each committed change at-least-once to a Kafka topic
 - **Full Java interoperability**
 
 ## Limitations and Design Trade-offs
@@ -411,6 +466,12 @@ val repo = SqlRepository<Int, Album>(
 Individual subscriptions can also carry an independent error handler via
 `subscribeAsync(action, onError)`, independent of the repository-level handler.
 
+## Upgrading to v3.2.0
+
+Version 3.2.0 adds the optional `lirp-kafka` module for transactional-outbox Kafka publishing. All
+changes are additive and non-breaking — existing code requires no migration. Opt in by adding the
+`lirp-kafka` dependency; see the [Kafka Integration](https://github.com/octaviospain/lirp/wiki/Kafka-Integration) wiki page.
+
 ## Upgrading to v3.1.0
 
 Version 3.1.0 adds first-class soft delete and removes two public API elements deprecated since 3.0.0.
@@ -458,6 +519,7 @@ The **[LIRP Wiki](https://github.com/octaviospain/lirp/wiki)** is the canonical 
 | [SQL Mappings](https://github.com/octaviospain/lirp/wiki/SQL-Mappings) | Column types, custom converters, embeddable value objects, element collections, `@PersistenceCreator`, `@Indexed`, UUID storage |
 | [SQL Schema & Relationships](https://github.com/octaviospain/lirp/wiki/SQL-Schema-and-Relationships) | Auto table creation, foreign keys & junction tables, `SqlTableDef` capability interfaces, dialect notes |
 | [Transactional Boundaries](https://github.com/octaviospain/lirp/wiki/Transactional-Boundaries) | Single-aggregate atomicity, `@Version` optimistic locking, `Conflict` event, saga/compensation pattern |
+| [Kafka Integration](https://github.com/octaviospain/lirp/wiki/Kafka-Integration) | `lirp-kafka` architecture (mutation → outbox → relay → Kafka → consumer), setup, the serialization + topic SPIs, delivery semantics (at-least-once, idempotency key, redelivery, dead-letter), and the inbound-consumption DIY pattern |
 | [Soft Delete](https://github.com/octaviospain/lirp/wiki/Soft-Delete) | Reversible deletes, `SoftDelete`/`Restore` events, cross-aggregate `via()` visibility |
 | [JSON Persistence](https://github.com/octaviospain/lirp/wiki/JSON-Persistence) | `JsonFileRepository`, `LirpEntitySerializer`, polymorphic serializers, deferred loading, `JsonFkPolicy` reconciliation |
 | [JavaFX Integration](https://github.com/octaviospain/lirp/wiki/JavaFX-Integration) | `lirp-fx`, `fxAggregateList`/`fxAggregateSet`, scalar delegates, dual notification, FX thread dispatch |
@@ -477,6 +539,7 @@ The **[LIRP Wiki](https://github.com/octaviospain/lirp/wiki)** is the canonical 
 | `lirp-sql-api` | Pure SQL contracts: `SqlTableDef`, `JunctionAware`, `ForeignKeyAware`, `VersionedTableDef`. Sits between `lirp-api` and `lirp-sql` — no implementation, no Exposed/HikariCP dependency. |
 | `lirp-sql` | `SqlRepository` built on JetBrains Exposed + HikariCP. Supports PostgreSQL/MySQL/MariaDB/SQLite (MS SQL/Oracle untested). |
 | `lirp-fx` | JavaFX bridge: `fxAggregateList`/`fxAggregateSet`, scalar delegates (`fxString`, `fxInteger`...), read-only `ObservableMap` projections, FX thread dispatch. |
+| `lirp-kafka` | Kafka event publishing via the transactional outbox — `KafkaOutboxSqlRepository` (co-inserts an outbox row in the same JDBC commit as the entity), `LirpKafkaConfig` / `KafkaOutboxConfig` (background relay), `KafkaEventPublisher`, and pluggable `LirpEventSerializer` (CloudEvents default) / `TopicResolver` SPIs. Builds on `lirp-sql`. |
 | `lirp-gradle-plugin` | `net.transgressoft.lirp.sql` Gradle plugin auto-configuring KSP for consumers. |
 | `lirp-benchmark` | JMH benchmarks. |
 

--- a/d2/README.md
+++ b/d2/README.md
@@ -26,6 +26,7 @@ This directory contains [D2](https://d2lang.com) diagram source files — the si
 | `saga-compensation.d2` | Sequence: cross-aggregate saga forward step and `Conflict`-driven compensation |
 | `projection-architecture.d2` | Projection map architecture: aggregate vs registry source, core vs fx flavour, optional capabilities |
 | `fx-thread-dispatch.d2` | JavaFX notification routing for `dispatchToFxThread` true/false |
+| `kafka-outbox-relay.d2` | Sequence: transactional-outbox co-insert → relay poll → Kafka publish → mark-sent-after-ACK (at-least-once) |
 
 ## Local Rendering
 

--- a/d2/kafka-outbox-relay.d2
+++ b/d2/kafka-outbox-relay.d2
@@ -1,0 +1,59 @@
+direction: down
+
+title: Kafka Transactional-Outbox Relay {
+    near: top-center
+    shape: text
+    style.font-size: 24
+    style.bold: true
+}
+
+flow: "" {
+    shape: sequence_diagram
+
+    app: "application"
+    repo: KafkaOutboxSqlRepository
+    db: "SQL backend\n(entity + lirp_kafka_outbox)"
+    relay: OutboxRelay
+    kafka: "Kafka broker"
+    consumer: consumer
+
+    app -> repo: "mutation / transaction { } commit"
+    repo -> db: "INSERT entity rows +\nINSERT outbox row\n(same JDBC commit)" {
+        style.bold: true
+    }
+    db -> repo: "COMMIT — atomic\n(rollback leaves no outbox row)" {
+        style.stroke: "#2e7d32"
+    }
+
+    relay -> db: "poll unsent outbox rows\n(every pollIntervalMs, batchSize)"
+    db -> relay: "unsent rows"
+    relay -> kafka: "publish, key = aggregateId\n(per-aggregate ordering)" {
+        style.bold: true
+    }
+    kafka -> relay: "broker ACK" {
+        style.stroke: "#1565c0"
+    }
+    relay -> db: "mark row sent\n(only after ACK → at-least-once)" {
+        style.bold: true
+    }
+    kafka -> consumer: "delivered event\n(application-owned consumer)"
+
+    retry: "on failure: retry up to maxRetries,\nthen move to lirp_kafka_dead_letter" {
+        style.stroke: "#c62828"
+    }
+    relay -> retry: "publish/ACK failure" {
+        style.stroke: "#c62828"
+    }
+}
+
+notes: Notes {
+    near: bottom-center
+    shape: text
+    style.font-size: 13
+    |md
+    - The outbox row is co-inserted in the **same JDBC commit** as the entity — no dual-write window.
+    - Only SQL-backed repositories participate; `JsonFileRepository` / `VolatileRepository` are unsupported.
+    - A row is marked sent **only after** the broker acknowledges, giving at-least-once delivery (consumers must be idempotent).
+    - Rows that exhaust `maxRetries` (default 5) or hit a non-retriable error move to the dead-letter table.
+    |
+}

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/entity/IdentifiableEntity.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/entity/IdentifiableEntity.kt
@@ -38,6 +38,8 @@ interface IdentifiableEntity<K> : LirpEntity, Cloneable where K : Comparable<K> 
     public override fun clone(): IdentifiableEntity<K>
 }
 
+/** Returns the ids of the entities in this list, preserving order. */
 fun <K : Comparable<K>> List<IdentifiableEntity<K>>.toIds() = map { it.id }.toList()
 
+/** Returns the ids of the entities in this set, as a set. */
 fun <K : Comparable<K>> Set<IdentifiableEntity<K>>.toIds() = map { it.id }.toSet()

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/event/CrudEvent.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/event/CrudEvent.kt
@@ -86,17 +86,24 @@ interface CrudEvent<K, out T: IdentifiableEntity<K>>: LirpEvent<CrudEvent.Type> 
      */
     val oldEntities: Map<K, T>
 
+    /** Returns `true` if this event was emitted for a create operation. */
     fun isCreate() = type == Type.CREATE
 
+    /** Returns `true` if this event was emitted for a read operation. */
     fun isRead() = type == Type.READ
 
+    /** Returns `true` if this event was emitted for an update operation. */
     fun isUpdate() = type == Type.UPDATE
 
+    /** Returns `true` if this event was emitted for a hard-delete operation. */
     fun isDelete() = type == Type.DELETE
 
+    /** Returns `true` if this event reports an optimistic-lock conflict. */
     fun isConflict() = type == Type.CONFLICT
 
+    /** Returns `true` if this event was emitted for a soft-delete operation. */
     fun isSoftDelete() = type == Type.SOFT_DELETE
 
+    /** Returns `true` if this event was emitted when a soft-deleted entity was restored. */
     fun isRestore() = type == Type.RESTORE
 }

--- a/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ColumnType.kt
+++ b/lirp-api/src/main/kotlin/net/transgressoft/lirp/persistence/ColumnType.kt
@@ -28,16 +28,22 @@ package net.transgressoft.lirp.persistence
  * module, which translates them into JetBrains Exposed column definitions.
  */
 sealed class ColumnType {
+    /** 32-bit signed integer column. */
     data object IntType : ColumnType()
 
+    /** 64-bit signed integer column. */
     data object LongType : ColumnType()
 
+    /** Unbounded text column, mapped to the dialect's largest character type. */
     data object TextType : ColumnType()
 
+    /** Boolean column, mapped to the dialect's native boolean or its closest equivalent. */
     data object BooleanType : ColumnType()
 
+    /** Double-precision floating-point column. */
     data object DoubleType : ColumnType()
 
+    /** Single-precision floating-point column. */
     data object FloatType : ColumnType()
 
     /**
@@ -56,8 +62,10 @@ sealed class ColumnType {
      */
     data object UuidType : ColumnType()
 
+    /** Date-only column (no time component). */
     data object DateType : ColumnType()
 
+    /** Timestamp column carrying both date and time. */
     data object DateTimeType : ColumnType()
 
     /**


### PR DESCRIPTION
## Summary

Documents the v3.2.0 `lirp-kafka` transactional-outbox event-publishing module across every user-facing documentation surface: README, CHANGELOG, the wiki, and a new architecture diagram. Documentation-only change — no runtime behavior is modified.

## Changes

**README.md**
- New "Kafka Integration" section (setup, relay startup, config knobs) plus `lirp-kafka` entries in the Features list, Module overview, and Documentation tables.
- Corrected a stale Kotlin version (`2.3.10` → `2.4.0`) and a dangling snippet variable; added a v3.2.0 (non-breaking) upgrade note.

**CHANGELOG.md**
- New `[3.2.0]` release section (Keep a Changelog) covering the module, outbox relay, `KafkaEventPublisher`, serialization/topic SPIs, `KafkaOutboxConfig`, and dead-letter handling.
- Added an `[Unreleased]` section and replaced non-portable `{#custom-id}` heading anchors with GitHub-compatible links.

**Diagram**
- New `d2/kafka-outbox-relay.d2` sequence diagram of the outbox → relay → Kafka at-least-once flow (co-insert, poll, publish, mark-sent-after-ACK), embedded in the Kafka wiki page.

**lirp-api KDoc**
- Documented previously undocumented public symbols: `ColumnType` scalar singletons, `CrudEvent` type-check helpers (`isCreate()`…`isRestore()`), and `IdentifiableEntity.toIds()`.

**Wiki** (authored in the separate `lirp.wiki` repository)
- New canonical Kafka Integration reference page (architecture, setup, SPIs, delivery semantics, inbound-consumption DIY pattern) with sidebar/home navigation wiring.
- Corrected stale "no outbox" claims in Transactional Boundaries, plus broader accuracy and link fixes across pages.

## Verification

- [x] `lirp-api` compiles and passes ktlint
- [x] Documentation internal links validated (GitHub-slug-accurate); only an intentional template placeholder remains
- [x] Sequence diagram renders successfully with `d2`
- No source logic changed; the published library surface is unaffected apart from additive KDoc.

## Key Decisions

- Inbound Kafka consumption is intentionally out of LIRP's scope. Rather than ship a consumer abstraction, the docs describe a DIY apply-then-commit consumer pattern — this answers the open question tracked in the linked issue.
- CloudEvents binary content mode is documented as the default serialization.
- No migration section in the changelog — all v3.2.0 changes are additive and non-breaking.

Closes #290
