### PR TITLE
Bucket-level ordering for registry projections (#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ see the [GitHub releases](https://github.com/octaviospain/lirp/releases).
 
 ## [Unreleased]
 
+### Added
+
+- **Bucket-level ordering for registry projections.** The registry projection factories now
+  accept optional comparators that order the projection's buckets: `bucketKeyOrdering` orders
+  buckets by their key on every registry projection (core and JavaFX), and `bucketValueOrdering`
+  orders buckets by their transformed value on the value-transformed variants. Both compose over a
+  primary-key natural-order final tiebreak so distinct buckets that compare equal are never
+  collapsed. Ordering is maintained incrementally as entries change — no full re-sort — and on the
+  JavaFX side it is applied before the FX-thread pulse, so listeners observe the ordered iteration.
+  Both parameters are nullable with a `null` default, so existing call sites are unaffected and the
+  change is binary compatible.
+  See [#298](https://github.com/octaviospain/lirp/issues/298).
+
+### Changed
+
+- **Value-transformed registry projections now iterate buckets in primary-key natural order by
+  default.** Previously the iteration order of `entries` / `keys` / `values` on the value-transformed
+  registry projections was unspecified (hash order). They now default to primary-key natural order,
+  matching the non-transformed variants. This is a behavioral change to iteration order only; it is
+  binary compatible and is **not** a breaking API change. Callers that require a specific order can
+  supply `bucketKeyOrdering` or `bucketValueOrdering`.
+  See [#298](https://github.com/octaviospain/lirp/issues/298).
+
 ## [3.2.0] - 2026-07-02
 
 Version 3.2.0 introduces the new `lirp-kafka` module, which adds transactional-outbox Kafka

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ see the [GitHub releases](https://github.com/octaviospain/lirp/releases).
   primary-key natural-order final tiebreak so distinct buckets that compare equal are never
   collapsed. Ordering is maintained incrementally as entries change — no full re-sort — and on the
   JavaFX side it is applied before the FX-thread pulse, so listeners observe the ordered iteration.
-  Both parameters are nullable with a `null` default, so existing call sites are unaffected and the
-  change is binary compatible.
+  Both parameters are nullable with a `null` default, so existing Kotlin call sites are unaffected.
+  As trailing default parameters without `@JvmOverloads`, they are a Kotlin source-compatible
+  addition (the prior JVM method descriptors are not retained), consistent with the library's
+  Kotlin-first API convention.
   See [#298](https://github.com/octaviospain/lirp/issues/298).
 
 ### Changed

--- a/lirp-core/api/lirp-core.api
+++ b/lirp-core/api/lirp-core.api
@@ -1199,8 +1199,8 @@ public final class net/transgressoft/lirp/persistence/projection/MultiKeyProject
 }
 
 public final class net/transgressoft/lirp/persistence/projection/MultiKeyRegistryProjection : kotlin/collections/AbstractMap, java/lang/AutoCloseable {
-	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;)V
-	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Ljava/util/Comparator;)V
+	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Ljava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addOnBucketsChangedListener (Lkotlin/jvm/functions/Function1;)Ljava/lang/AutoCloseable;
 	public final fun addOnChangeListener (Lkotlin/jvm/functions/Function1;)Ljava/lang/AutoCloseable;
 	public final fun bucketSnapshot (Ljava/lang/Comparable;)Ljava/util/List;
@@ -1270,19 +1270,19 @@ public final class net/transgressoft/lirp/persistence/projection/ProjectionFacto
 	public static final fun multiKeyProjection (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/persistence/projection/ObservableProjection;
 	public static final fun projection (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lnet/transgressoft/lirp/persistence/projection/Projection;
 	public static final fun projection (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/persistence/projection/ObservableProjection;
-	public static final fun registryMultiKeyProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;)Lnet/transgressoft/lirp/persistence/projection/MultiKeyRegistryProjection;
-	public static final fun registryMultiKeyProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/persistence/projection/ObservableProjection;
-	public static synthetic fun registryMultiKeyProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/projection/MultiKeyRegistryProjection;
-	public static synthetic fun registryMultiKeyProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/projection/ObservableProjection;
-	public static final fun registryProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;)Lnet/transgressoft/lirp/persistence/projection/RegistryProjection;
-	public static final fun registryProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/persistence/projection/ObservableProjection;
-	public static synthetic fun registryProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/projection/RegistryProjection;
-	public static synthetic fun registryProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/projection/ObservableProjection;
+	public static final fun registryMultiKeyProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Ljava/util/Comparator;)Lnet/transgressoft/lirp/persistence/projection/MultiKeyRegistryProjection;
+	public static final fun registryMultiKeyProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/persistence/projection/ObservableProjection;
+	public static synthetic fun registryMultiKeyProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Ljava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/projection/MultiKeyRegistryProjection;
+	public static synthetic fun registryMultiKeyProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/projection/ObservableProjection;
+	public static final fun registryProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Ljava/util/Comparator;)Lnet/transgressoft/lirp/persistence/projection/RegistryProjection;
+	public static final fun registryProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;Lkotlin/jvm/functions/Function2;)Lnet/transgressoft/lirp/persistence/projection/ObservableProjection;
+	public static synthetic fun registryProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Ljava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/projection/RegistryProjection;
+	public static synthetic fun registryProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/projection/ObservableProjection;
 }
 
 public final class net/transgressoft/lirp/persistence/projection/RegistryProjection : kotlin/collections/AbstractMap, java/lang/AutoCloseable {
-	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;)V
-	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Ljava/util/Comparator;)V
+	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Ljava/util/Comparator;Ljava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addOnBucketsChangedListener (Lkotlin/jvm/functions/Function1;)Ljava/lang/AutoCloseable;
 	public final fun addOnChangeListener (Lkotlin/jvm/functions/Function1;)Ljava/lang/AutoCloseable;
 	public final fun bucketSnapshot (Ljava/lang/Comparable;)Ljava/util/List;

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/BucketOrdering.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/BucketOrdering.kt
@@ -1,0 +1,69 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.projection
+
+/**
+ * Builds a composite bucket comparator over projection keys (`PK`) that resolves
+ * to a stable total order suitable for use as a [java.util.concurrent.ConcurrentSkipListMap] comparator.
+ *
+ * The composition order is:
+ * 1. **Value-primary** — when [bucketValueOrdering] is supplied, buckets are compared first by
+ *    the cached transformed value obtained via [valueOf]. The comparator reads the pre-computed
+ *    value; it does not invoke any transform.
+ * 2. **Key tiebreak** — when [bucketKeyOrdering] is supplied, buckets that compare equal under
+ *    [bucketValueOrdering] (or when [bucketValueOrdering] is absent) are further ordered by the
+ *    bucket key itself.
+ * 3. **PK natural-order final tiebreak** — `Comparator.naturalOrder<PK>()` is always appended
+ *    as the last tiebreak. This is mandatory for correctness: a coarse [bucketValueOrdering] or
+ *    [bucketKeyOrdering] may return `0` for two distinct bucket keys; without the PK tiebreak,
+ *    an ordered map would collapse those two distinct keys into one, silently dropping a bucket.
+ *    The `PK : Comparable<PK>` bound already imposed by all registry factories is the contract
+ *    — no additional comparator parameter is required.
+ *
+ * Either or both of [bucketValueOrdering] and [bucketKeyOrdering] may be `null`. When both are
+ * null the returned comparator is simply `Comparator.naturalOrder<PK>()`, matching the default
+ * PK-natural backing order of non-ordered projections.
+ *
+ * @param PK the projection key (bucket key) type; must be [Comparable]
+ * @param V the transformed value type; only used when [bucketValueOrdering] is non-null
+ * @param bucketValueOrdering optional comparator that orders buckets by their transformed value;
+ *   used with [valueOf] to compare the cached `V` for two keys. `null` skips value-primary ordering.
+ * @param bucketKeyOrdering optional comparator that orders buckets by the bucket key itself.
+ *   `null` skips key-level ordering (beyond the mandatory PK final tiebreak).
+ * @param valueOf accessor that returns the cached transformed value for a given bucket key;
+ *   called inside the returned comparator, so it must be fast and must read a cached result —
+ *   never recompute a transform inside this call.
+ * @return a [Comparator]<PK> that resolves to a stable total order over all distinct bucket keys
+ */
+internal fun <PK : Comparable<PK>, V : Any> bucketComparator(
+    bucketValueOrdering: Comparator<V>?,
+    bucketKeyOrdering: Comparator<PK>?,
+    valueOf: (PK) -> V
+): Comparator<PK> {
+    var cmp: Comparator<PK>? = null
+    if (bucketValueOrdering != null) {
+        cmp = Comparator { a, b -> bucketValueOrdering.compare(valueOf(a), valueOf(b)) }
+    }
+    if (bucketKeyOrdering != null) {
+        cmp = cmp?.thenComparing(bucketKeyOrdering) ?: bucketKeyOrdering
+    }
+    // Mandatory final tiebreak on PK uniqueness — guarantees a stable total order so two
+    // distinct buckets that compare equal on value or key do not collide or drop.
+    val natural = Comparator.naturalOrder<PK>()
+    return cmp?.thenComparing(natural) ?: natural
+}

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/MultiKeyRegistryProjection.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/MultiKeyRegistryProjection.kt
@@ -72,11 +72,15 @@ import kotlin.reflect.KProperty
  *   each returned key names one bucket the entity belongs to
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   `null` (the default) preserves insertion order. Equal elements retain arrival order.
+ * @param bucketKeyOrdering optional comparator that orders buckets (map entries) by their projection
+ *   key; `null` (the default) preserves PK natural order. A mandatory `Comparator.naturalOrder<PK>()`
+ *   tiebreak is always composed in to guarantee a stable total order over distinct keys.
  */
 class MultiKeyRegistryProjection<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>>(
     private val registry: Registry<K, E>,
     private val keyExtractor: (E) -> Collection<PK>,
-    private val entryOrdering: Comparator<E>? = null
+    private val entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null
 ) : AbstractMap<PK, List<E>>(), AutoCloseable {
 
     // Bucket engine — stores one List<E> per PK bucket key in a ConcurrentSkipListMap.
@@ -85,7 +89,8 @@ class MultiKeyRegistryProjection<K : Comparable<K>, PK : Comparable<PK>, E : Ide
     private val core =
         ProjectionCore<K, PK, E>(
             keyExtractor = { error("ProjectionCore keyExtractor must not be called in MultiKeyRegistryProjection") },
-            entryOrdering = entryOrdering
+            entryOrdering = entryOrdering,
+            bucketKeyOrdering = bucketKeyOrdering
         )
 
     /**

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/ProjectionCore.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/ProjectionCore.kt
@@ -43,10 +43,17 @@ import java.util.concurrent.CopyOnWriteArrayList
  * arriving equal element is inserted after the existing equal run). When [entryOrdering] is null,
  * buckets keep insertion order and every existing code path is unchanged.
  *
- * The [entryOrdering] comparator must obey the `Comparator` contract (total order, transitivity).
- * A non-transitive or throwing comparator will, at worst, misplace an element or propagate the
- * exception on the event-delivery thread; it will not raise "Comparison method violates its general
- * contract" because the single-element upper-bound insert never invokes `Collections.sort`.
+ * When [bucketKeyOrdering] is non-null, buckets (map entries) are maintained in the order defined
+ * by that comparator. A `Comparator.naturalOrder<PK>()` tiebreak is always composed in as the final
+ * level so a coarse comparator (e.g. case-insensitive) never collapses two distinct keys that compare
+ * equal under the supplied comparator. When [bucketKeyOrdering] is null, buckets iterate in PK
+ * natural order via the default [ConcurrentSkipListMap] ordering.
+ *
+ * The [entryOrdering] and [bucketKeyOrdering] comparators must obey the `Comparator` contract
+ * (total order, transitivity). A non-transitive or throwing comparator will, at worst, misplace an
+ * element or propagate the exception on the event-delivery thread; it will not raise "Comparison
+ * method violates its general contract" because the single-element upper-bound insert never invokes
+ * `Collections.sort`.
  *
  * @param K the entity ID type, must be [Comparable]
  * @param PK the projection key type, must be [Comparable]
@@ -54,12 +61,20 @@ import java.util.concurrent.CopyOnWriteArrayList
  * @param keyExtractor grouping function that extracts the projection key from an entity
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   `null` (the default) preserves insertion order
+ * @param bucketKeyOrdering optional comparator that orders buckets (map entries) by their projection
+ *   key; `null` (the default) preserves PK natural order. A mandatory `Comparator.naturalOrder<PK>()`
+ *   tiebreak is always composed in to guarantee a stable total order over distinct keys.
  */
 internal class ProjectionCore<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>>(
     private val keyExtractor: (E) -> PK,
-    private val entryOrdering: Comparator<E>? = null
+    private val entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null
 ) {
-    val backingMap = ConcurrentSkipListMap<PK, List<E>>()
+    val backingMap =
+        if (bucketKeyOrdering != null)
+            ConcurrentSkipListMap<PK, List<E>>(bucketKeyOrdering.thenComparing(Comparator.naturalOrder<PK>()))
+        else
+            ConcurrentSkipListMap<PK, List<E>>()
     val readOnlyView: Map<PK, List<E>> = Collections.unmodifiableMap(backingMap)
 
     private val onChangeListeners = CopyOnWriteArrayList<(Map<PK, List<E>>) -> Unit>()

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/ProjectionFactories.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/ProjectionFactories.kt
@@ -79,13 +79,17 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> projecti
  * @param keyExtractor grouping function that extracts the projection key from an entity
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   `null` (the default) preserves insertion order. Equal elements retain arrival order.
+ * @param bucketKeyOrdering optional comparator that orders buckets by their projection key; buckets
+ *   that compare equal under this comparator are further resolved by PK natural order so that distinct
+ *   keys are never collapsed. `null` (the default) preserves PK natural order.
  * @return a [RegistryProjection] delegate grouping registry entities by [keyExtractor]
  */
 fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> registryProjection(
     registry: Registry<K, E>,
     keyExtractor: (E) -> PK,
-    entryOrdering: Comparator<E>? = null
-): RegistryProjection<K, PK, E> = RegistryProjection(registry, keyExtractor, entryOrdering)
+    entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null
+): RegistryProjection<K, PK, E> = RegistryProjection(registry, keyExtractor, entryOrdering, bucketKeyOrdering)
 
 /**
  * Creates a read-only value-transformed projection that groups entities from a source collection
@@ -141,14 +145,21 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>
  * When [entryOrdering] is non-null, each per-key bucket's `List<E>` is maintained sorted and
  * [valueTransform] receives an already-ordered list. Equal elements retain arrival order.
  *
+ * By default, buckets are exposed in PK natural order. When [bucketValueOrdering] is supplied,
+ * buckets are ordered value-primary (by the cached transformed value, never re-invoking the transform),
+ * then by [bucketKeyOrdering] as a tiebreak, and finally by PK natural order as the mandatory
+ * deterministic final tiebreak. Omitting either comparator is binary compatible.
+ *
  * Usage:
  * ```kotlin
  * val summaryByAlbum = registryProjection(trackRepo) { it.albumName } { pk, items -> AlbumSummary(pk, items.size) }
  * val orderedSummary = registryProjection(trackRepo, { it.albumName }, entryOrdering = compareBy { it.title }) { pk, items -> AlbumSummary(pk, items) }
+ * val bucketOrdered = registryProjection(trackRepo, { it.albumName }, bucketValueOrdering = compareBy { it.displayTitle }) { pk, items -> AlbumSummary(pk, items) }
  * ```
  *
  * **Weak cross-key consistency:** Two consecutive reads on different keys are NOT a single
- * snapshot. Iteration is CME-free via [java.util.concurrent.ConcurrentHashMap].
+ * snapshot. Iteration is CME-free (snapshot-based from the ordered index) but each call
+ * represents a weakly consistent view.
  *
  * @param K the entity ID type, must be [Comparable]
  * @param PK the projection key type, must be [Comparable]
@@ -159,6 +170,14 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order
  *   before [valueTransform] is invoked; `null` (the default) preserves insertion order.
  *   Equal elements retain arrival order.
+ * @param bucketKeyOrdering optional comparator that orders buckets by their projection key; buckets
+ *   that compare equal under this comparator are further resolved by PK natural order so that distinct
+ *   keys are never collapsed. Used as a tiebreak after [bucketValueOrdering] when both are supplied.
+ *   `null` (the default) skips key-level ordering beyond the mandatory PK final tiebreak.
+ * @param bucketValueOrdering optional comparator that orders buckets by their cached transformed value;
+ *   the comparator reads the pre-computed `V` — it never re-invokes [valueTransform]. Buckets that
+ *   compare equal under this comparator are further resolved by [bucketKeyOrdering] (when supplied)
+ *   and then by PK natural order. `null` (the default) skips value-primary ordering.
  * @param valueTransform trailing-lambda applied to each `(PK, List<E>)` bucket to produce a non-null `V`
  *   value; invoked only for buckets affected by the latest delta. `V` is constrained to be non-null so
  *   the add/replace/remove encoding of [ProjectionEntryChange] stays sound (a null value cannot be
@@ -171,8 +190,16 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>
     registry: Registry<K, E>,
     keyExtractor: (E) -> PK,
     entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null,
+    bucketValueOrdering: Comparator<V>? = null,
     valueTransform: (PK, List<E>) -> V
-): ObservableProjection<PK, V> = TransformedRegistryProjection(RegistryProjection(registry, keyExtractor, entryOrdering), valueTransform)
+): ObservableProjection<PK, V> =
+    TransformedRegistryProjection(
+        RegistryProjection(registry, keyExtractor, entryOrdering, bucketKeyOrdering),
+        bucketKeyOrdering,
+        bucketValueOrdering,
+        valueTransform
+    )
 
 /**
  * Creates a read-only multi-key projection that groups entities from a source collection by every
@@ -261,13 +288,17 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>
  * @param keyExtractor grouping function that extracts a collection of projection keys from an entity
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   `null` (the default) preserves insertion order. Equal elements retain arrival order.
+ * @param bucketKeyOrdering optional comparator that orders buckets by their projection key; buckets
+ *   that compare equal under this comparator are further resolved by PK natural order so that distinct
+ *   keys are never collapsed. `null` (the default) preserves PK natural order.
  * @return a [MultiKeyRegistryProjection] delegate grouping registry entities by every key in [keyExtractor]
  */
 fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> registryMultiKeyProjection(
     registry: Registry<K, E>,
     keyExtractor: (E) -> Collection<PK>,
-    entryOrdering: Comparator<E>? = null
-): MultiKeyRegistryProjection<K, PK, E> = MultiKeyRegistryProjection(registry, keyExtractor, entryOrdering)
+    entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null
+): MultiKeyRegistryProjection<K, PK, E> = MultiKeyRegistryProjection(registry, keyExtractor, entryOrdering, bucketKeyOrdering)
 
 /**
  * Creates a read-only value-transformed multi-key projection that groups all entities from a
@@ -281,8 +312,14 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> registry
  * When [entryOrdering] is non-null, each per-key bucket's `List<E>` is maintained sorted and
  * [valueTransform] receives an already-ordered list. Equal elements retain arrival order.
  *
+ * By default, buckets are exposed in PK natural order. When [bucketValueOrdering] is supplied,
+ * buckets are ordered value-primary (by the cached transformed value, never re-invoking the transform),
+ * then by [bucketKeyOrdering] as a tiebreak, and finally by PK natural order as the mandatory
+ * deterministic final tiebreak. Omitting either comparator is binary compatible.
+ *
  * **Weak cross-key consistency:** Two consecutive reads on different keys are NOT a single
- * snapshot. Iteration is CME-free via [java.util.concurrent.ConcurrentHashMap].
+ * snapshot. Iteration is CME-free (snapshot-based from the ordered index) but each call
+ * represents a weakly consistent view.
  *
  * @param K the entity ID type, must be [Comparable]
  * @param PK the projection key type, must be [Comparable]
@@ -293,6 +330,14 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> registry
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order
  *   before [valueTransform] is invoked; `null` (the default) preserves insertion order.
  *   Equal elements retain arrival order.
+ * @param bucketKeyOrdering optional comparator that orders buckets by their projection key; buckets
+ *   that compare equal under this comparator are further resolved by PK natural order so that distinct
+ *   keys are never collapsed. Used as a tiebreak after [bucketValueOrdering] when both are supplied.
+ *   `null` (the default) skips key-level ordering beyond the mandatory PK final tiebreak.
+ * @param bucketValueOrdering optional comparator that orders buckets by their cached transformed value;
+ *   the comparator reads the pre-computed `V` — it never re-invokes [valueTransform]. Buckets that
+ *   compare equal under this comparator are further resolved by [bucketKeyOrdering] (when supplied)
+ *   and then by PK natural order. `null` (the default) skips value-primary ordering.
  * @param valueTransform trailing-lambda applied to each `(PK, List<E>)` bucket to produce a non-null `V`
  *   value; invoked only for buckets affected by the latest delta. `V` is constrained to be non-null so
  *   the add/replace/remove encoding of [ProjectionEntryChange] stays sound (a null value cannot be
@@ -306,5 +351,13 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>
     registry: Registry<K, E>,
     keyExtractor: (E) -> Collection<PK>,
     entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null,
+    bucketValueOrdering: Comparator<V>? = null,
     valueTransform: (PK, List<E>) -> V
-): ObservableProjection<PK, V> = TransformedMultiKeyRegistryProjection(MultiKeyRegistryProjection(registry, keyExtractor, entryOrdering), valueTransform)
+): ObservableProjection<PK, V> =
+    TransformedMultiKeyRegistryProjection(
+        MultiKeyRegistryProjection(registry, keyExtractor, entryOrdering, bucketKeyOrdering),
+        bucketKeyOrdering,
+        bucketValueOrdering,
+        valueTransform
+    )

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/ProjectionFactories.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/ProjectionFactories.kt
@@ -148,7 +148,9 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>
  * By default, buckets are exposed in PK natural order. When [bucketValueOrdering] is supplied,
  * buckets are ordered value-primary (by the cached transformed value, never re-invoking the transform),
  * then by [bucketKeyOrdering] as a tiebreak, and finally by PK natural order as the mandatory
- * deterministic final tiebreak. Omitting either comparator is binary compatible.
+ * deterministic final tiebreak. Omitting both comparators keeps the default PK-natural order and is
+ * source-compatible for existing Kotlin callers (these trailing parameters are not annotated with
+ * `@JvmOverloads`, so the prior JVM method descriptor is not retained).
  *
  * Usage:
  * ```kotlin
@@ -172,8 +174,10 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>
  *   Equal elements retain arrival order.
  * @param bucketKeyOrdering optional comparator that orders buckets by their projection key; buckets
  *   that compare equal under this comparator are further resolved by PK natural order so that distinct
- *   keys are never collapsed. Used as a tiebreak after [bucketValueOrdering] when both are supplied.
- *   `null` (the default) skips key-level ordering beyond the mandatory PK final tiebreak.
+ *   keys are never collapsed. Supplied on its own it is the primary bucket comparator (before the
+ *   mandatory PK final tiebreak); supplied together with [bucketValueOrdering] it is the tiebreak
+ *   applied after the value comparator. `null` (the default) skips key-level ordering beyond the
+ *   mandatory PK final tiebreak.
  * @param bucketValueOrdering optional comparator that orders buckets by their cached transformed value;
  *   the comparator reads the pre-computed `V` — it never re-invokes [valueTransform]. Buckets that
  *   compare equal under this comparator are further resolved by [bucketKeyOrdering] (when supplied)
@@ -315,7 +319,9 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> registry
  * By default, buckets are exposed in PK natural order. When [bucketValueOrdering] is supplied,
  * buckets are ordered value-primary (by the cached transformed value, never re-invoking the transform),
  * then by [bucketKeyOrdering] as a tiebreak, and finally by PK natural order as the mandatory
- * deterministic final tiebreak. Omitting either comparator is binary compatible.
+ * deterministic final tiebreak. Omitting both comparators keeps the default PK-natural order and is
+ * source-compatible for existing Kotlin callers (these trailing parameters are not annotated with
+ * `@JvmOverloads`, so the prior JVM method descriptor is not retained).
  *
  * **Weak cross-key consistency:** Two consecutive reads on different keys are NOT a single
  * snapshot. Iteration is CME-free (snapshot-based from the ordered index) but each call
@@ -332,8 +338,10 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> registry
  *   Equal elements retain arrival order.
  * @param bucketKeyOrdering optional comparator that orders buckets by their projection key; buckets
  *   that compare equal under this comparator are further resolved by PK natural order so that distinct
- *   keys are never collapsed. Used as a tiebreak after [bucketValueOrdering] when both are supplied.
- *   `null` (the default) skips key-level ordering beyond the mandatory PK final tiebreak.
+ *   keys are never collapsed. Supplied on its own it is the primary bucket comparator (before the
+ *   mandatory PK final tiebreak); supplied together with [bucketValueOrdering] it is the tiebreak
+ *   applied after the value comparator. `null` (the default) skips key-level ordering beyond the
+ *   mandatory PK final tiebreak.
  * @param bucketValueOrdering optional comparator that orders buckets by their cached transformed value;
  *   the comparator reads the pre-computed `V` — it never re-invokes [valueTransform]. Buckets that
  *   compare equal under this comparator are further resolved by [bucketKeyOrdering] (when supplied)

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/RegistryProjection.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/RegistryProjection.kt
@@ -66,14 +66,18 @@ import kotlin.reflect.KProperty
  * @param keyExtractor grouping function that extracts the projection key from an entity
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   `null` (the default) preserves insertion order. Equal elements retain arrival order.
+ * @param bucketKeyOrdering optional comparator that orders buckets (map entries) by their projection
+ *   key; `null` (the default) preserves PK natural order. A mandatory `Comparator.naturalOrder<PK>()`
+ *   tiebreak is always composed in to guarantee a stable total order over distinct keys.
  */
 class RegistryProjection<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>>(
     private val registry: Registry<K, E>,
     private val keyExtractor: (E) -> PK,
-    private val entryOrdering: Comparator<E>? = null
+    private val entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null
 ) : AbstractMap<PK, List<E>>(), AutoCloseable {
 
-    private val core = ProjectionCore<K, PK, E>(keyExtractor, entryOrdering)
+    private val core = ProjectionCore<K, PK, E>(keyExtractor, entryOrdering, bucketKeyOrdering)
 
     /** Reverse index: entity id → current bucket key. Enables O(1) old-key lookup on Update. */
     private val reverseIndex = ConcurrentHashMap<K, PK>()

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/TransformedMultiKeyRegistryProjection.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/TransformedMultiKeyRegistryProjection.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence.projection
 
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.TreeMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -29,9 +30,15 @@ import java.util.concurrent.CopyOnWriteArrayList
  * the entire map.
  *
  * This decorator wraps a [MultiKeyRegistryProjection] and registers on its `addOnBucketsChangedListener`
- * signal to maintain an internal `ConcurrentHashMap<PK, V>` transform cache. When a bucket is
- * emptied and its key is removed from the backing map, the corresponding key is also removed from
- * this view — the transform is never called over an empty list.
+ * signal to maintain an internal transform cache. When a bucket is emptied and its key is removed
+ * from the backing map, the corresponding key is also removed from this view — the transform is
+ * never called over an empty list.
+ *
+ * By default, [entries], [keys], and [values] iterate in PK natural order. When [bucketValueOrdering]
+ * is supplied, buckets are ordered value-primary (reading the cached transformed value — the transform
+ * is never re-invoked inside the comparator), then by [bucketKeyOrdering] as a tiebreak, and finally
+ * by PK natural order as the mandatory deterministic final tiebreak (preventing two distinct keys
+ * whose values compare equal from being collapsed).
  *
  * Because the cache holds the previous transformed value per key, this decorator can report both the
  * old and the new value for every changed key. It therefore implements [ObservableProjection]:
@@ -39,8 +46,8 @@ import java.util.concurrent.CopyOnWriteArrayList
  * letting a consumer drive a CRUD-style event stream directly without keeping its own diff cache.
  *
  * **Weak cross-key consistency:** Two consecutive `get()` calls for different keys are NOT
- * a single snapshot. Iteration via [entries], [keys], or [values] is CME-free (backed by
- * [ConcurrentHashMap]). This inherits the weakly-consistent contract of the underlying
+ * a single snapshot. Iteration via [entries], [keys], or [values] is CME-free (snapshot-based from
+ * the ordered index). This inherits the weakly-consistent contract of the underlying
  * [java.util.concurrent.ConcurrentSkipListMap] iteration.
  *
  * **Multi-subscriber:** This decorator registers one listener via `addOnBucketsChangedListener` on
@@ -52,17 +59,32 @@ import java.util.concurrent.CopyOnWriteArrayList
  * @param E the entity type
  * @param V the value type produced by [valueTransform]
  * @param backing the underlying [MultiKeyRegistryProjection] whose buckets are transformed
+ * @param bucketKeyOrdering optional comparator that orders buckets by their projection key; used as a
+ *   tiebreak after [bucketValueOrdering] (when supplied) and before the mandatory PK natural-order
+ *   final tiebreak. `null` skips key-level ordering beyond the PK tiebreak.
+ * @param bucketValueOrdering optional comparator that orders buckets by their cached transformed value;
+ *   the comparator reads the pre-computed `V` — it never re-invokes [valueTransform]. `null` skips
+ *   value-primary ordering.
  * @param valueTransform function applied to each `(PK, List<E>)` bucket to produce a `V` value;
  *   invoked only for buckets whose contents changed in a given delta
  */
 internal class TransformedMultiKeyRegistryProjection<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>(
     private val backing: MultiKeyRegistryProjection<K, PK, E>,
+    bucketKeyOrdering: Comparator<PK>? = null,
+    bucketValueOrdering: Comparator<V>? = null,
     private val valueTransform: (PK, List<E>) -> V
 ) : AbstractMap<PK, V>(), AutoCloseable by backing, ObservableProjection<PK, V> {
 
     private val log = KotlinLogging.logger {}
 
+    // By-key O(1) lookup cache — keyed on PK, never on V.
     private val transformCache = ConcurrentHashMap<PK, V>()
+
+    // Ordered read surface: a TreeMap whose comparator determines iteration order.
+    // Protected by cacheLock for all structural mutations (insert / remove to reposition keys).
+    // The comparator reads cached values from transformCache; it must only be consulted while
+    // transformCache holds a stable value for every key present in orderedIndex.
+    private val orderedIndex: TreeMap<PK, Unit> = TreeMap(bucketComparator(bucketValueOrdering, bucketKeyOrdering) { transformCache[it]!! })
 
     private val cacheLock = Any()
 
@@ -96,12 +118,20 @@ internal class TransformedMultiKeyRegistryProjection<K : Comparable<K>, PK : Com
                                     val oldValue = transformCache[key]
                                     if (bucket == null) {
                                         if (oldValue != null) {
+                                            // Remove from ordered index BEFORE cache update so the
+                                            // comparator can still find the old position.
+                                            orderedIndex.remove(key)
                                             transformCache.remove(key)
                                             add(ProjectionEntryChange(key, oldValue, null))
                                         }
                                     } else {
                                         val newValue = valueTransform(key, bucket)
+                                        // Reposition in orderedIndex: remove at old position (while
+                                        // cache still holds old value), update cache, re-insert at
+                                        // new position (comparator now sees the new value).
+                                        orderedIndex.remove(key)
                                         transformCache[key] = newValue
+                                        orderedIndex[key] = Unit
                                         if (newValue != oldValue) add(ProjectionEntryChange(key, oldValue, newValue))
                                     }
                                 }
@@ -123,7 +153,8 @@ internal class TransformedMultiKeyRegistryProjection<K : Comparable<K>, PK : Com
             synchronized(cacheLock) {
                 initializeCache()
                 entriesChangedListeners.add(listener)
-                transformCache.map { (key, value) -> ProjectionEntryChange(key, null, value) }
+                // Snapshot ordered entries for the replay batch.
+                orderedIndex.keys.mapNotNull { key -> transformCache[key]?.let { value -> ProjectionEntryChange(key, null, value) } }
             }
         if (initial.isNotEmpty()) notifyListeners(listOf(listener), initial)
         return AutoCloseable { entriesChangedListeners.remove(listener) }
@@ -149,7 +180,9 @@ internal class TransformedMultiKeyRegistryProjection<K : Comparable<K>, PK : Com
             seedingThread = Thread.currentThread()
             try {
                 for ((key, bucket) in backing) {
-                    transformCache[key] = valueTransform(key, bucket)
+                    val value = valueTransform(key, bucket)
+                    transformCache[key] = value
+                    orderedIndex[key] = Unit
                 }
             } finally {
                 seedingThread = null
@@ -158,10 +191,15 @@ internal class TransformedMultiKeyRegistryProjection<K : Comparable<K>, PK : Com
         }
     }
 
