### PR TITLE
#310 Fix FxAggregateSet/FxAggregateList non-atomic snapshot race

### DIFF
--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/TransformedMultiKeyRegistryProjection.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/TransformedMultiKeyRegistryProjection.kt
@@ -84,7 +84,7 @@ internal class TransformedMultiKeyRegistryProjection<K : Comparable<K>, PK : Com
     // Protected by cacheLock for all structural mutations (insert / remove to reposition keys).
     // The comparator reads cached values from transformCache; it must only be consulted while
     // transformCache holds a stable value for every key present in orderedIndex.
-    private val orderedIndex: TreeMap<PK, Unit> = TreeMap(bucketComparator(bucketValueOrdering, bucketKeyOrdering) { transformCache[it]!! })
+    private val orderedIndex: TreeMap<PK, Unit> = TreeMap(bucketComparator(bucketValueOrdering, bucketKeyOrdering) { transformCache.getValue(it) })
 
     private val cacheLock = Any()
 

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/TransformedRegistryProjection.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/projection/TransformedRegistryProjection.kt
@@ -90,7 +90,7 @@ internal class TransformedRegistryProjection<K : Comparable<K>, PK : Comparable<
     // Protected by cacheLock for all structural mutations (insert / remove to reposition keys).
     // The comparator reads cached values from transformCache; it must only be consulted while
     // transformCache holds a stable value for every key present in orderedIndex.
-    private val orderedIndex: TreeMap<PK, Unit> = TreeMap(bucketComparator(bucketValueOrdering, bucketKeyOrdering) { transformCache[it]!! })
+    private val orderedIndex: TreeMap<PK, Unit> = TreeMap(bucketComparator(bucketValueOrdering, bucketKeyOrdering) { transformCache.getValue(it) })
 
     private val cacheLock = Any()
 

--- a/lirp-fx/api/lirp-fx.api
+++ b/lirp-fx/api/lirp-fx.api
@@ -23,6 +23,7 @@ public final class net/transgressoft/lirp/persistence/fx/FxAggregateList : kotli
 	public final fun getValue (Ljava/lang/Object;Lkotlin/reflect/KProperty;)Lnet/transgressoft/lirp/persistence/fx/FxAggregateList;
 	public final fun indexOf (Ljava/lang/Object;)I
 	public fun indexOf (Lnet/transgressoft/lirp/entity/IdentifiableEntity;)I
