### PR TITLE
#314 Address flagged performance optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,24 @@ see the [GitHub releases](https://github.com/octaviospain/lirp/releases).
   supply `bucketKeyOrdering` or `bucketValueOrdering`.
   See [#298](https://github.com/octaviospain/lirp/issues/298).
 
+- **`VersionedTableDef` gains a `versionOf(entity)` accessor (breaking for hand-written
+  implementers).** Optimistic-lock version reads no longer rebuild the entity's full column
+  parameter map on every versioned mutation; `SqlRepository` now reads the `@Version` value
+  directly through `VersionedTableDef.versionOf(entity)`. Because the interface now declares two
+  abstract methods (`bumpVersion` and `versionOf`), it is no longer a Kotlin `fun interface`, so
+  SAM-lambda construction (`VersionedTableDef { … }`) is no longer possible and hand-written
+  implementations must supply `versionOf`. KSP-generated `_LirpTableDef` classes implement it
+  automatically — consumers relying on `@PersistenceMapping` codegen are unaffected. Migration for
+  hand-written table defs: add
+  `override fun versionOf(entity: E): Long = entity.<versionProperty>`.
+  See [#314](https://github.com/octaviospain/lirp/issues/314).
+
+- **Ordered queries with a limit use a bounded top-K selection.** `Query.orderBy` combined with
+  `Query.limit` now retains only `offset + limit` candidates via a bounded heap (`O(n log k)` time,
+  `O(offset + limit)` memory) instead of sorting the entire candidate set. Results are identical to
+  the previous full stable sort truncated at the same window — behavior is unchanged, only the cost.
+  See [#314](https://github.com/octaviospain/lirp/issues/314).
+
 ## [3.2.0] - 2026-07-02
 
 Version 3.2.0 introduces the new `lirp-kafka` module, which adds transactional-outbox Kafka

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/QueryPlanner.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/query/QueryPlanner.kt
@@ -138,8 +138,9 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
      * query call.
      *
      * **Note on ordering:** when [Query.orderBy] is non-empty, the candidate sequence
-     * is materialised into a [List] before sorting. For large unfiltered registries
-     * this is O(n) memory; combine with [Query.limit] where possible.
+     * is fully sorted (O(n) memory) unless a [Query.limit] is also set, in which case a
+     * bounded top-K heap is used instead, retaining only `offset + limit` elements
+     * (O(offset + limit) memory) rather than sorting the full candidate set.
      *
      * **Note on pagination without ordering:** [Strategy.INDEX_ONLY] returns results
      * in [Set] iteration order, which is non-deterministic across JVM runs. For
@@ -156,9 +157,8 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
         // for queries that do not use cross-aggregate traversal.
         val pred = query.predicate?.let { normalize(it) }
         val (strategy, indexLeaves, postFilterCount, viaStrat, candidates) = selectStrategyAndCandidates(pred, registry, query)
-        val ordered = applyOrdering(candidates, query.orderBy)
-        val sliced = applyPagination(ordered, query.offset, query.limit)
-        return PlanContext(strategy, indexLeaves, postFilterCount, viaStrat, sliced)
+        val results = orderAndPaginate(candidates, query.orderBy, query.offset, query.limit)
+        return PlanContext(strategy, indexLeaves, postFilterCount, viaStrat, results)
     }
 
     /**
@@ -397,17 +397,71 @@ internal class QueryPlanner<T : IdentifiableEntity<*>>(
         }
     }
 
-    private fun applyOrdering(candidates: Sequence<T>, orderBy: List<OrderClause<T>>): Sequence<T> {
-        if (orderBy.isEmpty()) return candidates
+    /**
+     * Applies ordering and pagination to the candidate sequence.
+     *
+     * - **No ordering:** streams the candidates through `drop(offset)` / `take(limit)` without
+     *   materialising — unchanged behaviour.
+     * - **Ordering, no limit:** full stable sort, then `drop(offset)` — unchanged behaviour.
+     * - **Ordering with a limit:** selects only the top `offset + limit` candidates via a bounded
+     *   heap ([boundedTopK]) — `O(n log k)` instead of `O(n log n)` — then drops the offset and
+     *   takes the limit. The bounded selection tie-breaks by input index, so its output is
+     *   identical to a full stable sort truncated at the same boundary.
+     *
+     * All branches stay lazy: no candidate is consumed until the returned sequence reaches a
+     * terminal operation, honouring the laziness contract in [execute]'s KDoc.
+     */
+    private fun orderAndPaginate(candidates: Sequence<T>, orderBy: List<OrderClause<T>>, offset: Int, limit: Int?): Sequence<T> {
+        if (orderBy.isEmpty()) {
+            val dropped = candidates.drop(offset)
+            return if (limit != null) dropped.take(limit) else dropped
+        }
         val cmp = composeComparator(orderBy)
         // Defer the materialise-and-sort to the first terminal operation so planning stays
         // execution-free; the sort runs when the consumer iterates, not at plan() / execute() time.
-        return sequence { yieldAll(candidates.toList().sortedWith(cmp)) }
+        if (limit == null) {
+            return sequence { yieldAll(candidates.toList().sortedWith(cmp).drop(offset)) }
+        }
+        if (limit == 0) return emptySequence()
+        val k = offset.toLong() + limit.toLong()
+        // Fall back to a full sort when the requested window exceeds Int range: the bounded heap
+        // would then retain (nearly) every candidate anyway, so it offers no advantage.
+        if (k > Int.MAX_VALUE) {
+            return sequence { yieldAll(candidates.toList().sortedWith(cmp).drop(offset).take(limit)) }
+        }
+        return sequence { yieldAll(boundedTopK(candidates, cmp, k.toInt()).drop(offset).take(limit)) }
     }
 
-    private fun applyPagination(seq: Sequence<T>, offset: Int, limit: Int?): Sequence<T> {
-        val dropped = seq.drop(offset)
-        return if (limit != null) dropped.take(limit) else dropped
+    /**
+     * Returns the [k] smallest candidates under [cmp], in ascending [cmp] order, selected with a
+     * bounded max-heap in `O(n log k)` time and `O(k)` space.
+     *
+     * Ties are broken by input index so the retained window matches a full stable sort exactly:
+     * a candidate replaces the current heap head only when it strictly precedes it under the
+     * index-augmented comparator, preserving first-seen order among equal keys.
+     */
+    private fun boundedTopK(candidates: Sequence<T>, cmp: Comparator<T>, k: Int): List<T> {
+        val stable =
+            Comparator<IndexedValue<T>> { a, b ->
+                val byValue = cmp.compare(a.value, b.value)
+                if (byValue != 0) byValue else a.index.compareTo(b.index)
+            }
+        // Max-heap: the current worst retained candidate sits at the head, so it is the one a
+        // better incoming candidate evicts.
+        val heap = java.util.PriorityQueue(minOf(k, 1024).coerceAtLeast(1), stable.reversed())
+        var index = 0
+        for (candidate in candidates) {
+            val tagged = IndexedValue(index++, candidate)
+            if (heap.size < k) {
+                heap.offer(tagged)
+            } else if (stable.compare(tagged, heap.peek()) < 0) {
+                heap.poll()
+                heap.offer(tagged)
+            }
+        }
+        val selected = ArrayList(heap)
+        selected.sortWith(stable)
+        return selected.map { it.value }
     }
 
     /**

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/QueryDslIntegrationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/query/QueryDslIntegrationTest.kt
@@ -114,6 +114,39 @@ internal class QueryDslIntegrationTest : FunSpec({
         results.map { it.name } shouldBe listOf("Gadget", "Book B")
     }
 
+    test("query with orderBy and limit matches full-sort truncation when ordering keys tie") {
+        // Duplicate prices force the tie-break path in the bounded top-K selection; the retained
+        // window must equal the full stable sort truncated at the same offset/limit, regardless of
+        // the registry's candidate iteration order.
+        productRepo.create(1, "books", 10.0, 5, "A")
+        productRepo.create(2, "books", 10.0, 5, "B")
+        productRepo.create(3, "books", 10.0, 5, "C")
+        productRepo.create(4, "books", 20.0, 5, "D")
+        productRepo.create(5, "books", 20.0, 5, "E")
+
+        val fullSort = productRepo.query { orderBy(Product::price) }.toList()
+        val bounded =
+            productRepo.query {
+                orderBy(Product::price)
+                offset(1)
+                limit(3)
+            }.toList()
+
+        bounded shouldBe fullSort.drop(1).take(3)
+    }
+
+    test("query with orderBy and limit of zero returns empty") {
+        productRepo.create(1, "books", 10.0, 5, "A")
+        productRepo.create(2, "books", 20.0, 5, "B")
+
+        val results =
+            productRepo.query {
+                orderBy(Product::price)
+                limit(0)
+            }.toList()
+        results shouldBe emptyList()
+    }
+
     test("query with offset and limit returns correct page") {
         productRepo.create(1, "books", 10.0, 5, "A")
         productRepo.create(2, "books", 20.0, 5, "B")

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/TableDefSourceEmitter.kt
@@ -145,6 +145,7 @@ internal object TableDefSourceEmitter {
             appendLine()
             appendApplyScalarRow(selfType, columns, params.setterSlots)
             appendBumpVersion(className, selfType, columns)
+            appendVersionOf(className, selfType, columns)
             appendForeignKeys(foreignKeys)
             appendJunctionOverrides(className, selfType, junctionRefs)
         }
@@ -453,6 +454,18 @@ internal object TableDefSourceEmitter {
         appendLine("    override fun bumpVersion(${receiverName(className, selfType)}: $selfType, newVersion: Long) {")
         if (className != selfType) appendCastToConcrete(className)
         appendLine("        entity.${versionCol.propertyName} = newVersion")
+        appendLine(METHOD_CLOSE)
+    }
+
+    fun StringBuilder.appendVersionOf(className: String, selfType: String, columns: List<ColumnMeta>) {
+        // Emit a non-default versionOf override only when the entity declares a @Version column.
+        // Reading the property directly avoids the O(columns) toParams map allocation on every
+        // versioned mutation. Unversioned entities do not implement VersionedTableDef, so no emission.
+        val versionCol = columns.singleOrNull { it.isVersion } ?: return
+        appendLine()
+        appendLine("    override fun versionOf(${receiverName(className, selfType)}: $selfType): Long {")
+        if (className != selfType) appendCastToConcrete(className)
+        appendLine("        return entity.${versionCol.propertyName}")
         appendLine(METHOD_CLOSE)
     }
 

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
@@ -1031,6 +1031,8 @@ internal class TableDefProcessorTest : FunSpec({
         val content = result.generatedFileContent("BumpCheck_LirpTableDef.kt")
         content shouldContain "override fun bumpVersion(entity: BumpCheck, newVersion: Long)"
         content shouldContain "entity.version = newVersion"
+        content shouldContain "override fun versionOf(entity: BumpCheck): Long"
+        content shouldContain "return entity.version"
     }
 
     test("does NOT generate bumpVersion override for entity without @Version") {
@@ -1057,6 +1059,7 @@ internal class TableDefProcessorTest : FunSpec({
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
         val content = result.generatedFileContent("NoBump_LirpTableDef.kt")
         content shouldNotContain "override fun bumpVersion"
+        content shouldNotContain "override fun versionOf"
     }
 
     // ---- Junction tables and FK constraints (#144) ----

--- a/lirp-sql-api/api/lirp-sql-api.api
+++ b/lirp-sql-api/api/lirp-sql-api.api
@@ -77,5 +77,6 @@ public abstract interface class net/transgressoft/lirp/persistence/sql/SqlTableD
 
 public abstract interface class net/transgressoft/lirp/persistence/sql/VersionedTableDef {
 	public abstract fun bumpVersion (Ljava/lang/Object;J)V
+	public abstract fun versionOf (Ljava/lang/Object;)J
 }
 

--- a/lirp-sql-api/src/main/kotlin/net/transgressoft/lirp/persistence/sql/VersionedTableDef.kt
+++ b/lirp-sql-api/src/main/kotlin/net/transgressoft/lirp/persistence/sql/VersionedTableDef.kt
@@ -32,7 +32,7 @@ package net.transgressoft.lirp.persistence.sql
  *
  * @param E The entity type whose version column is managed.
  */
-fun interface VersionedTableDef<E> {
+interface VersionedTableDef<E> {
 
     /**
      * Sets the `@Version` property of [entity] to [newVersion], bypassing reactive setters
@@ -45,4 +45,17 @@ fun interface VersionedTableDef<E> {
      * @param newVersion The new version value (typically `expectedVersion + 1`).
      */
     fun bumpVersion(entity: E, newVersion: Long)
+
+    /**
+     * Reads the `@Version` property of [entity] directly, without materializing the entity's
+     * full column parameter map.
+     *
+     * Called by `SqlRepository` on every versioned mutation to capture the expected version for
+     * the optimistic-lock WHERE clause. Returning the field value directly avoids the O(columns)
+     * cost of building a `toParams` map just to read a single cell.
+     *
+     * @param entity The entity whose current version is read.
+     * @return The entity's current version counter.
+     */
+    fun versionOf(entity: E): Long
 }

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryRawConstructorIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryRawConstructorIntegrationTest.kt
@@ -204,6 +204,8 @@ object VersionedRawCtorTableDef :
         entity.version = newVersion
     }
 
+    override fun versionOf(entity: VersionedRawCtorEntity): Long = entity.version
+
     @Suppress("UNCHECKED_CAST")
     override fun applyScalarRow(
         entity: VersionedRawCtorEntity,

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
@@ -206,6 +206,11 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
     @Suppress("UNCHECKED_CAST")
     private val junctionAware: JunctionAware<R>? = tableDef as? JunctionAware<R>
 
+    // Resolved once: safe unchecked cast for the same reason as junctionAware — VersionedTableDef
+    // members are typed on the same self-type R. Non-null exactly when the entity is versioned.
+    @Suppress("UNCHECKED_CAST")
+    private val versionedTableDef: VersionedTableDef<R>? = tableDef as? VersionedTableDef<R>
+
     /**
      * Cached interpretations of this entity's junction descriptors, keyed by descriptor reference.
      * Reused across `loadFromStore`, `writePending`, and `installJunctionForeignKeys` so we don't
@@ -357,22 +362,16 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
     }
 
     /**
-     * Reads the optimistic-lock version from [entity] via the table descriptor's `toParams`
-     * mapping. Returns `null` when the repository's `tableDef` has no `@Version` column.
+     * Reads the optimistic-lock version from [entity] via the table descriptor's targeted
+     * [VersionedTableDef.versionOf] accessor. Returns `null` when the repository's `tableDef`
+     * has no `@Version` column.
      *
-     * Rationale: LIRP has no runtime reflection API for typed property access. The existing
-     * `toParams(entity, table)` Map already exposes every persisted column value keyed by its
-     * [Column] reference, so a single map lookup on [versionCol] yields the value with zero
-     * reflection — the same zero-reflection invariant preserved by `fromRow`/`applyRow`. The
-     * O(columns) cost is acceptable for typical entity widths; if profiling shows the lookup
-     * dominates mutation hot paths, a KSP-generated VersionAccessor remains available as a
-     * future optimization.
+     * The accessor reads the single `@Version` property directly, avoiding the O(columns) cost of
+     * materializing the full `toParams` map just to read one cell — this runs on every versioned
+     * mutation. The [versionCol] guard preserves the exact null semantics for unversioned tables.
      */
-    override fun extractVersion(entity: R): Long? {
-        val vc = versionCol ?: return null
-        val params = tableDef.toParams(entity, table)
-        return params[vc] as? Long
-    }
+    override fun extractVersion(entity: R): Long? =
+        if (versionCol == null) null else versionedTableDef?.versionOf(entity)
 
     /**
      * Executes the grouped pending payload against the database in a single transaction.

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlWritePipeline.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlWritePipeline.kt
@@ -238,11 +238,14 @@ internal class SqlWritePipeline<K : Comparable<K>, R : ReactiveEntity<K, R>>(
 
             junction.table.deleteWhere { junction.parentIdCol eq parentId }
 
-            ids.forEachIndexed { index, itemId ->
-                junction.table.insert { stmt ->
-                    stmt[junction.parentIdCol] = parentId
-                    stmt[junction.itemIdCol] = toExposedId(itemId)
-                    junction.positionCol?.let { posCol -> stmt[posCol] = index }
+            // Batch-insert all junction rows in a single statement rather than one round-trip per
+            // item. The deleteWhere above runs unconditionally so clearing a collection still wipes
+            // its rows; the insert is skipped when there is nothing to write.
+            if (ids.isNotEmpty()) {
+                junction.table.batchInsert(ids.withIndex(), shouldReturnGeneratedValues = false) { (index, itemId) ->
+                    this[junction.parentIdCol] = parentId
+                    this[junction.itemIdCol] = toExposedId(itemId)
+                    junction.positionCol?.let { posCol -> this[posCol] = index }
                 }
             }
         }

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/FkTestFixtures.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/FkTestFixtures.kt
@@ -214,6 +214,8 @@ object FkParentTableDef : SqlTableDef<FkParent>, VersionedTableDef<FkParent>, Ju
         entity.withEventsDisabled { entity.version = newVersion }
     }
 
+    override fun versionOf(entity: FkParent): Long = entity.version
+
     /**
      * Reconciles [FkParent.childIds] from junction rows during bulk load. Mirrors what KSP would
      * generate for an `aggregateList` collection ref.

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/TestVersionedPersonTableDef.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/TestVersionedPersonTableDef.kt
@@ -76,6 +76,8 @@ object TestVersionedPersonTableDef : SqlTableDef<TestVersionedPerson>, Versioned
         entity.version = newVersion
     }
 
+    override fun versionOf(entity: TestVersionedPerson): Long = entity.version
+
     override fun applyScalarRow(entity: TestVersionedPerson, row: ResultRow, table: Table, rawInit: LirpRawInitializer<TestVersionedPerson>) {
         // No-op: entity state is fully populated by fromRow.
     }


### PR DESCRIPTION
Closes #314.

Behavior-preserving hot-path optimizations. The highest-value item flagged in the issue — the non-copying index read for the query planner — already shipped earlier (`findByIndexNoCopy` + planner wiring), so this PR covers the remaining three.

## Changes

### Targeted version accessor (was: full param-map rebuild)
`SqlRepository.extractVersion` previously called `tableDef.toParams(entity, table)`, materializing a map over *every* column just to read the one `@Version` cell — on every versioned mutation. This adds `VersionedTableDef.versionOf(entity)`, which reads the version property directly:
- KSP generates the override for `@Version` entities alongside `bumpVersion`.
- `extractVersion` reads it (guarded so unversioned tables still return `null`).
- `VersionedTableDef` changes from a `fun interface` to a regular interface; hand-written versioned table defs implement the new member.

### Junction-row batch insert (was: row-by-row insert)
`SqlWritePipeline.syncJunctionRows` did delete-then-`forEachIndexed { insert }` — one round-trip per collection item per parent update. It now uses `batchInsert(ids.withIndex())` in a single statement, matching the entity batch-insert path already used in the file. The `deleteWhere` still runs unconditionally, so clearing a collection continues to remove all its rows.

### Query-planner bounded top-K (was: full sort even with a small limit)
Ordered queries with a `limit` previously materialized and sorted the entire candidate set (`O(n log n)`). They now select only the top `offset + limit` candidates via a bounded heap (`O(n log k)`). The selection tie-breaks by input index, so its output is identical to the previous full stable sort truncated at the same window — no observable ordering change.

## Compatibility
- No public API contract broken: the `findByIndex` defensive-copy snapshot and `toParams` remain unchanged.
- KSP-generated table defs are updated automatically; only hand-written `VersionedTableDef` implementers need the new `versionOf` member (the compiler guides them).

## Testing
- Unit suites for `lirp-ksp`, `lirp-core`, and `lirp-sql` pass; the SQL integration source set compiles; ktlint is clean.
- New tests: KSP `versionOf` codegen assertion; query-planner bounded top-K stability under tied ordering keys and a zero limit.
- Aggregate coverage above baseline — line 88.01%, branch 73.59%.