+    // Snapshot the ordered keys under cacheLock to produce a stable, ordered set of entries.
     override val entries: Set<Map.Entry<PK, V>>
         get() {
             initializeCache()
-            return transformCache.entries
+            return synchronized(cacheLock) {
+                orderedIndex.keys.mapNotNull { key ->
+                    transformCache[key]?.let { value -> java.util.AbstractMap.SimpleImmutableEntry(key, value) }
+                }.toLinkedHashSet()
+            }
         }
 
     override val size: Int
@@ -173,13 +211,15 @@ internal class TransformedMultiKeyRegistryProjection<K : Comparable<K>, PK : Com
     override val keys: Set<PK>
         get() {
             initializeCache()
-            return transformCache.keys
+            return synchronized(cacheLock) { LinkedHashSet(orderedIndex.keys) }
         }
 
     override val values: Collection<V>
         get() {
             initializeCache()
-            return transformCache.values
+            return synchronized(cacheLock) {
+                orderedIndex.keys.mapNotNull { transformCache[it] }
+            }
         }
 
     override fun get(key: PK): V? {
@@ -202,3 +242,5 @@ internal class TransformedMultiKeyRegistryProjection<K : Comparable<K>, PK : Com
         return transformCache.isEmpty()
     }
 }
+
+private fun <T> List<T>.toLinkedHashSet(): LinkedHashSet<T> = LinkedHashSet(this)

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/TransformedMultiKeyRegistryProjection.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/TransformedMultiKeyRegistryProjection.kt
@@ -128,8 +128,11 @@ internal class TransformedMultiKeyRegistryProjection<K : Comparable<K>, PK : Com
                                         val newValue = valueTransform(key, bucket)
                                         // Reposition in orderedIndex: remove at old position (while
                                         // cache still holds old value), update cache, re-insert at