+	public fun iterator ()Ljava/util/Iterator;
 	public final fun lastIndexOf (Ljava/lang/Object;)I
 	public fun lastIndexOf (Lnet/transgressoft/lirp/entity/IdentifiableEntity;)I
 	public final fun remove (I)Lnet/transgressoft/lirp/entity/IdentifiableEntity;

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateList.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateList.kt
@@ -74,50 +74,104 @@ class FxAggregateList<K : Comparable<K>, E : IdentifiableEntity<K>>(
     // When lazySnapshot is true, this is never populated (zero allocation placeholder).
     private val localElements = if (lazySnapshot) ArrayList(0) else ArrayList<E>()
 
+    // Guards every read and write of localElements. The listener cascade may read this list
+    // on the FX thread while a mutation runs on flowScope (see fireChange's mixed dispatch), so
+    // a defensive copy such as ArrayList(localElements) must be atomic with respect to structural
+    // modification — otherwise the array construction races the mutation and throws
+    // ArrayIndexOutOfBoundsException. fireChange is invoked outside this lock so reentrant listener
+    // cascades and cross-thread notification never block on it.
+    private val cacheLock = Any()
+
     override fun syncLocalCache() {
         if (lazySnapshot) return
-        localElements.clear()
-        for (i in 0 until innerProxy.size) {
-            localElements.add(innerProxy[i])
+        synchronized(cacheLock) {
+            localElements.clear()
+            for (i in 0 until innerProxy.size) {
+                localElements.add(innerProxy[i])
+            }
         }
     }
 
-    override fun get(index: Int): E = if (lazySnapshot) innerProxy[index] else localElements[index]
+    override fun get(index: Int): E =
+        if (lazySnapshot) innerProxy[index] else synchronized(cacheLock) { localElements[index] }
 
-    override val size: Int get() = if (lazySnapshot) innerProxy.size else localElements.size
+    override val size: Int get() = if (lazySnapshot) innerProxy.size else synchronized(cacheLock) { localElements.size }
+
+    /**
+     * Returns an iterator over a stable snapshot of the current elements.
+     *
+     * The default [AbstractMutableList] iterator resolves elements lazily through `get(index)`
+     * against the live size, so a concurrent structural modification during iteration can throw
+     * [IndexOutOfBoundsException]. Snapshotting under [cacheLock] makes iteration atomic with
+     * respect to mutation, mirroring the guarantee provided by the sibling observable set.
+     */
+    override fun iterator(): MutableIterator<E> {
+        val snapshot =
+            if (lazySnapshot) ArrayList(innerProxy.resolveAll()) else synchronized(cacheLock) { ArrayList(localElements) }
+        return object : MutableIterator<E> {
+            private val delegate = snapshot.iterator()
+            private var lastReturned: E? = null
+
+            override fun hasNext() = delegate.hasNext()
+
+            override fun next(): E = delegate.next().also { lastReturned = it }
+
+            override fun remove() {
+                val element = lastReturned ?: throw IllegalStateException("next() not yet called or already removed")
+                this@FxAggregateList.remove(element)
+                lastReturned = null
+            }
+        }
+    }
 
     override fun add(index: Int, element: E) {
         innerProxy.add(index, element)
-        if (!lazySnapshot) localElements.add(index, element)
+        if (!lazySnapshot) synchronized(cacheLock) { localElements.add(index, element) }
         modCount++
         fireChange(AddChange(this, index, index + 1))
     }
 
     override fun set(index: Int, element: E): E {
         // Resolve old element BEFORE any inner proxy mutation to ensure it is still accessible
-        val old = if (lazySnapshot) innerProxy[index] else localElements[index]
+        val old = if (lazySnapshot) innerProxy[index] else synchronized(cacheLock) { localElements[index] }
         innerProxy.removeAll(listOf(old))
         innerProxy.add(index, element)
-        if (!lazySnapshot) localElements[index] = element
+        if (!lazySnapshot) synchronized(cacheLock) { localElements[index] = element }
         fireChange(SetChange(this, index, old))
         return old
     }
 
     override fun removeAt(index: Int): E {
         // In lazy mode, resolve element BEFORE removal; in eager mode, remove from local cache first
-        val removed = if (lazySnapshot) innerProxy[index] else localElements.removeAt(index)
+        val removed = if (lazySnapshot) innerProxy[index] else synchronized(cacheLock) { localElements.removeAt(index) }
         innerProxy.removeAll(listOf(removed))
         modCount++
         fireChange(RemoveChange(this, index, listOf(removed)))
         return removed
     }
 
+    // Explicit single-element removal. The default AbstractMutableCollection.remove drives removal
+    // through iterator().remove(); because iterator() is overridden to return a detached snapshot,
+    // that path cannot mutate the backing cache and would recurse into this method. Resolving the
+    // index and delegating to removeAt keeps removal correct and snapshot-safe.
+    override fun remove(element: E): Boolean {
+        val index =
+            if (lazySnapshot) {
+                innerProxy.referenceIds.indexOf(element.id)
+            } else {
+                synchronized(cacheLock) { localElements.indexOf(element) }
+            }
+        if (index < 0) return false
+        removeAt(index)
+        return true
+    }
+
     override fun addAll(elements: Collection<E>): Boolean {
         if (elements.isEmpty()) return false
-        val from = if (lazySnapshot) innerProxy.size else localElements.size
+        val from = if (lazySnapshot) innerProxy.size else synchronized(cacheLock) { localElements.size }
         val changed = innerProxy.addAll(elements)
         if (changed) {
-            if (!lazySnapshot) localElements.addAll(elements)
+            if (!lazySnapshot) synchronized(cacheLock) { localElements.addAll(elements) }
             modCount++
             fireChange(AddChange(this, from, from + elements.size))
         }
@@ -128,7 +182,7 @@ class FxAggregateList<K : Comparable<K>, E : IdentifiableEntity<K>>(
         if (elements.isEmpty()) return false
         val changed = innerProxy.addAll(index, elements)
         if (changed) {
-            if (!lazySnapshot) localElements.addAll(index, elements)
+            if (!lazySnapshot) synchronized(cacheLock) { localElements.addAll(index, elements) }
             modCount++
             fireChange(AddChange(this, index, index + elements.size))
         }
@@ -156,19 +210,24 @@ class FxAggregateList<K : Comparable<K>, E : IdentifiableEntity<K>>(
             }
             return changed
         }
-        val toRemove = elements.filter { localElements.contains(it) }
-        if (toRemove.isEmpty()) return false
-
+        // Build removals from localElements, not from the input collection: iterating the cache once
+        // yields each cached index exactly once (in ascending order), so a duplicated input element
+        // cannot map the same index twice and corrupt the descending-order removal below.
+        val elementsSet = elements.toSet()
         val removedEntries =
-            toRemove.mapNotNull { element ->
-                val idx = localElements.indexOf(element)
-                if (idx >= 0) idx to element else null
-            }.sortedBy { it.first }
+            synchronized(cacheLock) {
+                localElements.withIndex()
+                    .filter { (_, element) -> element in elementsSet }
+                    .map { (idx, element) -> idx to element }
+            }
+        if (removedEntries.isEmpty()) return false
 
         val changed = innerProxy.removeAll(elements)
         if (changed) {
             // Remove from localElements in descending order to preserve indices during removal
-            removedEntries.sortedByDescending { it.first }.forEach { (idx, _) -> localElements.removeAt(idx) }
+            synchronized(cacheLock) {
+                removedEntries.sortedByDescending { it.first }.forEach { (idx, _) -> localElements.removeAt(idx) }
+            }
             modCount++
             // Adjust indices for Change: each removal at position i shifts subsequent positions down by 1
             val adjustedRemovals =
@@ -182,7 +241,12 @@ class FxAggregateList<K : Comparable<K>, E : IdentifiableEntity<K>>(
 
     override fun retainAll(elements: Collection<E>): Boolean {
         val elementsSet = elements.toSet()
-        val toRemove = if (lazySnapshot) innerProxy.resolveAll().filter { it !in elementsSet } else localElements.filter { it !in elementsSet }
+        val toRemove =
+            if (lazySnapshot) {
+                innerProxy.resolveAll().filter { it !in elementsSet }
+            } else {
+                synchronized(cacheLock) { localElements.filter { it !in elementsSet } }
+            }
         if (toRemove.isEmpty()) return false
         return removeAll(toRemove)
     }
@@ -195,10 +259,12 @@ class FxAggregateList<K : Comparable<K>, E : IdentifiableEntity<K>>(
             modCount++
             fireChange(RemoveChange(this, 0, snapshot))
         } else {
-            if (localElements.isEmpty()) return
-            val snapshot = ArrayList(localElements)
+            val snapshot =
+                synchronized(cacheLock) {
+                    if (localElements.isEmpty()) return
+                    ArrayList(localElements).also { localElements.clear() }
+                }
             innerProxy.clear()
-            localElements.clear()
             modCount++
             fireChange(RemoveChange(this, 0, snapshot))
         }
@@ -218,14 +284,17 @@ class FxAggregateList<K : Comparable<K>, E : IdentifiableEntity<K>>(
             }
             return false
         }
-        val snapshot = ArrayList(localElements)
+        val snapshot = synchronized(cacheLock) { ArrayList(localElements).also { localElements.clear() } }
         innerProxy.clear()
-        localElements.clear()
         val added = innerProxy.addAll(col)
-        if (added) localElements.addAll(col)
+        val newSize =
+            synchronized(cacheLock) {
+                if (added) localElements.addAll(col)
+                localElements.size
+            }
         if (added || snapshot.isNotEmpty()) {
             modCount++
-            fireChange(ReplaceAllChange(this, snapshot, localElements.size))
+            fireChange(ReplaceAllChange(this, snapshot, newSize))
             return true
         }
         return false
@@ -244,9 +313,11 @@ class FxAggregateList<K : Comparable<K>, E : IdentifiableEntity<K>>(
             modCount++
             fireChange(RemoveChange(this, from, removed))
         } else {
-            val removed = ArrayList(localElements.subList(from, to))
+            val removed =
+                synchronized(cacheLock) {
+                    ArrayList(localElements.subList(from, to)).also { localElements.subList(from, to).clear() }
+                }
             innerProxy.removeAll(removed)
-            localElements.subList(from, to).clear()
             modCount++
             fireChange(RemoveChange(this, from, removed))
         }

--- a/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSet.kt
+++ b/lirp-fx/src/main/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSet.kt
@@ -74,13 +74,23 @@ class FxAggregateSet<K : Comparable<K>, E : IdentifiableEntity<K>>(
     // When lazySnapshot is true, this is never populated (zero allocation placeholder).
     private val localElements = if (lazySnapshot) LinkedHashSet<E>(0) else LinkedHashSet<E>()
 
+    // Guards every read and write of localElements. The listener cascade may iterate this set
+    // on the FX thread while a mutation runs on flowScope (see fireChange's mixed dispatch), so
+    // a defensive copy such as ArrayList(localElements) must be atomic with respect to structural
+    // modification — otherwise the array construction races the mutation and throws
+    // ArrayIndexOutOfBoundsException. fireChange is invoked outside this lock so reentrant listener
+    // cascades and cross-thread notification never block on it.
+    private val cacheLock = Any()
+
     override fun syncLocalCache() {
         if (lazySnapshot) return
-        localElements.clear()
-        localElements.addAll(innerProxy.resolveAll())
+        synchronized(cacheLock) {
+            localElements.clear()
+            localElements.addAll(innerProxy.resolveAll())
+        }
     }
 
-    override val size: Int get() = if (lazySnapshot) innerProxy.size else localElements.size
+    override val size: Int get() = if (lazySnapshot) innerProxy.size else synchronized(cacheLock) { localElements.size }
 
     override fun iterator(): MutableIterator<E> {
         if (lazySnapshot) {
@@ -100,7 +110,7 @@ class FxAggregateSet<K : Comparable<K>, E : IdentifiableEntity<K>>(
                 }
             }
         }
-        val snapshot = ArrayList(localElements)
+        val snapshot = synchronized(cacheLock) { ArrayList(localElements) }
         return object : MutableIterator<E> {
             private val delegate = snapshot.iterator()
             private var lastReturned: E? = null
@@ -117,12 +127,13 @@ class FxAggregateSet<K : Comparable<K>, E : IdentifiableEntity<K>>(
         }
     }
 
-    override fun contains(element: E): Boolean = if (lazySnapshot) innerProxy.contains(element) else element in localElements
+    override fun contains(element: E): Boolean =
+        if (lazySnapshot) innerProxy.contains(element) else synchronized(cacheLock) { element in localElements }
 
     override fun add(element: E): Boolean {
         val changed = innerProxy.add(element)
         if (changed) {
-            if (!lazySnapshot) localElements.add(element)
+            if (!lazySnapshot) synchronized(cacheLock) { localElements.add(element) }
             fireAdded(element)
         }
         return changed
@@ -131,7 +142,7 @@ class FxAggregateSet<K : Comparable<K>, E : IdentifiableEntity<K>>(
     override fun remove(element: E): Boolean {
         val changed = innerProxy.remove(element)
         if (changed) {
-            if (!lazySnapshot) localElements.remove(element)
+            if (!lazySnapshot) synchronized(cacheLock) { localElements.remove(element) }
             fireRemoved(element)
         }
         return changed
@@ -142,7 +153,7 @@ class FxAggregateSet<K : Comparable<K>, E : IdentifiableEntity<K>>(
         for (element in elements) {
             val changed = innerProxy.add(element)
             if (changed) {
-                if (!lazySnapshot) localElements.add(element)
+                if (!lazySnapshot) synchronized(cacheLock) { localElements.add(element) }
                 fireAdded(element)
                 anyChanged = true
             }
@@ -155,7 +166,7 @@ class FxAggregateSet<K : Comparable<K>, E : IdentifiableEntity<K>>(
         for (element in elements) {
             val changed = innerProxy.remove(element)
             if (changed) {
-                if (!lazySnapshot) localElements.remove(element)
+                if (!lazySnapshot) synchronized(cacheLock) { localElements.remove(element) }
                 fireRemoved(element)
                 anyChanged = true
             }
@@ -164,7 +175,12 @@ class FxAggregateSet<K : Comparable<K>, E : IdentifiableEntity<K>>(
     }
 
     override fun retainAll(elements: Collection<E>): Boolean {
-        val toRemove = if (lazySnapshot) innerProxy.resolveAll().filter { it !in elements } else localElements.filter { it !in elements }
+        val toRemove =
+            if (lazySnapshot) {
+                innerProxy.resolveAll().filter { it !in elements }
+            } else {
+                synchronized(cacheLock) { localElements.filter { it !in elements } }
+            }
         if (toRemove.isEmpty()) return false
         return removeAll(toRemove)
     }
@@ -178,10 +194,12 @@ class FxAggregateSet<K : Comparable<K>, E : IdentifiableEntity<K>>(
                 fireRemoved(element)
             }
         } else {
-            val snapshot = ArrayList(localElements)
-            if (snapshot.isEmpty()) return
+            val snapshot =
+                synchronized(cacheLock) {
+                    if (localElements.isEmpty()) return
+                    ArrayList(localElements).also { localElements.clear() }
+                }
             innerProxy.clear()
-            localElements.clear()
             for (element in snapshot) {
                 fireRemoved(element)
             }

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateConcurrentMutationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateConcurrentMutationTest.kt
@@ -23,9 +23,11 @@ import net.transgressoft.lirp.testing.Stress
 import net.transgressoft.lirp.testing.reactiveScope
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Tests for [FxAggregateList] and [FxAggregateSet] verifying that serialized (single-thread)
@@ -117,5 +119,101 @@ class FxAggregateConcurrentMutationTest : StringSpec({
         } finally {
             executor.shutdownNow()
         }
+    }
+
+    "FxAggregateSet iteration during concurrent mutation does not throw" {
+        val set = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
+        for (i in 0 until 100) set.add(MutableAudioItem(i, "Item-$i"))
+
+        val errors = CopyOnWriteArrayList<Throwable>()
+        val running = AtomicBoolean(true)
+
+        // Single writer mutating the backing cache while readers snapshot it. Before the fix,
+        // ArrayList(localElements) in iterator() raced the writer's structural modification and
+        // threw ArrayIndexOutOfBoundsException from HashSet.toArray (issue #310).
+        val writer =
+            Thread {
+                try {
+                    for (i in 100 until 2100) {
+                        val item = MutableAudioItem(i, "Item-$i")
+                        set.add(item)
+                        set.remove(item)
+                    }
+                } catch (t: Throwable) {
+                    errors.add(t)
+                } finally {
+                    // Always release the readers, even if a mutation throws, so a writer failure is
+                    // reported as the root cause instead of hanging the test on readers.forEach { join() }.
+                    running.set(false)
+                }
+            }
+        val readers =
+            (1..3).map {
+                Thread {
+                    while (running.get()) {
+                        try {
+                            set.toList()
+                        } catch (t: Throwable) {
+                            errors.add(t)
+                        }
+                    }
+                }
+            }
+
+        writer.start()
+        readers.forEach { it.start() }
+        writer.join()
+        readers.forEach { it.join() }
+
+        errors.firstOrNull()?.let { throw AssertionError("Concurrent iteration raced mutation", it) }
+        set.size shouldBe 100
+    }
+
+    "FxAggregateList iteration during concurrent mutation does not throw" {
+        val list = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        for (i in 0 until 100) list.add(list.size, MutableAudioItem(i, "Item-$i"))
+
+        val errors = CopyOnWriteArrayList<Throwable>()
+        val running = AtomicBoolean(true)
+
+        // Single writer appending/removing at the tail while readers iterate. Before the fix, the
+        // inherited index-based iterator resolved get(index) against a live, shrinking size and the
+        // ArrayList(localElements) snapshots raced structural modification.
+        val writer =
+            Thread {
+                try {
+                    for (i in 100 until 2100) {
+                        val item = MutableAudioItem(i, "Item-$i")
+                        list.add(list.size, item)
+                        list.remove(item)
+                    }
+                } catch (t: Throwable) {
+                    errors.add(t)
+                } finally {
+                    // Always release the readers, even if a mutation throws, so a writer failure is
+                    // reported as the root cause instead of hanging the test on readers.forEach { join() }.
+                    running.set(false)
+                }
+            }
+        val readers =
+            (1..3).map {
+                Thread {
+                    while (running.get()) {
+                        try {
+                            list.toList()
+                        } catch (t: Throwable) {
+                            errors.add(t)
+                        }
+                    }
+                }
+            }
+
+        writer.start()
+        readers.forEach { it.start() }
+        writer.join()
+        readers.forEach { it.join() }
+
+        errors.firstOrNull()?.let { throw AssertionError("Concurrent iteration raced mutation", it) }
+        list.size shouldBe 100
     }
 })

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateListTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateListTest.kt
@@ -199,6 +199,29 @@ class FxAggregateListTest : StringSpec({
         change.next() shouldBe false
     }
 
+    "FxAggregateList removeAll with duplicate input elements removes each once and keeps the cache consistent" {
+        val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
+        val item1 = MutableAudioItem(1, "A")
+        val item2 = MutableAudioItem(2, "B")
+        proxy.addAll(listOf(item1, item2))
+
+        val changes = mutableListOf<ListChangeListener.Change<out AudioItem>>()
+        proxy.addListener(ListChangeListener(changes::add))
+
+        // A duplicated input element must not resolve the same cache index twice; otherwise the
+        // descending-order removal would remove index 0 twice and drop item2 by mistake.
+        proxy.removeAll(listOf(item1, item1)) shouldBe true
+
+        proxy.toList() shouldBe listOf(item2)
+        proxy.size shouldBe 1
+        changes.size shouldBe 1
+        val change = changes[0]
+        change.next() shouldBe true
+        change.wasRemoved() shouldBe true
+        change.removed shouldBe listOf(item1)
+        change.next() shouldBe false
+    }
+
     "FxAggregateList MultiRemoveChange supports reset" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val items = listOf(MutableAudioItem(1, "A"), MutableAudioItem(2, "B"), MutableAudioItem(3, "C"))

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisher.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisher.kt
@@ -17,13 +17,11 @@
 
 package net.transgressoft.lirp.kafka
 
-import net.transgressoft.lirp.entity.LirpEntity
 import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.EventType
 import net.transgressoft.lirp.event.FlowEventPublisher
 import net.transgressoft.lirp.event.LirpEvent
 import net.transgressoft.lirp.event.LirpEventPublisher
-import net.transgressoft.lirp.event.LirpEventSubscription
 import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.kafka.outbox.OutboxEvent
 import net.transgressoft.lirp.kafka.outbox.OutboxStore
@@ -39,9 +37,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.Properties
 import java.util.UUID
 import java.util.concurrent.ExecutionException
-import java.util.concurrent.Flow
 import kotlin.time.Clock
-import kotlinx.coroutines.flow.SharedFlow
 
 /**
  * A full [LirpEventPublisher] implementation that publishes domain events to Kafka.
@@ -82,8 +78,9 @@ class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
         bootstrapServers: String,
         private val db: Database,
         private val outboxStore: OutboxStore,
-        producerConfig: Map<String, String> = emptyMap()
-    ) : LirpEventPublisher<ET, E> {
+        producerConfig: Map<String, String> = emptyMap(),
+        private val delegate: FlowEventPublisher<ET, E> = FlowEventPublisher(id)
+    ) : LirpEventPublisher<ET, E> by delegate {
 
         /**
          * Creates a [KafkaEventPublisher] connected to the given [bootstrapServers] and [db].
@@ -109,8 +106,6 @@ class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
 
         private val log = KotlinLogging.logger(javaClass.name)
 
-        private val delegate: FlowEventPublisher<ET, E> = FlowEventPublisher(id)
-
         private val producer: KafkaProducer<String, ByteArray> =
             KafkaProducer(
                 Properties().apply {
@@ -126,32 +121,6 @@ class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
                     putAll(producerConfig)
                 }
             )
-
-        override val changes: SharedFlow<E> get() = delegate.changes
-
-        override val isClosed: Boolean get() = delegate.isClosed
-
-        override val subscriberCount: Int get() = delegate.subscriberCount
-
-        override fun subscribe(callback: (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, E> = delegate.subscribe(callback)
-
-        override fun subscribe(vararg eventTypes: ET, callback: (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, E> =
-            delegate.subscribe(*eventTypes, callback = callback)
-
-        override fun subscribeAsync(action: suspend (E) -> Unit): LirpEventSubscription<in LirpEntity, ET, E> = delegate.subscribeAsync(action)
-
-        override fun subscribeAsync(
-            vararg eventTypes: ET,
-            action: suspend (E) -> Unit
-        ): LirpEventSubscription<in LirpEntity, ET, E> = delegate.subscribeAsync(*eventTypes, action = action)
-
-        override fun activateEvents(vararg types: ET) = delegate.activateEvents(*types)
-
-        override fun disableEvents(vararg types: ET) = delegate.disableEvents(*types)
-
-        override fun isEventActive(type: ET): Boolean = delegate.isEventActive(type)
-
-        override fun subscribe(subscriber: Flow.Subscriber<in E>) = delegate.subscribe(subscriber)
 
         /**
          * Emits [event] to local in-process subscribers and, when the event is not a framework-owned

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/TopicResolver.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/TopicResolver.kt
@@ -52,6 +52,4 @@ fun interface TopicResolver {
  * Consumers that need per-event-type or per-aggregate-instance routing can supply a custom
  * [TopicResolver] lambda at relay startup.
  */
-internal object DefaultTopicResolver : TopicResolver {
-    override fun resolve(envelope: LirpEventEnvelope): String = "${envelope.aggregateType}.events"
-}
+internal val DefaultTopicResolver = TopicResolver { envelope -> "${envelope.aggregateType}.events" }

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SoftDeleteSqlTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SoftDeleteSqlTest.kt
@@ -18,14 +18,12 @@
 package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.persistence.query.query
-import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.optional.shouldNotBePresent
 import io.kotest.matchers.shouldBe
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * H2-backed unit tests verifying the soft-delete persistence contract for [SoftDeletableVersionedTrack]:
@@ -76,14 +74,11 @@ internal class SoftDeleteSqlTest : StringSpec({
             val versionBeforeSoftDelete = loaded.version
             repo2.softDelete(loaded)
             // The deletedAt mutation propagates to the SQL write pipeline asynchronously and is
-            // persisted by the debounced background writer. Poll for the persisted version bump
-            // instead of racing a fixed sleep against async event delivery. The window is generous
-            // because the debounced writer (max ~1s) plus container/JVM warmup can exceed a tight
-            // 2s budget under CI load; eventually returns as soon as the bump is observed, so the
-            // larger ceiling only affects the rare slow case.
-            eventually(5.seconds) {
-                val row = DatabaseTestSupport.readRow(dataSource, tableDef.tableName, 2, "version", "deleted_at")
-                row.shouldNotBeNull()
+            // persisted by the debounced background writer. Poll for the persisted version bump via
+            // the shared helper (bounded by PERSISTED_ROW_POLL) instead of a fixed sleep or a
+            // hand-rolled window, so this assertion shares the same generous CI-safe budget as every
+            // other persistence poll.
+            DatabaseTestSupport.awaitRow(dataSource, tableDef.tableName, 2, "version", "deleted_at") { row ->
                 val dbVersion = (row["version"] as? Long) ?: (row["version"] as? Number)?.toLong()
                 dbVersion.shouldNotBeNull()
                 dbVersion shouldBe (versionBeforeSoftDelete + 1L)

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEntityForeignKeyInstallTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEntityForeignKeyInstallTest.kt
@@ -35,7 +35,6 @@ import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.Table
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Verifies that [SqlRepository.installEntityForeignKeys] actually applies the constraints
@@ -211,7 +210,7 @@ private fun freshDataSource(): HikariDataSource {
 // Polls the DB directly until a row with the given primary key appears, with a generous timeout.
 // Replaces fixed `delay(...)` sleeps so the suite stays deterministic under CI jitter.
 private suspend fun awaitRowPresent(ds: HikariDataSource, tableName: String, id: Int) {
-    eventually(5.seconds) {
+    eventually(DatabaseTestSupport.PERSISTED_ROW_POLL) {
         ds.connection.use { conn ->
             conn.createStatement().use { stmt ->
                 val rs = stmt.executeQuery("SELECT COUNT(*) FROM $tableName WHERE id = $id")

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryTest.kt
@@ -214,7 +214,7 @@ internal class SqlRepositoryTest : StringSpec({
         // Mutate the entity — triggers the subscription callback and synchronous flush
         person.firstName = "Franklin"
 
-        eventually(5.seconds) {
+        eventually(DatabaseTestSupport.PERSISTED_ROW_POLL) {
             val repo2 = SqlRepository(jdbcUrl, TestPersonTableDef)
             repo2.findById(5).shouldBePresent { it.firstName shouldBe "Franklin" }
             repo2.close()

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlVersionClobberTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlVersionClobberTest.kt
@@ -26,7 +26,6 @@ import io.kotest.matchers.shouldBe
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.UUID
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Regression tests for the `executeUpdate` version-clobber fix in [SqlWritePipeline].
@@ -67,7 +66,7 @@ internal class SqlVersionClobberTest : StringSpec({
                 }
             // Insert the entity so there is a row to update.
             repo.add(person)
-            eventually(5.seconds) { repo.findById(1).shouldBePresent { it shouldBe person } }
+            eventually(DatabaseTestSupport.PERSISTED_ROW_POLL) { repo.findById(1).shouldBePresent { it shouldBe person } }
 
             // Drive executeUpdate directly with null expectedVersion — the caller-bug path
             // that must be rejected with error() rather than silently clobbering the version column.
@@ -105,7 +104,7 @@ internal class SqlVersionClobberTest : StringSpec({
 
             // Wait for the INSERT to reach the DB before mutating, so the subsequent mutation
             // is enqueued as an UPDATE rather than merged into the pending INSERT.
-            eventually(5.seconds) {
+            eventually(DatabaseTestSupport.PERSISTED_ROW_POLL) {
                 val count =
                     transaction(db = db) {
                         exec("SELECT COUNT(*) FROM ${TestVersionedPersonTableDef.tableName} WHERE id = 2") { rs ->
@@ -119,7 +118,7 @@ internal class SqlVersionClobberTest : StringSpec({
             // Pipeline must persist version = 1L and bump the in-memory version to match.
             person.firstName = "Robert"
 
-            eventually(5.seconds) {
+            eventually(DatabaseTestSupport.PERSISTED_ROW_POLL) {
                 // person is the live registry entity; bumpVersion sets person.version directly after flush.
                 person.version shouldBe 1L
             }

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DatabaseTestSupport.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DatabaseTestSupport.kt
@@ -105,8 +105,14 @@ object DatabaseTestSupport {
      * reads the persisted row or reloads the entity immediately can race that delivery, especially under
      * CI load. Poll within this window instead of asserting once; the poll returns as soon as the write
      * is observed, so the ceiling only affects the rare slow case.
+     *
+     * The window is deliberately generous: the debounced writer alone can take up to ~1s, and under a
+     * loaded CI runner the isolated single-thread ioScope that flushes the write can be starved for
+     * several seconds. A tighter ceiling (the earlier 5s) intermittently expired before a slow flush
+     * landed; because `eventually` short-circuits on success, the larger value costs nothing on the
+     * happy path and only widens the safety margin for the rare contended case.
      */
-    val PERSISTED_ROW_POLL: Duration = 5.seconds
+    val PERSISTED_ROW_POLL: Duration = 15.seconds
 
     /**
      * Polls [readRow] for ([table], [id]) until [assert] passes or [timeout] elapses, absorbing the


### PR DESCRIPTION
## Problem

`FxAggregateSet.iterator()` intermittently threw `ArrayIndexOutOfBoundsException` under load (#310). In eager mode the local element cache (`localElements`, a plain `LinkedHashSet`) was snapshotted non-atomically via `ArrayList(localElements)`: the copy reads `size`, allocates an array, then fills it. Under the mixed change dispatch — `Platform.runLater` on the FX thread vs `flowScope.launch` on a background coroutine — a concurrent `add`/`remove`/`syncLocalCache` racing the copy corrupts the array construction and throws from `HashSet.toArray`.

`FxAggregateList` carried the identical latent race (plain `ArrayList` cache, same dual dispatch), so it is fixed in the same change.

## Changes

- **`FxAggregateSet`** — introduced a per-instance lock guarding every `localElements` read (iterator snapshot, `size`, `contains`, `retainAll` filter) and write (`add`/`remove`/`addAll`/`removeAll`/`syncLocalCache`). `clear()` snapshots-and-clears in a single locked block. Change notification runs **outside** the lock so reentrant listener cascades and cross-thread notification never block on it.
- **`FxAggregateList`** — same locking treatment across all cache accessors and mutators. Additionally:
  - Overrode `iterator()` to return a stable snapshot taken under the lock. The inherited `AbstractMutableList` iterator resolves `get(index)` against the live size, so a concurrent structural modification during iteration could throw `ConcurrentModificationException` / `IndexOutOfBoundsException`.
  - Overrode `remove(element)` (index lookup + `removeAt`). Required because the default `AbstractMutableCollection.remove` drives removal through `iterator().remove()`; with the new detached-snapshot iterator that path can no longer mutate the backing cache and would recurse.

## Testing

- Two new concurrency regression tests (a single writer mutating while multiple readers iterate). Both reproduce the failure on the pre-fix source (`ArrayIndexOutOfBoundsException` for the set, `ConcurrentModificationException` for the list) and pass after the fix.
- `FxAggregateListTest` + `FxAggregateSetTest` + `FxAggregateLazySnapshotTest`: 73 tests, no failures.
- `ktlintCheck` and `apiCheck` clean.

## Compatibility

No behavioral change to the public API. `FxAggregateList.iterator()` becomes an explicit public override (reflected in the binary-compatibility dump); iteration now returns a stable snapshot rather than a live view.

Fixes #310