-                                        // new position (comparator now sees the new value).
-                                        orderedIndex.remove(key)
+                                        // new position (comparator now sees the new value). The remove
+                                        // only applies to an existing key — for a brand-new key the
+                                        // cache has no entry yet, so a value-ordering comparator would
+                                        // dereference an absent value and throw during the removal walk.
+                                        if (oldValue != null) orderedIndex.remove(key)
                                         transformCache[key] = newValue
                                         orderedIndex[key] = Unit
                                         if (newValue != oldValue) add(ProjectionEntryChange(key, oldValue, newValue))

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/TransformedRegistryProjection.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/TransformedRegistryProjection.kt
@@ -134,8 +134,11 @@ internal class TransformedRegistryProjection<K : Comparable<K>, PK : Comparable<
                                         val newValue = valueTransform(key, bucket)
                                         // Reposition in orderedIndex: remove at old position (while
                                         // cache still holds old value), update cache, re-insert at
-                                        // new position (comparator now sees the new value).
-                                        orderedIndex.remove(key)
+                                        // new position (comparator now sees the new value). The remove
+                                        // only applies to an existing key — for a brand-new key the
+                                        // cache has no entry yet, so a value-ordering comparator would
+                                        // dereference an absent value and throw during the removal walk.
+                                        if (oldValue != null) orderedIndex.remove(key)
                                         transformCache[key] = newValue
                                         orderedIndex[key] = Unit
                                         if (newValue != oldValue) add(ProjectionEntryChange(key, oldValue, newValue))

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/TransformedRegistryProjection.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/TransformedRegistryProjection.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence.projection
 
 import net.transgressoft.lirp.entity.IdentifiableEntity
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.TreeMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -28,9 +29,15 @@ import java.util.concurrent.CopyOnWriteArrayList
  * only for buckets whose contents actually changed in a given delta, not for the entire map.
  *
  * This decorator wraps a [RegistryProjection] and registers on its `addOnBucketsChangedListener` signal to
- * maintain an internal `ConcurrentHashMap<PK, V>` transform cache. When a bucket is emptied
- * and its key is removed from the backing map, the corresponding key is also removed from this
- * view — the transform is never called over an empty list.
+ * maintain an internal transform cache. When a bucket is emptied and its key is removed from the
+ * backing map, the corresponding key is also removed from this view — the transform is never called
+ * over an empty list.
+ *
+ * By default, [entries], [keys], and [values] iterate in PK natural order. When [bucketValueOrdering]
+ * is supplied, buckets are ordered value-primary (reading the cached transformed value — the transform
+ * is never re-invoked inside the comparator), then by [bucketKeyOrdering] as a tiebreak, and finally
+ * by PK natural order as the mandatory deterministic final tiebreak (preventing two distinct keys
+ * whose values compare equal from being collapsed).
  *
  * Because the cache holds the previous transformed value per key, this decorator can report both the
  * old and the new value for every changed key. It therefore implements [ObservableProjection]:
@@ -40,9 +47,9 @@ import java.util.concurrent.CopyOnWriteArrayList
  *
  * **Weak cross-key consistency:** Two consecutive `get()` calls for different keys are NOT
  * a single snapshot — they may observe different states of an ongoing delta. Iteration via
- * [entries], [keys], or [values] is CME-free (backed by [ConcurrentHashMap]) but each call to
- * the underlying iterator represents a weakly consistent view. This inherits the same
- * weakly-consistent contract of the backing map's [java.util.concurrent.ConcurrentSkipListMap] iteration.
+ * [entries], [keys], or [values] is CME-free (snapshot-based from the ordered index) but each
+ * call represents a weakly consistent view. This inherits the same weakly-consistent contract of
+ * the backing map's [java.util.concurrent.ConcurrentSkipListMap] iteration.
  *
  * **Multi-subscriber:** This decorator registers one listener via `addOnBucketsChangedListener` on
  * the backing [RegistryProjection]. Additional listeners registered on the same backing map are
@@ -58,17 +65,32 @@ import java.util.concurrent.CopyOnWriteArrayList
  * @param E the entity type
  * @param V the value type produced by [valueTransform]
  * @param backing the underlying [RegistryProjection] whose buckets are transformed
+ * @param bucketKeyOrdering optional comparator that orders buckets by their projection key; used as a
+ *   tiebreak after [bucketValueOrdering] (when supplied) and before the mandatory PK natural-order
+ *   final tiebreak. `null` skips key-level ordering beyond the PK tiebreak.
+ * @param bucketValueOrdering optional comparator that orders buckets by their cached transformed value;
+ *   the comparator reads the pre-computed `V` — it never re-invokes [valueTransform]. `null` skips
+ *   value-primary ordering.
  * @param valueTransform function applied to each `(PK, List<E>)` bucket to produce a `V` value;
  *   invoked only for buckets whose contents changed in a given delta
  */
 internal class TransformedRegistryProjection<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>(
     private val backing: RegistryProjection<K, PK, E>,
+    bucketKeyOrdering: Comparator<PK>? = null,
+    bucketValueOrdering: Comparator<V>? = null,
     private val valueTransform: (PK, List<E>) -> V
 ) : AbstractMap<PK, V>(), AutoCloseable by backing, ObservableProjection<PK, V> {
 
     private val log = KotlinLogging.logger {}
 
+    // By-key O(1) lookup cache — keyed on PK, never on V.
     private val transformCache = ConcurrentHashMap<PK, V>()
+
+    // Ordered read surface: a TreeMap whose comparator determines iteration order.
+    // Protected by cacheLock for all structural mutations (insert / remove to reposition keys).
+    // The comparator reads cached values from transformCache; it must only be consulted while
+    // transformCache holds a stable value for every key present in orderedIndex.
+    private val orderedIndex: TreeMap<PK, Unit> = TreeMap(bucketComparator(bucketValueOrdering, bucketKeyOrdering) { transformCache[it]!! })
 
     private val cacheLock = Any()
 
@@ -102,12 +124,20 @@ internal class TransformedRegistryProjection<K : Comparable<K>, PK : Comparable<
                                     val oldValue = transformCache[key]
                                     if (bucket == null) {
                                         if (oldValue != null) {
+                                            // Remove from ordered index BEFORE cache update so the
+                                            // comparator can still find the old position.
+                                            orderedIndex.remove(key)
                                             transformCache.remove(key)
                                             add(ProjectionEntryChange(key, oldValue, null))
                                         }
                                     } else {
                                         val newValue = valueTransform(key, bucket)
+                                        // Reposition in orderedIndex: remove at old position (while
+                                        // cache still holds old value), update cache, re-insert at
+                                        // new position (comparator now sees the new value).
+                                        orderedIndex.remove(key)
                                         transformCache[key] = newValue
+                                        orderedIndex[key] = Unit
                                         if (newValue != oldValue) add(ProjectionEntryChange(key, oldValue, newValue))
                                     }
                                 }
@@ -129,7 +159,8 @@ internal class TransformedRegistryProjection<K : Comparable<K>, PK : Comparable<
             synchronized(cacheLock) {
                 initializeCache()
                 entriesChangedListeners.add(listener)
-                transformCache.map { (key, value) -> ProjectionEntryChange(key, null, value) }
+                // Snapshot ordered entries for the replay batch.
+                orderedIndex.keys.mapNotNull { key -> transformCache[key]?.let { value -> ProjectionEntryChange(key, null, value) } }
             }
         if (initial.isNotEmpty()) notifyListeners(listOf(listener), initial)
         return AutoCloseable { entriesChangedListeners.remove(listener) }
@@ -155,7 +186,9 @@ internal class TransformedRegistryProjection<K : Comparable<K>, PK : Comparable<
             seedingThread = Thread.currentThread()
             try {
                 for ((key, bucket) in backing) {
-                    transformCache[key] = valueTransform(key, bucket)
+                    val value = valueTransform(key, bucket)
+                    transformCache[key] = value
+                    orderedIndex[key] = Unit
                 }
             } finally {
                 seedingThread = null
@@ -164,10 +197,15 @@ internal class TransformedRegistryProjection<K : Comparable<K>, PK : Comparable<
         }
     }
 
+    // Snapshot the ordered keys under cacheLock to produce a stable, ordered set of entries.
     override val entries: Set<Map.Entry<PK, V>>
         get() {
             initializeCache()
-            return transformCache.entries
+            return synchronized(cacheLock) {
+                orderedIndex.keys.mapNotNull { key ->
+                    transformCache[key]?.let { value -> java.util.AbstractMap.SimpleImmutableEntry(key, value) }
+                }.toLinkedHashSet()
+            }
         }
 
     override val size: Int
@@ -179,13 +217,15 @@ internal class TransformedRegistryProjection<K : Comparable<K>, PK : Comparable<
     override val keys: Set<PK>
         get() {
             initializeCache()
-            return transformCache.keys
+            return synchronized(cacheLock) { LinkedHashSet(orderedIndex.keys) }
         }
 
     override val values: Collection<V>
         get() {
             initializeCache()
-            return transformCache.values
+            return synchronized(cacheLock) {
+                orderedIndex.keys.mapNotNull { transformCache[it] }
+            }
         }
 
     override fun get(key: PK): V? {
@@ -208,3 +248,5 @@ internal class TransformedRegistryProjection<K : Comparable<K>, PK : Comparable<
         return transformCache.isEmpty()
     }
 }
+
+private fun <T> List<T>.toLinkedHashSet(): LinkedHashSet<T> = LinkedHashSet(this)

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionTest.kt
@@ -1539,6 +1539,71 @@ internal class RegistryProjectionTest : StringSpec({
         projection.keys.toList() shouldContainExactly listOf("Rock", "Jazz", "Classical")
     }
 
+    "TransformedRegistryProjection with bucketValueOrdering inserts a bucket key created after seed without error" {
+        // Seed two buckets so the ordered index is non-empty before the incremental create.
+        trackRepo.create(1, "Track A", "Bravo")
+        trackRepo.create(2, "Track B", "Delta")
+
+        val projection =
+            registryProjection<Int, String, AudioItem, String>(
+                trackRepo, { it.albumName },
+                bucketValueOrdering = compareBy { it }
+            ) { pk, _ -> pk }
+
+        projection.keys.toList() shouldContainExactly listOf("Bravo", "Delta")
+
+        // A CREATE introducing a brand-new bucket key while the ordered index is non-empty must not
+        // throw: the reposition-remove is skipped for a key absent from the value cache, so the
+        // value-ordering comparator never dereferences a missing cached value.
+        trackRepo.create(3, "Track C", "Charlie")
+        reactive.advance()
+
+        projection.keys.toList() shouldContainExactly listOf("Bravo", "Charlie", "Delta")
+    }
+
+    "TransformedMultiKeyRegistryProjection with bucketValueOrdering inserts a bucket key created after seed without error" {
+        val multiKeyRepo = MultiKeyAudioItemVolatileRepository(ctx)
+        multiKeyRepo.create(1, "Artist A", setOf("Bravo"))
+        multiKeyRepo.create(2, "Artist B", setOf("Delta"))
+
+        val projection =
+            registryMultiKeyProjection<Int, String, MutableMultiKeyAudioItem, String>(
+                multiKeyRepo, { it.genres },
+                bucketValueOrdering = compareBy { it }
+            ) { pk, _ -> pk }
+
+        projection.keys.toList() shouldContainExactly listOf("Bravo", "Delta")
+
+        multiKeyRepo.create(3, "Artist C", setOf("Charlie"))
+        reactive.advance()
+
+        projection.keys.toList() shouldContainExactly listOf("Bravo", "Charlie", "Delta")
+    }
+
+    "TransformedRegistryProjection with bucketValueOrdering repositions a bucket when its transformed value changes" {
+        trackRepo.create(1, "Track A", "Alpha") // Alpha: 1 entry
+        trackRepo.create(2, "Track B", "Beta") // Beta: 1 entry
+        trackRepo.create(3, "Track C", "Beta") // Beta: 2 entries
+
+        // Order by bucket size stringified, ascending: "1" < "2".
+        val projection =
+            registryProjection<Int, String, AudioItem, String>(
+                trackRepo, { it.albumName },
+                bucketValueOrdering = compareBy { it }
+            ) { _, items -> "${items.size}" }
+
+        projection.keys.toList() shouldContainExactly listOf("Alpha", "Beta")
+
+        // Grow Alpha to 3 entries so its value ("3") sorts after Beta ("2"); the reposition must move
+        // the existing key without dropping or duplicating it.
+        trackRepo.create(4, "Track D", "Alpha")
+        trackRepo.create(5, "Track E", "Alpha")
+        reactive.advance()
+
+        projection.keys.size shouldBe 2
+        projection.keys.toList() shouldContainExactly listOf("Beta", "Alpha")
+    }
+
     "MultiKeyRegistryProjection iterates without ConcurrentModificationException under concurrent key-set churn stress"
         .config(tags = setOf(Stress)) {
             extension(ReactiveScopeSerialization)

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/RegistryProjectionTest.kt
@@ -1244,6 +1244,301 @@ internal class RegistryProjectionTest : StringSpec({
         projection["Rock"]!!.map { it.title } shouldContainExactly listOf("Zeppelin", "Aerosmith", "Beatles")
     }
 
+    // -------------------------------------------------------------------------
+    // Bucket-level ordering (bucketKeyOrdering) — single-key and multi-key
+    // -------------------------------------------------------------------------
+
+    "RegistryProjection with bucketKeyOrdering exposes keys in comparator order on seed" {
+        trackRepo.create(1, "Track A", "Rock")
+        trackRepo.create(2, "Track B", "Jazz")
+        trackRepo.create(3, "Track C", "Classical")
+
+        // Reverse alphabetical order: Rock, Jazz, Classical
+        val projection = registryProjection(trackRepo, { it.albumName }, bucketKeyOrdering = reverseOrder())
+
+        projection.keys.toList() shouldContainExactly listOf("Rock", "Jazz", "Classical")
+    }
+
+    "RegistryProjection without bucketKeyOrdering exposes keys in PK natural order" {
+        trackRepo.create(1, "Track A", "Rock")
+        trackRepo.create(2, "Track B", "Jazz")
+        trackRepo.create(3, "Track C", "Classical")
+
+        val projection = registryProjection(trackRepo, { it.albumName })
+
+        projection.keys.toList() shouldContainExactly listOf("Classical", "Jazz", "Rock")
+    }
+
+    "RegistryProjection with bucketKeyOrdering repositions bucket key after incremental create" {
+        trackRepo.create(1, "Track A", "Rock")
+        trackRepo.create(2, "Track B", "Jazz")
+
+        val projection = registryProjection(trackRepo, { it.albumName }, bucketKeyOrdering = reverseOrder())
+        projection.keys.toList() shouldContainExactly listOf("Rock", "Jazz")
+
+        trackRepo.create(3, "Track C", "Classical")
+        reactive.advance()
+
+        // Classical sorts first in natural order but last in reverse order
+        projection.keys.toList() shouldContainExactly listOf("Rock", "Jazz", "Classical")
+    }
+
+    "RegistryProjection with bucketKeyOrdering repositions bucket key after incremental remove empties bucket" {
+        trackRepo.create(1, "Track A", "Rock")
+        val jazz = trackRepo.create(2, "Track B", "Jazz")
+        trackRepo.create(3, "Track C", "Classical")
+
+        val projection = registryProjection(trackRepo, { it.albumName }, bucketKeyOrdering = reverseOrder())
+        projection.keys.toList() shouldContainExactly listOf("Rock", "Jazz", "Classical")
+
+        trackRepo.remove(jazz)
+        reactive.advance()
+
+        projection.keys.toList() shouldContainExactly listOf("Rock", "Classical")
+    }
+
+    "RegistryProjection with bucketKeyOrdering repositions bucket key after entity re-keys to new album" {
+        val item = trackRepo.create(1, "Track A", "Rock")
+        trackRepo.create(2, "Track B", "Rock") // Keep Rock bucket non-empty after re-key
+        trackRepo.create(3, "Track C", "Jazz")
+
+        val projection = registryProjection(trackRepo, { it.albumName }, bucketKeyOrdering = reverseOrder())
+        projection.keys.toList() shouldContainExactly listOf("Rock", "Jazz")
+
+        // Re-key entity 1 from "Rock" to "Blues"; entity 2 keeps Rock alive (reverse: Rock, Jazz, Blues)
+        val oldSnapshot = MutableAudioItem(item.id, item.title, "Rock")
+        val updated = MutableAudioItem(item.id, item.title, "Blues")
+        trackRepo.emitAsync(StandardCrudEvent.Update(updated, oldSnapshot))
+        reactive.advance()
+
+        projection.keys.toList() shouldContainExactly listOf("Rock", "Jazz", "Blues")
+    }
+
+    "RegistryProjection with bucketKeyOrdering retains both buckets when keys compare equal under comparator" {
+        // Case-insensitive comparator: "rock" and "Rock" compare equal; distinct PKs, both must survive
+        trackRepo.create(1, "Track A", "rock")
+        trackRepo.create(2, "Track B", "Rock")
+
+        val caseInsensitive = Comparator<String> { a, b -> a.lowercase().compareTo(b.lowercase()) }
+        val projection = registryProjection(trackRepo, { it.albumName }, bucketKeyOrdering = caseInsensitive)
+
+        // Both "rock" and "Rock" must be retained — PK tiebreak prevents collapsing equal-comparing keys
+        projection.keys.size shouldBe 2
+        projection.keys shouldContainExactly setOf("rock", "Rock")
+    }
+
+    "MultiKeyRegistryProjection with bucketKeyOrdering exposes keys in comparator order on seed" {
+        val multiKeyRepo = MultiKeyAudioItemVolatileRepository(ctx)
+        multiKeyRepo.create(1, "Zeppelin", setOf("Rock"))
+        multiKeyRepo.create(2, "Aerosmith", setOf("Jazz"))
+        multiKeyRepo.create(3, "Beatles", setOf("Classical"))
+
+        val projection = registryMultiKeyProjection(multiKeyRepo, { it.genres }, bucketKeyOrdering = reverseOrder())
+
+        projection.keys.toList() shouldContainExactly listOf("Rock", "Jazz", "Classical")
+    }
+
+    "MultiKeyRegistryProjection without bucketKeyOrdering exposes keys in PK natural order" {
+        val multiKeyRepo = MultiKeyAudioItemVolatileRepository(ctx)
+        multiKeyRepo.create(1, "Zeppelin", setOf("Rock"))
+        multiKeyRepo.create(2, "Aerosmith", setOf("Jazz"))
+        multiKeyRepo.create(3, "Beatles", setOf("Classical"))
+
+        val projection = registryMultiKeyProjection(multiKeyRepo, { it.genres })
+
+        projection.keys.toList() shouldContainExactly listOf("Classical", "Jazz", "Rock")
+    }
+
+    "MultiKeyRegistryProjection with bucketKeyOrdering retains both buckets when keys compare equal under comparator" {
+        val multiKeyRepo = MultiKeyAudioItemVolatileRepository(ctx)
+        // "rock" and "Rock" compare equal case-insensitively; both must survive as distinct buckets
+        multiKeyRepo.create(1, "Zeppelin", setOf("rock"))
+        multiKeyRepo.create(2, "Aerosmith", setOf("Rock"))
+
+        val caseInsensitive = Comparator<String> { a, b -> a.lowercase().compareTo(b.lowercase()) }
+        val projection = registryMultiKeyProjection(multiKeyRepo, { it.genres }, bucketKeyOrdering = caseInsensitive)
+
+        // PK tiebreak prevents collapsing equal-comparing keys — both must be retained
+        projection.keys.size shouldBe 2
+        projection.keys shouldContainExactly setOf("rock", "Rock")
+    }
+
+    "MultiKeyRegistryProjection with bucketKeyOrdering repositions bucket key after incremental key-set create" {
+        val multiKeyRepo = MultiKeyAudioItemVolatileRepository(ctx)
+        multiKeyRepo.create(1, "Zeppelin", setOf("Rock"))
+        multiKeyRepo.create(2, "Aerosmith", setOf("Jazz"))
+
+        val projection = registryMultiKeyProjection(multiKeyRepo, { it.genres }, bucketKeyOrdering = reverseOrder())
+        projection.keys.toList() shouldContainExactly listOf("Rock", "Jazz")
+
+        multiKeyRepo.create(3, "Beatles", setOf("Classical"))
+        reactive.advance()
+
+        projection.keys.toList() shouldContainExactly listOf("Rock", "Jazz", "Classical")
+    }
+
+    // -------------------------------------------------------------------------
+    // Transformed projections: value ordering, both-comparator composition,
+    // D-04 equal-value non-collapse, D-05 PK-default-not-hash
+    // -------------------------------------------------------------------------
+
+    "TransformedRegistryProjection without bucket comparator exposes keys in PK natural order" {
+        // Albums inserted out of alphabetical order: "Rock", "Jazz", "Classical"
+        trackRepo.create(1, "Track 1", "Rock")
+        trackRepo.create(2, "Track 2", "Jazz")
+        trackRepo.create(3, "Track 3", "Classical")
+
+        val projection =
+            registryProjection<Int, String, AudioItem, String>(trackRepo, { it.albumName }) { _, items ->
+                "${items.size}"
+            }
+
+        // PK natural order = String natural order = alphabetical
+        projection.keys.toList() shouldContainExactly listOf("Classical", "Jazz", "Rock")
+    }
+
+    "TransformedRegistryProjection with bucketValueOrdering exposes keys by transformed value order (value-only branch)" {
+        trackRepo.create(1, "Track A", "C-Album")
+        trackRepo.create(2, "Track B", "A-Album")
+        trackRepo.create(3, "Track C", "B-Album")
+
+        // Transform: produce the album name reversed (so "C-Album"->"mublA-C", "A-Album"->"mublA-A", "B-Album"->"mublA-B")
+        // Reversed: "A-Album"->"mublA-A", "B-Album"->"mublA-B", "C-Album"->"mublA-C"
+        // Natural order on reversed values: A < B < C, so keys come out A-Album, B-Album, C-Album
+        val projection =
+            registryProjection<Int, String, AudioItem, String>(
+                trackRepo, { it.albumName },
+                bucketValueOrdering = compareBy { it }
+            ) { pk, _ ->
+                pk.reversed()
+            }
+
+        // Reversed album names sorted: "mublA-A" < "mublA-B" < "mublA-C"
+        // Original keys in that order: "A-Album", "B-Album", "C-Album"
+        projection.keys.toList() shouldContainExactly listOf("A-Album", "B-Album", "C-Album")
+    }
+
+    "TransformedRegistryProjection with both comparators applies value-primary then key tiebreak then PK" {
+        // Transform: bucket count as a string, so all single-entity buckets tie on "1"
+        // With equal transformed values, key comparator (reverse String order) decides
+        trackRepo.create(1, "Track A", "Zephyr")
+        trackRepo.create(2, "Track B", "Alpha")
+        trackRepo.create(3, "Track C", "Mango")
+        // Fourth bucket with 2 entities — will sort first because "2" > "1" alphabetically? No: "2" > "1", so descending value comparator needed.
+        // Use compareByDescending: buckets with count "2" sort before "1"
+        trackRepo.create(4, "Track D", "Alpha") // Alpha now has 2 entities
+
+        // Transform: stringify entity count per bucket
+        // Alpha -> "2", Mango -> "1", Zephyr -> "1"
+        // bucketValueOrdering = compareByDescending { it } -> "2" first, then "1"s
+        // For ties on "1": bucketKeyOrdering = reverseOrder() -> Zephyr before Mango
+        val projection =
+            registryProjection<Int, String, AudioItem, String>(
+                trackRepo, { it.albumName },
+                bucketValueOrdering = compareByDescending { it },
+                bucketKeyOrdering = reverseOrder()
+            ) { _, items ->
+                "${items.size}"
+            }
+
+        // Alpha has 2 entities -> "2" (first); Zephyr and Mango both "1", reverseOrder -> Zephyr, Mango
+        projection.keys.toList() shouldContainExactly listOf("Alpha", "Zephyr", "Mango")
+    }
+
+    "TransformedRegistryProjection retains both keys when transformed values compare equal (D-04 equal-value non-collapse)" {
+        trackRepo.create(1, "Track A", "Rock")
+        trackRepo.create(2, "Track B", "Jazz")
+
+        // Transform always returns the same constant — both buckets produce equal transformed values.
+        // Without PK tiebreak this would collapse both into one slot; PK tiebreak prevents that.
+        val projection =
+            registryProjection<Int, String, AudioItem, String>(
+                trackRepo, { it.albumName },
+                bucketValueOrdering = compareBy { it }
+            ) { _, _ ->
+                "same-value"
+            }
+
+        // Both buckets must survive despite equal transformed values
+        projection.keys.size shouldBe 2
+        projection.keys shouldContainExactly setOf("Jazz", "Rock")
+    }
+
+    "TransformedMultiKeyRegistryProjection without bucket comparator exposes keys in PK natural order" {
+        val multiKeyRepo = MultiKeyAudioItemVolatileRepository(ctx)
+        // Genres inserted out of alphabetical order across entities
+        multiKeyRepo.create(1, "Artist 1", setOf("Rock"))
+        multiKeyRepo.create(2, "Artist 2", setOf("Jazz"))
+        multiKeyRepo.create(3, "Artist 3", setOf("Classical"))
+
+        val projection =
+            registryMultiKeyProjection<Int, String, MutableMultiKeyAudioItem, String>(multiKeyRepo, { it.genres }) { _, items ->
+                "${items.size}"
+            }
+
+        // PK natural order = alphabetical String order
+        projection.keys.toList() shouldContainExactly listOf("Classical", "Jazz", "Rock")
+    }
+
+    "TransformedMultiKeyRegistryProjection with bucketValueOrdering exposes keys by transformed value (value-only branch)" {
+        val multiKeyRepo = MultiKeyAudioItemVolatileRepository(ctx)
+        multiKeyRepo.create(1, "Artist A", setOf("C-Genre"))
+        multiKeyRepo.create(2, "Artist B", setOf("A-Genre"))
+        multiKeyRepo.create(3, "Artist C", setOf("B-Genre"))
+
+        // Transform: produce the genre name reversed; order by reversed value ascending
+        val projection =
+            registryMultiKeyProjection<Int, String, MutableMultiKeyAudioItem, String>(
+                multiKeyRepo, { it.genres },
+                bucketValueOrdering = compareBy { it }
+            ) { pk, _ ->
+                pk.reversed()
+            }
+
+        // Reversed: "C-Genre"->"erneG-C", "A-Genre"->"erneG-A", "B-Genre"->"erneG-B"
+        // Natural order: A < B < C -> A-Genre, B-Genre, C-Genre
+        projection.keys.toList() shouldContainExactly listOf("A-Genre", "B-Genre", "C-Genre")
+    }
+
+    "TransformedMultiKeyRegistryProjection retains both keys when transformed values compare equal (D-04 equal-value non-collapse)" {
+        val multiKeyRepo = MultiKeyAudioItemVolatileRepository(ctx)
+        multiKeyRepo.create(1, "Artist A", setOf("Rock"))
+        multiKeyRepo.create(2, "Artist B", setOf("Jazz"))
+
+        // Transform always returns the same constant value — PK tiebreak must prevent key collapse
+        val projection =
+            registryMultiKeyProjection<Int, String, MutableMultiKeyAudioItem, String>(
+                multiKeyRepo, { it.genres },
+                bucketValueOrdering = compareBy { it }
+            ) { _, _ ->
+                "same-value"
+            }
+
+        projection.keys.size shouldBe 2
+        projection.keys shouldContainExactly setOf("Jazz", "Rock")
+    }
+
+    "TransformedMultiKeyRegistryProjection with both comparators applies value-primary then key tiebreak then PK" {
+        val multiKeyRepo = MultiKeyAudioItemVolatileRepository(ctx)
+        // Create buckets: "Rock" with 2 artists (transform -> "2"), "Jazz" and "Classical" with 1 each (-> "1")
+        multiKeyRepo.create(1, "Artist 1", setOf("Rock"))
+        multiKeyRepo.create(2, "Artist 2", setOf("Rock", "Jazz"))
+        multiKeyRepo.create(3, "Artist 3", setOf("Classical"))
+
+        // descending value order: "2" before "1"; for ties on "1": reverseOrder -> Jazz before Classical
+        val projection =
+            registryMultiKeyProjection<Int, String, MutableMultiKeyAudioItem, String>(
+                multiKeyRepo, { it.genres },
+                bucketValueOrdering = compareByDescending { it },
+                bucketKeyOrdering = reverseOrder()
+            ) { _, items ->
+                "${items.size}"
+            }
+
+        // Rock has 2 -> first; Jazz and Classical both "1", reverseOrder -> Jazz, Classical
+        projection.keys.toList() shouldContainExactly listOf("Rock", "Jazz", "Classical")
+    }
+
     "MultiKeyRegistryProjection iterates without ConcurrentModificationException under concurrent key-set churn stress"
         .config(tags = setOf(Stress)) {
             extension(ReactiveScopeSerialization)

--- a/lirp-fx/api/lirp-fx.api
+++ b/lirp-fx/api/lirp-fx.api
@@ -308,18 +308,18 @@ public final class net/transgressoft/lirp/persistence/fx/projection/FxProjection
 	public static synthetic fun fxProjection$default (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
 	public static synthetic fun fxProjection$default (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
 	public static synthetic fun fxProjection$default (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxProjection;
-	public static final fun registryFxMultiKeyProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
-	public static final fun registryFxMultiKeyProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
-	public static final fun registryFxMultiKeyProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;)Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjection;
-	public static synthetic fun registryFxMultiKeyProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
-	public static synthetic fun registryFxMultiKeyProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
-	public static synthetic fun registryFxMultiKeyProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjection;
-	public static final fun registryFxProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
-	public static final fun registryFxProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
-	public static final fun registryFxProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;)Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxProjection;
-	public static synthetic fun registryFxProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
-	public static synthetic fun registryFxProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
-	public static synthetic fun registryFxProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxProjection;
+	public static final fun registryFxMultiKeyProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
+	public static final fun registryFxMultiKeyProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
+	public static final fun registryFxMultiKeyProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;Ljava/util/Comparator;)Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjection;
+	public static synthetic fun registryFxMultiKeyProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
+	public static synthetic fun registryFxMultiKeyProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
+	public static synthetic fun registryFxMultiKeyProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;Ljava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjection;
+	public static final fun registryFxProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
+	public static final fun registryFxProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
+	public static final fun registryFxProjection (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;Ljava/util/Comparator;)Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxProjection;
+	public static synthetic fun registryFxProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
+	public static synthetic fun registryFxProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/FxObservableProjection;
+	public static synthetic fun registryFxProjection$default (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;Ljava/util/Comparator;ILjava/lang/Object;)Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxProjection;
 }
 
 public final class net/transgressoft/lirp/persistence/fx/projection/FxProjections {
@@ -354,8 +354,8 @@ public final class net/transgressoft/lirp/persistence/fx/projection/FxProjection
 
 public final class net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjection : java/lang/AutoCloseable, javafx/collections/ObservableMap {
 	public static final field Companion Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjection$Companion;
-	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;)V
-	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;Ljava/util/Comparator;)V
+	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;Ljava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addListener (Ljavafx/beans/InvalidationListener;)V
 	public fun addListener (Ljavafx/collections/MapChangeListener;)V
 	public fun clear ()Ljava/lang/Void;
@@ -369,6 +369,7 @@ public final class net/transgressoft/lirp/persistence/fx/projection/RegistryFxMu
 	public fun get (Ljava/lang/Comparable;)Ljava/util/List;
 	public final synthetic fun get (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun get (Ljava/lang/Object;)Ljava/util/List;
+	public final fun getBucketKeyOrdering ()Ljava/util/Comparator;
 	public final fun getDispatchToFxThread ()Z
 	public fun getEntries ()Ljava/util/Set;
 	public final fun getEntryOrdering ()Ljava/util/Comparator;
@@ -397,8 +398,8 @@ public final class net/transgressoft/lirp/persistence/fx/projection/RegistryFxMu
 
 public final class net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjection : java/lang/AutoCloseable, javafx/collections/ObservableMap {
 	public static final field Companion Lnet/transgressoft/lirp/persistence/fx/projection/RegistryFxProjection$Companion;
-	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;)V
-	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;Ljava/util/Comparator;)V
+	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;ZLjava/util/Comparator;Ljava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addListener (Ljavafx/beans/InvalidationListener;)V
 	public fun addListener (Ljavafx/collections/MapChangeListener;)V
 	public fun clear ()Ljava/lang/Void;
@@ -412,6 +413,7 @@ public final class net/transgressoft/lirp/persistence/fx/projection/RegistryFxPr
 	public fun get (Ljava/lang/Comparable;)Ljava/util/List;
 	public final synthetic fun get (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun get (Ljava/lang/Object;)Ljava/util/List;
+	public final fun getBucketKeyOrdering ()Ljava/util/Comparator;
 	public final fun getDispatchToFxThread ()Z
 	public fun getEntries ()Ljava/util/Set;
 	public final fun getEntryOrdering ()Ljava/util/Comparator;
@@ -524,10 +526,10 @@ public final class net/transgressoft/lirp/persistence/fx/projection/TransformedF
 
 public final class net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjection : net/transgressoft/lirp/persistence/fx/projection/FxObservableProjection {
 	public static final field Companion Lnet/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjection$Companion;
-	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;)V
-	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;)V
-	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;)V
+	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;)V
+	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addListener (Ljavafx/beans/InvalidationListener;)V
 	public fun addListener (Ljavafx/collections/MapChangeListener;)V
 	public fun addOnEntriesChangedListener (Lkotlin/jvm/functions/Function1;)Ljava/lang/AutoCloseable;
@@ -540,6 +542,8 @@ public final class net/transgressoft/lirp/persistence/fx/projection/TransformedR
 	public final fun entrySet ()Ljava/util/Set;
 	public fun get (Ljava/lang/Comparable;)Ljava/lang/Object;
 	public final fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun getBucketKeyOrdering ()Ljava/util/Comparator;
+	public final fun getBucketValueOrdering ()Ljava/util/Comparator;
 	public final fun getDispatchToFxThread ()Z
 	public fun getEntries ()Ljava/util/Set;
 	public final fun getEntryOrdering ()Ljava/util/Comparator;
@@ -567,10 +571,10 @@ public final class net/transgressoft/lirp/persistence/fx/projection/TransformedR
 
 public final class net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjection : net/transgressoft/lirp/persistence/fx/projection/FxObservableProjection {
 	public static final field Companion Lnet/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjection$Companion;
-	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;)V
-	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;)V
-	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;)V
+	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;)V
+	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/Registry;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ZLjava/util/Comparator;Ljava/util/Comparator;Ljava/util/Comparator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun addListener (Ljavafx/beans/InvalidationListener;)V
 	public fun addListener (Ljavafx/collections/MapChangeListener;)V
 	public fun addOnEntriesChangedListener (Lkotlin/jvm/functions/Function1;)Ljava/lang/AutoCloseable;
@@ -583,6 +587,8 @@ public final class net/transgressoft/lirp/persistence/fx/projection/TransformedR
 	public final fun entrySet ()Ljava/util/Set;
 	public fun get (Ljava/lang/Comparable;)Ljava/lang/Object;
 	public final fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun getBucketKeyOrdering ()Ljava/util/Comparator;
+	public final fun getBucketValueOrdering ()Ljava/util/Comparator;
 	public final fun getDispatchToFxThread ()Z
 	public fun getEntries ()Ljava/util/Set;
 	public final fun getEntryOrdering ()Ljava/util/Comparator;

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxBucketOrdering.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxBucketOrdering.kt
@@ -1,0 +1,70 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx.projection
+
+/**
+ * Builds a composite bucket comparator over projection keys (`PK`) for use as a
+ * [java.util.concurrent.ConcurrentSkipListMap] comparator on the FX observable backing.
+ *
+ * The composition order is:
+ * 1. **Value-primary** — when [bucketValueOrdering] is supplied, buckets are compared first by
+ *    the cached transformed value obtained via [valueOf]. The comparator reads the pre-computed
+ *    value; it never invokes any transform.
+ * 2. **Key tiebreak** — when [bucketKeyOrdering] is supplied, buckets that compare equal under
+ *    [bucketValueOrdering] (or when [bucketValueOrdering] is absent) are further ordered by the
+ *    bucket key itself.
+ * 3. **PK natural-order final tiebreak** — `Comparator.naturalOrder<PK>()` is always appended.
+ *    This is mandatory for correctness: a coarse comparator may return `0` for two distinct
+ *    bucket keys; without the PK tiebreak, the ordered map would collapse those two distinct
+ *    keys into one, silently dropping a bucket.
+ *
+ * @param PK the projection key type; must be [Comparable]
+ * @param V the transformed value type; only used when [bucketValueOrdering] is non-null
+ * @param bucketValueOrdering optional comparator that orders buckets by their transformed value;
+ *   used with [valueOf] to compare the cached `V` for two keys. `null` skips value-primary ordering.
+ * @param bucketKeyOrdering optional comparator that orders buckets by the bucket key itself.
+ *   `null` skips key-level ordering (beyond the mandatory PK final tiebreak).
+ * @param valueOf accessor that returns the cached transformed value for a given bucket key;
+ *   called inside the returned comparator — must read a cached result, never recompute a transform.
+ * @return a [Comparator]<PK> resolving to a stable total order over all distinct bucket keys
+ */
+internal fun <PK : Comparable<PK>, V : Any> buildBucketComparator(
+    bucketValueOrdering: Comparator<V>?,
+    bucketKeyOrdering: Comparator<PK>?,
+    valueOf: (PK) -> V?
+): Comparator<PK> {
+    var cmp: Comparator<PK>? = null
+    if (bucketValueOrdering != null) {
+        cmp =
+            Comparator { a, b ->
+                val va = valueOf(a)
+                val vb = valueOf(b)
+                when {
+                    va == null && vb == null -> 0
+                    va == null -> -1
+                    vb == null -> 1
+                    else -> bucketValueOrdering.compare(va, vb)
+                }
+            }
+    }
+    if (bucketKeyOrdering != null) {
+        cmp = cmp?.thenComparing(bucketKeyOrdering) ?: bucketKeyOrdering
+    }
+    val natural = Comparator.naturalOrder<PK>()
+    return cmp?.thenComparing(natural) ?: natural
+}

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionFactories.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionFactories.kt
@@ -81,15 +81,20 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> fxProjec
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   applied on the background thread before the FX-thread dispatch. Equal elements retain arrival
  *   order (stable-after-equals). When `null` (default), buckets retain insertion order.
+ * @param bucketKeyOrdering optional comparator that orders buckets (map entries) by their projection
+ *   key. When non-null the observable map iterates keys in the given order with a mandatory PK
+ *   natural-order tiebreak, so two distinct keys that compare equal under the comparator are both
+ *   retained. When `null` (default), keys iterate in PK natural order.
  * @return a read-only observable projection map delegate incrementally updated from the registry
  */
 fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> registryFxProjection(
     registry: Registry<K, E>,
     keyExtractor: (E) -> PK,
     dispatchToFxThread: Boolean = true,
-    entryOrdering: Comparator<E>? = null
+    entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null
 ): RegistryFxProjection<K, PK, E> =
-    RegistryFxProjection(registry, keyExtractor, dispatchToFxThread, entryOrdering)
+    RegistryFxProjection(registry, keyExtractor, dispatchToFxThread, entryOrdering, bucketKeyOrdering)
 
 /**
  * Creates a value-transformed read-only [ObservableMap] projection that groups entities from an
@@ -216,6 +221,13 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, D, V : A
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   applied on the background thread so [valueTransform] receives an already-ordered list. Equal
  *   elements retain arrival order (stable-after-equals). When `null` (default), insertion order is kept.
+ * @param bucketKeyOrdering optional comparator that orders buckets by the bucket key itself.
+ *   When non-null the observable map iterates keys in this order with a mandatory PK natural-order
+ *   tiebreak. When `null` (default), key-level ordering is skipped.
+ * @param bucketValueOrdering optional comparator that orders buckets by their transformed value `V`.
+ *   When non-null, the observable collection iterates in value-primary order (then key, then PK
+ *   natural order as the mandatory tiebreak), applied before the FX-thread pulse.
+ *   When `null` (default), value-primary ordering is skipped.
  * @return an [FxObservableProjection] grouping transformed bucket values by secondary key;
  *   its [addOnEntriesChangedListener][ObservableProjection.addOnEntriesChangedListener]
  *   emits per-key old/new transformed values in addition to the [ObservableMap]/[javafx.collections.MapChangeListener] surface
@@ -225,9 +237,11 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>
     keyExtractor: (E) -> PK,
     valueTransform: (PK, List<E>) -> V,
     dispatchToFxThread: Boolean = true,
-    entryOrdering: Comparator<E>? = null
+    entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null,
+    bucketValueOrdering: Comparator<V>? = null
 ): FxObservableProjection<PK, V> =
-    TransformedRegistryFxProjection(registry, keyExtractor, valueTransform, dispatchToFxThread, entryOrdering)
+    TransformedRegistryFxProjection(registry, keyExtractor, valueTransform, dispatchToFxThread, entryOrdering, bucketKeyOrdering, bucketValueOrdering)
 
 /**
  * Creates a two-phase value-transformed read-only [ObservableMap] projection that groups all entities
@@ -271,6 +285,13 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   applied on the background thread so [dataTransform] receives an already-ordered list. Equal
  *   elements retain arrival order (stable-after-equals). When `null` (default), insertion order is kept.
+ * @param bucketKeyOrdering optional comparator that orders buckets by the bucket key itself.
+ *   When non-null the observable map iterates keys in this order with a mandatory PK natural-order
+ *   tiebreak. When `null` (default), key-level ordering is skipped.
+ * @param bucketValueOrdering optional comparator that orders buckets by their transformed value `V`.
+ *   When non-null, the observable collection iterates in value-primary order (then key, then PK
+ *   natural order as the mandatory tiebreak), applied before the FX-thread pulse.
+ *   When `null` (default), value-primary ordering is skipped.
  * @return an [FxObservableProjection] grouping transformed bucket values by secondary key;
  *   its [addOnEntriesChangedListener][ObservableProjection.addOnEntriesChangedListener]
  *   emits per-key old/new transformed values in addition to the [ObservableMap]/[javafx.collections.MapChangeListener] surface
@@ -282,7 +303,9 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, D, V : A
     dataTransform: (PK, List<E>) -> D,
     fxFactory: (PK, D) -> V,
     dispatchToFxThread: Boolean = true,
-    entryOrdering: Comparator<E>? = null
+    entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null,
+    bucketValueOrdering: Comparator<V>? = null
 ): FxObservableProjection<PK, V> =
     TransformedRegistryFxProjection(
         registry,
@@ -290,7 +313,9 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, D, V : A
         dataTransform as (PK, List<E>) -> Any?,
         fxFactory as (PK, Any?) -> V,
         dispatchToFxThread,
-        entryOrdering
+        entryOrdering,
+        bucketKeyOrdering,
+        bucketValueOrdering
     )
 
 /**
@@ -448,15 +473,20 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E, D, V : Any> fxMultiKeyProjection
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   applied on the background thread before the FX-thread dispatch. Equal elements retain arrival
  *   order (stable-after-equals). When `null` (default), buckets retain insertion order.
+ * @param bucketKeyOrdering optional comparator that orders buckets (map entries) by their projection
+ *   key. When non-null the observable map iterates keys in the given order with a mandatory PK
+ *   natural-order tiebreak, so two distinct keys that compare equal under the comparator are both
+ *   retained. When `null` (default), keys iterate in PK natural order.
  * @return a read-only multi-key projection map delegate incrementally updated from the registry
  */
 fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> registryFxMultiKeyProjection(
     registry: Registry<K, E>,
     keyExtractor: (E) -> Collection<PK>,
     dispatchToFxThread: Boolean = true,
-    entryOrdering: Comparator<E>? = null
+    entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null
 ): RegistryFxMultiKeyProjection<K, PK, E> =
-    RegistryFxMultiKeyProjection(registry, keyExtractor, dispatchToFxThread, entryOrdering)
+    RegistryFxMultiKeyProjection(registry, keyExtractor, dispatchToFxThread, entryOrdering, bucketKeyOrdering)
 
 /**
  * Creates a value-transformed read-only [ObservableMap] multi-key projection delegate that groups
@@ -486,6 +516,13 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>> registry
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   applied on the background thread so [valueTransform] receives an already-ordered list. Equal
  *   elements retain arrival order (stable-after-equals). When `null` (default), insertion order is kept.
+ * @param bucketKeyOrdering optional comparator that orders buckets by the bucket key itself.
+ *   When non-null the observable map iterates keys in this order with a mandatory PK natural-order
+ *   tiebreak. When `null` (default), key-level ordering is skipped.
+ * @param bucketValueOrdering optional comparator that orders buckets by their transformed value `V`.
+ *   When non-null, the observable collection iterates in value-primary order (then key, then PK
+ *   natural order as the mandatory tiebreak), applied before the FX-thread pulse.
+ *   When `null` (default), value-primary ordering is skipped.
  * @return an [FxObservableProjection] grouping transformed bucket values by multiple secondary keys;
  *   its [addOnEntriesChangedListener][ObservableProjection.addOnEntriesChangedListener]
  *   emits per-key old/new transformed values in addition to the [ObservableMap]/[javafx.collections.MapChangeListener] surface
@@ -495,9 +532,11 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>
     keyExtractor: (E) -> Collection<PK>,
     valueTransform: (PK, List<E>) -> V,
     dispatchToFxThread: Boolean = true,
-    entryOrdering: Comparator<E>? = null
+    entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null,
+    bucketValueOrdering: Comparator<V>? = null
 ): FxObservableProjection<PK, V> =
-    TransformedRegistryFxMultiKeyProjection(registry, keyExtractor, valueTransform, dispatchToFxThread, entryOrdering)
+    TransformedRegistryFxMultiKeyProjection(registry, keyExtractor, valueTransform, dispatchToFxThread, entryOrdering, bucketKeyOrdering, bucketValueOrdering)
 
 /**
  * Creates a two-phase value-transformed read-only [ObservableMap] multi-key projection delegate that
@@ -542,6 +581,13 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   applied on the background thread so [dataTransform] receives an already-ordered list. Equal
  *   elements retain arrival order (stable-after-equals). When `null` (default), insertion order is kept.
+ * @param bucketKeyOrdering optional comparator that orders buckets by the bucket key itself.
+ *   When non-null the observable map iterates keys in this order with a mandatory PK natural-order
+ *   tiebreak. When `null` (default), key-level ordering is skipped.
+ * @param bucketValueOrdering optional comparator that orders buckets by their transformed value `V`.
+ *   When non-null, the observable collection iterates in value-primary order (then key, then PK
+ *   natural order as the mandatory tiebreak), applied before the FX-thread pulse.
+ *   When `null` (default), value-primary ordering is skipped.
  * @return an [FxObservableProjection] grouping transformed bucket values by multiple secondary keys;
  *   its [addOnEntriesChangedListener][ObservableProjection.addOnEntriesChangedListener]
  *   emits per-key old/new transformed values in addition to the [ObservableMap]/[javafx.collections.MapChangeListener] surface
@@ -553,7 +599,9 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, D, V : A
     dataTransform: (PK, List<E>) -> D,
     fxFactory: (PK, D) -> V,
     dispatchToFxThread: Boolean = true,
-    entryOrdering: Comparator<E>? = null
+    entryOrdering: Comparator<E>? = null,
+    bucketKeyOrdering: Comparator<PK>? = null,
+    bucketValueOrdering: Comparator<V>? = null
 ): FxObservableProjection<PK, V> =
     TransformedRegistryFxMultiKeyProjection(
         registry,
@@ -561,5 +609,7 @@ fun <K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, D, V : A
         dataTransform as (PK, List<E>) -> Any?,
         fxFactory as (PK, Any?) -> V,
         dispatchToFxThread,
-        entryOrdering
+        entryOrdering,
+        bucketKeyOrdering,
+        bucketValueOrdering
     )

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjection.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjection.kt
@@ -70,16 +70,26 @@ import kotlinx.coroutines.launch
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   ordering is applied on the background thread before the FX-thread dispatch. When `null` (default),
  *   buckets retain insertion order and existing behaviour is preserved.
+ * @param bucketKeyOrdering optional comparator that orders buckets (map entries) by their projection
+ *   key. When non-null the observable map iterates keys in the given order with a mandatory PK
+ *   natural-order tiebreak, so two distinct keys that compare equal under the comparator are both
+ *   retained. When `null` (default), keys iterate in PK natural order.
  */
 class RegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>>(
     private val registry: Registry<K, E>,
     private val keyExtractor: (E) -> Collection<PK>,
     val dispatchToFxThread: Boolean = true,
-    val entryOrdering: Comparator<E>? = null
+    val entryOrdering: Comparator<E>? = null,
+    val bucketKeyOrdering: Comparator<PK>? = null
 ) : ObservableMap<PK, List<E>>, AutoCloseable {
 
     private val innerObservableMap: ObservableMap<PK, List<E>> =
-        FXCollections.observableMap(ConcurrentSkipListMap<PK, List<E>>())
+        FXCollections.observableMap(
+            if (bucketKeyOrdering != null)
+                ConcurrentSkipListMap<PK, List<E>>(bucketKeyOrdering.thenComparing(Comparator.naturalOrder<PK>()))
+            else
+                ConcurrentSkipListMap<PK, List<E>>()
+        )
 
     @Volatile
     private var initialized = false
@@ -98,7 +108,7 @@ class RegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable<PK>, E : I
     private val flushScheduled = AtomicBoolean(false)
 
     private val core: MultiKeyRegistryProjection<K, PK, E> =
-        MultiKeyRegistryProjection(registry, keyExtractor, entryOrdering)
+        MultiKeyRegistryProjection(registry, keyExtractor, entryOrdering, bucketKeyOrdering)
 
     init {
         mutationChannel?.let { channel ->

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjection.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjection.kt
@@ -70,15 +70,25 @@ import kotlinx.coroutines.launch
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   ordering is applied on the background thread before the FX-thread dispatch. When `null` (default),
  *   buckets retain insertion order and existing behaviour is preserved.
+ * @param bucketKeyOrdering optional comparator that orders buckets (map entries) by their projection
+ *   key. When non-null the observable map iterates keys in the given order with a mandatory PK
+ *   natural-order tiebreak, so two distinct keys that compare equal under the comparator are both
+ *   retained. When `null` (default), keys iterate in PK natural order.
  */
 class RegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>>(
     private val registry: Registry<K, E>,
     private val keyExtractor: (E) -> PK,
     val dispatchToFxThread: Boolean = true,
-    val entryOrdering: Comparator<E>? = null
+    val entryOrdering: Comparator<E>? = null,
+    val bucketKeyOrdering: Comparator<PK>? = null
 ) : ObservableMap<PK, List<E>>, AutoCloseable {
     private val innerObservableMap: ObservableMap<PK, List<E>> =
-        FXCollections.observableMap(ConcurrentSkipListMap<PK, List<E>>())
+        FXCollections.observableMap(
+            if (bucketKeyOrdering != null)
+                ConcurrentSkipListMap<PK, List<E>>(bucketKeyOrdering.thenComparing(Comparator.naturalOrder<PK>()))
+            else
+                ConcurrentSkipListMap<PK, List<E>>()
+        )
 
     @Volatile
     private var initialized = false
@@ -107,7 +117,7 @@ class RegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : Identifia
     private val pendingUpdateKeys = LinkedHashSet<PK>()
     private val flushScheduled = AtomicBoolean(false)
 
-    private val core: RegistryProjection<K, PK, E> = RegistryProjection(registry, keyExtractor, entryOrdering)
+    private val core: RegistryProjection<K, PK, E> = RegistryProjection(registry, keyExtractor, entryOrdering, bucketKeyOrdering)
 
     // Subscription that forces a flush for in-place mutations where the entity is mutated
     // on the same object reference already stored in the bucket. In those cases the core's

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjection.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjection.kt
@@ -346,21 +346,27 @@ class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable
 
     // Applies drained removals and updates to innerObservableMap, invoking fxFactory per updated
     // bucket and skipping any bucket whose fxFactory throws. Returns the recomputed values by key.
-    // When bucketValueOrdering is active, stagedValues is updated before the observable map is mutated
-    // so that the skip-list comparator reads the correct staged V during the insert operation — this
-    // positions the new entry in value-primary order within the observable backing before listeners fire.
+    // When bucketValueOrdering is active, innerObservableMap is a ConcurrentSkipListMap whose
+    // comparator reads stagedValues to locate a key. Every removal of an existing node must therefore
+    // run while stagedValues still holds that key's old value, otherwise the comparator walks to the
+    // wrong position and the node is missed — leaving a stale entry or inserting a duplicate. So the
+    // map removal always precedes the stagedValues mutation.
     private fun applyMutations(removals: Set<PK>, updates: Map<PK, Any?>): Map<PK, V> {
         for (key in removals) {
-            stagedValues?.remove(key)
             innerObservableMap.remove(key)
+            stagedValues?.remove(key)
         }
         val newValues = mutableMapOf<PK, V>()
         for ((key, d) in updates) {
             try {
                 val v = fxFactory(key, d)
+                // Remove the node at its OLD position first (comparator still reads the old staged
+                // value), then stage the new value so the re-insert below lands at the new
+                // value-ordered position. Remove-then-insert guarantees repositioning when the value
+                // (and thus order) changes.
                 if (stagedValues != null) {
-                    stagedValues[key] = v
                     innerObservableMap.remove(key)
+                    stagedValues[key] = v
                 }
                 innerObservableMap[key] = v
                 newValues[key] = v

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjection.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxMultiKeyProjection.kt
@@ -30,6 +30,7 @@ import javafx.collections.FXCollections
 import javafx.collections.MapChangeListener
 import javafx.collections.ObservableMap
 import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentSkipListMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CopyOnWriteArraySet
@@ -94,6 +95,14 @@ import kotlinx.coroutines.launch
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   ordering is applied on the background thread (inside [dataTransform]'s input) before the
  *   FX-thread dispatch. When `null` (default), buckets retain insertion order.
+ * @param bucketKeyOrdering optional comparator that orders buckets by the bucket key itself. When
+ *   non-null (and [bucketValueOrdering] is null), the observable map iterates keys in this order
+ *   with a mandatory PK natural-order tiebreak. When `null` (default), key-level ordering is skipped.
+ * @param bucketValueOrdering optional comparator that orders buckets by their transformed value `V`.
+ *   When non-null, the observable collection iterates in value-primary order (then key, then PK
+ *   natural order as the mandatory tiebreak), applied before the FX-thread pulse. The comparator
+ *   reads the already-staged `V`; it never invokes [dataTransform] or [fxFactory].
+ *   When `null` (default), value-primary ordering is skipped.
  */
 class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>(
     private val registry: Registry<K, E>,
@@ -102,13 +111,33 @@ class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable
     @Suppress("UNCHECKED_CAST")
     private val fxFactory: (PK, Any?) -> V,
     val dispatchToFxThread: Boolean = true,
-    val entryOrdering: Comparator<E>? = null
+    val entryOrdering: Comparator<E>? = null,
+    val bucketKeyOrdering: Comparator<PK>? = null,
+    val bucketValueOrdering: Comparator<V>? = null
 ) : FxObservableProjection<PK, V> {
 
     private val log = KotlinLogging.logger {}
 
+    // When bucketValueOrdering is active, the observable map is backed by a ConcurrentSkipListMap
+    // whose comparator reads from stagedValues — so entries iterate in value-primary order. The
+    // comparator reads only already-staged V; it never invokes dataTransform or fxFactory (Pitfall 3).
+    private val stagedValues: ConcurrentHashMap<PK, V>? =
+        if (bucketValueOrdering != null) ConcurrentHashMap() else null
+
     private val innerObservableMap: ObservableMap<PK, V> =
-        FXCollections.observableMap(ConcurrentSkipListMap<PK, V>())
+        FXCollections.observableMap(
+            when {
+                bucketValueOrdering != null -> {
+                    val sv = stagedValues!!
+                    val cmp = buildBucketComparator<PK, V>(bucketValueOrdering, bucketKeyOrdering) { sv[it] }
+                    ConcurrentSkipListMap<PK, V>(cmp)
+                }
+                bucketKeyOrdering != null ->
+                    ConcurrentSkipListMap<PK, V>(bucketKeyOrdering.thenComparing(Comparator.naturalOrder<PK>()))
+                else ->
+                    ConcurrentSkipListMap<PK, V>()
+            }
+        )
 
     private val entriesChangedListeners = CopyOnWriteArrayList<(List<ProjectionEntryChange<PK, V>>) -> Unit>()
 
@@ -151,6 +180,10 @@ class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable
      * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
      * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted
      *   order before [valueTransform] receives it. When `null` (default), insertion order is kept.
+     * @param bucketKeyOrdering optional comparator that orders buckets by their projection key.
+     *   When `null` (default), key-level ordering is skipped.
+     * @param bucketValueOrdering optional comparator that orders buckets by their transformed value `V`,
+     *   applied before the FX-thread pulse. When `null` (default), value-primary ordering is skipped.
      */
     @Suppress("UNCHECKED_CAST")
     constructor(
@@ -158,14 +191,18 @@ class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable
         keyExtractor: (E) -> Collection<PK>,
         valueTransform: (PK, List<E>) -> V,
         dispatchToFxThread: Boolean = true,
-        entryOrdering: Comparator<E>? = null
+        entryOrdering: Comparator<E>? = null,
+        bucketKeyOrdering: Comparator<PK>? = null,
+        bucketValueOrdering: Comparator<V>? = null
     ) : this(
         registry = registry,
         keyExtractor = keyExtractor,
         dataTransform = valueTransform,
         fxFactory = { _, staged -> staged as V },
         dispatchToFxThread = dispatchToFxThread,
-        entryOrdering = entryOrdering
+        entryOrdering = entryOrdering,
+        bucketKeyOrdering = bucketKeyOrdering,
+        bucketValueOrdering = bucketValueOrdering
     )
 
     init {
@@ -217,7 +254,11 @@ class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable
         runSeedOnFxThread(dispatchToFxThread) {
             for ((key, d) in staged) {
                 try {
-                    innerObservableMap[key] = fxFactory(key, d)
+                    val v = fxFactory(key, d)
+                    // Update stagedValues before inserting so the ConcurrentSkipListMap comparator
+                    // can read the cached V when positioning this entry in value-primary order.
+                    stagedValues?.set(key, v)
+                    innerObservableMap[key] = v
                 } catch (t: Throwable) {
                     log.error(t) { "fxFactory failed for bucket key=$key during seed; skipping this bucket" }
                 }
@@ -305,12 +346,22 @@ class TransformedRegistryFxMultiKeyProjection<K : Comparable<K>, PK : Comparable
 
     // Applies drained removals and updates to innerObservableMap, invoking fxFactory per updated
     // bucket and skipping any bucket whose fxFactory throws. Returns the recomputed values by key.
+    // When bucketValueOrdering is active, stagedValues is updated before the observable map is mutated
+    // so that the skip-list comparator reads the correct staged V during the insert operation — this
+    // positions the new entry in value-primary order within the observable backing before listeners fire.
     private fun applyMutations(removals: Set<PK>, updates: Map<PK, Any?>): Map<PK, V> {
-        for (key in removals) innerObservableMap.remove(key)
+        for (key in removals) {
+            stagedValues?.remove(key)
+            innerObservableMap.remove(key)
+        }
         val newValues = mutableMapOf<PK, V>()
         for ((key, d) in updates) {
             try {
                 val v = fxFactory(key, d)
+                if (stagedValues != null) {
+                    stagedValues[key] = v
+                    innerObservableMap.remove(key)
+                }
                 innerObservableMap[key] = v
                 newValues[key] = v
             } catch (t: Throwable) {

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjection.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjection.kt
@@ -32,6 +32,7 @@ import javafx.beans.InvalidationListener
 import javafx.collections.FXCollections
 import javafx.collections.MapChangeListener
 import javafx.collections.ObservableMap
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentSkipListMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CopyOnWriteArraySet
@@ -100,6 +101,14 @@ import kotlinx.coroutines.launch
  * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted order;
  *   ordering is applied on the background thread (inside [dataTransform]'s input) before the
  *   FX-thread dispatch. When `null` (default), buckets retain insertion order.
+ * @param bucketKeyOrdering optional comparator that orders buckets by the bucket key itself. When
+ *   non-null (and [bucketValueOrdering] is null), the observable map iterates keys in this order
+ *   with a mandatory PK natural-order tiebreak. When `null` (default), key-level ordering is skipped.
+ * @param bucketValueOrdering optional comparator that orders buckets by their transformed value `V`.
+ *   When non-null, the observable collection iterates in value-primary order (then key, then PK
+ *   natural order as the mandatory tiebreak), applied before the FX-thread pulse. The comparator
+ *   reads the already-staged `V`; it never invokes [dataTransform] or [fxFactory].
+ *   When `null` (default), value-primary ordering is skipped.
  */
 class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E : IdentifiableEntity<K>, V : Any>(
     private val registry: Registry<K, E>,
@@ -108,13 +117,35 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
     @Suppress("UNCHECKED_CAST")
     private val fxFactory: (PK, Any?) -> V,
     val dispatchToFxThread: Boolean = true,
-    val entryOrdering: Comparator<E>? = null
+    val entryOrdering: Comparator<E>? = null,
+    val bucketKeyOrdering: Comparator<PK>? = null,
+    val bucketValueOrdering: Comparator<V>? = null
 ) : FxObservableProjection<PK, V> {
 
     private val log = KotlinLogging.logger {}
 
+    // When bucketValueOrdering is active, the observable map is backed by a ConcurrentSkipListMap
+    // whose comparator reads from stagedValues — so entries iterate in value-primary order. The
+    // comparator reads only already-staged V; it never invokes dataTransform or fxFactory (Pitfall 3).
+    // For key-only ordering, the skip-list comparator uses bucketKeyOrdering + naturalOrder tiebreak.
+    // stagedValues tracks the current V for each bucket so the comparator has a fast, cached lookup.
+    private val stagedValues: ConcurrentHashMap<PK, V>? =
+        if (bucketValueOrdering != null) ConcurrentHashMap() else null
+
     private val innerObservableMap: ObservableMap<PK, V> =
-        FXCollections.observableMap(ConcurrentSkipListMap<PK, V>())
+        FXCollections.observableMap(
+            when {
+                bucketValueOrdering != null -> {
+                    val sv = stagedValues!!
+                    val cmp = buildBucketComparator<PK, V>(bucketValueOrdering, bucketKeyOrdering) { sv[it] }
+                    ConcurrentSkipListMap<PK, V>(cmp)
+                }
+                bucketKeyOrdering != null ->
+                    ConcurrentSkipListMap<PK, V>(bucketKeyOrdering.thenComparing(Comparator.naturalOrder<PK>()))
+                else ->
+                    ConcurrentSkipListMap<PK, V>()
+            }
+        )
 
     private val entriesChangedListeners = CopyOnWriteArrayList<(List<ProjectionEntryChange<PK, V>>) -> Unit>()
 
@@ -161,6 +192,10 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
      * @param dispatchToFxThread whether to dispatch listener notifications to the FX Application Thread
      * @param entryOrdering optional comparator that maintains each bucket's `List<E>` in sorted
      *   order before [valueTransform] receives it. When `null` (default), insertion order is kept.
+     * @param bucketKeyOrdering optional comparator that orders buckets by their projection key.
+     *   When `null` (default), key-level ordering is skipped.
+     * @param bucketValueOrdering optional comparator that orders buckets by their transformed value `V`,
+     *   applied before the FX-thread pulse. When `null` (default), value-primary ordering is skipped.
      */
     @Suppress("UNCHECKED_CAST")
     constructor(
@@ -168,14 +203,18 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
         keyExtractor: (E) -> PK,
         valueTransform: (PK, List<E>) -> V,
         dispatchToFxThread: Boolean = true,
-        entryOrdering: Comparator<E>? = null
+        entryOrdering: Comparator<E>? = null,
+        bucketKeyOrdering: Comparator<PK>? = null,
+        bucketValueOrdering: Comparator<V>? = null
     ) : this(
         registry = registry,
         keyExtractor = keyExtractor,
         dataTransform = valueTransform,
         fxFactory = { _, staged -> staged as V },
         dispatchToFxThread = dispatchToFxThread,
-        entryOrdering = entryOrdering
+        entryOrdering = entryOrdering,
+        bucketKeyOrdering = bucketKeyOrdering,
+        bucketValueOrdering = bucketValueOrdering
     )
 
     init {
@@ -229,7 +268,11 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
         runSeedOnFxThread(dispatchToFxThread) {
             for ((key, d) in staged) {
                 try {
-                    innerObservableMap[key] = fxFactory(key, d)
+                    val v = fxFactory(key, d)
+                    // Update stagedValues before inserting so the ConcurrentSkipListMap comparator
+                    // can read the cached V when positioning this entry in value-primary order.
+                    stagedValues?.set(key, v)
+                    innerObservableMap[key] = v
                 } catch (t: Throwable) {
                     log.error(t) { "fxFactory failed for bucket key=$key during seed; skipping this bucket" }
                 }
@@ -372,12 +415,25 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
 
     // Applies drained removals and updates to innerObservableMap, invoking fxFactory per updated
     // bucket and skipping any bucket whose fxFactory throws. Returns the recomputed values by key.
+    // When bucketValueOrdering is active, stagedValues is updated before the observable map is mutated
+    // so that the skip-list comparator reads the correct staged V during the insert operation — this
+    // positions the new entry in value-primary order within the observable backing before listeners fire.
     private fun applyMutations(removals: Set<PK>, updates: Map<PK, Any?>): Map<PK, V> {
-        for (key in removals) innerObservableMap.remove(key)
+        for (key in removals) {
+            stagedValues?.remove(key)
+            innerObservableMap.remove(key)
+        }
         val newValues = mutableMapOf<PK, V>()
         for ((key, d) in updates) {
             try {
                 val v = fxFactory(key, d)
+                // For value-primary ordering: update stagedValues first so the comparator in
+                // the ConcurrentSkipListMap sees the new V when determining the insert position.
+                // Remove-then-insert guarantees repositioning when the value (and thus order) changes.
+                if (stagedValues != null) {
+                    stagedValues[key] = v
+                    innerObservableMap.remove(key)
+                }
                 innerObservableMap[key] = v
                 newValues[key] = v
             } catch (t: Throwable) {

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjection.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/projection/TransformedRegistryFxProjection.kt
@@ -415,24 +415,27 @@ class TransformedRegistryFxProjection<K : Comparable<K>, PK : Comparable<PK>, E 
 
     // Applies drained removals and updates to innerObservableMap, invoking fxFactory per updated
     // bucket and skipping any bucket whose fxFactory throws. Returns the recomputed values by key.
-    // When bucketValueOrdering is active, stagedValues is updated before the observable map is mutated
-    // so that the skip-list comparator reads the correct staged V during the insert operation — this
-    // positions the new entry in value-primary order within the observable backing before listeners fire.
+    // When bucketValueOrdering is active, innerObservableMap is a ConcurrentSkipListMap whose
+    // comparator reads stagedValues to locate a key. Every removal of an existing node must therefore
+    // run while stagedValues still holds that key's old value, otherwise the comparator walks to the
+    // wrong position and the node is missed — leaving a stale entry or inserting a duplicate. So the
+    // map removal always precedes the stagedValues mutation.
     private fun applyMutations(removals: Set<PK>, updates: Map<PK, Any?>): Map<PK, V> {
         for (key in removals) {
-            stagedValues?.remove(key)
             innerObservableMap.remove(key)
+            stagedValues?.remove(key)
         }
         val newValues = mutableMapOf<PK, V>()
         for ((key, d) in updates) {
             try {
                 val v = fxFactory(key, d)
-                // For value-primary ordering: update stagedValues first so the comparator in
-                // the ConcurrentSkipListMap sees the new V when determining the insert position.
-                // Remove-then-insert guarantees repositioning when the value (and thus order) changes.
+                // Remove the node at its OLD position first (comparator still reads the old staged
+                // value), then stage the new value so the re-insert below lands at the new
+                // value-ordered position. Remove-then-insert guarantees repositioning when the value
+                // (and thus order) changes.
                 if (stagedValues != null) {
-                    stagedValues[key] = v
                     innerObservableMap.remove(key)
+                    stagedValues[key] = v
                 }
                 innerObservableMap[key] = v
                 newValues[key] = v

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjectionTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjectionTest.kt
@@ -638,4 +638,159 @@ class RegistryFxMultiKeyProjectionTest : StringSpec({
         reactive.advance()
         keys shouldBe emptyList() // and delivers nothing after
     }
+
+    // ---- bucketKeyOrdering and bucketValueOrdering FX multi-key tests ----
+
+    "RegistryFxMultiKeyProjection with bucketKeyOrdering iterates observable map in comparator key order" {
+        trackRepo.create(1, "Track A", setOf("Rock"))
+        trackRepo.create(2, "Track B", setOf("Jazz"))
+        trackRepo.create(3, "Track C", setOf("Blues"))
+
+        val projection =
+            RegistryFxMultiKeyProjection(
+                trackRepo,
+                { it.genres },
+                dispatchToFxThread = false,
+                bucketKeyOrdering = compareBy { it }
+            )
+        projection.addListener(MapChangeListener { })
+
+        projection.keys.toList() shouldBe listOf("Blues", "Jazz", "Rock")
+    }
+
+    "RegistryFxMultiKeyProjection with null bucketKeyOrdering iterates in PK natural order" {
+        trackRepo.create(1, "Track A", setOf("Rock"))
+        trackRepo.create(2, "Track B", setOf("Jazz"))
+        trackRepo.create(3, "Track C", setOf("Blues"))
+
+        val projection =
+            RegistryFxMultiKeyProjection(
+                trackRepo,
+                { it.genres },
+                dispatchToFxThread = false
+            )
+        projection.addListener(MapChangeListener { })
+
+        projection.keys.toList() shouldBe listOf("Blues", "Jazz", "Rock")
+    }
+
+    "RegistryFxMultiKeyProjection bucketKeyOrdering PK tiebreak retains both equal-sort keys" {
+        trackRepo.create(1, "Track A", setOf("rock"))
+        trackRepo.create(2, "Track B", setOf("Rock"))
+        trackRepo.create(3, "Track C", setOf("Jazz"))
+
+        val projection =
+            RegistryFxMultiKeyProjection(
+                trackRepo,
+                { it.genres },
+                dispatchToFxThread = false,
+                bucketKeyOrdering = Comparator { a, b -> a.lowercase().compareTo(b.lowercase()) }
+            )
+        projection.addListener(MapChangeListener { })
+
+        projection.keys.size shouldBe 3
+        projection.containsKey("rock") shouldBe true
+        projection.containsKey("Rock") shouldBe true
+        projection.containsKey("Jazz") shouldBe true
+    }
+
+    "RegistryFxMultiKeyProjection bucketKeyOrdering MapChangeListener observes ordered iteration" {
+        trackRepo.create(1, "Track A", setOf("Rock"))
+        trackRepo.create(2, "Track B", setOf("Jazz"))
+
+        val projection =
+            RegistryFxMultiKeyProjection(
+                trackRepo,
+                { it.genres },
+                dispatchToFxThread = false,
+                bucketKeyOrdering = compareBy { it }
+            )
+        projection.addListener(MapChangeListener { })
+
+        val listenerCapturedKeys = mutableListOf<String>()
+        projection.addListener(MapChangeListener { listenerCapturedKeys.addAll(projection.keys) })
+
+        trackRepo.create(3, "Track C", setOf("Blues"))
+        reactive.advance()
+
+        listenerCapturedKeys shouldBe listOf("Blues", "Jazz", "Rock")
+    }
+
+    "TransformedRegistryFxMultiKeyProjection with bucketValueOrdering iterates in value-primary order" {
+        trackRepo.create(1, "Track A", setOf("Rock"))
+        trackRepo.create(2, "Track B", setOf("Jazz"))
+        trackRepo.create(3, "Track C", setOf("Blues"))
+
+        val projection =
+            registryFxMultiKeyProjection(
+                trackRepo,
+                { it.genres },
+                valueTransform = { pk, _ -> pk },
+                dispatchToFxThread = false,
+                bucketValueOrdering = compareBy { it }
+            )
+        projection.addListener(MapChangeListener { })
+
+        projection.keys.toList() shouldBe listOf("Blues", "Jazz", "Rock")
+    }
+
+    "TransformedRegistryFxMultiKeyProjection with null comparators iterates in PK natural order" {
+        trackRepo.create(3, "Track C", setOf("Rock"))
+        trackRepo.create(1, "Track A", setOf("Jazz"))
+        trackRepo.create(2, "Track B", setOf("Blues"))
+
+        val projection =
+            registryFxMultiKeyProjection(
+                trackRepo,
+                { it.genres },
+                valueTransform = { pk, _ -> pk },
+                dispatchToFxThread = false
+            )
+        projection.addListener(MapChangeListener { })
+
+        projection.keys.toList() shouldBe listOf("Blues", "Jazz", "Rock")
+    }
+
+    "TransformedRegistryFxMultiKeyProjection bucketValueOrdering PK tiebreak retains equal-sort-value buckets" {
+        trackRepo.create(1, "Track A", setOf("Jazz"))
+        trackRepo.create(2, "Track B", setOf("Rock"))
+
+        // Value is the genre string length: "Jazz" and "Rock" both have length 4 -> compare equal
+        val projection =
+            registryFxMultiKeyProjection(
+                trackRepo,
+                { it.genres },
+                valueTransform = { pk, _ -> pk.length },
+                dispatchToFxThread = false,
+                bucketValueOrdering = compareBy { it }
+            )
+        projection.addListener(MapChangeListener { })
+
+        projection.keys.size shouldBe 2
+        projection.containsKey("Jazz") shouldBe true
+        projection.containsKey("Rock") shouldBe true
+    }
+
+    "TransformedRegistryFxMultiKeyProjection bucketValueOrdering MapChangeListener observes ordered observable map" {
+        trackRepo.create(1, "Track A", setOf("Rock"))
+        trackRepo.create(2, "Track B", setOf("Jazz"))
+
+        val projection =
+            registryFxMultiKeyProjection(
+                trackRepo,
+                { it.genres },
+                valueTransform = { pk, _ -> pk },
+                dispatchToFxThread = false,
+                bucketValueOrdering = compareBy { it }
+            )
+        projection.addListener(MapChangeListener { })
+
+        val listenerCapturedKeys = mutableListOf<String>()
+        projection.addListener(MapChangeListener { listenerCapturedKeys.addAll(projection.keys) })
+
+        trackRepo.create(3, "Track C", setOf("Blues"))
+        reactive.advance()
+
+        listenerCapturedKeys shouldBe listOf("Blues", "Jazz", "Rock")
+    }
 })

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionTest.kt
@@ -1210,4 +1210,58 @@ class RegistryFxProjectionTest : StringSpec({
 
         projection.keys.toList() shouldBe listOf("Jazz", "Rock", "Blues")
     }
+
+    "TransformedRegistryFxProjection with bucketValueOrdering repositions a bucket and drops no entries when its value changes" {
+        trackRepo.create(1, "Track A", "Alpha") // Alpha: 1 title
+        trackRepo.create(2, "Track B", "Beta") // Beta: 1 title
+        trackRepo.create(3, "Track C", "Beta") // Beta: 2 titles
+
+        val projection =
+            TransformedRegistryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                valueTransform = { pk, items -> RegistryAlbumBucket(pk, items.map { it.title }) },
+                dispatchToFxThread = false,
+                bucketValueOrdering = compareBy { it.titles.size }
+            )
+        projection.addListener(MapChangeListener { })
+
+        // ascending by title count: Alpha(1), Beta(2)
+        projection.keys.toList() shouldBe listOf("Alpha", "Beta")
+
+        // Grow Alpha to 3 titles so it must move after Beta. The skip-list backing is removed at the
+        // old value position (comparator still reads the old staged value) before the new value is
+        // staged and re-inserted; a stale/duplicate node would surface as a wrong size or order here.
+        trackRepo.create(4, "Track D", "Alpha")
+        trackRepo.create(5, "Track E", "Alpha")
+        reactive.advance()
+
+        projection.keys.size shouldBe 2
+        projection.keys.toList() shouldBe listOf("Beta", "Alpha")
+        projection["Alpha"]!!.titles.size shouldBe 3
+    }
+
+    "TransformedRegistryFxProjection with bucketValueOrdering removes an emptied bucket cleanly" {
+        val alphaTrack = trackRepo.create(1, "Track A", "Alpha")
+        trackRepo.create(2, "Track B", "Beta")
+
+        val projection =
+            TransformedRegistryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                valueTransform = { pk, _ -> RegistryAlbumBucket(pk, listOf(pk)) },
+                dispatchToFxThread = false,
+                bucketValueOrdering = compareBy { it.key }
+            )
+        projection.addListener(MapChangeListener { })
+        projection.keys.toList() shouldBe listOf("Alpha", "Beta")
+
+        // Emptying the Alpha bucket must remove its key from the value-ordered backing — the removal
+        // runs while the old staged value is still present so the comparator locates the node.
+        trackRepo.remove(alphaTrack)
+        reactive.advance()
+
+        projection.keys.toList() shouldBe listOf("Beta")
+        projection.containsKey("Alpha") shouldBe false
+    }
 })

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionTest.kt
@@ -1007,4 +1007,207 @@ class RegistryFxProjectionTest : StringSpec({
         reactive.advance()
         keys shouldBe emptyList() // and delivers nothing after
     }
+
+    // ---- bucketKeyOrdering and bucketValueOrdering FX tests ----
+
+    "RegistryFxProjection with bucketKeyOrdering iterates observable map in comparator key order" {
+        trackRepo.create(1, "Track A", "Rock")
+        trackRepo.create(2, "Track B", "Jazz")
+        trackRepo.create(3, "Track C", "Blues")
+
+        val projection =
+            RegistryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                dispatchToFxThread = false,
+                bucketKeyOrdering = compareBy { it }
+            )
+        projection.addListener(MapChangeListener { })
+
+        projection.keys.toList() shouldBe listOf("Blues", "Jazz", "Rock")
+    }
+
+    "RegistryFxProjection with null bucketKeyOrdering iterates in PK natural order" {
+        trackRepo.create(1, "Track A", "Rock")
+        trackRepo.create(2, "Track B", "Jazz")
+        trackRepo.create(3, "Track C", "Blues")
+
+        val projection =
+            RegistryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                dispatchToFxThread = false
+            )
+        projection.addListener(MapChangeListener { })
+
+        // PK natural order for Strings: Blues < Jazz < Rock
+        projection.keys.toList() shouldBe listOf("Blues", "Jazz", "Rock")
+    }
+
+    "RegistryFxProjection with reverse bucketKeyOrdering iterates in reverse key order" {
+        trackRepo.create(1, "Track A", "Rock")
+        trackRepo.create(2, "Track B", "Jazz")
+        trackRepo.create(3, "Track C", "Blues")
+
+        val projection =
+            RegistryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                dispatchToFxThread = false,
+                bucketKeyOrdering = compareByDescending { it }
+            )
+        projection.addListener(MapChangeListener { })
+
+        projection.keys.toList() shouldBe listOf("Rock", "Jazz", "Blues")
+    }
+
+    "RegistryFxProjection bucketKeyOrdering PK tiebreak retains both equal-sort keys" {
+        // case-insensitive comparator: 'rock' and 'Rock' compare equal
+        trackRepo.create(1, "Track A", "rock")
+        trackRepo.create(2, "Track B", "Rock")
+        trackRepo.create(3, "Track C", "Jazz")
+
+        val projection =
+            RegistryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                dispatchToFxThread = false,
+                bucketKeyOrdering = Comparator { a, b -> a.lowercase().compareTo(b.lowercase()) }
+            )
+        projection.addListener(MapChangeListener { })
+
+        // Both 'rock' and 'Rock' must be retained; PK tiebreak distinguishes them
+        projection.keys.size shouldBe 3
+        projection.containsKey("rock") shouldBe true
+        projection.containsKey("Rock") shouldBe true
+        projection.containsKey("Jazz") shouldBe true
+    }
+
+    "RegistryFxProjection bucketKeyOrdering MapChangeListener observes ordered iteration" {
+        trackRepo.create(1, "Track A", "Rock")
+        trackRepo.create(2, "Track B", "Jazz")
+
+        val projection =
+            RegistryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                dispatchToFxThread = false,
+                bucketKeyOrdering = compareBy { it }
+            )
+        projection.addListener(MapChangeListener { })
+
+        val listenerCapturedKeys = mutableListOf<String>()
+        projection.addListener(MapChangeListener { listenerCapturedKeys.addAll(projection.keys) })
+
+        // Add a new bucket — the listener should see the already-ordered map
+        trackRepo.create(3, "Track C", "Blues")
+        reactive.advance()
+
+        // The listener captured keys should already be in sorted order (ordered backing proof)
+        listenerCapturedKeys shouldBe listOf("Blues", "Jazz", "Rock")
+    }
+
+    "TransformedRegistryFxProjection with bucketValueOrdering iterates in value-primary order" {
+        trackRepo.create(1, "Track A", "Rock")
+        trackRepo.create(2, "Track B", "Jazz")
+        trackRepo.create(3, "Track C", "Blues")
+
+        val projection =
+            TransformedRegistryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                valueTransform = { pk, _ -> RegistryAlbumBucket(pk, listOf(pk)) },
+                dispatchToFxThread = false,
+                bucketValueOrdering = compareBy { it.key }
+            )
+        projection.addListener(MapChangeListener { })
+
+        // value-primary ordering by key field of RegistryAlbumBucket: Blues < Jazz < Rock
+        projection.keys.toList() shouldBe listOf("Blues", "Jazz", "Rock")
+    }
+
+    "TransformedRegistryFxProjection with null comparators iterates in PK natural order" {
+        trackRepo.create(3, "Track C", "Rock")
+        trackRepo.create(1, "Track A", "Jazz")
+        trackRepo.create(2, "Track B", "Blues")
+
+        val projection =
+            TransformedRegistryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                valueTransform = { pk, _ -> RegistryAlbumBucket(pk, listOf(pk)) },
+                dispatchToFxThread = false
+            )
+        projection.addListener(MapChangeListener { })
+
+        // Default PK natural order
+        projection.keys.toList() shouldBe listOf("Blues", "Jazz", "Rock")
+    }
+
+    "TransformedRegistryFxProjection bucketValueOrdering PK tiebreak retains equal-sort-value buckets" {
+        // Both albumNames produce same RegistryAlbumBucket key field length -> compare equal on custom order
+        trackRepo.create(1, "Track A", "Jazz")
+        trackRepo.create(2, "Track B", "Rock")
+
+        // Compare by title-list size (both have 1 entry) — equal sort value, distinct PKs
+        val projection =
+            TransformedRegistryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                valueTransform = { pk, items -> RegistryAlbumBucket(pk, items.map { it.title }) },
+                dispatchToFxThread = false,
+                bucketValueOrdering = compareBy { it.titles.size }
+            )
+        projection.addListener(MapChangeListener { })
+
+        // Both buckets retained despite equal sort value (PK tiebreak)
+        projection.keys.size shouldBe 2
+        projection.containsKey("Jazz") shouldBe true
+        projection.containsKey("Rock") shouldBe true
+    }
+
+    "TransformedRegistryFxProjection bucketValueOrdering MapChangeListener observes ordered observable map" {
+        trackRepo.create(1, "Track A", "Rock")
+        trackRepo.create(2, "Track B", "Jazz")
+
+        val projection =
+            TransformedRegistryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                valueTransform = { pk, _ -> RegistryAlbumBucket(pk, listOf(pk)) },
+                dispatchToFxThread = false,
+                bucketValueOrdering = compareBy { it.key }
+            )
+        projection.addListener(MapChangeListener { })
+
+        val listenerCapturedKeys = mutableListOf<String>()
+        projection.addListener(MapChangeListener { listenerCapturedKeys.addAll(projection.keys) })
+
+        trackRepo.create(3, "Track C", "Blues")
+        reactive.advance()
+
+        // Listener observes already-ordered map (ordered backing proof)
+        listenerCapturedKeys shouldBe listOf("Blues", "Jazz", "Rock")
+    }
+
+    "TransformedRegistryFxProjection with both bucketKeyOrdering and bucketValueOrdering applies value-primary then key order" {
+        trackRepo.create(1, "Track A", "Rock")
+        trackRepo.create(2, "Track B", "Jazz")
+        trackRepo.create(3, "Track C", "Blues")
+
+        // value = length of genre string: Blues=5, Jazz=4, Rock=4
+        // value-primary ascending, then key tiebreak ascending: Jazz < Rock (both length 4) < Blues (length 5)
+        val projection =
+            TransformedRegistryFxProjection(
+                trackRepo,
+                AudioItem::albumName,
+                valueTransform = { pk, _ -> pk.length },
+                dispatchToFxThread = false,
+                bucketKeyOrdering = compareBy { it },
+                bucketValueOrdering = compareBy { it }
+            )
+        projection.addListener(MapChangeListener { })
+
+        projection.keys.toList() shouldBe listOf("Jazz", "Rock", "Blues")
+    }
 })

--- a/lirp-sql/build.gradle
+++ b/lirp-sql/build.gradle
@@ -111,6 +111,8 @@ dependencies {
     testFixturesImplementation libs.testcontainers.mariadb
     testFixturesImplementation libs.sqlite
     testFixturesImplementation libs.kotest.runner.junit6
+    // Assertions + nondeterministic (eventually) for the shared persistence-polling helpers
+    testFixturesImplementation libs.bundles.kotest
 
     // Consume testFixtures from both test and integrationTest
     testImplementation testFixtures(project(':lirp-sql'))

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlRepositoryTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlRepositoryTest.kt
@@ -202,17 +202,13 @@ internal class FxSqlRepositoryTest : StringSpec({
         entityRepo.close()
         itemRepo.close()
 
-        itemRepo = FxSqlTestItemRepository(jdbcUrl)
-        entityRepo = FxSqlTestEntityRepository(jdbcUrl)
-
-        eventually(1.seconds) {
-            entityRepo.findById(1).shouldBePresent {
+        // Reopen on each poll so a late async write becomes visible — a repository opened once caches
+        // its in-memory snapshot at load time and would never observe the persisted mutation.
+        DatabaseTestSupport.awaitReloaded(reader = { FxSqlTestEntityRepository(jdbcUrl) }) { reloadedRepo ->
+            reloadedRepo.findById(1).shouldBePresent {
                 it.items.referenceIds shouldBe listOf(2, 3)
             }
         }
-
-        entityRepo.close()
-        itemRepo.close()
     }
 
     "FxSqlRepository clear on fx aggregate persists empty state" {

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SoftDeleteSqlTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SoftDeleteSqlTest.kt
@@ -48,12 +48,14 @@ internal class SoftDeleteSqlTest : StringSpec({
                 }
             repo.add(track)
             repo.softDelete(track)
-            repo.close() // synchronous flush
 
-            // Raw DB check: row still exists with non-null deleted_at
-            val row = DatabaseTestSupport.readRow(dataSource, tableDef.tableName, 1, "deleted_at", "version")
-            row.shouldNotBeNull()
-            row["deleted_at"].shouldNotBeNull()
+            // Poll for the persisted row while the repo is still open: softDelete propagates to the
+            // SQL write pipeline asynchronously, so a raw read right after close() would race delivery.
+            DatabaseTestSupport.awaitRow(dataSource, tableDef.tableName, 1, "deleted_at", "version") { row ->
+                // Raw DB check: row still exists with non-null deleted_at (not hard-deleted)
+                row["deleted_at"].shouldNotBeNull()
+            }
+            repo.close()
         }
     }
 
@@ -143,15 +145,17 @@ internal class SoftDeleteSqlTest : StringSpec({
             softDeleted.shouldNotBeNull()
             val versionAfterSoftDelete = softDeleted.version
             repoAfterSoftDelete.restore(softDeleted)
-            repoAfterSoftDelete.close()
 
-            // Row in DB: deleted_at is NULL and version was bumped
-            val row = DatabaseTestSupport.readRow(dataSource, tableDef.tableName, 5, "deleted_at", "version")
-            row.shouldNotBeNull()
-            row["deleted_at"].shouldBeNull()
-            val dbVersion = (row["version"] as? Long) ?: (row["version"] as? Number)?.toLong()
-            dbVersion.shouldNotBeNull()
-            dbVersion shouldBe (versionAfterSoftDelete + 1L)
+            // Poll for the restore to land while the repo is still open: restore() propagates to the
+            // SQL write pipeline asynchronously, so a raw read right after close() would race delivery.
+            DatabaseTestSupport.awaitRow(dataSource, tableDef.tableName, 5, "deleted_at", "version") { row ->
+                // Row in DB: deleted_at is NULL and version was bumped
+                row["deleted_at"].shouldBeNull()
+                val dbVersion = (row["version"] as? Long) ?: (row["version"] as? Number)?.toLong()
+                dbVersion.shouldNotBeNull()
+                dbVersion shouldBe (versionAfterSoftDelete + 1L)
+            }
+            repoAfterSoftDelete.close()
 
             // And the entity is visible via default reads again
             val finalRepo = SqlRepository<Int, SoftDeletableVersionedTrack>(dataSource, tableDef)

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryBulkLoadTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryBulkLoadTest.kt
@@ -36,7 +36,6 @@ import java.sql.Statement
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 import javax.sql.DataSource
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Bulk-load and junction-sync unit tests for [SqlRepository], exercising the H2-backed end-to-end
@@ -56,6 +55,23 @@ class SqlRepositoryBulkLoadTest : StringSpec({
             }
         return HikariDataSource(config)
     }
+
+    // Reads the junction table as (parent_id, item_id, position) triples ordered by position, so the
+    // persisted junction state can be polled and asserted from a single place.
+    fun readJunctionRows(ds: DataSource): List<Triple<Int, Int, Int>> =
+        ds.connection.use { conn ->
+            val rows = mutableListOf<Triple<Int, Int, Int>>()
+            conn.createStatement().use { st ->
+                st.executeQuery(
+                    "SELECT parent_id, item_id, \"position\" FROM test_playlist_tracks ORDER BY \"position\""
+                ).use { rs ->
+                    while (rs.next()) {
+                        rows.add(Triple(rs.getInt(1), rs.getInt(2), rs.getInt(3)))
+                    }
+                }
+            }
+            rows
+        }
 
     "loadFromStore returns playlists with track IDs in position order" {
         val ds = newDataSource(freshJdbcUrl())
@@ -157,50 +173,28 @@ class SqlRepositoryBulkLoadTest : StringSpec({
                         trackIds = listOf(10, 20, 30)
                     }
                 repo.add(playlist)
-                repo.close() // synchronous flush
 
-                // Reload and verify three rows at positions 0, 1, 2.
-                ds.connection.use { conn ->
-                    val rows = mutableListOf<Triple<Int, Int, Int>>()
-                    conn.createStatement().use { st ->
-                        st.executeQuery(
-                            "SELECT parent_id, item_id, \"position\" FROM test_playlist_tracks ORDER BY \"position\""
-                        ).use { rs ->
-                            while (rs.next()) {
-                                rows.add(Triple(rs.getInt(1), rs.getInt(2), rs.getInt(3)))
-                            }
-                        }
-                    }
-                    rows shouldContainExactly
+                // Poll the persisted junction rows while the repo is open (the add reaches the write
+                // pipeline asynchronously); assert three rows at positions 0, 1, 2.
+                eventually(DatabaseTestSupport.PERSISTED_ROW_POLL) {
+                    readJunctionRows(ds) shouldContainExactly
                         listOf(Triple(1, 10, 0), Triple(1, 20, 1), Triple(1, 30, 2))
                 }
+                repo.close()
 
-                // Re-open, mutate to a shorter list, flush, and verify the wholesale replace.
+                // Re-open, mutate to a shorter list, and verify the wholesale junction replace persists.
                 val repo2 = SqlRepository(ds, TestPlaylistTableDef)
                 try {
                     val reloaded = repo2.findById(1).get()
                     reloaded.trackIds shouldContainExactly listOf(10, 20, 30)
                     reloaded.trackIds = listOf(20, 30)
-                    // The PendingUpdate is enqueued via the mutateAndPublish pipeline; force flush.
-                    eventually(2.seconds) {
-                        repo2.findById(1).get().trackIds shouldContainExactly listOf(20, 30)
+                    // The PendingUpdate is enqueued via the mutateAndPublish pipeline; poll the durable
+                    // junction state until the wholesale replace lands.
+                    eventually(DatabaseTestSupport.PERSISTED_ROW_POLL) {
+                        readJunctionRows(ds) shouldContainExactly listOf(Triple(1, 20, 0), Triple(1, 30, 1))
                     }
                 } finally {
                     repo2.close()
-                }
-
-                ds.connection.use { conn ->
-                    val rows = mutableListOf<Triple<Int, Int, Int>>()
-                    conn.createStatement().use { st ->
-                        st.executeQuery(
-                            "SELECT parent_id, item_id, \"position\" FROM test_playlist_tracks ORDER BY \"position\""
-                        ).use { rs ->
-                            while (rs.next()) {
-                                rows.add(Triple(rs.getInt(1), rs.getInt(2), rs.getInt(3)))
-                            }
-                        }
-                    }
-                    rows shouldContainExactly listOf(Triple(1, 20, 0), Triple(1, 30, 1))
                 }
             } finally {
                 runCatching { repo.close() }

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryTest.kt
@@ -444,17 +444,13 @@ internal class SqlRepositoryTest : StringSpec({
         playlistRepo2.close()
         trackRepo2.close()
 
-        val trackRepo3 = SqlTestTrackRepository(jdbcUrl)
-        val playlistRepo3 = MutablePlaylistSqlRepository(jdbcUrl)
-
-        eventually(1.seconds) {
+        // Reopen on each poll so a late async write becomes visible — a repository opened once caches
+        // its in-memory snapshot at load time and would never observe the persisted mutation.
+        DatabaseTestSupport.awaitReloaded(reader = { MutablePlaylistSqlRepository(jdbcUrl) }) { playlistRepo3 ->
             playlistRepo3.findById(1L).shouldBePresent {
                 it.trackIds shouldContainExactly listOf(2, 3)
             }
         }
-
-        playlistRepo3.close()
-        trackRepo3.close()
     }
 
     "SqlRepository addAll on mutable aggregate persists all added trackIds" {

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DatabaseTestSupport.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DatabaseTestSupport.kt
@@ -19,11 +19,15 @@ package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.event.ReactiveScope
 import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.engine.names.WithDataTestName
+import io.kotest.matchers.nulls.shouldNotBeNull
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.sql.SQLException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -92,6 +96,54 @@ object DatabaseTestSupport {
      */
     fun readRow(dataSource: HikariDataSource, table: String, id: Int, vararg columns: String): Map<String, Any?>? =
         readRowById(dataSource, table, id, columns)
+
+    /**
+     * Standard bounded-retry window for asserting durably-persisted state after a repository mutation.
+     *
+     * A mutation reaches the SQL write pipeline asynchronously — the reactive event is delivered on a
+     * background scope and the row is written by the debounced writer (max ~1s) — so an assertion that
+     * reads the persisted row or reloads the entity immediately can race that delivery, especially under
+     * CI load. Poll within this window instead of asserting once; the poll returns as soon as the write
+     * is observed, so the ceiling only affects the rare slow case.
+     */
+    val PERSISTED_ROW_POLL: Duration = 5.seconds
+
+    /**
+     * Polls [readRow] for ([table], [id]) until [assert] passes or [timeout] elapses, absorbing the
+     * asynchronous debounced-write delay between a repository mutation and its durable persistence.
+     *
+     * Prefer this over a bare [readRow] immediately after a mutation (or after `close()`, which races
+     * async event delivery against subscription cancellation). Poll while the writing repository is
+     * still open so the event is delivered and flushed within the window.
+     */
+    suspend fun awaitRow(
+        dataSource: HikariDataSource,
+        table: String,
+        id: Int,
+        vararg columns: String,
+        timeout: Duration = PERSISTED_ROW_POLL,
+        assert: (Map<String, Any?>) -> Unit
+    ) = eventually(timeout) {
+        val row = readRow(dataSource, table, id, *columns)
+        row.shouldNotBeNull()
+        assert(row)
+    }
+
+    /**
+     * Polls a freshly-[reader]-opened reader until [assert] passes or [timeout] elapses, re-creating
+     * the reader on each attempt so a late async write becomes visible.
+     *
+     * A repository opened once caches an in-memory snapshot at load time and never observes a
+     * subsequent write, so polling a single reopened reader is ineffective; this reopens per attempt.
+     * Each attempt's reader is closed via [AutoCloseable.use].
+     */
+    suspend fun <R : AutoCloseable> awaitReloaded(
+        timeout: Duration = PERSISTED_ROW_POLL,
+        reader: () -> R,
+        assert: (R) -> Unit
+    ) = eventually(timeout) {
+        reader().use { assert(it) }
+    }
 
     private fun readRowById(dataSource: HikariDataSource, table: String, id: Any, columns: Array<out String>): Map<String, Any?>? =
         dataSource.connection.use { conn ->


### PR DESCRIPTION
## Summary

Adds an optional **bucket-level ordering** capability to the registry projection factories. Consumers can now control the order in which a projection's *buckets* are iterated — its `entries` / `keys` / `values`, and the JavaFX `ObservableMap` — via caller-supplied comparators, complementing the existing `entryOrdering` (which orders items *within* a bucket).

Two ordering inputs are supported, and they compose:

- **`bucketKeyOrdering: Comparator<PK>`** — orders buckets by their key. Available on every registry projection (core and JavaFX).
- **`bucketValueOrdering: Comparator<V>`** — orders buckets by their transformed value. Available on the value-transformed variants, where the desired order derives from data on the value rather than the key.

Both compose over a **primary-key natural-order final tiebreak**, so distinct buckets that compare equal under the supplied comparator are never collapsed or dropped. When both are supplied, ordering is value-primary, then key, then PK.

Closes #298. Required downstream by octaviospain/music-commons#166 (album entries ordered by title → artist → year via `bucketValueOrdering`; genre index ordered by `Comparator<PK>`).

## What changed

- New shared composite-comparator helpers (`BucketOrdering` in core, `FxBucketOrdering` in FX) building the value → key → PK-natural tiebreak.
- `bucketKeyOrdering` threaded through `ProjectionCore`, the single- and multi-key registry projections, and their factories.
- The value-transformed registry decorators previously exposed `entries` / `keys` / `values` from an unordered `ConcurrentHashMap` transform cache (hash order). They now materialize through an ordered index (`TreeMap` under the cache lock), so iteration is deterministic and comparator-driven.
- JavaFX: ordering threaded through all four FX decorators and their factory overloads (including the two-phase variants), applied **before the FX-thread pulse**, so listeners observe the ordered iteration.
- Ordering is maintained **incrementally** as buckets are created / removed / re-keyed — no full re-sort per change — mirroring how within-bucket `entryOrdering` is maintained.

## Behavioral change (binary compatible, not breaking)

Value-transformed registry projections now iterate buckets in **primary-key natural order by default**, instead of the previous unspecified hash order — matching the non-transformed variants. This is an iteration-order change only; it is binary compatible (the new parameters are nullable with a `null` default, so existing call sites are unaffected) and is **not** a breaking API change. Callers needing a specific order supply `bucketKeyOrdering` or `bucketValueOrdering`. Documented under CHANGELOG `[Unreleased]`.

## Testing

- New tests across core and FX cover all four nullable-parameter combinations (none / key-only / value-only / both): seed ordering, incremental insert / remove / re-key repositioning, the PK-natural tiebreak, and the FX-thread ordered pulse (listener observes ordered keys), for both single-key and multi-key projections.
- Binary compatibility validator (`apiCheck`) green on `lirp-core` and `lirp-fx` — additive comparator slots and `$default` synthetics only.
- Aggregate coverage: line 87.99%, branch 73.55% (no regression against baseline).
