### PR TITLE
Harden the concurrency test suite, bound the transaction flush-lock, and modernize the test code

### DIFF
--- a/.github/workflows/flaky-hunt.yml
+++ b/.github/workflows/flaky-hunt.yml
@@ -1,0 +1,48 @@
+name: flaky hunt
+
+# Manually-triggered job that runs the full test suite repeatedly to surface
+# intermittent failures and hangs (notably the historic cross-thread transaction
+# deadlock) that a single run cannot prove absent. Not wired to push/PR so normal
+# CI stays fast; run it on demand before merging concurrency-sensitive changes.
+
+on:
+    workflow_dispatch:
+        inputs:
+            iterations:
+                description: "Number of full-suite runs"
+                required: false
+                default: "10"
+            run_timeout:
+                description: "Per-run wall-clock budget (seconds); a run exceeding it is treated as a hang"
+                required: false
+                default: "900"
+
+jobs:
+    flaky-hunt:
+        runs-on: ubuntu-latest
+        timeout-minutes: 180
+
+        steps:
+            -   uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+                with:
+                    fetch-depth: 0
+
+            -   name: Set up JDK 21
+                uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+                with:
+                    java-version: 21
+                    distribution: 'zulu'
+                    java-package: 'jdk+fx'
+
+            -   name: Cache Gradle packages
+                uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+                with:
+                    path: |
+                        ~/.gradle/caches
+                        ~/.gradle/wrapper
+                    key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+                    restore-keys: |
+                        ${{ runner.os }}-gradle-
+
+            -   name: Repeatedly run the full test suite
+                run: scripts/flaky-hunt.sh "${{ inputs.iterations }}" "${{ inputs.run_timeout }}"

--- a/.github/workflows/flaky-hunt.yml
+++ b/.github/workflows/flaky-hunt.yml
@@ -26,6 +26,7 @@ jobs:
             -   uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
                 with:
                     fetch-depth: 0
+                    persist-credentials: false
 
             -   name: Set up JDK 21
                 uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
@@ -45,4 +46,7 @@ jobs:
                         ${{ runner.os }}-gradle-
 
             -   name: Repeatedly run the full test suite
-                run: scripts/flaky-hunt.sh "${{ inputs.iterations }}" "${{ inputs.run_timeout }}"
+                env:
+                    ITERATIONS: ${{ inputs.iterations }}
+                    RUN_TIMEOUT: ${{ inputs.run_timeout }}
+                run: scripts/flaky-hunt.sh "$ITERATIONS" "$RUN_TIMEOUT"

--- a/lirp-api/src/test/kotlin/net/transgressoft/lirp/persistence/DefaultColumnConvertersTest.kt
+++ b/lirp-api/src/test/kotlin/net/transgressoft/lirp/persistence/DefaultColumnConvertersTest.kt
@@ -18,6 +18,8 @@
 package net.transgressoft.lirp.persistence
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.datatest.withData
+import io.kotest.engine.names.WithDataTestName
 import io.kotest.matchers.shouldBe
 import java.math.BigInteger
 import java.net.URI
@@ -29,10 +31,34 @@ import java.time.ZoneOffset
 
 /**
  * Round-trip and `sqlType` assertions for the built-in default [ColumnConverter] singletons. Each
- * test verifies that a domain value survives `toSql` followed by `fromSql` and that the declared
+ * case verifies that a domain value survives `toSql` followed by `fromSql` and that the declared
  * persistence scalar matches the documented column shape.
  */
 class DefaultColumnConvertersTest : StringSpec({
+
+    // Converters whose contract is the uniform "TextType, symmetric fromSql(toSql(x)) == x" shape.
+    // The converters with a distinct contract (asymmetric expected value, exact encoding, or a
+    // double round-trip) keep their own named tests below.
+    withData(
+        SymmetricRoundTrip(
+            "InstantColumnConverter round-trips an instant through its ISO-8601 form on a TextType column",
+            InstantColumnConverter, Instant.parse("2026-06-23T10:15:30.250Z")
+        ),
+        SymmetricRoundTrip(
+            "OffsetDateTimeColumnConverter preserves the offset across a round-trip on a TextType column",
+            OffsetDateTimeColumnConverter, OffsetDateTime.of(2026, 6, 23, 10, 15, 30, 0, ZoneOffset.ofHours(2))
+        ),
+        SymmetricRoundTrip(
+            "UriColumnConverter round-trips a URI through its string form on a TextType column",
+            UriColumnConverter, URI("https://example.com/path?query=1#frag")
+        ),
+        SymmetricRoundTrip(
+            "BigIntegerColumnConverter round-trips an arbitrary-precision integer on a TextType column",
+            BigIntegerColumnConverter, BigInteger("123456789012345678901234567890")
+        )
+    ) { case ->
+        case.verify()
+    }
 
     "PathColumnConverter round-trips a path through its URI form on a Long-free TextType column" {
         PathColumnConverter.sqlType shouldBe ColumnType.TextType
@@ -47,33 +73,26 @@ class DefaultColumnConvertersTest : StringSpec({
         DurationColumnConverter.fromSql(DurationColumnConverter.toSql(duration)) shouldBe duration
     }
 
-    "InstantColumnConverter round-trips an instant through its ISO-8601 form on a TextType column" {
-        InstantColumnConverter.sqlType shouldBe ColumnType.TextType
-        val instant = Instant.parse("2026-06-23T10:15:30.250Z")
-        InstantColumnConverter.fromSql(InstantColumnConverter.toSql(instant)) shouldBe instant
-    }
-
-    "OffsetDateTimeColumnConverter preserves the offset across a round-trip on a TextType column" {
-        OffsetDateTimeColumnConverter.sqlType shouldBe ColumnType.TextType
-        val offsetDateTime = OffsetDateTime.of(2026, 6, 23, 10, 15, 30, 0, ZoneOffset.ofHours(2))
-        OffsetDateTimeColumnConverter.fromSql(OffsetDateTimeColumnConverter.toSql(offsetDateTime)) shouldBe offsetDateTime
-    }
-
-    "UriColumnConverter round-trips a URI through its string form on a TextType column" {
-        UriColumnConverter.sqlType shouldBe ColumnType.TextType
-        val uri = URI("https://example.com/path?query=1#frag")
-        UriColumnConverter.fromSql(UriColumnConverter.toSql(uri)) shouldBe uri
-    }
-
     "UrlColumnConverter round-trips a URL through its string form on a TextType column" {
         UrlColumnConverter.sqlType shouldBe ColumnType.TextType
         val url = URI("https://example.com/path").toURL()
         UrlColumnConverter.toSql(UrlColumnConverter.fromSql(UrlColumnConverter.toSql(url))) shouldBe url.toString()
     }
-
-    "BigIntegerColumnConverter round-trips an arbitrary-precision integer on a TextType column" {
-        BigIntegerColumnConverter.sqlType shouldBe ColumnType.TextType
-        val bigInteger = BigInteger("123456789012345678901234567890")
-        BigIntegerColumnConverter.fromSql(BigIntegerColumnConverter.toSql(bigInteger)) shouldBe bigInteger
-    }
 })
+
+/**
+ * A converter whose round-trip is symmetric and text-backed: `sqlType == TextType` and
+ * `fromSql(toSql(value)) == value`. Generics are captured at construction so [verify] needs no cast.
+ */
+private class SymmetricRoundTrip<T : Any>(
+    val name: String,
+    val converter: ColumnConverter<T, String>,
+    val value: T
+) : WithDataTestName {
+    override fun dataTestName() = name
+
+    fun verify() {
+        converter.sqlType shouldBe ColumnType.TextType
+        converter.fromSql(converter.toSql(value)) shouldBe value
+    }
+}

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/KspAccessorLoader.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/KspAccessorLoader.kt
@@ -28,13 +28,17 @@ import java.util.concurrent.ConcurrentHashMap
  * class is loaded at most once per JVM lifetime. Returns `null` when no generated class exists
  * (KSP not applied, anonymous entity, or no matching annotation on the entity type).
  *
- * The suffix constants mirror those in `LirpGenNames` (lirp-ksp), defined here to avoid
- * introducing a runtime dependency on the compile-only KSP module.
+ * The suffix constants below intentionally mirror their counterparts in `LirpGenNames` (lirp-ksp),
+ * which is the producer-side authority for all generated-name suffixes. They are redeclared here
+ * because lirp-core must not carry a runtime dependency on the compile-only lirp-ksp module.
+ * This consumer only needs the subset of suffixes for accessor types it actually loads; it does
+ * not replicate TABLE_DEF, FX, or junction suffixes, which are never loaded at runtime here.
  */
 internal object KspAccessorLoader {
 
-    // Suffix constants that mirror LirpGenNames in lirp-ksp.
-    // lirp-core must not depend on lirp-ksp at runtime, so these are defined independently here.
+    // Suffix constants that intentionally mirror LirpGenNames in lirp-ksp. lirp-core must not
+    // depend on lirp-ksp at runtime, so these are defined independently for the accessor types
+    // this loader actually needs.
     internal const val INDEX_ACCESSOR_SUFFIX = "_LirpIndexAccessor"
     internal const val REF_ACCESSOR_SUFFIX = "_LirpRefAccessor"
     internal const val VIA_ACCESSOR_SUFFIX = "_LirpViaAccessor"

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
@@ -31,6 +31,7 @@ import net.transgressoft.lirp.event.ReactiveScope
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.slf4j.MDC
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.ReentrantLock
@@ -38,6 +39,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.withLock
 import kotlin.concurrent.write
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Job
@@ -274,6 +276,19 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
 
         /** Acquires [flushLock]. For use by the transaction orchestration layer in the same module. */
         internal fun lockFlush() = flushLock.lock()
+
+        /**
+         * Attempts to acquire [flushLock], waiting at most [timeout]. Returns `true` when the lock
+         * was taken and `false` when the wait elapsed first.
+         *
+         * The transaction orchestration layer uses the bounded variant instead of [lockFlush] so a
+         * flush that never releases the lock (a stuck backing-store write or a lock leaked by an
+         * earlier transaction) surfaces as a fast, diagnosable failure rather than an indefinite hang.
+         *
+         * @throws InterruptedException if the current thread is interrupted while waiting.
+         */
+        internal fun tryLockFlush(timeout: Duration): Boolean =
+            flushLock.tryLock(timeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)
 
         /** Releases [flushLock]. Symmetric to [lockFlush]. */
         internal fun unlockFlush() = flushLock.unlock()

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/Transactions.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/Transactions.kt
@@ -20,6 +20,10 @@ package net.transgressoft.lirp.persistence
 import net.transgressoft.lirp.entity.ReactiveEntity
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.event.ReactiveScope
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.asContextElement
 import kotlinx.coroutines.withContext
@@ -39,11 +43,18 @@ private val activeTransactionCount = ThreadLocal.withInitial { 0 }
  * Sized far above any legitimate flush (a debounced write completes in ~1s, a few seconds at worst
  * under load) so it never trips on healthy contention, yet finite so a stuck flush or a lock leaked
  * by an earlier transaction fails fast with a diagnostic instead of hanging indefinitely.
- *
- * Exposed as a mutable seam so tests can shrink it to assert the fail-fast path without waiting the
- * full production window; production code never reassigns it.
  */
-internal var flushLockAcquireTimeout = 60.seconds
+private val DEFAULT_FLUSH_LOCK_ACQUIRE_TIMEOUT = 60.seconds
+
+/**
+ * Coroutine-scoped override for the flush-lock acquisition timeout, read by [transaction] from the
+ * calling coroutine's context. It exists so a test can assert the fail-fast path with a short window
+ * without waiting the full production timeout; because it is carried per-coroutine rather than in a
+ * shared mutable field, concurrent specs cannot affect each other's transactions.
+ */
+internal class FlushLockTimeoutOverride(val timeout: Duration) : AbstractCoroutineContextElement(Key) {
+    companion object Key : CoroutineContext.Key<FlushLockTimeoutOverride>
+}
 
 /**
  * Executes [block] as an atomic unit of work against [repo].
@@ -118,6 +129,10 @@ suspend fun <K : Comparable<K>, R : ReactiveEntity<K, R>> transaction(
     // coroutine from contending for the lock while the transaction holds it.
     repo.cancelDebounce()
 
+    // Read the flush-lock timeout from the calling coroutine's context (tests may shorten it),
+    // captured here because the withContext below installs a fresh context without this element.
+    val flushTimeout = coroutineContext[FlushLockTimeoutOverride]?.timeout ?: DEFAULT_FLUSH_LOCK_ACQUIRE_TIMEOUT
+
     // Run the entire transaction on the dedicated, thread-pinned transaction dispatcher.
     // Because the block is suspend and Kotlin forbids suspending inside withLock { }, the
     // flush lock is managed with explicit lock/unlock under a try/finally. [flushLock] is a
@@ -140,7 +155,7 @@ suspend fun <K : Comparable<K>, R : ReactiveEntity<K, R>> transaction(
         // contention. Acquired outside the try so a failed acquisition does not reach unlockFlush.
         val acquired =
             try {
-                repo.tryLockFlush(flushLockAcquireTimeout)
+                repo.tryLockFlush(flushTimeout)
             } catch (interrupted: InterruptedException) {
                 Thread.currentThread().interrupt()
                 throw LirpTransactionException(
@@ -151,7 +166,7 @@ suspend fun <K : Comparable<K>, R : ReactiveEntity<K, R>> transaction(
         if (!acquired) {
             throw LirpTransactionException(
                 "Could not acquire the transaction flush lock on '${repo.repoName}' within " +
-                    "$flushLockAcquireTimeout — a prior flush or transaction likely did not release it. " +
+                    "$flushTimeout — a prior flush or transaction likely did not release it. " +
                     "Aborting to avoid an indefinite hang."
             )
         }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/Transactions.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/Transactions.kt
@@ -20,6 +20,7 @@ package net.transgressoft.lirp.persistence
 import net.transgressoft.lirp.entity.ReactiveEntity
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.event.ReactiveScope
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.asContextElement
 import kotlinx.coroutines.withContext
 
@@ -31,6 +32,18 @@ import kotlinx.coroutines.withContext
  * supported in the single-participant form.
  */
 private val activeTransactionCount = ThreadLocal.withInitial { 0 }
+
+/**
+ * Upper bound on how long the transaction commit path waits for the repository's flush lock.
+ *
+ * Sized far above any legitimate flush (a debounced write completes in ~1s, a few seconds at worst
+ * under load) so it never trips on healthy contention, yet finite so a stuck flush or a lock leaked
+ * by an earlier transaction fails fast with a diagnostic instead of hanging indefinitely.
+ *
+ * Exposed as a mutable seam so tests can shrink it to assert the fail-fast path without waiting the
+ * full production window; production code never reassigns it.
+ */
+internal var flushLockAcquireTimeout = 60.seconds
 
 /**
  * Executes [block] as an atomic unit of work against [repo].
@@ -120,10 +133,30 @@ suspend fun <K : Comparable<K>, R : ReactiveEntity<K, R>> transaction(
             ReactiveScope.transactionDispatcher +
             activeTransactionCount.asContextElement(activeTransactionCount.get())
     ) {
-        repo.lockFlush()
-        // The lock is acquired outside the try only on the line above; everything that can throw —
-        // including snapshot capture and event-buffer installation — runs inside so the finally
-        // always releases the lock and restores per-repo transaction state.
+        // Bounded acquisition: a flush that never releases the lock (a stuck backing-store write or a
+        // lock leaked by an earlier transaction) must fail fast and loud instead of hanging the caller
+        // — and, in the test suite, the whole JVM. The ceiling is far larger than any legitimate flush
+        // (a debounced write is ~1s, seconds at worst under load), so it never trips on healthy
+        // contention. Acquired outside the try so a failed acquisition does not reach unlockFlush.
+        val acquired =
+            try {
+                repo.tryLockFlush(flushLockAcquireTimeout)
+            } catch (interrupted: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw LirpTransactionException(
+                    "Interrupted while acquiring the transaction flush lock on '${repo.repoName}'",
+                    interrupted
+                )
+            }
+        if (!acquired) {
+            throw LirpTransactionException(
+                "Could not acquire the transaction flush lock on '${repo.repoName}' within " +
+                    "$flushLockAcquireTimeout — a prior flush or transaction likely did not release it. " +
+                    "Aborting to avoid an indefinite hang."
+            )
+        }
+        // Everything that can throw — including snapshot capture and event-buffer installation — runs
+        // inside the try so the finally always releases the lock and restores per-repo transaction state.
         var loadedEntities: List<ReactiveEntityBase<K, R>> = emptyList()
         try {
             activeTransactionCount.set(activeTransactionCount.get() + 1)

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/ReactiveEntityLifecycleTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/ReactiveEntityLifecycleTest.kt
@@ -24,6 +24,7 @@ import net.transgressoft.lirp.event.PropertyChanged
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.testing.reactiveScope
+import net.transgressoft.lirp.testing.recordAsync
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -174,16 +175,15 @@ class ReactiveEntityLifecycleTest : StringSpec({
         reactive.advance()
 
         // Reactivate: subscribe again — must not throw
-        val receivedEvents = mutableListOf<MutationEvent<String, LazyTestEntity>>()
-        val sub2 = entity.subscribeAsync { event -> receivedEvents.add(event) }
+        val recorder = entity.recordAsync()
 
         entity.value = "reactivated"
         reactive.advance()
 
-        receivedEvents.size shouldBe 1
-        (receivedEvents[0] as PropertyChanged<String, LazyTestEntity, String>).newValue shouldBe "reactivated"
+        recorder.count shouldBe 1
+        (recorder.last as PropertyChanged<String, LazyTestEntity, String>).newValue shouldBe "reactivated"
 
-        sub2.cancel()
+        entity.close()
     }
 
     "ReactiveEntity supports multiple dormant-active cycles" {
@@ -203,16 +203,15 @@ class ReactiveEntityLifecycleTest : StringSpec({
         reactive.advance()
 
         // Cycle 3: subscribe (active), receive events
-        val receivedEvents = mutableListOf<MutationEvent<String, LazyTestEntity>>()
-        val sub3 = entity.subscribeAsync { event -> receivedEvents.add(event) }
+        val recorder = entity.recordAsync()
         creationCounter.get() shouldBe 3
 
         entity.value = "after-cycles"
         reactive.advance()
 
-        receivedEvents.size shouldBe 1
+        recorder.count shouldBe 1
 
-        sub3.cancel()
+        entity.close()
     }
 
     "ReactiveEntity lifecycle: Created -> Active -> Dormant -> Active -> Closed" {
@@ -288,51 +287,46 @@ class ReactiveEntityLifecycleTest : StringSpec({
 
     "disableEvents suppresses mutation events from reactiveProperty setters" {
         val audioItem = MutableAudioItem(1, "Track Alpha")
-        val received = mutableListOf<MutationEvent<Int, AudioItem>>()
-        val subscription = audioItem.subscribeAsync { event -> received.add(event) }
+        val recorder = audioItem.recordAsync()
 
         audioItem.suppressEvents()
         audioItem.title = "Track Beta"
         reactive.advance()
 
-        received.size shouldBe 0
+        recorder.count shouldBe 0
         audioItem.title shouldBe "Track Beta"
 
         audioItem.restoreEvents()
         audioItem.title = "Track Charlie"
         reactive.advance()
 
-        received.size shouldBe 1
-        (received[0] as PropertyChanged<Int, AudioItem, String>).newValue shouldBe "Track Charlie"
+        recorder.count shouldBe 1
+        (recorder.last as PropertyChanged<Int, AudioItem, String>).newValue shouldBe "Track Charlie"
 
-        subscription.cancel()
         audioItem.close()
     }
 
     "withEventsDisabled suppresses events and restores emission afterward" {
         val audioItem = MutableAudioItem(1, "Track Alpha")
-        val received = mutableListOf<MutationEvent<Int, AudioItem>>()
-        val subscription = audioItem.subscribeAsync { event -> received.add(event) }
+        val recorder = audioItem.recordAsync()
 
         audioItem.silently {
             audioItem.title = "Silent Track"
         }
         reactive.advance()
-        received.size shouldBe 0
+        recorder.count shouldBe 0
         audioItem.title shouldBe "Silent Track"
 
         audioItem.title = "Loud Track"
         reactive.advance()
-        received.size shouldBe 1
+        recorder.count shouldBe 1
 
-        subscription.cancel()
         audioItem.close()
     }
 
     "withEventsDisabled restores state even if action throws" {
         val audioItem = MutableAudioItem(1, "Track Alpha")
-        val received = mutableListOf<MutationEvent<Int, AudioItem>>()
-        val subscription = audioItem.subscribeAsync { event -> received.add(event) }
+        val recorder = audioItem.recordAsync()
 
         shouldThrow<RuntimeException> {
             audioItem.silently {
@@ -343,25 +337,22 @@ class ReactiveEntityLifecycleTest : StringSpec({
 
         audioItem.title = "AfterError"
         reactive.advance()
-        received.size shouldBe 1
+        recorder.count shouldBe 1
 
-        subscription.cancel()
         audioItem.close()
     }
 
     "disableEvents suppresses mutateAndPublish block emission" {
         val audioItem = MutableAudioItem(1, "Track Alpha")
-        val received = mutableListOf<MutationEvent<Int, AudioItem>>()
-        val subscription = audioItem.subscribeAsync { event -> received.add(event) }
+        val recorder = audioItem.recordAsync()
 
         audioItem.suppressEvents()
         audioItem.bulkUpdate("Silent Track")
         reactive.advance()
 
-        received.size shouldBe 0
+        recorder.count shouldBe 0
         audioItem.title shouldBe "Silent Track"
 
-        subscription.cancel()
         audioItem.close()
     }
 })

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/SubscriptionExtensionsTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/SubscriptionExtensionsTest.kt
@@ -34,6 +34,7 @@ import net.transgressoft.lirp.persistence.DefaultAudioPlaylist
 import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.testing.reactiveScope
+import net.transgressoft.lirp.testing.recordAsync
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -189,21 +190,15 @@ class SubscriptionExtensionsTest : StringSpec({
         val t1 = trackRepo.create(1, "Track 1")
         val playlist = DefaultAudioPlaylist(1, "Original Name").also(playlistRepo::add)
 
-        val receivedEvents = mutableListOf<Any>()
-        val latch = CountDownLatch(2)
-
-        playlist.subscribeAsync { event ->
-            receivedEvents.add(event)
-            latch.countDown()
-        }
+        val recorder = playlist.recordAsync()
 
         playlist.name = "New Name"
         playlist.audioItems.add(t1)
 
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        receivedEvents.size shouldBe 2
-        receivedEvents.any { it is PropertyChanged<*, *, *> } shouldBe true
-        receivedEvents.any { it is AggregateMutationEvent<*, *> } shouldBe true
+        recorder.awaitCount(2) shouldBe true
+        recorder.count shouldBe 2
+        recorder.events.any { it is PropertyChanged<*, *, *> } shouldBe true
+        recorder.events.any { it is AggregateMutationEvent<*, *> } shouldBe true
     }
 
     "subscribeToProperty delivers typed old and new values on property change" {
@@ -288,21 +283,13 @@ class SubscriptionExtensionsTest : StringSpec({
         val item = trackRepo.create(1, "Original Title", "Original Album")
         require(item is MutableAudioItem)
 
-        val receivedBatch = AtomicReference<Any?>(null)
-        val latch = CountDownLatch(1)
-
-        item.subscribeAsync { event ->
-            if (event is BatchChanged<*, *>) {
-                receivedBatch.set(event)
-                latch.countDown()
-            }
-        }
+        val recorder = item.recordAsync()
 
         item.bulkUpdate("New Title")
 
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        @Suppress("UNCHECKED_CAST")
-        val batch = receivedBatch.get() as BatchChanged<Int, AudioItem>
+        recorder.awaitCount(1) shouldBe true
+        val batch = recorder.last
+        batch.shouldBeInstanceOf<BatchChanged<Int, AudioItem>>()
         val titleChanges: List<FieldChange<AudioItem, String>> = batch.changesOf(AudioItem::title)
         titleChanges.size shouldBe 1
         titleChanges[0].oldValue shouldBe "Original Title"
@@ -313,21 +300,13 @@ class SubscriptionExtensionsTest : StringSpec({
         val item = trackRepo.create(1, "Original Title", "Original Album")
         require(item is MutableAudioItem)
 
-        val receivedBatch = AtomicReference<Any?>(null)
-        val latch = CountDownLatch(1)
-
-        item.subscribeAsync { event ->
-            if (event is BatchChanged<*, *>) {
-                receivedBatch.set(event)
-                latch.countDown()
-            }
-        }
+        val recorder = item.recordAsync()
 
         item.bulkAlbumUpdate("New Album")
 
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        @Suppress("UNCHECKED_CAST")
-        val batch = receivedBatch.get() as BatchChanged<Int, AudioItem>
+        recorder.awaitCount(1) shouldBe true
+        val batch = recorder.last
+        batch.shouldBeInstanceOf<BatchChanged<Int, AudioItem>>()
         val titleChanges: List<FieldChange<AudioItem, String>> = batch.changesOf(AudioItem::title)
         titleChanges shouldBe emptyList()
     }
@@ -336,21 +315,13 @@ class SubscriptionExtensionsTest : StringSpec({
         val track = bubbleTrackRepo.create(1, "Original Name")
         val playlist = bubblePlaylistRepo.create(1, track.id)
 
-        val receivedAggEvent = AtomicReference<Any?>(null)
-        val latch = CountDownLatch(1)
-
-        playlist.subscribeAsync { event ->
-            if (event is AggregateMutationEvent<*, *>) {
-                receivedAggEvent.set(event)
-                latch.countDown()
-            }
-        }
+        val recorder = playlist.recordAsync()
 
         track.updateTrackName("New Name")
 
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        @Suppress("UNCHECKED_CAST")
-        val aggEvent = receivedAggEvent.get() as AggregateMutationEvent<Int, BubbleAudioPlaylist>
+        recorder.awaitCount(1) shouldBe true
+        val aggEvent = recorder.last
+        aggEvent.shouldBeInstanceOf<AggregateMutationEvent<Int, BubbleAudioPlaylist>>()
         val childChanged = aggEvent.childPropertyChanged(BubbleAudioTrack::trackName)
         childChanged shouldNotBe null
         childChanged!!.oldValue shouldBe "Original Name"
@@ -361,21 +332,13 @@ class SubscriptionExtensionsTest : StringSpec({
         val track = bubbleTrackRepo.create(1, "Original Name")
         val playlist = bubblePlaylistRepo.create(1, track.id)
 
-        val receivedAggEvent = AtomicReference<Any?>(null)
-        val latch = CountDownLatch(1)
-
-        playlist.subscribeAsync { event ->
-            if (event is AggregateMutationEvent<*, *>) {
-                receivedAggEvent.set(event)
-                latch.countDown()
-            }
-        }
+        val recorder = playlist.recordAsync()
 
         track.updateTrackName("New Name")
 
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        @Suppress("UNCHECKED_CAST")
-        val aggEvent = receivedAggEvent.get() as AggregateMutationEvent<Int, BubbleAudioPlaylist>
+        recorder.awaitCount(1) shouldBe true
+        val aggEvent = recorder.last
+        aggEvent.shouldBeInstanceOf<AggregateMutationEvent<Int, BubbleAudioPlaylist>>()
         // AudioItem::title has name "title", BubbleAudioTrack has "trackName" — no match
         val result = aggEvent.childPropertyChanged(AudioItem::title)
         result shouldBe null

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/TransactionEntitySnapshotTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/entity/TransactionEntitySnapshotTest.kt
@@ -21,9 +21,9 @@ import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.testing.reactiveScope
+import net.transgressoft.lirp.testing.record
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 
 /**
@@ -73,22 +73,20 @@ internal class TransactionEntitySnapshotTest : StringSpec({
         val snapshot = item.captureSnapshot()
         item.title = "after"
 
-        val capturedEvents = mutableListOf<MutationEvent<Int, AudioItem>>()
-        item.subscribe { capturedEvents.add(it) }
+        val recorder = item.record()
         reactive.advance()
 
         item.restoreSnapshot(snapshot)
         reactive.advance()
 
-        capturedEvents.shouldBeEmpty()
+        recorder.count shouldBe 0
     }
 
     "withEventsDeferred routes PropertyChanged into the provided buffer instead of publishing" {
         val item = MutableAudioItem(5, "initial", "album")
         val buffer = mutableListOf<MutationEvent<Int, AudioItem>>()
 
-        val capturedLive = mutableListOf<MutationEvent<Int, AudioItem>>()
-        item.subscribe { capturedLive.add(it) }
+        val recorder = item.record()
         reactive.advance()
 
         item.withEventsDeferred(buffer) {
@@ -97,7 +95,7 @@ internal class TransactionEntitySnapshotTest : StringSpec({
         reactive.advance()
 
         // Live subscriber received nothing while deferral was active.
-        capturedLive.shouldBeEmpty()
+        recorder.count shouldBe 0
         // Buffer captured the deferred event.
         buffer.size shouldBe 1
     }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/AggregateBubbleUpTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/AggregateBubbleUpTest.kt
@@ -29,15 +29,13 @@ import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.MutableRefPlaylistRepo
 import net.transgressoft.lirp.testing.reactiveScope
+import net.transgressoft.lirp.testing.recordAsync
 import io.kotest.assertions.nondeterministic.continually
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -70,18 +68,12 @@ internal class AggregateBubbleUpTest : FunSpec({
         val playlistRepo = BubbleUpAudioPlaylistRepo(ctx)
         val playlist = playlistRepo.create(id = 100, audioItemId = 1)
 
-        val receivedEvent = AtomicReference<MutationEvent<*, *>>(null)
-        val latch = CountDownLatch(1)
-
-        playlist.subscribeAsync { event ->
-            receivedEvent.set(event)
-            latch.countDown()
-        }
+        val recorder = playlist.recordAsync()
 
         audioItem.title = "Track A Updated"
 
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        receivedEvent.get().shouldBeInstanceOf<AggregateMutationEvent<*, *>>()
+        recorder.awaitCount(1) shouldBe true
+        recorder.last.shouldBeInstanceOf<AggregateMutationEvent<*, *>>()
     }
 
     test("AggregateMutationEvent refName matches the declared reference property name") {
@@ -91,20 +83,14 @@ internal class AggregateBubbleUpTest : FunSpec({
         val playlistRepo = BubbleUpAudioPlaylistRepo(ctx)
         val playlist = playlistRepo.create(id = 100, audioItemId = 1)
 
-        val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
-        val latch = CountDownLatch(1)
-
-        playlist.subscribeAsync { event ->
-            if (event is AggregateMutationEvent<*, *>) {
-                receivedEvent.set(event)
-                latch.countDown()
-            }
-        }
+        val recorder = playlist.recordAsync()
 
         audioItem.title = "Track A Updated"
 
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        receivedEvent.get().refName shouldBe "audioItem"
+        recorder.awaitCount(1) shouldBe true
+        val event = recorder.last
+        event.shouldBeInstanceOf<AggregateMutationEvent<*, *>>()
+        event.refName shouldBe "audioItem"
     }
 
     test("AggregateMutationEvent childEvent contains the original MutationEvent from the referenced audio item") {
@@ -114,20 +100,13 @@ internal class AggregateBubbleUpTest : FunSpec({
         val playlistRepo = BubbleUpAudioPlaylistRepo(ctx)
         val playlist = playlistRepo.create(id = 100, audioItemId = 1)
 
-        val receivedEvent = AtomicReference<AggregateMutationEvent<*, *>>(null)
-        val latch = CountDownLatch(1)
-
-        playlist.subscribeAsync { event ->
-            if (event is AggregateMutationEvent<*, *>) {
-                receivedEvent.set(event)
-                latch.countDown()
-            }
-        }
+        val recorder = playlist.recordAsync()
 
         audioItem.title = "Track A Updated"
 
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        val aggregateEvent = receivedEvent.get()
+        recorder.awaitCount(1) shouldBe true
+        val aggregateEvent = recorder.last
+        aggregateEvent.shouldBeInstanceOf<AggregateMutationEvent<*, *>>()
         aggregateEvent.childEvent.shouldBeInstanceOf<PropertyChanged<Int, AudioItem, String>>()
         val childMutation = aggregateEvent.childEvent as PropertyChanged<Int, AudioItem, String>
         childMutation.newValue shouldBe "Track A Updated"
@@ -160,41 +139,26 @@ internal class AggregateBubbleUpTest : FunSpec({
         val playlistRepo = MutableRefPlaylistRepo(ctx)
         val playlist = playlistRepo.create(id = 100, audioItemId = 1)
 
-        val latch1 = CountDownLatch(1)
-        val receivedCount = java.util.concurrent.atomic.AtomicInteger(0)
-
-        playlist.subscribeAsync { event ->
-            if (event is AggregateMutationEvent<*, *>) {
-                receivedCount.incrementAndGet()
-                latch1.countDown()
-            }
-        }
+        val recorder = playlist.recordAsync()
 
         // Verify initial wiring: audioItem1 mutation arrives
         audioItem1.title = "Track A Updated"
-        latch1.await(2, TimeUnit.SECONDS) shouldBe true
-        receivedCount.get() shouldBe 1
+        recorder.awaitCount(1) shouldBe true
+        recorder.count shouldBe 1
 
         // Change reference to audioItem2, then trigger re-wire via resolve()
         playlist.changeItem(2)
         playlist.audioItem.resolve()
 
-        val latch2 = CountDownLatch(1)
-        playlist.subscribeAsync { event ->
-            if (event is AggregateMutationEvent<*, *>) {
-                latch2.countDown()
-            }
-        }
-
         // Mutate audioItem2 — should arrive (re-wired)
         audioItem2.title = "Track B Updated"
-        latch2.await(2, TimeUnit.SECONDS) shouldBe true
+        recorder.awaitCount(2) shouldBe true
 
         // Mutate audioItem1 — should NOT produce further aggregate events
-        val countBeforeOldMutation = receivedCount.get()
+        val countBeforeOldMutation = recorder.count
         audioItem1.title = "Track A Again"
         // No additional events from old audioItem1 subscription
-        continually(300.milliseconds) { receivedCount.get() shouldBe countBeforeOldMutation }
+        continually(300.milliseconds) { recorder.count shouldBe countBeforeOldMutation }
     }
 
     test("Bubble-up stays on old audio item when new reference ID does not resolve") {
@@ -204,28 +168,20 @@ internal class AggregateBubbleUpTest : FunSpec({
         val playlistRepo = MutableRefPlaylistRepo(ctx)
         val playlist = playlistRepo.create(id = 100, audioItemId = 1)
 
-        val eventCount = java.util.concurrent.atomic.AtomicInteger(0)
-        val latch = CountDownLatch(1)
-
-        playlist.subscribeAsync { event ->
-            if (event is AggregateMutationEvent<*, *>) {
-                eventCount.incrementAndGet()
-                latch.countDown()
-            }
-        }
+        val recorder = playlist.recordAsync()
 
         // Verify initial wiring
         audioItem1.title = "Track A Updated"
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
+        recorder.awaitCount(1) shouldBe true
 
         // Change to non-existent ID — re-wire should fail, old subscription preserved
         playlist.changeItem(999)
         playlist.audioItem.resolve() // triggers re-wire attempt — should fail
 
         // Old subscription to audioItem1 still active
-        val countBefore = eventCount.get()
+        val countBefore = recorder.count
         audioItem1.title = "Track A Again"
-        eventually(5.seconds) { eventCount.get() shouldBe countBefore + 1 }
+        eventually(5.seconds) { recorder.count shouldBe countBefore + 1 }
     }
 
     test("Bubble-up re-wires after initially unresolvable new ID becomes available") {
@@ -245,20 +201,12 @@ internal class AggregateBubbleUpTest : FunSpec({
         // Trigger re-wire again — now succeeds
         playlist.audioItem.resolve()
 
-        val eventCount = java.util.concurrent.atomic.AtomicInteger(0)
-        val latch = CountDownLatch(1)
-
-        playlist.subscribeAsync { event ->
-            if (event is AggregateMutationEvent<*, *>) {
-                eventCount.incrementAndGet()
-                latch.countDown()
-            }
-        }
+        val recorder = playlist.recordAsync()
 
         // Mutate audioItem2 — should arrive after successful re-wire
         audioItem2.title = "Track B Updated"
-        latch.await(2, TimeUnit.SECONDS) shouldBe true
-        eventCount.get() shouldBe 1
+        recorder.awaitCount(1) shouldBe true
+        recorder.count shouldBe 1
     }
 
     test("Bubble-up propagation is single-level only: BubbleAudioTrack mutation notifies BubbleAudioPlaylist but NOT BubbleAudioLibrary") {
@@ -270,22 +218,17 @@ internal class AggregateBubbleUpTest : FunSpec({
         val audioPlaylist = repoB.create(id = 10, trackId = 1)
         val audioLibrary = repoC.create(id = 100, playlistId = 10)
 
-        val bReceivedLatch = CountDownLatch(1)
+        val bRecorder = audioPlaylist.recordAsync()
         val cReceivedCount = java.util.concurrent.atomic.AtomicInteger(0)
-
-        // BubbleAudioPlaylist should receive bubble-up from BubbleAudioTrack
-        audioPlaylist.subscribeAsync { event ->
-            if (event is AggregateMutationEvent<*, *>) {
-                bReceivedLatch.countDown()
-            }
-        }
 
         // BubbleAudioLibrary should NOT receive any events — bubble-up is single-level
         audioLibrary.subscribeAsync { cReceivedCount.incrementAndGet() }
 
         track.updateTrackName("mutated")
 
-        bReceivedLatch.await(2, TimeUnit.SECONDS) shouldBe true
+        // BubbleAudioPlaylist should receive bubble-up from BubbleAudioTrack
+        bRecorder.awaitCount(1) shouldBe true
+        bRecorder.last.shouldBeInstanceOf<AggregateMutationEvent<*, *>>()
         continually(300.milliseconds) { cReceivedCount.get() shouldBe 0 }
     }
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/DelegationRegistrationIntegrationTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/DelegationRegistrationIntegrationTest.kt
@@ -17,6 +17,7 @@
 
 package net.transgressoft.lirp.persistence
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
@@ -72,12 +73,14 @@ internal class DelegationRegistrationIntegrationTest : StringSpec({
 
         val audioItem = wrapper.create(1, "Track Alpha")
 
-        wrapper.contains(1) shouldBe true
-        wrapper.size() shouldBe 1
-        delegate.contains(1) shouldBe true
-        delegate.size() shouldBe 1
-        delegate.findById(1).isPresent shouldBe true
-        delegate.findById(1).get() shouldBe audioItem
+        assertSoftly {
+            wrapper.contains(1) shouldBe true
+            wrapper.size() shouldBe 1
+            delegate.contains(1) shouldBe true
+            delegate.size() shouldBe 1
+            delegate.findById(1).isPresent shouldBe true
+            delegate.findById(1).get() shouldBe audioItem
+        }
     }
 
     "closing the wrapper deregisters from LirpContext.default and closes the delegate" {

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/InnerClassRegistryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/InnerClassRegistryTest.kt
@@ -22,6 +22,7 @@ import net.transgressoft.lirp.testing.reactiveScope
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.datatest.withData
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 
@@ -63,16 +64,23 @@ internal class InnerClassRegistryTest : StringSpec({
         }
     }
 
-    "RegistryBase stores anonymous entity after add" {
-        val anonymousEntity =
+    withData<Pair<String, () -> SimpleTestEntity>>(
+        nameFn = { (label, _) -> "RegistryBase stores and retrieves $label after add" },
+        "anonymous entity" to {
             object : SimpleTestEntity(2) {
                 override val uniqueId = "anon-2"
             }
+        },
+        "single-level inner class entity" to { OuterEntity.InnerEntity(11) },
+        "two-level nested inner class entity" to { OuterEntity.MiddleEntity.DeepEntity(21) },
+        "three-level nested inner class entity" to { OuterEntity.MiddleEntity.DeepEntity.DeeperEntity(31) }
+    ) { (_, entityFactory) ->
+        val entity = entityFactory()
 
-        repo.add(anonymousEntity)
+        repo.add(entity)
 
         repo.size() shouldBe 1
-        repo.findById(2).get() shouldBe anonymousEntity
+        repo.findById(entity.id).get() shouldBe entity
     }
 
     // --- Local class entity tests ---
@@ -107,15 +115,6 @@ internal class InnerClassRegistryTest : StringSpec({
         }
     }
 
-    "RegistryBase stores and retrieves single-level inner class entity" {
-        val entity = OuterEntity.InnerEntity(11)
-
-        repo.add(entity)
-
-        repo.size() shouldBe 1
-        repo.findById(11).get() shouldBe entity
-    }
-
     // --- Two-level nested inner class entity tests ---
 
     "RegistryBase adds two-level nested inner class entity without throwing" {
@@ -126,15 +125,6 @@ internal class InnerClassRegistryTest : StringSpec({
         }
     }
 
-    "RegistryBase stores and retrieves two-level nested inner class entity" {
-        val entity = OuterEntity.MiddleEntity.DeepEntity(21)
-
-        repo.add(entity)
-
-        repo.size() shouldBe 1
-        repo.findById(21).get() shouldBe entity
-    }
-
     // --- Three-level nested inner class entity tests ---
 
     "RegistryBase adds three-level nested inner class entity without throwing" {
@@ -143,15 +133,6 @@ internal class InnerClassRegistryTest : StringSpec({
         shouldNotThrow<Exception> {
             repo.add(entity)
         }
-    }
-
-    "RegistryBase stores and retrieves three-level nested inner class entity" {
-        val entity = OuterEntity.MiddleEntity.DeepEntity.DeeperEntity(31)
-
-        repo.add(entity)
-
-        repo.size() shouldBe 1
-        repo.findById(31).get() shouldBe entity
     }
 
     // --- Mixed entity types in a single repository ---

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/MutableAggregateCollectionRefTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/MutableAggregateCollectionRefTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence
 
 import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.testing.reactiveScope
+import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -30,6 +31,7 @@ import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import java.time.LocalDateTime
 import java.util.Collections
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -159,12 +161,9 @@ internal class MutableAggregateCollectionRefTest : StringSpec({
         playlist.subscribeAsync { events.add(it) }
         val beforeModified = playlist.lastDateModified
 
-        // Bounded spin-wait until system clock advances past the captured timestamp.
+        // Wait until the system clock advances past the captured timestamp.
         // LocalDateTime.now() reads wall-clock time, not virtual time, so advanceTimeBy cannot be used.
-        val deadline = System.currentTimeMillis() + 500
-        while (LocalDateTime.now() <= beforeModified && System.currentTimeMillis() < deadline) {
-            Thread.sleep(1)
-        }
+        eventually(500.milliseconds) { LocalDateTime.now() shouldBeGreaterThan beforeModified }
 
         playlist.audioItems.add(t1)
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/SoftDeleteRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/SoftDeleteRepositoryTest.kt
@@ -34,6 +34,7 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import java.time.Instant
 
 /**
@@ -114,8 +115,7 @@ internal class SoftDeleteRepositoryTest : StringSpec({
 
         recorder.count shouldBe 1
         val emitted = recorder.last
-        emitted.shouldNotBeNull()
-        (emitted is StandardCrudEvent.SoftDelete).shouldBeTrue()
+        emitted.shouldBeInstanceOf<StandardCrudEvent.SoftDelete<Int, AudioItem>>()
         emitted.entities shouldBe mapOf(entity.id to entity)
     }
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ToOneAggregateExtAccessorTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/ToOneAggregateExtAccessorTest.kt
@@ -272,8 +272,8 @@ internal class ToOneAggregateExtAccessorTest : StringSpec({
     "TestAlbumEntry.catalog accessor throws IllegalStateException when entity is not in a repository" {
         val album = TestAlbumEntry(400, "Orphaned", catalogId = 5)
 
-        val ex = runCatching { album.catalog }.exceptionOrNull()
-        ex?.message?.contains("Ensure the entity is added to its repository") shouldBe true
+        shouldThrow<IllegalStateException> { album.catalog }
+            .message shouldContain "Ensure the entity is added to its repository"
     }
 
     "TestRestrictAlbum RESTRICT delete does not throw when another album has a null optional FK scalar" {
@@ -332,7 +332,7 @@ internal class ToOneAggregateExtAccessorTest : StringSpec({
         // Close before adding to any repository — must not throw and must not create a delegate
         shouldNotThrowAny { album.close() }
         // After close, getToOneRef must still throw (no delegate was created during teardown)
-        val ex = runCatching { album.catalog }.exceptionOrNull()
-        ex?.message?.contains("Ensure the entity is added to its repository") shouldBe true
+        shouldThrow<IllegalStateException> { album.catalog }
+            .message shouldContain "Ensure the entity is added to its repository"
     }
 })

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/TransactionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/TransactionTest.kt
@@ -343,10 +343,9 @@ internal class TransactionTest : StringSpec() {
             // A flush that never releases the lock (a stuck backing-store write, or a lock leaked by an
             // earlier transaction) must surface as a bounded, diagnosable failure rather than an
             // indefinite hang. Holding the lock on a foreign thread simulates that stuck state; the
-            // transaction must abort within the shrunk acquisition window. withTimeout is the safety net
-            // that turns a regression (unbounded wait) into a fast test failure.
-            val previousTimeout = flushLockAcquireTimeout
-            flushLockAcquireTimeout = 200.milliseconds
+            // per-call FlushLockTimeoutOverride shrinks the acquisition window so the test does not wait
+            // the full production timeout, and is coroutine-scoped so it cannot leak into other specs.
+            // withTimeout is the safety net that turns a regression (unbounded wait) into a fast failure.
             val repo = InMemoryAudioItemRepo()
             repo.create(40, "Fat Bottomed Girls", "Jazz")
             repo.lockFlush()
@@ -354,8 +353,10 @@ internal class TransactionTest : StringSpec() {
                 withTimeout(5_000) {
                     val failure =
                         shouldThrow<LirpTransactionException> {
-                            transaction(repo) { r ->
-                                (r.findById(40).get() as MutableAudioItem).title = "Bicycle Race"
+                            withContext(FlushLockTimeoutOverride(200.milliseconds)) {
+                                transaction(repo) { r ->
+                                    (r.findById(40).get() as MutableAudioItem).title = "Bicycle Race"
+                                }
                             }
                         }
                     failure.message shouldContain "Could not acquire the transaction flush lock"
@@ -364,7 +365,6 @@ internal class TransactionTest : StringSpec() {
                 repo shouldHaveItemWithTitle (40 to "Fat Bottomed Girls")
             } finally {
                 repo.unlockFlush()
-                flushLockAcquireTimeout = previousTimeout
                 repo.close()
             }
         }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/TransactionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/TransactionTest.kt
@@ -47,16 +47,33 @@ import kotlinx.coroutines.yield
 @DisplayName("transaction() core repository contract")
 internal class TransactionTest : StringSpec() {
 
+    /**
+     * Runs [block] against a freshly-created [InMemoryAudioItemRepo], always closing the repo
+     * afterwards. Collapses the create-try-finally-close scaffolding shared by nearly every
+     * transaction test so each body reads as its own arrange/act/assert.
+     */
+    suspend fun withRepo(
+        name: String = "InMemoryAudioItems",
+        onError: LirpErrorHandler? = null,
+        block: suspend (InMemoryAudioItemRepo) -> Unit
+    ) {
+        val repo = InMemoryAudioItemRepo(name, onError)
+        try {
+            block(repo)
+        } finally {
+            repo.close()
+        }
+    }
+
     init {
         extension(ReactiveScopeSerialization)
 
         "transaction commits in-memory mutations and fires collapsed events to subscribers" {
-            val repo = InMemoryAudioItemRepo()
-            val item = repo.create(1, "Bohemian Rhapsody", "A Night at the Opera")
-            val events = mutableListOf<MutationEvent<Int, AudioItem>>()
-            item.subscribe { events.add(it) }
+            withRepo { repo ->
+                val item = repo.create(1, "Bohemian Rhapsody", "A Night at the Opera")
+                val events = mutableListOf<MutationEvent<Int, AudioItem>>()
+                item.subscribe { events.add(it) }
 
-            try {
                 transaction(repo) { r ->
                     (r.findById(1).get() as MutableAudioItem).title = "Killer Queen"
                 }
@@ -64,18 +81,15 @@ internal class TransactionTest : StringSpec() {
                 (item as MutableAudioItem).title shouldBe "Killer Queen"
                 events shouldHaveSize 1
                 events.single().shouldBeInstanceOf<PropertyChanged<*, *, *>>()
-            } finally {
-                repo.close()
             }
         }
 
         "transaction rollback on block throw restores in-memory state and discards events" {
-            val repo = InMemoryAudioItemRepo()
-            val item = repo.create(2, "Don't Stop Me Now", "Jazz")
-            val events = mutableListOf<MutationEvent<Int, AudioItem>>()
-            item.subscribe { events.add(it) }
+            withRepo { repo ->
+                val item = repo.create(2, "Don't Stop Me Now", "Jazz")
+                val events = mutableListOf<MutationEvent<Int, AudioItem>>()
+                item.subscribe { events.add(it) }
 
-            try {
                 shouldThrow<LirpTransactionException> {
                     transaction(repo) { r ->
                         (r.findById(2).get() as MutableAudioItem).title = "mutated-inside"
@@ -85,18 +99,15 @@ internal class TransactionTest : StringSpec() {
 
                 (item as MutableAudioItem).title shouldBe "Don't Stop Me Now"
                 events.shouldBeEmpty()
-            } finally {
-                repo.close()
             }
         }
 
         "deferred events collapse empty-to-Rock-to-Jazz into a single empty-to-Jazz PropertyChanged" {
-            val repo = InMemoryAudioItemRepo()
-            val item = repo.create(3, "", "")
-            val events = mutableListOf<MutationEvent<Int, AudioItem>>()
-            item.subscribe { events.add(it) }
+            withRepo { repo ->
+                val item = repo.create(3, "", "")
+                val events = mutableListOf<MutationEvent<Int, AudioItem>>()
+                item.subscribe { events.add(it) }
 
-            try {
                 transaction(repo) { r ->
                     val e = r.findById(3).get() as MutableAudioItem
                     e.title = "Rock"
@@ -108,8 +119,6 @@ internal class TransactionTest : StringSpec() {
                 val propertyChanged = events.single() as PropertyChanged<Int, AudioItem, String>
                 propertyChanged.oldValue shouldBe ""
                 propertyChanged.newValue shouldBe "Jazz"
-            } finally {
-                repo.close()
             }
         }
 
@@ -136,12 +145,11 @@ internal class TransactionTest : StringSpec() {
         }
 
         "nested transaction on the same repo joins the outer and results in one collapsed commit" {
-            val repo = InMemoryAudioItemRepo()
-            val item = repo.create(4, "We Will Rock You", "News of the World")
-            val events = mutableListOf<MutationEvent<Int, AudioItem>>()
-            item.subscribe { events.add(it) }
+            withRepo { repo ->
+                val item = repo.create(4, "We Will Rock You", "News of the World")
+                val events = mutableListOf<MutationEvent<Int, AudioItem>>()
+                item.subscribe { events.add(it) }
 
-            try {
                 transaction(repo) { r ->
                     (r.findById(4).get() as MutableAudioItem).title = "outer"
                     transaction(r) { inner ->
@@ -152,27 +160,22 @@ internal class TransactionTest : StringSpec() {
                 (item as MutableAudioItem).title shouldBe "inner"
                 // Both mutations collapse to one event (outer title → inner title).
                 events shouldHaveSize 1
-            } finally {
-                repo.close()
             }
         }
 
         "nested transaction on a different repo throws LirpTransactionException immediately" {
-            val repo1 = InMemoryAudioItemRepo()
-            val repo2 = InMemoryAudioItemRepo("InMemoryAudioItems2")
-            repo1.create(5, "Radio Ga Ga", "The Works")
+            withRepo { repo1 ->
+                withRepo("InMemoryAudioItems2") { repo2 ->
+                    repo1.create(5, "Radio Ga Ga", "The Works")
 
-            try {
-                shouldThrow<LirpTransactionException> {
-                    transaction(repo1) { _ ->
-                        transaction(repo2) { _ ->
-                            // unreachable
+                    shouldThrow<LirpTransactionException> {
+                        transaction(repo1) { _ ->
+                            transaction(repo2) { _ ->
+                                // unreachable
+                            }
                         }
                     }
                 }
-            } finally {
-                repo1.close()
-                repo2.close()
             }
         }
 
@@ -180,10 +183,9 @@ internal class TransactionTest : StringSpec() {
             val handlerInvocations = CopyOnWriteArrayList<Pair<Throwable, LirpErrorContext>>()
             val handler = LirpErrorHandler { t, ctx -> handlerInvocations.add(t to ctx) }
 
-            val repo = InMemoryAudioItemRepo("transaction-error-notify-repo", onError = handler)
-            repo.add(MutableAudioItem(6, "Another One Bites the Dust", "The Game") as AudioItem)
+            withRepo("transaction-error-notify-repo", onError = handler) { repo ->
+                repo.add(MutableAudioItem(6, "Another One Bites the Dust", "The Game") as AudioItem)
 
-            try {
                 shouldThrow<LirpTransactionException> {
                     transaction(repo) { r ->
                         (r.findById(6).get() as MutableAudioItem).title = "mutated"
@@ -197,17 +199,14 @@ internal class TransactionTest : StringSpec() {
                 // Carries entity identity only — not field values.
                 ctx.entityIds shouldHaveSize 1
                 ctx.entityIds.first() shouldBe 6
-            } finally {
-                repo.close()
             }
         }
 
         "onError handler suppresses the exception and receives the failure throwable" {
             var capturedThrowable: Throwable? = null
-            val repo = InMemoryAudioItemRepo()
-            repo.add(MutableAudioItem(7, "Somebody to Love", "A Day at the Races") as AudioItem)
+            withRepo { repo ->
+                repo.add(MutableAudioItem(7, "Somebody to Love", "A Day at the Races") as AudioItem)
 
-            try {
                 transaction(repo, onError = { capturedThrowable = throwable }) { r ->
                     (r.findById(7).get() as MutableAudioItem).title = "changed"
                     throw RuntimeException("handled failure")
@@ -215,14 +214,11 @@ internal class TransactionTest : StringSpec() {
 
                 capturedThrowable?.message shouldBe "handled failure"
                 (repo.findById(7).get() as MutableAudioItem).title shouldBe "Somebody to Love"
-            } finally {
-                repo.close()
             }
         }
 
         "entity added inside a failing block is absent from the repo after rollback" {
-            val repo = InMemoryAudioItemRepo()
-            try {
+            withRepo { repo ->
                 shouldThrow<LirpTransactionException> {
                     transaction(repo) { r ->
                         r.add(MutableAudioItem(8, "Flash", "The Game") as AudioItem)
@@ -233,15 +229,13 @@ internal class TransactionTest : StringSpec() {
                 // The insert was rolled back — entity must not be present.
                 repo.findById(8).isPresent shouldBe false
                 repo.size() shouldBe 0
-            } finally {
-                repo.close()
             }
         }
 
         "entity removed inside a failing block is re-added to the repo after rollback" {
-            val repo = InMemoryAudioItemRepo()
-            repo.add(MutableAudioItem(9, "Innuendo", "Innuendo") as AudioItem)
-            try {
+            withRepo { repo ->
+                repo.add(MutableAudioItem(9, "Innuendo", "Innuendo") as AudioItem)
+
                 shouldThrow<LirpTransactionException> {
                     transaction(repo) { r ->
                         r.remove(r.findById(9).get())
@@ -250,17 +244,15 @@ internal class TransactionTest : StringSpec() {
                 }
 
                 // The delete was rolled back — entity must still be present.
-                repo.findById(9).shouldBePresent { it.title shouldBe "Innuendo" }
-            } finally {
-                repo.close()
+                repo shouldHaveItemWithTitle (9 to "Innuendo")
             }
         }
 
         "lastDateModified is restored to its pre-block value after a failing block" {
-            val repo = InMemoryAudioItemRepo()
-            val item = repo.create(10, "The Show Must Go On", "Innuendo")
-            val preDateModified = item.lastDateModified
-            try {
+            withRepo { repo ->
+                val item = repo.create(10, "The Show Must Go On", "Innuendo")
+                val preDateModified = item.lastDateModified
+
                 shouldThrow<LirpTransactionException> {
                     transaction(repo) { r ->
                         (r.findById(10).get() as MutableAudioItem).title = "mutated-title"
@@ -270,8 +262,6 @@ internal class TransactionTest : StringSpec() {
 
                 // lastDateModified must revert to the pre-block value after rollback.
                 item.lastDateModified shouldBe preDateModified
-            } finally {
-                repo.close()
             }
         }
 
@@ -279,12 +269,11 @@ internal class TransactionTest : StringSpec() {
             // Verifies that _txEventBuffer is propagated across coroutine suspension via
             // asContextElement: a scalar mutation after a thread switch must still be buffered
             // (not published directly) and committed in the same transaction.
-            val repo = InMemoryAudioItemRepo()
-            val item = repo.create(11, "Bicycle Race", "Jazz")
-            val events = mutableListOf<MutationEvent<Int, AudioItem>>()
-            item.subscribe { events.add(it) }
+            withRepo { repo ->
+                val item = repo.create(11, "Bicycle Race", "Jazz")
+                val events = mutableListOf<MutationEvent<Int, AudioItem>>()
+                item.subscribe { events.add(it) }
 
-            try {
                 transaction(repo) { r ->
                     // Real suspension that resumes on a worker thread.
                     withContext(Dispatchers.IO) { yield() }
@@ -295,15 +284,13 @@ internal class TransactionTest : StringSpec() {
                 // Exactly one collapsed event fired after commit — none during the block.
                 events shouldHaveSize 1
                 (item as MutableAudioItem).title shouldBe "Fat Bottomed Girls"
-            } finally {
-                repo.close()
             }
         }
 
         "transaction remove-then-add same pre-existing id results in committed UPDATE" {
-            val repo = InMemoryAudioItemRepo()
-            repo.create(20, "Killer Queen", "Sheer Heart Attack")
-            try {
+            withRepo { repo ->
+                repo.create(20, "Killer Queen", "Sheer Heart Attack")
+
                 transaction(repo) { r ->
                     val existing = r.findById(20).get()
                     r.remove(existing)
@@ -311,16 +298,13 @@ internal class TransactionTest : StringSpec() {
                 }
 
                 // After commit: entity present with re-added value (no duplicate-key failure).
-                repo.findById(20).shouldBePresent { it.title shouldBe "Bohemian Rhapsody" }
+                repo shouldHaveItemWithTitle (20 to "Bohemian Rhapsody")
                 repo.size() shouldBe 1
-            } finally {
-                repo.close()
             }
         }
 
         "transaction add-then-remove same new id is a no-op after commit" {
-            val repo = InMemoryAudioItemRepo()
-            try {
+            withRepo { repo ->
                 transaction(repo) { r ->
                     r.add(MutableAudioItem(21, "Radio Ga Ga", "The Works") as AudioItem)
                     r.remove(r.findById(21).get())
@@ -329,8 +313,6 @@ internal class TransactionTest : StringSpec() {
                 // After commit: entity is absent because insert+delete cancel out.
                 repo.findById(21).isPresent shouldBe false
                 repo.size() shouldBe 0
-            } finally {
-                repo.close()
             }
         }
 
@@ -341,9 +323,8 @@ internal class TransactionTest : StringSpec() {
             // close()) blocks forever. withTimeout turns a regression into a fast failure instead of a
             // hung suite.
             withTimeout(10_000) {
-                val repo = InMemoryAudioItemRepo()
-                repo.create(30, "Don't Stop Me Now", "Jazz")
-                try {
+                withRepo { repo ->
+                    repo.create(30, "Don't Stop Me Now", "Jazz")
                     transaction(repo) { r ->
                         withContext(Dispatchers.IO) { yield() }
                         (r.findById(30).get() as MutableAudioItem).title = "Somebody to Love"
@@ -353,9 +334,7 @@ internal class TransactionTest : StringSpec() {
                         withContext(Dispatchers.Default) { yield() }
                         (r.findById(30).get() as MutableAudioItem).title = "Under Pressure"
                     }
-                    repo.findById(30).shouldBePresent { it.title shouldBe "Under Pressure" }
-                } finally {
-                    repo.close()
+                    repo shouldHaveItemWithTitle (30 to "Under Pressure")
                 }
             }
         }
@@ -382,7 +361,7 @@ internal class TransactionTest : StringSpec() {
                     failure.message shouldContain "Could not acquire the transaction flush lock"
                 }
                 // The block never ran: the lock was never acquired, so in-memory state is untouched.
-                repo.findById(40).shouldBePresent { it.title shouldBe "Fat Bottomed Girls" }
+                repo shouldHaveItemWithTitle (40 to "Fat Bottomed Girls")
             } finally {
                 repo.unlockFlush()
                 flushLockAcquireTimeout = previousTimeout
@@ -390,6 +369,14 @@ internal class TransactionTest : StringSpec() {
             }
         }
     }
+}
+
+/**
+ * Asserts the repository holds an entity under `idAndTitle.first` whose title equals
+ * `idAndTitle.second`, keeping the recurring "present with expected title" claim to one line.
+ */
+private infix fun InMemoryAudioItemRepo.shouldHaveItemWithTitle(idAndTitle: Pair<Int, String>) {
+    findById(idAndTitle.first).shouldBePresent { it.title shouldBe idAndTitle.second }
 }
 
 /**

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/TransactionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/TransactionTest.kt
@@ -30,8 +30,10 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -355,6 +357,36 @@ internal class TransactionTest : StringSpec() {
                 } finally {
                     repo.close()
                 }
+            }
+        }
+
+        "transaction fails fast when the flush lock cannot be acquired instead of hanging forever" {
+            // A flush that never releases the lock (a stuck backing-store write, or a lock leaked by an
+            // earlier transaction) must surface as a bounded, diagnosable failure rather than an
+            // indefinite hang. Holding the lock on a foreign thread simulates that stuck state; the
+            // transaction must abort within the shrunk acquisition window. withTimeout is the safety net
+            // that turns a regression (unbounded wait) into a fast test failure.
+            val previousTimeout = flushLockAcquireTimeout
+            flushLockAcquireTimeout = 200.milliseconds
+            val repo = InMemoryAudioItemRepo()
+            repo.create(40, "Fat Bottomed Girls", "Jazz")
+            repo.lockFlush()
+            try {
+                withTimeout(5_000) {
+                    val failure =
+                        shouldThrow<LirpTransactionException> {
+                            transaction(repo) { r ->
+                                (r.findById(40).get() as MutableAudioItem).title = "Bicycle Race"
+                            }
+                        }
+                    failure.message shouldContain "Could not acquire the transaction flush lock"
+                }
+                // The block never ran: the lock was never acquired, so in-memory state is untouched.
+                repo.findById(40).shouldBePresent { it.title shouldBe "Fat Bottomed Girls" }
+            } finally {
+                repo.unlockFlush()
+                flushLockAcquireTimeout = previousTimeout
+                repo.close()
             }
         }
     }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/VolatileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/VolatileRepositoryTest.kt
@@ -8,15 +8,14 @@ import net.transgressoft.lirp.event.CrudEvent.Type.UPDATE
 import net.transgressoft.lirp.event.EventType
 import net.transgressoft.lirp.event.FlowEventPublisher
 import net.transgressoft.lirp.event.LirpEventSubscriberBase
-import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.testing.arbitraryAudioItem
 import net.transgressoft.lirp.testing.reactiveScope
+import net.transgressoft.lirp.testing.recordAsync
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContainOnly
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -24,7 +23,6 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.next
 import io.kotest.property.arbitrary.set
 import io.kotest.property.checkAll
-import java.util.Collections
 import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
@@ -391,31 +389,23 @@ internal class VolatileRepositoryTest : FunSpec({
         test("addAll on mutable aggregate emits exactly one MutationEvent") {
             val trackRepo = repository
             val playlistRepo = AudioPlaylistVolatileRepository(ctx)
-            val events =
-                Collections.synchronizedList(
-                    mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>()
-                )
 
             val t1 = trackRepo.create(1, "T1")
             val t2 = trackRepo.create(2, "T2")
             val t3 = trackRepo.create(3, "T3")
             val playlist = DefaultAudioPlaylist(1, "Bulk Add").also(playlistRepo::add)
 
-            playlist.subscribeAsync { events.add(it) }
+            val recorder = playlist.recordAsync()
 
             playlist.audioItems.addAll(listOf(t1, t2, t3))
             reactive.advance()
 
-            events shouldHaveSize 1
+            recorder.count shouldBe 1
         }
 
         test("removeAll on mutable aggregate emits exactly one MutationEvent") {
             val trackRepo = repository
             val playlistRepo = AudioPlaylistVolatileRepository(ctx)
-            val events =
-                Collections.synchronizedList(
-                    mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>()
-                )
 
             val t1 = trackRepo.create(1, "T1")
             val t2 = trackRepo.create(2, "T2")
@@ -424,131 +414,107 @@ internal class VolatileRepositoryTest : FunSpec({
                 DefaultAudioPlaylist(1, "Bulk Remove", listOf(1, 2, 3))
                     .also(playlistRepo::add)
 
-            playlist.subscribeAsync { events.add(it) }
+            val recorder = playlist.recordAsync()
 
             playlist.audioItems.removeAll(listOf(t1, t3))
             reactive.advance()
 
-            events shouldHaveSize 1
+            recorder.count shouldBe 1
         }
 
         test("addAll with empty collection returns false and emits no event") {
             val playlistRepo = AudioPlaylistVolatileRepository(ctx)
-            val events =
-                Collections.synchronizedList(
-                    mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>()
-                )
 
             val playlist = DefaultAudioPlaylist(1, "Empty Add").also(playlistRepo::add)
 
-            playlist.subscribeAsync { events.add(it) }
+            val recorder = playlist.recordAsync()
 
             val result = playlist.audioItems.addAll(emptyList())
             reactive.advance()
 
             result shouldBe false
-            events shouldHaveSize 0
+            recorder.count shouldBe 0
         }
 
         test("removeAll with no matching elements returns false and emits no event") {
             val trackRepo = repository
             val playlistRepo = AudioPlaylistVolatileRepository(ctx)
-            val events =
-                Collections.synchronizedList(
-                    mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>()
-                )
 
             val unrelated = trackRepo.create(99, "Unrelated")
             val playlist = DefaultAudioPlaylist(1, "No Match Remove").also(playlistRepo::add)
 
-            playlist.subscribeAsync { events.add(it) }
+            val recorder = playlist.recordAsync()
 
             val result = playlist.audioItems.removeAll(listOf(unrelated))
             reactive.advance()
 
             result shouldBe false
-            events shouldHaveSize 0
+            recorder.count shouldBe 0
         }
 
         test("addAll on mutable aggregate set emits exactly one MutationEvent") {
             val sharedRepo = AudioPlaylistVolatileRepository(ctx)
-            val events =
-                Collections.synchronizedList(
-                    mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>()
-                )
 
             val p1 = DefaultAudioPlaylist(1, "P1").also(sharedRepo::add)
             val p2 = DefaultAudioPlaylist(2, "P2").also(sharedRepo::add)
             val p3 = DefaultAudioPlaylist(3, "P3").also(sharedRepo::add)
             val group = DefaultAudioPlaylist(100, "Group").also(sharedRepo::add)
 
-            group.subscribeAsync { events.add(it) }
+            val recorder = group.recordAsync()
 
             group.playlists.addAll(listOf(p1, p2, p3))
             reactive.advance()
 
-            events shouldHaveSize 1
+            recorder.count shouldBe 1
         }
 
         test("entity emits MutationEvent on add to mutable aggregate") {
             val trackRepo = repository
             val playlistRepo = AudioPlaylistVolatileRepository(ctx)
-            val events =
-                Collections.synchronizedList(
-                    mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>()
-                )
 
             val t1 = trackRepo.create(1, "Track")
             val playlist = DefaultAudioPlaylist(1, "Test").also(playlistRepo::add)
 
-            playlist.subscribeAsync { events.add(it) }
+            val recorder = playlist.recordAsync()
 
             playlist.audioItems.add(t1)
             reactive.advance()
 
-            events shouldHaveSize 1
+            recorder.count shouldBe 1
         }
 
         test("entity emits MutationEvent on remove from mutable aggregate") {
             val trackRepo = repository
             val playlistRepo = AudioPlaylistVolatileRepository(ctx)
-            val events =
-                Collections.synchronizedList(
-                    mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>()
-                )
 
             val t1 = trackRepo.create(1, "Track")
             val playlist =
                 DefaultAudioPlaylist(1, "Test", listOf(1))
                     .also(playlistRepo::add)
 
-            playlist.subscribeAsync { events.add(it) }
+            val recorder = playlist.recordAsync()
 
             playlist.audioItems.remove(t1)
             reactive.advance()
 
-            events shouldHaveSize 1
+            recorder.count shouldBe 1
         }
 
         test("entity emits MutationEvent on clear of mutable aggregate") {
             val trackRepo = repository
             val playlistRepo = AudioPlaylistVolatileRepository(ctx)
-            val events =
-                Collections.synchronizedList(
-                    mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>()
-                )
 
             trackRepo.create(1, "T1")
             val playlist =
                 DefaultAudioPlaylist(1, "Test", listOf(1))
                     .also(playlistRepo::add)
 
-            playlist.subscribeAsync { events.add(it) }
+            val recorder = playlist.recordAsync()
 
             playlist.audioItems.clear()
             reactive.advance()
 
-            events shouldHaveSize 1
+            recorder.count shouldBe 1
         }
 
         test("multiple entities with independent mutable aggregates") {
@@ -587,10 +553,6 @@ internal class VolatileRepositoryTest : FunSpec({
         test("retainAll on mutable aggregate emits exactly one MutationEvent") {
             val trackRepo = repository
             val playlistRepo = AudioPlaylistVolatileRepository(ctx)
-            val events =
-                Collections.synchronizedList(
-                    mutableListOf<MutationEvent<Int, MutableAudioPlaylist>>()
-                )
 
             val t1 = trackRepo.create(1, "T1")
             val t2 = trackRepo.create(2, "T2")
@@ -599,12 +561,12 @@ internal class VolatileRepositoryTest : FunSpec({
                 DefaultAudioPlaylist(1, "Retain", listOf(1, 2, 3))
                     .also(playlistRepo::add)
 
-            playlist.subscribeAsync { events.add(it) }
+            val recorder = playlist.recordAsync()
 
             playlist.audioItems.retainAll(listOf(t2))
             reactive.advance()
 
-            events shouldHaveSize 1
+            recorder.count shouldBe 1
         }
     }
 })

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/AggregateJsonPersistenceTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/AggregateJsonPersistenceTest.kt
@@ -26,6 +26,7 @@ import net.transgressoft.lirp.persistence.LirpRepository
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.MutableAudioPlaylist
 import net.transgressoft.lirp.testing.reactiveScope
+import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.spec.tempfile
 import io.kotest.matchers.collections.shouldContainExactly
@@ -34,10 +35,9 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import java.io.File
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
@@ -114,14 +114,12 @@ class AggregateJsonPersistenceTest : FunSpec({
         reactive.advance()
 
         val initialJson = playlistFile.readText()
-        val persistenceLatch = CountDownLatch(1)
         val bubbleUpReceived = AtomicBoolean(false)
 
         // Subscribe to the playlist to detect that a bubble-up event was emitted
         playlist.subscribeAsync { event ->
             if (event is AggregateMutationEvent) {
                 bubbleUpReceived.set(true)
-                persistenceLatch.countDown()
             }
         }
 
@@ -130,8 +128,7 @@ class AggregateJsonPersistenceTest : FunSpec({
         reactive.advance()
 
         // Wait for debounce + write
-        persistenceLatch.await(2, TimeUnit.SECONDS) shouldBe true
-        bubbleUpReceived.get() shouldBe true
+        eventually(2.seconds) { bubbleUpReceived.get() shouldBe true }
 
         // The repo should have been written because AggregateMutationEvent flows through subscribeEntity
         // (entity.changes emits all events including bubble-up) — triggering markDirtyAndTrigger
@@ -166,17 +163,17 @@ class AggregateJsonPersistenceTest : FunSpec({
         reactive.advance()
 
         val reloadedPlaylist = playlistRepo2.findById(10).get()
-        val bubbleUpLatch = CountDownLatch(1)
+        val bubbleUpReceived = AtomicBoolean(false)
 
         reloadedPlaylist.subscribeAsync { event ->
-            if (event is AggregateMutationEvent) bubbleUpLatch.countDown()
+            if (event is AggregateMutationEvent) bubbleUpReceived.set(true)
         }
 
         // Mutate child: bubble-up should flow to the reloaded playlist's subscribers
         (audioItemRepo2.findById(1).get() as MutableAudioItem).title = "Track D Updated"
         reactive.advance()
 
-        bubbleUpLatch.await(2, TimeUnit.SECONDS) shouldBe true
+        eventually(2.seconds) { bubbleUpReceived.get() shouldBe true }
 
         ctx2.close()
     }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryRawInitLoadTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryRawInitLoadTest.kt
@@ -18,12 +18,14 @@
 package net.transgressoft.lirp.persistence.json
 
 import net.transgressoft.lirp.entity.ReactiveEntityBase
+import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 
@@ -107,9 +109,9 @@ class JsonFileRepositoryRawInitLoadTest : StringSpec({
         // emits exactly one event so we know the subscription is wired.
         val one = repo.findById(0).orElseThrow()
         one.label = "mutated"
-        // Give the reactive dispatch a tick to settle.
-        Thread.sleep(50)
-        events.shouldHaveSize(1)
+        // Poll until the async reactive dispatch delivers the single mutation event, rather than
+        // racing it with a fixed sleep.
+        eventually(2.seconds) { events.shouldHaveSize(1) }
         repo.close()
         file.parentFile?.deleteRecursively()
     }

--- a/lirp-core/src/testFixtures/kotlin/net/transgressoft/lirp/testing/EventRecorder.kt
+++ b/lirp-core/src/testFixtures/kotlin/net/transgressoft/lirp/testing/EventRecorder.kt
@@ -18,11 +18,17 @@
 package net.transgressoft.lirp.testing
 
 import net.transgressoft.lirp.entity.LirpEntity
+import net.transgressoft.lirp.entity.ReactiveEntity
 import net.transgressoft.lirp.event.EventType
 import net.transgressoft.lirp.event.LirpEvent
 import net.transgressoft.lirp.event.LirpEventPublisher
 import net.transgressoft.lirp.event.LirpEventSubscription
+import net.transgressoft.lirp.event.MutationEvent
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Thread-safe test helper that captures events emitted to a subscriber into a typed queue.
@@ -43,6 +49,8 @@ import java.util.concurrent.ConcurrentLinkedQueue
 class EventRecorder<E : Any> {
 
     private val captured = ConcurrentLinkedQueue<E>()
+    private val lock = ReentrantLock()
+    private val countChanged = lock.newCondition()
 
     /** Number of events captured since the last [reset]. */
     val count: Int get() = captured.size
@@ -55,7 +63,30 @@ class EventRecorder<E : Any> {
 
     /** Append [event] to the internal queue. Bound to a publisher via [record]. */
     fun record(event: E) {
-        captured.add(event)
+        lock.withLock {
+            captured.add(event)
+            countChanged.signalAll()
+        }
+    }
+
+    /**
+     * Blocks until at least [n] events have been captured or [timeout] elapses, returning `true`
+     * when the target was reached. Replaces the ad-hoc `CountDownLatch` + `await` dance in tests
+     * that emit asynchronously and then need to wait for delivery before asserting.
+     *
+     * Intended for tests wired to real dispatchers (async delivery). Test-dispatcher specs should
+     * keep driving the scheduler with `advance()` and asserting [count] synchronously instead.
+     */
+    fun awaitCount(n: Int, timeout: Duration = 2.seconds): Boolean {
+        val deadlineNanos = System.nanoTime() + timeout.inWholeNanoseconds
+        lock.withLock {
+            while (captured.size < n) {
+                val remaining = deadlineNanos - System.nanoTime()
+                if (remaining <= 0) return captured.size >= n
+                countChanged.awaitNanos(remaining)
+            }
+            return true
+        }
     }
 
     /** Drops all captured events. Useful between subscription phases in long-running specs. */
@@ -84,5 +115,33 @@ fun <ET : EventType, E : LirpEvent<ET>> LirpEventPublisher<ET, E>.record(
     // annotation above silences a compiler inference warning on the vararg branch.
     @Suppress("UNUSED_VARIABLE")
     val keepAlive = subscription
+    return recorder
+}
+
+/**
+ * Subscribes a fresh [EventRecorder] synchronously to this entity's mutation events and returns it.
+ *
+ * When [types] is empty every mutation is captured; otherwise only the listed types are. The
+ * synchronous [ReactiveEntity.subscribe] path records inline on the emitting thread — use this when
+ * the test drives delivery deterministically (e.g. a test dispatcher advanced via `advance()`).
+ */
+fun <K, R> R.record(vararg types: MutationEvent.Type): EventRecorder<MutationEvent<K, R>>
+    where K : Comparable<K>, R : ReactiveEntity<K, R> {
+    val recorder = EventRecorder<MutationEvent<K, R>>()
+    if (types.isEmpty()) subscribe(callback = recorder::record)
+    else subscribe(*types, callback = recorder::record)
+    return recorder
+}
+
+/**
+ * Subscribes a fresh [EventRecorder] asynchronously to this entity's mutation events and returns it.
+ *
+ * Pairs with [EventRecorder.awaitCount] to replace the `AtomicReference` + `CountDownLatch` + await
+ * pattern: record asynchronously, emit, then `awaitCount(n)` before asserting on the captured events.
+ */
+fun <K, R> R.recordAsync(): EventRecorder<MutationEvent<K, R>>
+    where K : Comparable<K>, R : ReactiveEntity<K, R> {
+    val recorder = EventRecorder<MutationEvent<K, R>>()
+    subscribeAsync { event -> recorder.record(event) }
     return recorder
 }

--- a/lirp-fx/build.gradle
+++ b/lirp-fx/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     testImplementation libs.coroutines.test
     testImplementation libs.serialization.json
 
+    testFixturesImplementation libs.bundles.kotest
     testFixturesImplementation "org.openjfx:javafx-base:21:${fxPlatform}"
     testFixturesImplementation "org.openjfx:javafx-graphics:21:${fxPlatform}"
     testFixturesImplementation 'org.testfx:openjfx-monocle:21.0.2'

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/CombinedDelegateSerializationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/CombinedDelegateSerializationTest.kt
@@ -20,6 +20,7 @@ package net.transgressoft.lirp.persistence.fx
 import net.transgressoft.lirp.persistence.json.lirpSerializer
 import net.transgressoft.lirp.testing.reactiveScope
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import kotlinx.serialization.json.Json
@@ -37,10 +38,6 @@ class CombinedDelegateSerializationTest : StringSpec({
     val json = Json { prettyPrint = true }
     val serializer = lirpSerializer(CombinedDelegateEntity(0, ""))
 
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
-
     "serializes entity with reactiveProperty, @Indexed, and FxScalar delegates" {
         val entity = CombinedDelegateEntity(1, "Test", "electronics", 5)
         entity.labelProperty.set("urgent")
@@ -54,48 +51,53 @@ class CombinedDelegateSerializationTest : StringSpec({
         encoded shouldContain "\"labelProperty\": \"urgent\""
     }
 
-    "round-trip preserves all three delegate types" {
-        val entity = CombinedDelegateEntity(1, "Alpha", "books", 10)
-        entity.labelProperty.set("premium")
+    data class RoundTripCase(
+        val name: String,
+        val build: () -> CombinedDelegateEntity,
+        val verify: (CombinedDelegateEntity) -> Unit
+    )
 
-        val encoded = json.encodeToString(serializer, entity)
-        val decoded = json.decodeFromString(serializer, encoded)
-
-        decoded.id shouldBe 1
-        decoded.name shouldBe "Alpha"
-        decoded.category shouldBe "books"
-        decoded.priorityProperty.get() shouldBe 10
-        decoded.labelProperty.get() shouldBe "premium"
-    }
-
-    "round-trip preserves mutated values across all delegate types" {
-        val entity = CombinedDelegateEntity(1, "Original", "old-category", 1)
-        entity.labelProperty.set("old-label")
-
-        entity.name = "Mutated"
-        entity.category = "updated"
-        entity.priorityProperty.set(99)
-        entity.labelProperty.set("changed")
-
-        val encoded = json.encodeToString(serializer, entity)
-        val decoded = json.decodeFromString(serializer, encoded)
-
-        decoded.name shouldBe "Mutated"
-        decoded.category shouldBe "updated"
-        decoded.priorityProperty.get() shouldBe 99
-        decoded.labelProperty.get() shouldBe "changed"
-    }
-
-    "round-trip preserves default values when no explicit values set" {
-        val entity = CombinedDelegateEntity(1, "Defaults")
-
-        val encoded = json.encodeToString(serializer, entity)
-        val decoded = json.decodeFromString(serializer, encoded)
-
-        decoded.id shouldBe 1
-        decoded.name shouldBe "Defaults"
-        decoded.category shouldBe ""
-        decoded.priorityProperty.get() shouldBe 0
-        decoded.labelProperty.get() shouldBe ""
+    withData(
+        nameFn = RoundTripCase::name,
+        RoundTripCase(
+            "round-trip preserves all three delegate types",
+            { CombinedDelegateEntity(1, "Alpha", "books", 10).apply { labelProperty.set("premium") } }
+        ) { decoded ->
+            decoded.id shouldBe 1
+            decoded.name shouldBe "Alpha"
+            decoded.category shouldBe "books"
+            decoded.priorityProperty.get() shouldBe 10
+            decoded.labelProperty.get() shouldBe "premium"
+        },
+        RoundTripCase(
+            "round-trip preserves mutated values across all delegate types",
+            {
+                CombinedDelegateEntity(1, "Original", "old-category", 1).apply {
+                    labelProperty.set("old-label")
+                    name = "Mutated"
+                    category = "updated"
+                    priorityProperty.set(99)
+                    labelProperty.set("changed")
+                }
+            }
+        ) { decoded ->
+            decoded.name shouldBe "Mutated"
+            decoded.category shouldBe "updated"
+            decoded.priorityProperty.get() shouldBe 99
+            decoded.labelProperty.get() shouldBe "changed"
+        },
+        RoundTripCase(
+            "round-trip preserves default values when no explicit values set",
+            { CombinedDelegateEntity(1, "Defaults") }
+        ) { decoded ->
+            decoded.id shouldBe 1
+            decoded.name shouldBe "Defaults"
+            decoded.category shouldBe ""
+            decoded.priorityProperty.get() shouldBe 0
+            decoded.labelProperty.get() shouldBe ""
+        }
+    ) { case ->
+        val encoded = json.encodeToString(serializer, case.build())
+        case.verify(json.decodeFromString(serializer, encoded))
     }
 })

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateConcurrentMutationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateConcurrentMutationTest.kt
@@ -42,10 +42,6 @@ class FxAggregateConcurrentMutationTest : StringSpec({
 
     reactiveScope()
 
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
-
     "FxAggregateList serialized mutations produce no lost updates" {
         val list = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         val executor = Executors.newSingleThreadExecutor()

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateLazySnapshotTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateLazySnapshotTest.kt
@@ -89,10 +89,6 @@ class FxAggregateLazySnapshotTest : StringSpec({
     val audioItemRepo = FxAudioItemVolatileRepository()
     val playlistRepo = LazyFxPlaylistRepo()
 
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
-
     afterSpec {
         audioItemRepo.close()
         playlistRepo.close()
@@ -123,11 +119,7 @@ class FxAggregateLazySnapshotTest : StringSpec({
         playlist.audioItems.add(0, item)
 
         changes.size shouldBe 1
-        val change = changes[0]
-        change.next() shouldBe true
-        change.wasAdded() shouldBe true
-        change.from shouldBe 0
-        change.to shouldBe 1
+        changes[0].shouldBeSingleAdd(0, 1)
     }
 
     "FxAggregateList lazy-snapshot fires RemoveChange on removeAt" {
@@ -142,10 +134,7 @@ class FxAggregateLazySnapshotTest : StringSpec({
         playlist.audioItems.removeAt(0)
 
         changes.size shouldBe 1
-        val change = changes[0]
-        change.next() shouldBe true
-        change.wasRemoved() shouldBe true
-        change.removed.size shouldBe 1
+        changes[0].shouldBeSingleRemove(1)
     }
 
     "FxAggregateList lazy-snapshot fires SetChange on set" {
@@ -160,9 +149,7 @@ class FxAggregateLazySnapshotTest : StringSpec({
         playlist.audioItems[0] = item2
 
         changes.size shouldBe 1
-        val change = changes[0]
-        change.next() shouldBe true
-        change.wasReplaced() shouldBe true
+        changes[0].shouldBeSingleReplace()
     }
 
     "FxAggregateList lazy-snapshot fires single AddChange on addAll" {
@@ -180,11 +167,7 @@ class FxAggregateLazySnapshotTest : StringSpec({
         playlist.audioItems.addAll(items)
 
         changes.size shouldBe 1
-        val change = changes[0]
-        change.next() shouldBe true
-        change.wasAdded() shouldBe true
-        change.from shouldBe 0
-        change.to shouldBe 3
+        changes[0].shouldBeSingleAdd(0, 3)
     }
 
     "FxAggregateList lazy-snapshot fires RemoveChange on clear" {
@@ -199,10 +182,7 @@ class FxAggregateLazySnapshotTest : StringSpec({
         playlist.audioItems.clear()
 
         changes.size shouldBe 1
-        val change = changes[0]
-        change.next() shouldBe true
-        change.wasRemoved() shouldBe true
-        change.removed.size shouldBe 2
+        changes[0].shouldBeSingleRemove(2)
     }
 
     "FxAggregateList lazy-snapshot fires ReplaceAllChange on setAll" {
@@ -217,9 +197,7 @@ class FxAggregateLazySnapshotTest : StringSpec({
         playlist.audioItems.setAll(item2)
 
         changes.size shouldBe 1
-        val change = changes[0]
-        change.next() shouldBe true
-        change.wasReplaced() shouldBe true
+        changes[0].shouldBeSingleReplace()
     }
 
     "FxAggregateList lazy-snapshot fires MultiRemoveChange on removeAll" {

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateListTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateListTest.kt
@@ -38,10 +38,6 @@ class FxAggregateListTest : StringSpec({
 
     reactiveScope()
 
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
-
     "FxAggregateList returns correct size after add" {
         val proxy = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)
         proxy.add(0, MutableAudioItem(1, "Song A"))
@@ -56,11 +52,7 @@ class FxAggregateListTest : StringSpec({
         proxy.add(0, MutableAudioItem(1, "Song A"))
 
         changes.size shouldBe 1
-        val change = changes[0]
-        change.next() shouldBe true
-        change.wasAdded() shouldBe true
-        change.from shouldBe 0
-        change.to shouldBe 1
+        changes[0].shouldBeSingleAdd(0, 1)
     }
 
     "FxAggregateList fires ListChangeListener on single remove" {
@@ -74,10 +66,7 @@ class FxAggregateListTest : StringSpec({
         proxy.removeAt(0)
 
         changes.size shouldBe 1
-        val change = changes[0]
-        change.next() shouldBe true
-        change.wasRemoved() shouldBe true
-        change.removed.size shouldBe 1
+        changes[0].shouldBeSingleRemove(1)
     }
 
     "FxAggregateList fires ListChangeListener on set" {
@@ -92,9 +81,7 @@ class FxAggregateListTest : StringSpec({
         proxy[0] = item2
 
         changes.size shouldBe 1
-        val change = changes[0]
-        change.next() shouldBe true
-        change.wasReplaced() shouldBe true
+        changes[0].shouldBeSingleReplace()
     }
 
     "FxAggregateList fires single Change on addAll" {
@@ -106,11 +93,7 @@ class FxAggregateListTest : StringSpec({
         proxy.addAll(testItems)
 
         changes.size shouldBe 1
-        val change = changes[0]
-        change.next() shouldBe true
-        change.wasAdded() shouldBe true
-        change.from shouldBe 0
-        change.to shouldBe 3
+        changes[0].shouldBeSingleAdd(0, 3)
     }
 
     "FxAggregateList fires Change on clear" {
@@ -124,10 +107,7 @@ class FxAggregateListTest : StringSpec({
         proxy.clear()
 
         changes.size shouldBe 1
-        val change = changes[0]
-        change.next() shouldBe true
-        change.wasRemoved() shouldBe true
-        change.removed.size shouldBe 2
+        changes[0].shouldBeSingleRemove(2)
     }
 
     "FxAggregateList fires listeners on flowScope when dispatchToFxThread=false" {
@@ -357,11 +337,7 @@ class FxAggregateListTest : StringSpec({
         proxy[1].id shouldBe 2
         proxy[2].id shouldBe 3
         changes.size shouldBe 1
-        val change = changes[0]
-        change.next() shouldBe true
-        change.wasAdded() shouldBe true
-        change.from shouldBe 1
-        change.to shouldBe 3
+        changes[0].shouldBeSingleAdd(1, 3)
     }
 
     "FxAggregateList AddChange supports reset and getPermutation" {

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSetTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxAggregateSetTest.kt
@@ -41,10 +41,6 @@ class FxAggregateSetTest : StringSpec({
 
     reactiveScope()
 
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
-
     "FxAggregateSet returns correct size after add" {
         val proxy = fxAggregateSet<Int, AudioItem>(dispatchToFxThread = false)
         proxy.add(MutableAudioItem(1, "Song A"))
@@ -60,8 +56,7 @@ class FxAggregateSetTest : StringSpec({
         proxy.add(item)
 
         changes.size shouldBe 1
-        changes[0].wasAdded() shouldBe true
-        changes[0].elementAdded shouldBe item
+        changes[0].shouldBeAddOf(item)
     }
 
     "FxAggregateSet fires SetChangeListener per element on remove" {
@@ -75,8 +70,7 @@ class FxAggregateSetTest : StringSpec({
         proxy.remove(item)
 
         changes.size shouldBe 1
-        changes[0].wasRemoved() shouldBe true
-        changes[0].elementRemoved shouldBe item
+        changes[0].shouldBeRemoveOf(item)
     }
 
     "FxAggregateSet fires one Change per element on addAll" {

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxJsonSerializationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxJsonSerializationTest.kt
@@ -22,6 +22,7 @@ import net.transgressoft.lirp.persistence.json.lirpSerializer
 import net.transgressoft.lirp.testing.reactiveScope
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
@@ -53,152 +54,131 @@ class FxJsonSerializationTest : StringSpec({
     val json = Json { prettyPrint = true }
     val serializer = lirpSerializer(FxAudioPlaylistEntity(0, ""))
 
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
+    data class EncodeCase(val name: String, val build: () -> FxAudioPlaylistEntity, val verify: (String) -> Unit)
 
-    "serializes entity with fxAggregateList as ID list only" {
-        val entity = FxAudioPlaylistEntity(1, "My Playlist", initialAudioItemIds = listOf(10, 20))
+    withData(
+        nameFn = EncodeCase::name,
+        EncodeCase(
+            "serializes entity with fxAggregateList as ID list only",
+            { FxAudioPlaylistEntity(1, "My Playlist", initialAudioItemIds = listOf(10, 20)) }
+        ) { encoded ->
+            encoded shouldContain "\"id\": 1"
+            encoded shouldContain "\"name\": \"My Playlist\""
+            encoded shouldContain "\"audioItems\""
+            encoded shouldContain "10"
+            encoded shouldContain "20"
+            encoded shouldNotContain "\"innerProxy\""
+            encoded shouldNotContain "\"localElements\""
+        },
+        EncodeCase(
+            "serializes entity with fxAggregateSet as ID set only",
+            { FxAudioPlaylistEntity(1, "Parent", initialPlaylistIds = setOf(2, 3)) }
+        ) { encoded ->
+            encoded shouldContain "\"playlists\""
+            encoded shouldContain "2"
+            encoded shouldContain "3"
+            encoded shouldNotContain "\"innerProxy\""
+        },
+        EncodeCase(
+            "serializes entity with empty fx collections",
+            { FxAudioPlaylistEntity(1, "Empty") }
+        ) { encoded ->
+            encoded shouldContain "\"id\": 1"
+            encoded shouldContain "\"name\": \"Empty\""
+            encoded shouldContain "\"audioItems\": []"
+            encoded shouldContain "\"playlists\": []"
+        },
+        EncodeCase(
+            "serializes fx scalar delegate values in JSON",
+            {
+                FxAudioPlaylistEntity(
+                    1, "Scalars", initialYear = 2025, initialActive = true,
+                    initialRating = 4.5, initialTag = "rock", initialDescription = "Best of"
+                )
+            }
+        ) { encoded ->
+            encoded shouldContain "\"tagProperty\": \"rock\""
+            encoded shouldContain "\"yearProperty\": 2025"
+            encoded shouldContain "\"activeProperty\": true"
+            encoded shouldContain "\"ratingProperty\": 4.5"
+            encoded shouldContain "\"descriptionProperty\": \"Best of\""
+            encoded shouldContain "\"name\": \"Scalars\""
+        }
+    ) { case -> case.verify(json.encodeToString(serializer, case.build())) }
 
-        val encoded = json.encodeToString(serializer, entity)
+    data class RoundTripCase(val name: String, val build: () -> FxAudioPlaylistEntity, val verify: (FxAudioPlaylistEntity) -> Unit)
 
-        encoded shouldContain "\"id\": 1"
-        encoded shouldContain "\"name\": \"My Playlist\""
-        encoded shouldContain "\"audioItems\""
-        encoded shouldContain "10"
-        encoded shouldContain "20"
-        encoded shouldNotContain "\"innerProxy\""
-        encoded shouldNotContain "\"localElements\""
-    }
-
-    "serializes entity with fxAggregateSet as ID set only" {
-        val entity = FxAudioPlaylistEntity(1, "Parent", initialPlaylistIds = setOf(2, 3))
-
-        val encoded = json.encodeToString(serializer, entity)
-
-        encoded shouldContain "\"playlists\""
-        encoded shouldContain "2"
-        encoded shouldContain "3"
-        encoded shouldNotContain "\"innerProxy\""
-    }
-
-    "serializes entity with empty fx collections" {
-        val entity = FxAudioPlaylistEntity(1, "Empty")
-
-        val encoded = json.encodeToString(serializer, entity)
-
-        encoded shouldContain "\"id\": 1"
-        encoded shouldContain "\"name\": \"Empty\""
-        encoded shouldContain "\"audioItems\": []"
-        encoded shouldContain "\"playlists\": []"
-    }
-
-    "deserializes entity preserving fxAggregateList IDs and collection facade" {
-        val original = FxAudioPlaylistEntity(5, "Round Trip", initialAudioItemIds = listOf(10, 20, 30))
-
-        val encoded = json.encodeToString(serializer, original)
-        val decoded = json.decodeFromString(serializer, encoded)
-
-        decoded.id shouldBe 5
-        decoded.name shouldBe "Round Trip"
-        decoded.audioItems.referenceIds shouldBe listOf(10, 20, 30)
-        decoded.audioItems.shouldBeInstanceOf<ObservableList<*>>()
-        decoded.audioItems.shouldBeInstanceOf<FxAggregateList<*, *>>()
-    }
-
-    "deserializes entity preserving fxAggregateSet IDs and collection facade" {
-        val original = FxAudioPlaylistEntity(1, "With Sets", initialPlaylistIds = setOf(2, 3))
-
-        val encoded = json.encodeToString(serializer, original)
-        val decoded = json.decodeFromString(serializer, encoded)
-
-        decoded.id shouldBe 1
-        decoded.name shouldBe "With Sets"
-        decoded.playlists.referenceIds shouldBe setOf(2, 3)
-        decoded.playlists.shouldBeInstanceOf<ObservableSet<*>>()
-        decoded.playlists.shouldBeInstanceOf<FxAggregateSet<*, *>>()
-    }
-
-    "round-trip preserves list order" {
-        val original = FxAudioPlaylistEntity(1, "Ordered", initialAudioItemIds = listOf(30, 10, 20))
-
-        val encoded = json.encodeToString(serializer, original)
-        val decoded = json.decodeFromString(serializer, encoded)
-
-        decoded.audioItems.referenceIds shouldBe listOf(30, 10, 20)
-    }
-
-    "round-trip after mutation preserves updated state" {
-        val entity = FxAudioPlaylistEntity(1, "Mutable", initialAudioItemIds = listOf(10))
-        entity.name = "Updated Name"
-
-        val encoded = json.encodeToString(serializer, entity)
-        val decoded = json.decodeFromString(serializer, encoded)
-
-        decoded.name shouldBe "Updated Name"
-        decoded.audioItems.referenceIds shouldBe listOf(10)
-    }
-
-    "round-trip with both collections populated and facade intact" {
-        val original = FxAudioPlaylistEntity(1, "Full", initialAudioItemIds = listOf(10, 20), initialPlaylistIds = setOf(2, 3))
-
-        val encoded = json.encodeToString(serializer, original)
-        val decoded = json.decodeFromString(serializer, encoded)
-
-        decoded.id shouldBe 1
-        decoded.name shouldBe "Full"
-        decoded.audioItems.referenceIds shouldBe listOf(10, 20)
-        decoded.audioItems.shouldBeInstanceOf<FxAggregateList<*, *>>()
-        decoded.playlists.referenceIds shouldBe setOf(2, 3)
-        decoded.playlists.shouldBeInstanceOf<FxAggregateSet<*, *>>()
-    }
-
-    "serializes fx scalar delegate values in JSON" {
-        val entity =
-            FxAudioPlaylistEntity(
-                1, "Scalars", initialYear = 2025, initialActive = true,
-                initialRating = 4.5, initialTag = "rock", initialDescription = "Best of"
-            )
-
-        val encoded = json.encodeToString(serializer, entity)
-
-        encoded shouldContain "\"tagProperty\": \"rock\""
-        encoded shouldContain "\"yearProperty\": 2025"
-        encoded shouldContain "\"activeProperty\": true"
-        encoded shouldContain "\"ratingProperty\": 4.5"
-        encoded shouldContain "\"descriptionProperty\": \"Best of\""
-        encoded shouldContain "\"name\": \"Scalars\""
-    }
-
-    "round-trip preserves fx scalar delegate values" {
-        val original =
-            FxAudioPlaylistEntity(
-                1, "Complete", initialYear = 2024, initialActive = true,
-                initialRating = 9.5, initialTag = "jazz", initialDescription = "Classic",
-                initialAudioItemIds = listOf(10, 20), initialPlaylistIds = setOf(2)
-            )
-
-        val encoded = json.encodeToString(serializer, original)
-        val decoded = json.decodeFromString(serializer, encoded)
-
-        decoded.id shouldBe 1
-        decoded.name shouldBe "Complete"
-        decoded.tagProperty.get() shouldBe "jazz"
-        decoded.yearProperty.get() shouldBe 2024
-        decoded.activeProperty.get() shouldBe true
-        decoded.ratingProperty.get() shouldBe 9.5
-        decoded.descriptionProperty.get() shouldBe "Classic"
-        decoded.audioItems.referenceIds shouldBe listOf(10, 20)
-        decoded.playlists.referenceIds shouldBe setOf(2)
-    }
-
-    "round-trip preserves null fx object property" {
-        val original = FxAudioPlaylistEntity(1, "NullDesc", initialDescription = null)
-
-        val encoded = json.encodeToString(serializer, original)
-        val decoded = json.decodeFromString(serializer, encoded)
-
-        decoded.descriptionProperty.get() shouldBe null
+    withData(
+        nameFn = RoundTripCase::name,
+        RoundTripCase(
+            "deserializes entity preserving fxAggregateList IDs and collection facade",
+            { FxAudioPlaylistEntity(5, "Round Trip", initialAudioItemIds = listOf(10, 20, 30)) }
+        ) { decoded ->
+            decoded.id shouldBe 5
+            decoded.name shouldBe "Round Trip"
+            decoded.audioItems.referenceIds shouldBe listOf(10, 20, 30)
+            decoded.audioItems.shouldBeInstanceOf<ObservableList<*>>()
+            decoded.audioItems.shouldBeInstanceOf<FxAggregateList<*, *>>()
+        },
+        RoundTripCase(
+            "deserializes entity preserving fxAggregateSet IDs and collection facade",
+            { FxAudioPlaylistEntity(1, "With Sets", initialPlaylistIds = setOf(2, 3)) }
+        ) { decoded ->
+            decoded.id shouldBe 1
+            decoded.name shouldBe "With Sets"
+            decoded.playlists.referenceIds shouldBe setOf(2, 3)
+            decoded.playlists.shouldBeInstanceOf<ObservableSet<*>>()
+            decoded.playlists.shouldBeInstanceOf<FxAggregateSet<*, *>>()
+        },
+        RoundTripCase(
+            "round-trip preserves list order",
+            { FxAudioPlaylistEntity(1, "Ordered", initialAudioItemIds = listOf(30, 10, 20)) }
+        ) { decoded -> decoded.audioItems.referenceIds shouldBe listOf(30, 10, 20) },
+        RoundTripCase(
+            "round-trip after mutation preserves updated state",
+            { FxAudioPlaylistEntity(1, "Mutable", initialAudioItemIds = listOf(10)).apply { name = "Updated Name" } }
+        ) { decoded ->
+            decoded.name shouldBe "Updated Name"
+            decoded.audioItems.referenceIds shouldBe listOf(10)
+        },
+        RoundTripCase(
+            "round-trip with both collections populated and facade intact",
+            { FxAudioPlaylistEntity(1, "Full", initialAudioItemIds = listOf(10, 20), initialPlaylistIds = setOf(2, 3)) }
+        ) { decoded ->
+            decoded.id shouldBe 1
+            decoded.name shouldBe "Full"
+            decoded.audioItems.referenceIds shouldBe listOf(10, 20)
+            decoded.audioItems.shouldBeInstanceOf<FxAggregateList<*, *>>()
+            decoded.playlists.referenceIds shouldBe setOf(2, 3)
+            decoded.playlists.shouldBeInstanceOf<FxAggregateSet<*, *>>()
+        },
+        RoundTripCase(
+            "round-trip preserves fx scalar delegate values",
+            {
+                FxAudioPlaylistEntity(
+                    1, "Complete", initialYear = 2024, initialActive = true,
+                    initialRating = 9.5, initialTag = "jazz", initialDescription = "Classic",
+                    initialAudioItemIds = listOf(10, 20), initialPlaylistIds = setOf(2)
+                )
+            }
+        ) { decoded ->
+            decoded.id shouldBe 1
+            decoded.name shouldBe "Complete"
+            decoded.tagProperty.get() shouldBe "jazz"
+            decoded.yearProperty.get() shouldBe 2024
+            decoded.activeProperty.get() shouldBe true
+            decoded.ratingProperty.get() shouldBe 9.5
+            decoded.descriptionProperty.get() shouldBe "Classic"
+            decoded.audioItems.referenceIds shouldBe listOf(10, 20)
+            decoded.playlists.referenceIds shouldBe setOf(2)
+        },
+        RoundTripCase(
+            "round-trip preserves null fx object property",
+            { FxAudioPlaylistEntity(1, "NullDesc", initialDescription = null) }
+        ) { decoded -> decoded.descriptionProperty.get() shouldBe null }
+    ) { case ->
+        val encoded = json.encodeToString(serializer, case.build())
+        case.verify(json.decodeFromString(serializer, encoded))
     }
 
     "fx object property holding a non-serializable type round-trips when registered contextually" {

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxKotestProjectConfig.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxKotestProjectConfig.kt
@@ -25,9 +25,14 @@ import io.kotest.engine.concurrency.TestExecutionMode
  * Kotest project configuration for JavaFX tests.
  *
  * JavaFX toolkit state is process-wide, so FX specs and tests remain serialized even when
- * other modules opt into spec-level parallelism.
+ * other modules opt into spec-level parallelism. The headless toolkit is started once here,
+ * before any spec, so individual FX specs no longer need their own `beforeSpec` init block.
  */
 class FxKotestProjectConfig : AbstractProjectConfig() {
     override val specExecutionMode = SpecExecutionMode.Sequential
     override val testExecutionMode = TestExecutionMode.Sequential
+
+    override suspend fun beforeProject() {
+        FxToolkitInit.ensureInitialized()
+    }
 }

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxRegistryIntegrationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxRegistryIntegrationTest.kt
@@ -44,10 +44,6 @@ class FxRegistryIntegrationTest : StringSpec({
 
     reactiveScope()
 
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
-
     lateinit var trackRepo: AudioItemVolatileRepository
     lateinit var fxPlaylistRepo: FxAudioPlaylistVolatileRepository
 
@@ -149,8 +145,7 @@ class FxRegistryIntegrationTest : StringSpec({
         latch.await(2, TimeUnit.SECONDS) shouldBe true
 
         fxChanges.size shouldBe 1
-        fxChanges[0].wasAdded() shouldBe true
-        fxChanges[0].elementAdded shouldBe playlist2
+        fxChanges[0].shouldBeAddOf(playlist2)
 
         val collectionEvent = lirpEvent.get()
         collectionEvent.type shouldBe CollectionChangeEvent.Type.ADD

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxScalarPropertyTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxScalarPropertyTest.kt
@@ -20,6 +20,7 @@ package net.transgressoft.lirp.persistence.fx
 import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
 import net.transgressoft.lirp.persistence.LirpDelegate
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.datatest.withData
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldBeNull
@@ -34,10 +35,6 @@ import javafx.beans.value.ChangeListener
  * interface compliance with [LirpDelegate] and [FxScalarPropertyDelegate].
  */
 class FxScalarPropertyTest : StringSpec({
-
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
 
     // --- LirpStringProperty ---
 
@@ -258,62 +255,29 @@ class FxScalarPropertyTest : StringSpec({
 
     // --- Factory functions ---
 
-    "fxString factory creates LirpStringProperty with initial value" {
-        fxString("init").get() shouldBe "init"
-    }
+    data class FactoryCase(val name: String, val actual: Any?, val expected: Any?)
 
-    "fxInteger factory creates LirpIntegerProperty" {
-        fxInteger(7).get() shouldBe 7
-    }
-
-    "fxDouble factory creates LirpDoubleProperty" {
-        fxDouble(3.14).get() shouldBe 3.14
-    }
-
-    "fxFloat factory creates LirpFloatProperty" {
-        fxFloat(1.5f).get() shouldBe 1.5f
-    }
-
-    "fxLong factory creates LirpLongProperty" {
-        fxLong(100L).get() shouldBe 100L
-    }
-
-    "fxBoolean factory creates LirpBooleanProperty" {
-        fxBoolean(true).get().shouldBeTrue()
-    }
-
-    "fxObject factory supports nullable type" {
-        fxObject<String?>(null).get().shouldBeNull()
-    }
+    withData(
+        nameFn = FactoryCase::name,
+        FactoryCase("fxString factory creates LirpStringProperty with initial value", fxString("init").get(), "init"),
+        FactoryCase("fxInteger factory creates LirpIntegerProperty", fxInteger(7).get(), 7),
+        FactoryCase("fxDouble factory creates LirpDoubleProperty", fxDouble(3.14).get(), 3.14),
+        FactoryCase("fxFloat factory creates LirpFloatProperty", fxFloat(1.5f).get(), 1.5f),
+        FactoryCase("fxLong factory creates LirpLongProperty", fxLong(100L).get(), 100L),
+        FactoryCase("fxBoolean factory creates LirpBooleanProperty", fxBoolean(true).get(), true),
+        FactoryCase("fxObject factory supports nullable type", fxObject<String?>(null).get(), null)
+    ) { case -> case.actual shouldBe case.expected }
 
     // --- FxProperties static factories ---
 
-    "FxProperties.fxString creates LirpStringProperty" {
-        FxProperties.fxString("test").get() shouldBe "test"
-    }
-
-    "FxProperties.fxInteger creates LirpIntegerProperty" {
-        FxProperties.fxInteger(42).get() shouldBe 42
-    }
-
-    "FxProperties.fxDouble creates LirpDoubleProperty" {
-        FxProperties.fxDouble(2.72).get() shouldBe 2.72
-    }
-
-    "FxProperties.fxFloat creates LirpFloatProperty" {
-        FxProperties.fxFloat(0.5f).get() shouldBe 0.5f
-    }
-
-    "FxProperties.fxLong creates LirpLongProperty" {
-        FxProperties.fxLong(999L).get() shouldBe 999L
-    }
-
-    "FxProperties.fxBoolean creates LirpBooleanProperty" {
-        FxProperties.fxBoolean(false).get() shouldBe false
-    }
-
-    "FxProperties.fxObject creates LirpObjectProperty" {
-        val prop = FxProperties.fxObject<String>("hello")
-        prop.get() shouldBe "hello"
-    }
+    withData(
+        nameFn = FactoryCase::name,
+        FactoryCase("FxProperties.fxString creates LirpStringProperty", FxProperties.fxString("test").get(), "test"),
+        FactoryCase("FxProperties.fxInteger creates LirpIntegerProperty", FxProperties.fxInteger(42).get(), 42),
+        FactoryCase("FxProperties.fxDouble creates LirpDoubleProperty", FxProperties.fxDouble(2.72).get(), 2.72),
+        FactoryCase("FxProperties.fxFloat creates LirpFloatProperty", FxProperties.fxFloat(0.5f).get(), 0.5f),
+        FactoryCase("FxProperties.fxLong creates LirpLongProperty", FxProperties.fxLong(999L).get(), 999L),
+        FactoryCase("FxProperties.fxBoolean creates LirpBooleanProperty", FxProperties.fxBoolean(false).get(), false),
+        FactoryCase("FxProperties.fxObject creates LirpObjectProperty", FxProperties.fxObject<String>("hello").get(), "hello")
+    ) { case -> case.actual shouldBe case.expected }
 })

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxScalarRegistryIntegrationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/FxScalarRegistryIntegrationTest.kt
@@ -24,6 +24,7 @@ import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.testing.reactiveScope
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 
 /**
@@ -40,10 +41,6 @@ class FxScalarRegistryIntegrationTest : StringSpec({
 
     val reactive = reactiveScope()
 
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
-
     lateinit var trackRepo: AudioItemVolatileRepository
     lateinit var fxPlaylistRepo: FxAudioPlaylistVolatileRepository
 
@@ -56,19 +53,44 @@ class FxScalarRegistryIntegrationTest : StringSpec({
         LirpContext.default.close()
     }
 
-    "RegistryBase binds fx string property and emits PropertyChanged event on set" {
-        val entity = fxPlaylistRepo.create(1, "playlist", tag = "initial")
+    data class ScalarCase(
+        val name: String,
+        val create: (FxAudioPlaylistVolatileRepository) -> FxAudioPlaylistEntity,
+        val mutate: (FxAudioPlaylistEntity) -> Unit,
+        val expectedOld: Any?,
+        val expectedNew: Any?
+    )
+
+    withData(
+        nameFn = ScalarCase::name,
+        ScalarCase(
+            "RegistryBase binds fx string property and emits PropertyChanged event on set",
+            { it.create(1, "playlist", tag = "initial") }, { it.tagProperty.set("updated") }, "initial", "updated"
+        ),
+        ScalarCase(
+            "fx integer property emits PropertyChanged event on set",
+            { it.create(2, "playlist", year = 0) }, { it.yearProperty.set(2025) }, 0, 2025
+        ),
+        ScalarCase(
+            "fx boolean property emits PropertyChanged event on set",
+            { it.create(3, "playlist", active = false) }, { it.activeProperty.set(true) }, false, true
+        ),
+        ScalarCase(
+            "fx object property emits PropertyChanged event on set",
+            { it.create(4, "playlist", description = null) }, { it.descriptionProperty.set("vip") }, null, "vip"
+        )
+    ) { case ->
+        val entity = case.create(fxPlaylistRepo)
 
         val received = mutableListOf<MutationEvent<Int, FxAudioPlaylistEntity>>()
-
         entity.subscribe { event -> received.add(event) }
 
-        entity.tagProperty.set("updated")
+        case.mutate(entity)
 
         received.size shouldBe 1
-        val pc = received[0] as PropertyChanged<Int, FxAudioPlaylistEntity, String>
-        pc.oldValue shouldBe "initial"
-        pc.newValue shouldBe "updated"
+        val pc = received[0] as PropertyChanged<Int, FxAudioPlaylistEntity, *>
+        pc.oldValue shouldBe case.expectedOld
+        pc.newValue shouldBe case.expectedNew
     }
 
     "fx string property fires JavaFX ChangeListener after RegistryBase binding" {
@@ -85,51 +107,6 @@ class FxScalarRegistryIntegrationTest : StringSpec({
 
         observedOld shouldBe "old"
         observedNew shouldBe "new"
-    }
-
-    "fx integer property emits PropertyChanged event on set" {
-        val entity = fxPlaylistRepo.create(2, "playlist", year = 0)
-
-        val received = mutableListOf<MutationEvent<Int, FxAudioPlaylistEntity>>()
-
-        entity.subscribe { event -> received.add(event) }
-
-        entity.yearProperty.set(2025)
-
-        received.size shouldBe 1
-        val pc = received[0] as PropertyChanged<Int, FxAudioPlaylistEntity, Int>
-        pc.oldValue shouldBe 0
-        pc.newValue shouldBe 2025
-    }
-
-    "fx boolean property emits PropertyChanged event on set" {
-        val entity = fxPlaylistRepo.create(3, "playlist", active = false)
-
-        val received = mutableListOf<MutationEvent<Int, FxAudioPlaylistEntity>>()
-
-        entity.subscribe { event -> received.add(event) }
-
-        entity.activeProperty.set(true)
-
-        received.size shouldBe 1
-        val pc = received[0] as PropertyChanged<Int, FxAudioPlaylistEntity, Boolean>
-        pc.oldValue shouldBe false
-        pc.newValue shouldBe true
-    }
-
-    "fx object property emits PropertyChanged event on set" {
-        val entity = fxPlaylistRepo.create(4, "playlist", description = null)
-
-        val received = mutableListOf<MutationEvent<Int, FxAudioPlaylistEntity>>()
-
-        entity.subscribe { event -> received.add(event) }
-
-        entity.descriptionProperty.set("vip")
-
-        received.size shouldBe 1
-        val pc = received[0] as PropertyChanged<Int, FxAudioPlaylistEntity, String>
-        pc.oldValue shouldBe null
-        pc.newValue shouldBe "vip"
     }
 
     "withEventsDisabled suppresses MutationEvent for fx scalar property" {

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxMultiKeyProjectionTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxMultiKeyProjectionTest.kt
@@ -21,7 +21,6 @@ import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.MultiKeyAudioItemVolatileRepository
 import net.transgressoft.lirp.persistence.MultiKeyAudioPlaylistRepo
 import net.transgressoft.lirp.persistence.MutableMultiKeyAudioItem
-import net.transgressoft.lirp.persistence.fx.FxToolkitInit
 import net.transgressoft.lirp.persistence.fx.fxAggregateList
 import net.transgressoft.lirp.testing.Stress
 import net.transgressoft.lirp.testing.reactiveScope
@@ -54,10 +53,6 @@ import kotlinx.coroutines.launch
 class FxMultiKeyProjectionTest : StringSpec({
 
     val reactive = reactiveScope()
-
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
 
     lateinit var trackRepo: MultiKeyAudioItemVolatileRepository
     lateinit var mkPlaylistRepo: MultiKeyAudioPlaylistRepo

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionIntegrationTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionIntegrationTest.kt
@@ -21,7 +21,6 @@ import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.fx.FxAudioItemVolatileRepository
 import net.transgressoft.lirp.persistence.fx.FxAudioPlaylistVolatileRepository
-import net.transgressoft.lirp.persistence.fx.FxToolkitInit
 import net.transgressoft.lirp.testing.reactiveScope
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -37,10 +36,6 @@ import io.kotest.matchers.shouldBe
 class FxProjectionIntegrationTest : StringSpec({
 
     reactiveScope()
-
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
 
     afterEach {
         LirpContext.default.close()

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionKeyChangeTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionKeyChangeTest.kt
@@ -19,7 +19,6 @@ package net.transgressoft.lirp.persistence.fx.projection
 
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.fx.FxAudioItem
-import net.transgressoft.lirp.persistence.fx.FxToolkitInit
 import net.transgressoft.lirp.persistence.fx.fxAggregateList
 import net.transgressoft.lirp.testing.reactiveScope
 import io.kotest.core.spec.style.StringSpec
@@ -36,10 +35,6 @@ import io.kotest.matchers.shouldBe
 class FxProjectionKeyChangeTest : StringSpec({
 
     reactiveScope()
-
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
 
     "FxProjection reflects new bucket after entity key changes and is removed then re-added" {
         val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/FxProjectionTest.kt
@@ -20,7 +20,6 @@ package net.transgressoft.lirp.persistence.fx.projection
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.MutableMultiKeyAudioItem
 import net.transgressoft.lirp.persistence.fx.FxAudioItem
-import net.transgressoft.lirp.persistence.fx.FxToolkitInit
 import net.transgressoft.lirp.persistence.fx.fxAggregateList
 import net.transgressoft.lirp.persistence.fx.fxAggregateSet
 import net.transgressoft.lirp.persistence.projection.ObservableProjection
@@ -59,10 +58,6 @@ data class FxAlbumBucket(val key: String, val titles: List<String>)
 class FxProjectionTest : StringSpec({
 
     reactiveScope()
-
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
 
     "FxProjection groups entities by key extractor on add" {
         val source = fxAggregateList<Int, AudioItem>(dispatchToFxThread = false)

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjectionTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxMultiKeyProjectionTest.kt
@@ -22,7 +22,6 @@ import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.MultiKeyAudioItemVolatileRepository
 import net.transgressoft.lirp.persistence.MutableMultiKeyAudioItem
 import net.transgressoft.lirp.persistence.SoftDeletableMultiKeyAudioItemRepo
-import net.transgressoft.lirp.persistence.fx.FxToolkitInit
 import net.transgressoft.lirp.persistence.projection.ProjectionEntryChange
 import net.transgressoft.lirp.testing.reactiveScope
 import io.kotest.assertions.throwables.shouldThrow
@@ -55,10 +54,6 @@ import java.util.concurrent.atomic.AtomicInteger
 class RegistryFxMultiKeyProjectionTest : StringSpec({
 
     val reactive = reactiveScope()
-
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
 
     lateinit var trackRepo: MultiKeyAudioItemVolatileRepository
 

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionConcurrencyStressTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionConcurrencyStressTest.kt
@@ -19,7 +19,6 @@ package net.transgressoft.lirp.persistence.fx.projection
 
 import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.MultiKeyAudioItemVolatileRepository
-import net.transgressoft.lirp.persistence.fx.FxToolkitInit
 import net.transgressoft.lirp.testing.ReactiveScopeSerialization
 import net.transgressoft.lirp.testing.Stress
 import io.kotest.assertions.throwables.shouldNotThrowAny
@@ -52,7 +51,6 @@ import java.util.concurrent.atomic.AtomicInteger
 class RegistryFxProjectionConcurrencyStressTest : StringSpec({
     extension(ReactiveScopeSerialization)
 
-    beforeSpec { FxToolkitInit.ensureInitialized() }
     afterEach { LirpContext.default.close() }
 
     val itemCount = 1200

--- a/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionTest.kt
+++ b/lirp-fx/src/test/kotlin/net/transgressoft/lirp/persistence/fx/projection/RegistryFxProjectionTest.kt
@@ -23,7 +23,6 @@ import net.transgressoft.lirp.persistence.AudioItemVolatileRepository
 import net.transgressoft.lirp.persistence.LirpContext
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.SoftDeletableMutableAudioItem
-import net.transgressoft.lirp.persistence.fx.FxToolkitInit
 import net.transgressoft.lirp.persistence.projection.ProjectionEntryChange
 import net.transgressoft.lirp.testing.reactiveScope
 import io.kotest.assertions.throwables.shouldThrow
@@ -64,10 +63,6 @@ data class RegistryAlbumBucket(val key: String, val titles: List<String>)
 class RegistryFxProjectionTest : StringSpec({
 
     val reactive = reactiveScope()
-
-    beforeSpec {
-        FxToolkitInit.ensureInitialized()
-    }
 
     lateinit var trackRepo: AudioItemVolatileRepository
 

--- a/lirp-fx/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/fx/FxCollectionChangeAssertions.kt
+++ b/lirp-fx/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/fx/FxCollectionChangeAssertions.kt
@@ -1,0 +1,65 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.fx
+
+import io.kotest.matchers.shouldBe
+import javafx.collections.ListChangeListener
+import javafx.collections.SetChangeListener
+
+/*
+ * Assertions for JavaFX collection-change notifications, collapsing the recurring
+ * `change.next() shouldBe true` -> `change.wasX() shouldBe true` -> field-by-field cursor walk into
+ * one named claim.
+ *
+ * These cover the common single-segment change only. Tests that assert an ordered walk across
+ * multiple segments (e.g. a multi-remove producing several ranges) must keep driving the cursor
+ * explicitly — the ordered progression is the behaviour under test there.
+ */
+
+/** Asserts the change is a single contiguous add spanning `[from, to)`. */
+fun ListChangeListener.Change<*>.shouldBeSingleAdd(from: Int, to: Int) {
+    next() shouldBe true
+    wasAdded() shouldBe true
+    this.from shouldBe from
+    this.to shouldBe to
+}
+
+/** Asserts the change is a single removal of [removedCount] elements. */
+fun ListChangeListener.Change<*>.shouldBeSingleRemove(removedCount: Int) {
+    next() shouldBe true
+    wasRemoved() shouldBe true
+    removed.size shouldBe removedCount
+}
+
+/** Asserts the change is a single replacement (a set on an existing index). */
+fun ListChangeListener.Change<*>.shouldBeSingleReplace() {
+    next() shouldBe true
+    wasReplaced() shouldBe true
+}
+
+/** Asserts this set change added exactly [element]. */
+fun <E> SetChangeListener.Change<out E>.shouldBeAddOf(element: E) {
+    wasAdded() shouldBe true
+    elementAdded shouldBe element
+}
+
+/** Asserts this set change removed exactly [element]. */
+fun <E> SetChangeListener.Change<out E>.shouldBeRemoveOf(element: E) {
+    wasRemoved() shouldBe true
+    elementRemoved shouldBe element
+}

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ForeignKeyAnalyzer.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ForeignKeyAnalyzer.kt
@@ -192,7 +192,7 @@ internal class ForeignKeyAnalyzer(
         val parentSimpleName = parentClass.simpleName.asString()
         val itemSimpleName = agg.referencedClass.simpleName.asString()
         val propertyCapitalized = agg.propertyName.replaceFirstChar { it.uppercase() }
-        val descriptorName = "${parentSimpleName}_${propertyCapitalized}_LirpJunctionTableDef"
+        val descriptorName = "${parentSimpleName}_${propertyCapitalized}${LirpGenNames.JUNCTION_TABLE_DEF_SUFFIX}"
 
         val parentTableName = resolveTableName(parentClass, parentSimpleName)
         val itemTableName = resolveTableName(agg.referencedClass, itemSimpleName)
@@ -295,7 +295,7 @@ internal class ForeignKeyAnalyzer(
 
         val itemSimpleName = elementFqnToSimpleName(elementFqn)
         val propertyCapitalized = agg.propertyName.replaceFirstChar { it.uppercase() }
-        val descriptorName = "${parentSimpleName}_${propertyCapitalized}_LirpJunctionTableDef"
+        val descriptorName = "${parentSimpleName}_${propertyCapitalized}${LirpGenNames.JUNCTION_TABLE_DEF_SUFFIX}"
         val isMutableCollection = typeFqn == "kotlin.collections.MutableList" || typeFqn == "kotlin.collections.MutableSet"
 
         return JunctionRefInfo(

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpGenNames.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/LirpGenNames.kt
@@ -18,12 +18,13 @@
 package net.transgressoft.lirp.ksp
 
 /**
- * Centralizes the generated-name suffixes used by every KSP emitter and consumed by
- * [net.transgressoft.lirp.persistence.RegistryBase] via [net.transgressoft.lirp.persistence.KspAccessorLoader].
+ * Producer-side single source of truth for the generated-name suffixes used by every KSP emitter
+ * in this module.
  *
- * Both the producer side (KSP processors that write class files) and the consumer side
- * (runtime lookup via [Class.forName]) reference these constants so that a suffix change
- * is a single edit and the compiler enforces consistency.
+ * The runtime consumer ([net.transgressoft.lirp.persistence.KspAccessorLoader] in lirp-core)
+ * intentionally maintains a parallel copy of the suffixes it needs, because lirp-core must not
+ * carry a runtime dependency on the compile-only lirp-ksp module. Any suffix change here that
+ * affects a runtime-loaded accessor must therefore also be mirrored in `KspAccessorLoader`.
  */
 internal object LirpGenNames {
     const val INDEX_ACCESSOR_SUFFIX = "_LirpIndexAccessor"
@@ -33,6 +34,7 @@ internal object LirpGenNames {
     const val RAW_INITIALIZER_SUFFIX = "_LirpRawInitializer"
     const val REGISTRY_INFO_SUFFIX = "_LirpRegistryInfo"
     const val TABLE_DEF_SUFFIX = "_LirpTableDef"
+    const val JUNCTION_TABLE_DEF_SUFFIX = "_LirpJunctionTableDef"
     const val FX_SCALAR_ACCESSOR_SUFFIX = "_LirpFxScalarAccessor"
     const val TO_ONE_EXT_ACCESSOR_SUFFIX = "_LirpToOneExtAccessor"
 }

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ReactivePropertyAccessorProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/ReactivePropertyAccessorProcessor.kt
@@ -39,9 +39,9 @@ import com.google.devtools.ksp.validate
  * bypassing event emission, lastDateModified bumping, and clone comparison.
  *
  * Detection mirrors [FxScalarAccessorProcessor] but consumes the composite predicate
- * [isReactivePropertyDelegate] from [KspUtils] — KSP exposes no direct delegate-type accessor on
- * [KSPropertyDeclaration], so detection relies on `isDelegated`, `isMutable`, and exclusion of
- * FxScalar / kotlin-collections value types.
+ * `isReactivePropertyDelegate` from [KspEntityPredicates] — KSP exposes no direct delegate-type
+ * accessor on [KSPropertyDeclaration], so detection relies on `isDelegated`, `isMutable`, and
+ * exclusion of FxScalar / kotlin-collections value types.
  */
 class ReactivePropertyAccessorProcessor(private val codeGenerator: CodeGenerator, private val logger: KSPLogger) : SymbolProcessor {
 
@@ -79,7 +79,7 @@ class ReactivePropertyAccessorProcessor(private val codeGenerator: CodeGenerator
         val packageName = classDecl.packageName.asString()
         val jvmName = classDecl.jvmBinaryName()
         val kotlinName = classDecl.kotlinNestedName()
-        val accessorName = "${jvmName}_LirpReactivePropertyAccessor"
+        val accessorName = "$jvmName${LirpGenNames.REACTIVE_PROPERTY_ACCESSOR_SUFFIX}"
         // Backtick-escape the class name in Kotlin source when it contains '$' (nested class separator)
         val accessorSourceName = if ('$' in accessorName) "`$accessorName`" else accessorName
 

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ColumnTypeInferenceTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ColumnTypeInferenceTest.kt
@@ -17,11 +17,9 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
+import io.kotest.datatest.withData
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
 /**
@@ -37,190 +35,91 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 @OptIn(ExperimentalCompilerApi::class)
 class ColumnTypeInferenceTest : StringSpec({
 
-    "TableDefProcessor maps Short property to IntType with narrowing on read and widening on write" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "ShortPropEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-
-                    @PersistenceMapping
-                    data class ShortPropEntity(
-                        override val id: Int,
-                        val priority: Short
-                    ) : ReactiveEntityBase<Int, ShortPropEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = ShortPropEntity(id, priority)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("ShortPropEntity_LirpTableDef.kt")
-        content shouldContain "ColumnType.IntType"
-        // Narrowing on read: (row[...] as Int).toShort()
-        content shouldContain ".toShort()"
-        // Widening on write: entity.priority.toInt()
-        content shouldContain ".toInt()"
+    data class InferenceCase(
+        val name: String,
+        val entityName: String,
+        val annotation: String,
+        val fieldName: String,
+        val fieldType: String,
+        val expected: List<String>
+    ) {
+        override fun toString() = name
     }
 
-    "TableDefProcessor maps Byte property to IntType with narrowing on read and widening on write" {
+    withData(
+        InferenceCase(
+            name = "TableDefProcessor maps Short property to IntType with narrowing on read and widening on write",
+            entityName = "ShortPropEntity",
+            annotation = "",
+            fieldName = "priority",
+            fieldType = "Short",
+            // Narrowing on read: (row[...] as Int).toShort(); widening on write: entity.priority.toInt()
+            expected = listOf("ColumnType.IntType", ".toShort()", ".toInt()")
+        ),
+        InferenceCase(
+            name = "TableDefProcessor maps Byte property to IntType with narrowing on read and widening on write",
+            entityName = "BytePropEntity",
+            annotation = "",
+            fieldName = "flags",
+            fieldType = "Byte",
+            expected = listOf("ColumnType.IntType", ".toByte()", ".toInt()")
+        ),
+        InferenceCase(
+            name = "TableDefProcessor maps nullable Short property with narrowing and safe-cast",
+            entityName = "NullableShortEntity",
+            annotation = "",
+            fieldName = "rank",
+            fieldType = "Short?",
+            // Nullable narrowing: (rawAccess as? Number)?.toShort(); nullable widening: entity.rank?.toInt()
+            expected = listOf("ColumnType.IntType", "as? Number", ".toShort()", "?.toInt()")
+        ),
+        InferenceCase(
+            name = "TableDefProcessor maps Float property to FloatType",
+            entityName = "FloatPropEntity",
+            annotation = "",
+            fieldName = "ratio",
+            fieldType = "Float",
+            expected = listOf("ColumnType.FloatType")
+        ),
+        InferenceCase(
+            name = "TableDefProcessor maps Double property to DoubleType",
+            entityName = "DoublePropEntity",
+            annotation = "",
+            fieldName = "score",
+            fieldType = "Double",
+            expected = listOf("ColumnType.DoubleType")
+        ),
+        InferenceCase(
+            name = "TableDefProcessor maps BigDecimal property to DecimalType with default precision and scale",
+            entityName = "BigDecimalDefaultEntity",
+            annotation = "",
+            fieldName = "amount",
+            fieldType = "BigDecimal",
+            // Default: precision=19, scale=2
+            expected = listOf("ColumnType.DecimalType(19, 2)")
+        ),
+        InferenceCase(
+            name = "TableDefProcessor maps BigDecimal property with explicit length hint to DecimalType",
+            entityName = "BigDecimalPrecisionEntity",
+            annotation = "@PersistenceProperty(precision = 12, scale = 4) ",
+            fieldName = "price",
+            fieldType = "BigDecimal",
+            expected = listOf("ColumnType.DecimalType(12, 4)")
+        ),
+        InferenceCase(
+            name = "TableDefProcessor maps String property with length annotation to VarcharType",
+            entityName = "VarcharStringEntity",
+            annotation = "@PersistenceProperty(length = 255) ",
+            fieldName = "name",
+            fieldType = "String",
+            expected = listOf("ColumnType.VarcharType(255)")
+        )
+    ) { case ->
         val result =
             KspTestSupport.compile(
                 TableDefProcessorProvider(),
                 SourceFile.kotlin(
-                    "BytePropEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-
-                    @PersistenceMapping
-                    data class BytePropEntity(
-                        override val id: Int,
-                        val flags: Byte
-                    ) : ReactiveEntityBase<Int, BytePropEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = BytePropEntity(id, flags)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("BytePropEntity_LirpTableDef.kt")
-        content shouldContain "ColumnType.IntType"
-        content shouldContain ".toByte()"
-        content shouldContain ".toInt()"
-    }
-
-    "TableDefProcessor maps nullable Short property with narrowing and safe-cast" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "NullableShortEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-
-                    @PersistenceMapping
-                    data class NullableShortEntity(
-                        override val id: Int,
-                        val rank: Short?
-                    ) : ReactiveEntityBase<Int, NullableShortEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = NullableShortEntity(id, rank)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("NullableShortEntity_LirpTableDef.kt")
-        content shouldContain "ColumnType.IntType"
-        // Nullable narrowing: (rawAccess as? Number)?.toShort()
-        content shouldContain "as? Number"
-        content shouldContain ".toShort()"
-        // Nullable widening: entity.rank?.toInt()
-        content shouldContain "?.toInt()"
-    }
-
-    "TableDefProcessor maps Float property to FloatType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "FloatPropEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-
-                    @PersistenceMapping
-                    data class FloatPropEntity(
-                        override val id: Int,
-                        val ratio: Float
-                    ) : ReactiveEntityBase<Int, FloatPropEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = FloatPropEntity(id, ratio)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("FloatPropEntity_LirpTableDef.kt") shouldContain "ColumnType.FloatType"
-    }
-
-    "TableDefProcessor maps Double property to DoubleType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "DoublePropEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-
-                    @PersistenceMapping
-                    data class DoublePropEntity(
-                        override val id: Int,
-                        val score: Double
-                    ) : ReactiveEntityBase<Int, DoublePropEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = DoublePropEntity(id, score)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("DoublePropEntity_LirpTableDef.kt") shouldContain "ColumnType.DoubleType"
-    }
-
-    "TableDefProcessor maps BigDecimal property to DecimalType with default precision and scale" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "BigDecimalDefaultEntity.kt",
-                    """
-                    package test
-                    import java.math.BigDecimal
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-
-                    @PersistenceMapping
-                    data class BigDecimalDefaultEntity(
-                        override val id: Int,
-                        val amount: BigDecimal
-                    ) : ReactiveEntityBase<Int, BigDecimalDefaultEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = BigDecimalDefaultEntity(id, amount)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        // Default: precision=19, scale=2
-        result.generatedFileContent("BigDecimalDefaultEntity_LirpTableDef.kt") shouldContain "ColumnType.DecimalType(19, 2)"
-    }
-
-    "TableDefProcessor maps BigDecimal property with explicit length hint to DecimalType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "BigDecimalPrecisionEntity.kt",
+                    "${case.entityName}.kt",
                     """
                     package test
                     import java.math.BigDecimal
@@ -229,19 +128,19 @@ class ColumnTypeInferenceTest : StringSpec({
                     import net.transgressoft.lirp.persistence.PersistenceProperty
 
                     @PersistenceMapping
-                    data class BigDecimalPrecisionEntity(
+                    data class ${case.entityName}(
                         override val id: Int,
-                        @PersistenceProperty(precision = 12, scale = 4) val price: BigDecimal
-                    ) : ReactiveEntityBase<Int, BigDecimalPrecisionEntity>() {
+                        ${case.annotation}val ${case.fieldName}: ${case.fieldType}
+                    ) : ReactiveEntityBase<Int, ${case.entityName}>() {
                         override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = BigDecimalPrecisionEntity(id, price)
+                        override fun clone() = ${case.entityName}(id, ${case.fieldName})
                     }
                     """
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("BigDecimalPrecisionEntity_LirpTableDef.kt") shouldContain "ColumnType.DecimalType(12, 4)"
+        result.shouldSucceed()
+        result.generatedFileContent("${case.entityName}_LirpTableDef.kt").shouldContainEach(*case.expected.toTypedArray())
     }
 
     "TableDefProcessor rejects unsupported column type with error diagnostic" {
@@ -268,37 +167,7 @@ class ColumnTypeInferenceTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "Unsupported column type"
-        result.messages shouldContain "tags"
-    }
-
-    "TableDefProcessor maps String property with length annotation to VarcharType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "VarcharStringEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.PersistenceProperty
-
-                    @PersistenceMapping
-                    data class VarcharStringEntity(
-                        override val id: Int,
-                        @PersistenceProperty(length = 255) val name: String
-                    ) : ReactiveEntityBase<Int, VarcharStringEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = VarcharStringEntity(id, name)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("VarcharStringEntity_LirpTableDef.kt") shouldContain "ColumnType.VarcharType(255)"
+        result.shouldFailWith("Unsupported column type", "tags")
     }
 
     "TableDefProcessor emits Short/Byte widening for converter with Short S type" {
@@ -335,14 +204,16 @@ class ColumnTypeInferenceTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("ShortConverterWideningEntity_LirpTableDef.kt")
-        // Converter read-side: (row[...] as Int).toShort() routed into fromSql
-        content shouldContain "test.LevelConverter.fromSql("
-        content shouldContain ".toShort()"
-        // Converter write-side: toSql(entity.level).toInt()
-        content shouldContain "test.LevelConverter.toSql("
-        content shouldContain ".toInt()"
+        content.shouldContainEach(
+            // Converter read-side: (row[...] as Int).toShort() routed into fromSql
+            "test.LevelConverter.fromSql(",
+            ".toShort()",
+            // Converter write-side: toSql(entity.level).toInt()
+            "test.LevelConverter.toSql(",
+            ".toInt()"
+        )
     }
 
     "TableDefProcessor emits Byte widening for converter with Byte S type on nullable column" {
@@ -379,12 +250,14 @@ class ColumnTypeInferenceTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("ByteConverterNullableEntity_LirpTableDef.kt")
-        // Nullable converter read-side: (raw as? Int)?.toByte() routed into fromSql via ?.let
-        content shouldContain ".toByte()"
-        content shouldContain "?.let { test.FlagConverter.fromSql(it) }"
-        // Nullable write-side: entity.flag?.let { ... }?.toInt()
-        content shouldContain "?.toInt()"
+        content.shouldContainEach(
+            // Nullable converter read-side: (raw as? Int)?.toByte() routed into fromSql via ?.let
+            ".toByte()",
+            "?.let { test.FlagConverter.fromSql(it) }",
+            // Nullable write-side: entity.flag?.let { ... }?.toInt()
+            "?.toInt()"
+        )
     }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ConverterCodegenTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ConverterCodegenTest.kt
@@ -17,12 +17,9 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.string.shouldNotContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
 /**
@@ -57,10 +54,12 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val generated = result.generatedFileContent("SentinelEntity_LirpTableDef.kt")
-        generated shouldNotContain ".fromSql("
-        generated shouldNotContain ".toSql("
+        generated.shouldContainEachAndNone(
+            present = listOf(),
+            absent = listOf(".fromSql(", ".toSql(")
+        )
     }
 
     "TableDefProcessor rejects non-object converter with a diagnostic naming the converter" {
@@ -95,10 +94,7 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "test.NotAnObjectConverter"
-        result.messages shouldContain "must be a Kotlin"
-        result.messages shouldContain "object"
+        result.shouldFailWith("test.NotAnObjectConverter", "must be a Kotlin", "object")
     }
 
     "TableDefProcessor rejects converter with unsupported S type via a diagnostic" {
@@ -134,10 +130,7 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "test.BadSConverter"
-        result.messages shouldContain "java.util.Date"
-        result.messages shouldContain "not supported"
+        result.shouldFailWith("test.BadSConverter", "java.util.Date", "not supported")
     }
 
     "TableDefProcessor emits converter-routed fromRow and toParams for non-null scalar" {
@@ -172,12 +165,14 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val generated = result.generatedFileContent("TagEntity_LirpTableDef.kt")
-        generated shouldContain "test.UpperCaseConverter.sqlType"
-        generated shouldContain "test.UpperCaseConverter.fromSql("
-        generated shouldContain "as kotlin.String"
-        generated shouldContain "test.UpperCaseConverter.toSql(entity.tag)"
+        generated.shouldContainEach(
+            "test.UpperCaseConverter.sqlType",
+            "test.UpperCaseConverter.fromSql(",
+            "as kotlin.String",
+            "test.UpperCaseConverter.toSql(entity.tag)"
+        )
     }
 
     "TableDefProcessor emits nullable converter-routed fromRow and toParams" {
@@ -212,11 +207,13 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val generated = result.generatedFileContent("NullableTagEntity_LirpTableDef.kt")
-        generated shouldContain "as? kotlin.String"
-        generated shouldContain "?.let { test.NullableConverter.fromSql(it) }"
-        generated shouldContain "entity.nickname?.let { test.NullableConverter.toSql(it) }"
+        generated.shouldContainEach(
+            "as? kotlin.String",
+            "?.let { test.NullableConverter.fromSql(it) }",
+            "entity.nickname?.let { test.NullableConverter.toSql(it) }"
+        )
     }
 
     "TableDefProcessor refines TextType converter sqlType to VarcharType when length hint is set" {
@@ -251,13 +248,15 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val generated = result.generatedFileContent("VarcharTagEntity_LirpTableDef.kt")
-        generated shouldContain "ColumnType.VarcharType(64)"
         // The base converter sqlType reference must NOT appear for this column — the refinement
         // supersedes it. Search for "PathLikeConverter.sqlType" specifically because the
         // converter is still referenced in fromSql / toSql calls.
-        generated shouldNotContain "PathLikeConverter.sqlType"
+        generated.shouldContainEachAndNone(
+            present = listOf("ColumnType.VarcharType(64)"),
+            absent = listOf("PathLikeConverter.sqlType")
+        )
     }
 
     "TableDefProcessor refines numeric converter sqlType to DecimalType when precision and scale hints are set" {
@@ -294,7 +293,7 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val generated = result.generatedFileContent("MoneyEntity_LirpTableDef.kt")
         generated shouldContain "ColumnType.DecimalType(19, 4)"
     }
@@ -331,10 +330,7 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "incompatible with converter"
-        result.messages shouldContain "test.BadHintEntity.flag"
-        result.messages shouldContain "test.FlagConverter"
+        result.shouldFailWith("incompatible with converter", "test.BadHintEntity.flag", "test.FlagConverter")
     }
 
     "TableDefProcessor accepts converter with supported S type kotlin.Short" {
@@ -371,7 +367,7 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
     }
 
     "TableDefProcessor accepts entity when no converter annotation is declared" {
@@ -404,7 +400,7 @@ class ConverterCodegenTest : StringSpec({
             )
 
         // No converter annotation => no converter validation path is triggered.
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
     }
 
     "TableDefProcessor accepts converter with supported S type kotlin.Byte" {
@@ -441,7 +437,7 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
     }
 
     "TableDefProcessor accepts converter with supported S type kotlin.Boolean" {
@@ -478,13 +474,15 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val generated = result.generatedFileContent("BoolConverterEntity_LirpTableDef.kt")
         // The converter's sqlType reference (not the literal ColumnType.BooleanType) is used when
         // no length/precision/scale hint is present — the base expression delegates to the converter.
-        generated shouldContain "test.TriStateConverter.sqlType"
-        generated shouldContain "test.TriStateConverter.fromSql("
-        generated shouldContain "test.TriStateConverter.toSql("
+        generated.shouldContainEach(
+            "test.TriStateConverter.sqlType",
+            "test.TriStateConverter.fromSql(",
+            "test.TriStateConverter.toSql("
+        )
     }
 
     "TableDefProcessor accepts converter with supported S type kotlin.Double" {
@@ -521,7 +519,7 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
     }
 
     "TableDefProcessor accepts converter with supported S type kotlin.Float" {
@@ -558,7 +556,7 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
     }
 
     "TableDefProcessor accepts converter with supported S type java.math.BigDecimal" {
@@ -596,6 +594,6 @@ class ConverterCodegenTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
     }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ElementCollectionDiagnosticsTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ElementCollectionDiagnosticsTest.kt
@@ -17,11 +17,8 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
 /**
@@ -70,9 +67,10 @@ class ElementCollectionDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@ElementCollection requires `List<E>` or `Set<E>`"
-        result.messages shouldContain "test.MapTagEntity.tags"
+        result.shouldFailWith(
+            "@ElementCollection requires `List<E>` or `Set<E>`",
+            "test.MapTagEntity.tags"
+        )
     }
 
     // MutableList property type
@@ -108,9 +106,10 @@ class ElementCollectionDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@ElementCollection requires the immutable interface"
-        result.messages shouldContain "test.MutableListTagEntity.tags"
+        result.shouldFailWith(
+            "@ElementCollection requires the immutable interface",
+            "test.MutableListTagEntity.tags"
+        )
     }
 
     // MutableSet property type
@@ -146,9 +145,10 @@ class ElementCollectionDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@ElementCollection requires the immutable interface"
-        result.messages shouldContain "test.MutableSetTagEntity.tags"
+        result.shouldFailWith(
+            "@ElementCollection requires the immutable interface",
+            "test.MutableSetTagEntity.tags"
+        )
     }
 
     // nullable element type
@@ -184,9 +184,10 @@ class ElementCollectionDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@ElementCollection element type must be non-nullable"
-        result.messages shouldContain "test.NullableElementEntity.tags"
+        result.shouldFailWith(
+            "@ElementCollection element type must be non-nullable",
+            "test.NullableElementEntity.tags"
+        )
     }
 
     // nullable collection type
@@ -222,9 +223,10 @@ class ElementCollectionDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@ElementCollection property type must be non-nullable"
-        result.messages shouldContain "test.NullableCollectionEntity.tags"
+        result.shouldFailWith(
+            "@ElementCollection property type must be non-nullable",
+            "test.NullableCollectionEntity.tags"
+        )
     }
 
     // @ElementCollection declared inside an @Embeddable
@@ -268,9 +270,10 @@ class ElementCollectionDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "is not supported inside an @Embeddable"
-        result.messages shouldContain "test.Inner.tags"
+        result.shouldFailWith(
+            "is not supported inside an @Embeddable",
+            "test.Inner.tags"
+        )
     }
 
     // missing/sentinel elementConverter
@@ -299,9 +302,10 @@ class ElementCollectionDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "requires an explicit `elementConverter`"
-        result.messages shouldContain "test.MissingConverterEntity.tags"
+        result.shouldFailWith(
+            "requires an explicit `elementConverter`",
+            "test.MissingConverterEntity.tags"
+        )
     }
 
     // co-occurrence with @PersistenceProperty
@@ -340,9 +344,10 @@ class ElementCollectionDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@ElementCollection and @PersistenceProperty cannot be combined"
-        result.messages shouldContain "test.CompositionConflictEntity.tags"
+        result.shouldFailWith(
+            "@ElementCollection and @PersistenceProperty cannot be combined",
+            "test.CompositionConflictEntity.tags"
+        )
     }
 
     // Positive coverage — both ctor-param and body-declared reactive-property targets compile.
@@ -382,7 +387,7 @@ class ElementCollectionDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
     }
 
     // body-declared read-only `val` has no setter to populate from a row
@@ -418,9 +423,10 @@ class ElementCollectionDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@ElementCollection on a body-declared property requires a mutable `var`"
-        result.messages shouldContain "test.BodyValCollectionEntity.tags"
+        result.shouldFailWith(
+            "@ElementCollection on a body-declared property requires a mutable `var`",
+            "test.BodyValCollectionEntity.tags"
+        )
     }
 
     // element-S type outside the 8 Kotlin primitives
@@ -457,8 +463,9 @@ class ElementCollectionDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@ElementCollection element converter's S type must be one of {String, Int, Long, Short, Byte, Boolean, Double, Float}"
-        result.messages shouldContain "test.UuidConverterCollectionEntity.ids"
+        result.shouldFailWith(
+            "@ElementCollection element converter's S type must be one of {String, Int, Long, Short, Byte, Boolean, Double, Float}",
+            "test.UuidConverterCollectionEntity.ids"
+        )
     }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableDiagnosticsTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/EmbeddableDiagnosticsTest.kt
@@ -17,11 +17,8 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
 /**
@@ -65,7 +62,7 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
     }
 
     "rejects @Embedded on body-declared read-only val" {
@@ -95,9 +92,10 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "requires a mutable `var`"
-        result.messages shouldContain "test.BodyValEmbeddedEntity.addr"
+        result.shouldFailWith(
+            "requires a mutable `var`",
+            "test.BodyValEmbeddedEntity.addr"
+        )
     }
 
     "rejects @Embedded on body-declared var with custom getter" {
@@ -129,9 +127,10 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "must not have a custom getter"
-        result.messages shouldContain "test.BodyVarCustomGetterEmbeddedEntity.addr"
+        result.shouldFailWith(
+            "must not have a custom getter",
+            "test.BodyVarCustomGetterEmbeddedEntity.addr"
+        )
     }
 
     "rejects @Embedded referencing a non-@Embeddable type" {
@@ -160,10 +159,11 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "must reference an @Embeddable type"
-        result.messages shouldContain "test.NonEmbeddableTargetEntity.addr"
-        result.messages shouldContain "test.PlainDataClass"
+        result.shouldFailWith(
+            "must reference an @Embeddable type",
+            "test.NonEmbeddableTargetEntity.addr",
+            "test.PlainDataClass"
+        )
     }
 
     "rejects @Embedded referencing a non-class typealias" {
@@ -197,8 +197,7 @@ class EmbeddableDiagnosticsTest : StringSpec({
         // either ("must reference a class type") or ("must reference an
         // @Embeddable type") is acceptable — the structural error condition (typealias is not
         // a permissible @Embedded target) is what we lock in.
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "test.TypeAliasTargetEntity.addr"
+        result.shouldFailWith("test.TypeAliasTargetEntity.addr")
     }
 
     "rejects @Embeddable on non-data class" {
@@ -229,9 +228,10 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@Embeddable must be a concrete data class"
-        result.messages shouldContain "test.NotData"
+        result.shouldFailWith(
+            "@Embeddable must be a concrete data class",
+            "test.NotData"
+        )
     }
 
     "rejects @Embeddable on abstract class" {
@@ -262,9 +262,10 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@Embeddable must be a concrete data class"
-        result.messages shouldContain "test.AbsEmbeddable"
+        result.shouldFailWith(
+            "@Embeddable must be a concrete data class",
+            "test.AbsEmbeddable"
+        )
     }
 
     "rejects @Embeddable on sealed class" {
@@ -295,9 +296,10 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@Embeddable must be a concrete data class"
-        result.messages shouldContain "test.SealedEmbeddable"
+        result.shouldFailWith(
+            "@Embeddable must be a concrete data class",
+            "test.SealedEmbeddable"
+        )
     }
 
     "rejects @Embeddable on object declaration" {
@@ -330,9 +332,10 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@Embeddable must be a concrete data class"
-        result.messages shouldContain "test.ObjEmbeddable"
+        result.shouldFailWith(
+            "@Embeddable must be a concrete data class",
+            "test.ObjEmbeddable"
+        )
     }
 
     "rejects column collision across two @Embedded siblings with identical explicit prefix" {
@@ -364,11 +367,12 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "Column name collision"
-        result.messages shouldContain "X_name"
-        result.messages shouldContain "test.SiblingCollisionEntity.left.name"
-        result.messages shouldContain "test.SiblingCollisionEntity.right.name"
+        result.shouldFailWith(
+            "Column name collision",
+            "X_name",
+            "test.SiblingCollisionEntity.left.name",
+            "test.SiblingCollisionEntity.right.name"
+        )
     }
 
     "rejects @Embeddable data class with zero-parameter primary constructor" {
@@ -399,9 +403,10 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "@Embeddable must be a concrete data class"
-        result.messages shouldContain "test.ZeroParamEmbeddable"
+        result.shouldFailWith(
+            "@Embeddable must be a concrete data class",
+            "test.ZeroParamEmbeddable"
+        )
     }
 
     "rejects nullable @Embedded property with clear diagnostic" {
@@ -432,9 +437,10 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "`@Embedded` nullable properties are not supported yet"
-        result.messages shouldContain "test.NullableEmbeddedEntity.address"
+        result.shouldFailWith(
+            "`@Embedded` nullable properties are not supported yet",
+            "test.NullableEmbeddedEntity.address"
+        )
     }
 
     "rejects @Embeddable with unsupported scalar leaf type causing whole entity to fail" {
@@ -469,8 +475,7 @@ class EmbeddableDiagnosticsTest : StringSpec({
 
         // The unsupported leaf type causes buildEmbeddedSlot to return null, which causes the
         // whole entity to be treated as unmapped rather than emitting partial codegen.
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "Unsupported column type"
+        result.shouldFailWith("Unsupported column type")
     }
 
     "rejects column collision between @Embedded grandchild and a sibling scalar with matching name" {
@@ -508,12 +513,13 @@ class EmbeddableDiagnosticsTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "Column name collision"
-        result.messages shouldContain "inner_deep_value"
         // Both the entity-rooted path through the grandchild AND the sibling scalar path are
         // named, proving the full transitive walk surfaces every contributor.
-        result.messages shouldContain "test.GrandchildCollisionEntity.inner.grandchild.value"
-        result.messages shouldContain "test.GrandchildCollisionEntity.sibling"
+        result.shouldFailWith(
+            "Column name collision",
+            "inner_deep_value",
+            "test.GrandchildCollisionEntity.inner.grandchild.value",
+            "test.GrandchildCollisionEntity.sibling"
+        )
     }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/FxScalarAccessorProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/FxScalarAccessorProcessorTest.kt
@@ -17,7 +17,6 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -121,14 +120,15 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("ProductEntity_LirpFxScalarAccessor.kt")
-        content shouldContain "class ProductEntity_LirpFxScalarAccessor : LirpFxScalarAccessor<ProductEntity>"
-        content shouldContain "override val entries: List<FxScalarEntry<ProductEntity>>"
-        content shouldContain "name = \"title\""
-        content shouldContain "getter = { it.title.get() }"
-        content shouldContain "setter = { entity, value -> entity.title.set(value as String?) }"
-        content shouldContain "serializer<String?>()"
+        val content = result.shouldSucceed().generatedFileContent("ProductEntity_LirpFxScalarAccessor.kt")
+        content.shouldContainEach(
+            "class ProductEntity_LirpFxScalarAccessor : LirpFxScalarAccessor<ProductEntity>",
+            "override val entries: List<FxScalarEntry<ProductEntity>>",
+            "name = \"title\"",
+            "getter = { it.title.get() }",
+            "setter = { entity, value -> entity.title.set(value as String?) }",
+            "serializer<String?>()"
+        )
     }
 
     "generates entries with correct serializer types for all six scalar property types" {
@@ -162,20 +162,21 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("AllScalarsEntity_LirpFxScalarAccessor.kt")
-        content shouldContain "serializer<String?>()"
-        content shouldContain "serializer<Int>()"
-        content shouldContain "serializer<Double>()"
-        content shouldContain "serializer<Float>()"
-        content shouldContain "serializer<Long>()"
-        content shouldContain "serializer<Boolean>()"
-        content shouldContain "name = \"name\""
-        content shouldContain "name = \"count\""
-        content shouldContain "name = \"ratio\""
-        content shouldContain "name = \"weight\""
-        content shouldContain "name = \"size\""
-        content shouldContain "name = \"active\""
+        val content = result.shouldSucceed().generatedFileContent("AllScalarsEntity_LirpFxScalarAccessor.kt")
+        content.shouldContainEach(
+            "serializer<String?>()",
+            "serializer<Int>()",
+            "serializer<Double>()",
+            "serializer<Float>()",
+            "serializer<Long>()",
+            "serializer<Boolean>()",
+            "name = \"name\"",
+            "name = \"count\"",
+            "name = \"ratio\"",
+            "name = \"weight\"",
+            "name = \"size\"",
+            "name = \"active\""
+        )
     }
 
     "generates entry with typed serializer for entity with ObjectProperty type argument" {
@@ -203,12 +204,13 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("TaggedEntity_LirpFxScalarAccessor.kt")
-        content shouldContain "name = \"tag\""
-        content shouldContain "serializer<test.Tag?>()"
-        content shouldContain "getter = { it.tag.get() }"
-        content shouldContain "setter = { entity, value -> entity.tag.set(value as test.Tag?) }"
+        val content = result.shouldSucceed().generatedFileContent("TaggedEntity_LirpFxScalarAccessor.kt")
+        content.shouldContainEach(
+            "name = \"tag\"",
+            "serializer<test.Tag?>()",
+            "getter = { it.tag.get() }",
+            "setter = { entity, value -> entity.tag.set(value as test.Tag?) }"
+        )
     }
 
     "does not generate accessor file for entity with no FxScalar delegate properties" {
@@ -229,7 +231,7 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val generatedFiles = result.generatedNames()
         generatedFiles.contains("PlainEntity_LirpFxScalarAccessor.kt") shouldBe false
     }
@@ -255,8 +257,7 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("InternalFxEntity_LirpFxScalarAccessor.kt")
+        val content = result.shouldSucceed().generatedFileContent("InternalFxEntity_LirpFxScalarAccessor.kt")
         content shouldContain "internal class InternalFxEntity_LirpFxScalarAccessor"
     }
 
@@ -283,8 +284,7 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("InternalOuterFx\$InnerFx_LirpFxScalarAccessor.kt")
+        val content = result.shouldSucceed().generatedFileContent("InternalOuterFx\$InnerFx_LirpFxScalarAccessor.kt")
         content shouldContain "internal class"
     }
 
@@ -311,7 +311,7 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         // Structural processors silently skip private/protected entities
         val generatedNames = result.generatedNames()
         generatedNames.contains("PrivateOuterFx\$HiddenFx_LirpFxScalarAccessor.kt") shouldBe false
@@ -340,11 +340,13 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val generatedFiles = result.generatedNames()
         generatedFiles.contains("OuterContainer\$InnerEntity_LirpFxScalarAccessor.kt") shouldBe true
         val content = result.generatedFileContent("OuterContainer\$InnerEntity_LirpFxScalarAccessor.kt")
-        content shouldContain "class `OuterContainer\$InnerEntity_LirpFxScalarAccessor` : LirpFxScalarAccessor<OuterContainer.InnerEntity>"
-        content shouldContain "name = \"label\""
+        content.shouldContainEach(
+            "class `OuterContainer\$InnerEntity_LirpFxScalarAccessor` : LirpFxScalarAccessor<OuterContainer.InnerEntity>",
+            "name = \"label\""
+        )
     }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/IndexedProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/IndexedProcessorTest.kt
@@ -17,14 +17,8 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.JvmCompilationResult
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
-import com.tschuchort.compiletesting.configureKsp
-import com.tschuchort.compiletesting.sourcesGeneratedBySymbolProcessor
-import com.tschuchort.compiletesting.symbolProcessorProviders
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
@@ -40,24 +34,10 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 @OptIn(ExperimentalCompilerApi::class)
 internal class IndexedProcessorTest : StringSpec({
 
-    fun compileWithIndexedProcessor(vararg sources: SourceFile): JvmCompilationResult {
-        val compilation =
-            KotlinCompilation().apply {
-                this.sources = sources.toList()
-                inheritClassPath = true
-            }
-        compilation.configureKsp { withCompilation = true }
-        compilation.symbolProcessorProviders += IndexedProcessorProvider()
-        compilation.symbolProcessorProviders += RawInitializerProcessorProvider()
-        return compilation.compile()
-    }
+    val processors = listOf(IndexedProcessorProvider(), RawInitializerProcessorProvider())
 
-    fun JvmCompilationResult.generatedFileContent(name: String): String {
-        val file =
-            sourcesGeneratedBySymbolProcessor.firstOrNull { it.name == name }
-                ?: error("Generated file '$name' not found among: ${sourcesGeneratedBySymbolProcessor.map { it.name }.toList()}")
-        return file.readText()
-    }
+    fun compileWithIndexedProcessor(vararg sources: SourceFile) =
+        KspTestSupport.compile(providers = processors, sources = sources.toList())
 
     "IndexedProcessor generates accessor with default sorted=false for plain @Indexed property" {
         val result =
@@ -78,7 +58,7 @@ internal class IndexedProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("LabelEntity_LirpIndexAccessor.kt")
         content shouldContain """IndexEntry("label") { it.label }"""
     }
@@ -102,7 +82,7 @@ internal class IndexedProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("AgeEntity_LirpIndexAccessor.kt")
         content shouldContain """IndexEntry("age", "age", sorted = true) { it.age }"""
     }
@@ -126,7 +106,7 @@ internal class IndexedProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("RankEntity_LirpIndexAccessor.kt")
         content shouldContain """IndexEntry("score", "rank", sorted = true) { it.rank }"""
     }
@@ -150,7 +130,7 @@ internal class IndexedProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
     }
 
     "IndexedProcessor fails compilation when @Indexed(sorted = true) property is not Comparable" {
@@ -172,9 +152,7 @@ internal class IndexedProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "payload"
-        result.messages shouldContain "Comparable"
+        result.shouldFailWith("payload", "Comparable")
     }
 
     "IndexedProcessor emits internal class declaration for top-level internal entity" {
@@ -196,7 +174,7 @@ internal class IndexedProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("InternalLabelEntity_LirpIndexAccessor.kt")
         content shouldContain "internal class InternalLabelEntity_LirpIndexAccessor"
     }
@@ -222,11 +200,13 @@ internal class IndexedProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("InternalMultiIndexed_LirpIndexAccessor.kt")
-        content shouldContain "internal class InternalMultiIndexed_LirpIndexAccessor"
-        content shouldContain "code"
-        content shouldContain "rank"
+        content.shouldContainEach(
+            "internal class InternalMultiIndexed_LirpIndexAccessor",
+            "code",
+            "rank"
+        )
     }
 
     "IndexedProcessor fails compilation for private-nested entity with @Indexed property" {
@@ -250,9 +230,10 @@ internal class IndexedProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "must be public or internal"
-        result.messages shouldContain "Private and protected entities cannot have accessible generated code"
+        result.shouldFailWith(
+            "must be public or internal",
+            "Private and protected entities cannot have accessible generated code"
+        )
     }
 
     "IndexedProcessor does not require Comparable for default @Indexed (sorted=false)" {
@@ -274,6 +255,6 @@ internal class IndexedProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
     }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/KspTestSupport.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/KspTestSupport.kt
@@ -25,12 +25,16 @@ import com.tschuchort.compiletesting.configureKsp
 import com.tschuchort.compiletesting.kspProcessorOptions
 import com.tschuchort.compiletesting.sourcesGeneratedBySymbolProcessor
 import com.tschuchort.compiletesting.symbolProcessorProviders
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
 /**
  * Shared KSP in-process compilation helper for lirp-ksp tests.
  *
- * Each test file passes its own [SymbolProcessorProvider] so processor isolation is preserved.
+ * Each test passes the [SymbolProcessorProvider]s it needs, so processor isolation is preserved.
  * [generatedFileContent] and [generatedNames] provide uniform access to KSP output.
  */
 @OptIn(ExperimentalCompilerApi::class)
@@ -40,25 +44,86 @@ internal object KspTestSupport {
      * Compiles [sources] with [provider] registered as the sole KSP processor.
      *
      * @param options KSP processor options forwarded via [KotlinCompilation.kspProcessorOptions].
+     * @param jvmTarget Optional JVM target override (e.g. `"21"` for tests that inline reified helpers).
      * @param withCompilation Whether to also run full Kotlin compilation after KSP (default `true`).
      */
     fun compile(
         provider: SymbolProcessorProvider,
         vararg sources: SourceFile,
         options: Map<String, String> = emptyMap(),
+        jvmTarget: String? = null,
+        withCompilation: Boolean = true
+    ): JvmCompilationResult =
+        compile(listOf(provider), sources.toList(), options, jvmTarget, withCompilation)
+
+    /**
+     * Compiles [sources] with every provider in [providers] registered, preserving per-processor
+     * isolation while supporting the few tests that legitimately need more than one processor.
+     *
+     * @param options KSP processor options forwarded via [KotlinCompilation.kspProcessorOptions].
+     * @param jvmTarget Optional JVM target override (e.g. `"21"` for tests that inline reified helpers).
+     * @param withCompilation Whether to also run full Kotlin compilation after KSP (default `true`).
+     */
+    fun compile(
+        providers: List<SymbolProcessorProvider>,
+        sources: List<SourceFile>,
+        options: Map<String, String> = emptyMap(),
+        jvmTarget: String? = null,
         withCompilation: Boolean = true
     ): JvmCompilationResult {
         val compilation =
             KotlinCompilation().apply {
-                this.sources = sources.toList()
+                this.sources = sources
                 inheritClassPath = true
+                jvmTarget?.let { this.jvmTarget = it }
             }
         compilation.configureKsp { this.withCompilation = withCompilation }
         if (options.isNotEmpty()) {
             compilation.kspProcessorOptions.putAll(options)
         }
-        compilation.symbolProcessorProviders += provider
+        providers.forEach { compilation.symbolProcessorProviders += it }
         return compilation.compile()
+    }
+}
+
+/**
+ * Asserts the compilation succeeded, returning the result so callers can chain generated-file
+ * assertions. Reads as the intent ("this must compile") instead of a bare exit-code equality.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+internal fun JvmCompilationResult.shouldSucceed(): JvmCompilationResult {
+    exitCode shouldBe KotlinCompilation.ExitCode.OK
+    return this
+}
+
+/**
+ * Asserts the compilation failed and every substring in [expectedMessages] appears in the compiler
+ * output. Soft-asserts the substrings so a missing one is reported alongside the others rather than
+ * short-circuiting at the first — replacing the `exitCode shouldBe ERROR` + N× `messages shouldContain`
+ * roulette that recurs across the diagnostic tests.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+internal fun JvmCompilationResult.shouldFailWith(vararg expectedMessages: String) {
+    exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+    assertSoftly { expectedMessages.forEach { messages shouldContain it } }
+}
+
+/**
+ * Asserts this generated-source text contains every substring in [substrings], soft-asserting so a
+ * failure names all missing fragments at once instead of stopping at the first.
+ */
+internal fun String.shouldContainEach(vararg substrings: String) {
+    assertSoftly { substrings.forEach { this@shouldContainEach shouldContain it } }
+}
+
+/**
+ * Asserts this generated-source text contains every substring in [present] and none of those in
+ * [absent], reporting all violations together.
+ */
+internal fun String.shouldContainEachAndNone(present: List<String>, absent: List<String>) {
+    assertSoftly {
+        present.forEach { this@shouldContainEachAndNone shouldContain it }
+        absent.forEach { this@shouldContainEachAndNone shouldNotContain it }
     }
 }
 

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/LirpAccessorValidationProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/LirpAccessorValidationProcessorTest.kt
@@ -17,13 +17,8 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
-import com.tschuchort.compiletesting.configureKsp
-import com.tschuchort.compiletesting.symbolProcessorProviders
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.DisplayName
@@ -62,71 +57,64 @@ internal class LirpAccessorValidationProcessorTest : StringSpec({
         )
 
     "emits build error when entity has @Indexed delegates but no generated LirpIndexAccessor" {
-        val compilation =
-            KotlinCompilation().apply {
-                sources =
-                    listOf(
-                        SourceFile.kotlin(
-                            "OrderEntity.kt",
-                            """
-                            package test
-                            import net.transgressoft.lirp.entity.ReactiveEntityBase
-                            import net.transgressoft.lirp.persistence.Indexed
+        val result =
+            KspTestSupport.compile(
+                LirpAccessorValidationProcessorProvider(),
+                SourceFile.kotlin(
+                    "OrderEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Indexed
 
-                            data class OrderEntity(override val id: Int) : ReactiveEntityBase<Int, OrderEntity>() {
-                                override val uniqueId: String get() = "${'$'}id"
-                                override fun clone() = copy()
-                                @Indexed val status: String = "NEW"
-                            }
-                            """
-                        )
-                    )
-                inheritClassPath = true
-            }
-        compilation.configureKsp { withCompilation = true }
-        // Only the validation processor, not the IndexedProcessor — simulating missing generator
-        compilation.symbolProcessorProviders += LirpAccessorValidationProcessorProvider()
-        val result = compilation.compile()
+                    data class OrderEntity(override val id: Int) : ReactiveEntityBase<Int, OrderEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                        @Indexed val status: String = "NEW"
+                    }
+                    """
+                )
+            )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "has @Indexed delegates but no generated LirpIndexAccessor"
+        result.shouldFailWith("has @Indexed delegates but no generated LirpIndexAccessor")
     }
 
     "emits build error when entity has FxScalar delegates but no generated LirpFxScalarAccessor" {
-        val compilation =
-            KotlinCompilation().apply {
-                sources =
-                    listOf(
-                        fxPropertyStubs,
-                        SourceFile.kotlin(
-                            "TrackEntity.kt",
-                            """
-                            package test
-                            import net.transgressoft.lirp.entity.ReactiveEntityBase
-                            import net.transgressoft.lirp.persistence.StubStringProperty
+        val result =
+            KspTestSupport.compile(
+                LirpAccessorValidationProcessorProvider(),
+                fxPropertyStubs,
+                SourceFile.kotlin(
+                    "TrackEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.StubStringProperty
 
-                            data class TrackEntity(override val id: Int) : ReactiveEntityBase<Int, TrackEntity>() {
-                                override val uniqueId: String get() = "${'$'}id"
-                                override fun clone() = copy()
-                                val name by StubStringProperty()
-                            }
-                            """
-                        )
-                    )
-                inheritClassPath = true
-            }
-        compilation.configureKsp { withCompilation = true }
-        // Only the validation processor, not the FxScalarAccessorProcessor
-        compilation.symbolProcessorProviders += LirpAccessorValidationProcessorProvider()
-        val result = compilation.compile()
+                    data class TrackEntity(override val id: Int) : ReactiveEntityBase<Int, TrackEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                        val name by StubStringProperty()
+                    }
+                    """
+                )
+            )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "has FxScalar delegates but no generated LirpFxScalarAccessor"
+        result.shouldFailWith("has FxScalar delegates but no generated LirpFxScalarAccessor")
     }
 
     "compiles successfully when entity with @Indexed delegates has IndexedProcessor registered" {
-        val compilation =
-            KotlinCompilation().apply {
+        // Both the generator and the validator are registered — no false positive expected.
+        // RawInitializerProcessor is registered to satisfy the raw-init validation now applied
+        // to every persisted entity.
+        val result =
+            KspTestSupport.compile(
+                providers =
+                    listOf(
+                        IndexedProcessorProvider(),
+                        RawInitializerProcessorProvider(),
+                        LirpAccessorValidationProcessorProvider()
+                    ),
                 sources =
                     listOf(
                         SourceFile.kotlin(
@@ -144,24 +132,24 @@ internal class LirpAccessorValidationProcessorTest : StringSpec({
                             """
                         )
                     )
-                inheritClassPath = true
-            }
-        compilation.configureKsp { withCompilation = true }
-        // Both the generator and the validator are registered — no false positive expected.
-        // RawInitializerProcessor is registered to satisfy the raw-init validation now applied
-        // to every persisted entity.
-        compilation.symbolProcessorProviders += IndexedProcessorProvider()
-        compilation.symbolProcessorProviders += RawInitializerProcessorProvider()
-        compilation.symbolProcessorProviders += LirpAccessorValidationProcessorProvider()
-        val result = compilation.compile()
+            )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         result.messages shouldNotContain "has @Indexed delegates but no generated LirpIndexAccessor"
     }
 
     "compiles successfully when entity with FxScalar delegates has FxScalarAccessorProcessor registered" {
-        val compilation =
-            KotlinCompilation().apply {
+        // Both the generator and the validator are registered — no false positive expected.
+        // RawInitializerProcessor is registered to satisfy the raw-init validation now applied
+        // to every persisted entity.
+        val result =
+            KspTestSupport.compile(
+                providers =
+                    listOf(
+                        FxScalarAccessorProcessorProvider(),
+                        RawInitializerProcessorProvider(),
+                        LirpAccessorValidationProcessorProvider()
+                    ),
                 sources =
                     listOf(
                         fxPropertyStubs,
@@ -180,120 +168,97 @@ internal class LirpAccessorValidationProcessorTest : StringSpec({
                             """
                         )
                     )
-                inheritClassPath = true
-            }
-        compilation.configureKsp { withCompilation = true }
-        // Both the generator and the validator are registered — no false positive expected.
-        // RawInitializerProcessor is registered to satisfy the raw-init validation now applied
-        // to every persisted entity.
-        compilation.symbolProcessorProviders += FxScalarAccessorProcessorProvider()
-        compilation.symbolProcessorProviders += RawInitializerProcessorProvider()
-        compilation.symbolProcessorProviders += LirpAccessorValidationProcessorProvider()
-        val result = compilation.compile()
+            )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         result.messages shouldNotContain "has FxScalar delegates but no generated LirpFxScalarAccessor"
     }
 
     "does not emit validation error for non-entity class with FxScalar-typed properties" {
-        val compilation =
-            KotlinCompilation().apply {
-                sources =
-                    listOf(
-                        fxPropertyStubs,
-                        SourceFile.kotlin(
-                            "NonEntityHelper.kt",
-                            """
-                            package test
-                            import net.transgressoft.lirp.persistence.StubStringProperty
+        val result =
+            KspTestSupport.compile(
+                LirpAccessorValidationProcessorProvider(),
+                fxPropertyStubs,
+                SourceFile.kotlin(
+                    "NonEntityHelper.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.persistence.StubStringProperty
 
-                            // This class does NOT extend ReactiveEntityBase or implement IdentifiableEntity
-                            class NonEntityHelper {
-                                val label by StubStringProperty()
-                            }
-                            """
-                        )
-                    )
-                inheritClassPath = true
-            }
-        compilation.configureKsp { withCompilation = true }
-        compilation.symbolProcessorProviders += LirpAccessorValidationProcessorProvider()
-        val result = compilation.compile()
+                    // This class does NOT extend ReactiveEntityBase or implement IdentifiableEntity
+                    class NonEntityHelper {
+                        val label by StubStringProperty()
+                    }
+                    """
+                )
+            )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         result.messages shouldNotContain "has FxScalar delegates but no generated LirpFxScalarAccessor"
     }
 
     "fails build when entity has reactive-property fields but no LirpReactivePropertyAccessor" {
-        val compilation =
-            KotlinCompilation().apply {
-                sources =
-                    listOf(
-                        SourceFile.kotlin(
-                            "ReactiveEntity.kt",
-                            """
-                            package test
-                            import net.transgressoft.lirp.entity.ReactiveEntityBase
+        val result =
+            KspTestSupport.compile(
+                LirpAccessorValidationProcessorProvider(),
+                SourceFile.kotlin(
+                    "ReactiveEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
 
-                            data class ReactiveEntity(override val id: Int) : ReactiveEntityBase<Int, ReactiveEntity>() {
-                                override val uniqueId: String get() = "${'$'}id"
-                                override fun clone() = copy()
-                                var x: Int by reactiveProperty(0)
-                            }
-                            """
-                        )
-                    )
-                inheritClassPath = true
-            }
-        compilation.configureKsp { withCompilation = true }
-        // Only the validation processor, not the ReactivePropertyAccessorProcessor
-        compilation.symbolProcessorProviders += LirpAccessorValidationProcessorProvider()
-        val result = compilation.compile()
+                    data class ReactiveEntity(override val id: Int) : ReactiveEntityBase<Int, ReactiveEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                        var x: Int by reactiveProperty(0)
+                    }
+                    """
+                )
+            )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
         // Lock the failure path explicitly: the entity has reactive-property delegates AND no
         // raw initializer, so generic hint matching alone could pass on the wrong branch.
         // Assert on the reactive-accessor message and the entity name to pin the intent.
-        result.messages shouldContain "ReactiveEntity"
-        result.messages shouldContain "LirpReactivePropertyAccessor"
-        result.messages shouldContain "apply the net.transgressoft.lirp.sql Gradle plugin or add lirp-ksp to your build.gradle dependencies block"
+        result.shouldFailWith(
+            "ReactiveEntity",
+            "LirpReactivePropertyAccessor",
+            "apply the net.transgressoft.lirp.sql Gradle plugin or add lirp-ksp to your build.gradle dependencies block"
+        )
     }
 
     "error message contains entity name, missing accessor type, and fix hint" {
-        val compilation =
-            KotlinCompilation().apply {
-                sources =
-                    listOf(
-                        SourceFile.kotlin(
-                            "CustomerEntity.kt",
-                            """
-                            package test
-                            import net.transgressoft.lirp.entity.ReactiveEntityBase
-                            import net.transgressoft.lirp.persistence.Indexed
+        val result =
+            KspTestSupport.compile(
+                LirpAccessorValidationProcessorProvider(),
+                SourceFile.kotlin(
+                    "CustomerEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Indexed
 
-                            data class CustomerEntity(override val id: Int) : ReactiveEntityBase<Int, CustomerEntity>() {
-                                override val uniqueId: String get() = "${'$'}id"
-                                override fun clone() = copy()
-                                @Indexed val email: String = ""
-                            }
-                            """
-                        )
-                    )
-                inheritClassPath = true
-            }
-        compilation.configureKsp { withCompilation = true }
-        compilation.symbolProcessorProviders += LirpAccessorValidationProcessorProvider()
-        val result = compilation.compile()
+                    data class CustomerEntity(override val id: Int) : ReactiveEntityBase<Int, CustomerEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                        @Indexed val email: String = ""
+                    }
+                    """
+                )
+            )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "CustomerEntity"
-        result.messages shouldContain "LirpIndexAccessor"
-        result.messages shouldContain "Ensure lirp-ksp is applied"
+        result.shouldFailWith("CustomerEntity", "LirpIndexAccessor", "Ensure lirp-ksp is applied")
     }
 
     "LirpAccessorValidationProcessor validates an internal entity without false-positive" {
-        val compilation =
-            KotlinCompilation().apply {
+        // All generators plus the validator registered — internal entity must pass validation
+        val result =
+            KspTestSupport.compile(
+                providers =
+                    listOf(
+                        IndexedProcessorProvider(),
+                        RawInitializerProcessorProvider(),
+                        LirpAccessorValidationProcessorProvider()
+                    ),
                 sources =
                     listOf(
                         SourceFile.kotlin(
@@ -311,23 +276,24 @@ internal class LirpAccessorValidationProcessorTest : StringSpec({
                             """
                         )
                     )
-                inheritClassPath = true
-            }
-        compilation.configureKsp { withCompilation = true }
-        // All generators plus the validator registered — internal entity must pass validation
-        compilation.symbolProcessorProviders += IndexedProcessorProvider()
-        compilation.symbolProcessorProviders += RawInitializerProcessorProvider()
-        compilation.symbolProcessorProviders += LirpAccessorValidationProcessorProvider()
-        val result = compilation.compile()
+            )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         result.messages shouldNotContain "has @Indexed delegates but no generated LirpIndexAccessor"
         result.messages shouldNotContain "has no generated LirpRawInitializer"
     }
 
     "fails build when entity is missing LirpRawInitializer" {
-        val compilation =
-            KotlinCompilation().apply {
+        // ReactivePropertyAccessor + FxScalar generators present but NOT RawInitializerProcessor —
+        // the validator must surface the missing raw initializer with the remediation message.
+        val result =
+            KspTestSupport.compile(
+                providers =
+                    listOf(
+                        ReactivePropertyAccessorProcessorProvider(),
+                        FxScalarAccessorProcessorProvider(),
+                        LirpAccessorValidationProcessorProvider()
+                    ),
                 sources =
                     listOf(
                         fxPropertyStubs,
@@ -346,18 +312,11 @@ internal class LirpAccessorValidationProcessorTest : StringSpec({
                             """
                         )
                     )
-                inheritClassPath = true
-            }
-        compilation.configureKsp { withCompilation = true }
-        // ReactivePropertyAccessor + FxScalar generators present but NOT RawInitializerProcessor —
-        // the validator must surface the missing raw initializer with the remediation message.
-        compilation.symbolProcessorProviders += ReactivePropertyAccessorProcessorProvider()
-        compilation.symbolProcessorProviders += FxScalarAccessorProcessorProvider()
-        compilation.symbolProcessorProviders += LirpAccessorValidationProcessorProvider()
-        val result = compilation.compile()
+            )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "has no generated LirpRawInitializer"
-        result.messages shouldContain "apply the net.transgressoft.lirp.sql Gradle plugin or add lirp-ksp to your build.gradle dependencies block"
+        result.shouldFailWith(
+            "has no generated LirpRawInitializer",
+            "apply the net.transgressoft.lirp.sql Gradle plugin or add lirp-ksp to your build.gradle dependencies block"
+        )
     }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/PersistenceCreatorProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/PersistenceCreatorProcessorTest.kt
@@ -23,7 +23,6 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.string.shouldNotContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
 /**
@@ -71,11 +70,13 @@ class PersistenceCreatorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("FlyweightArtistEntity_LirpTableDef.kt")
         val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
-        fromRowBlock shouldContain "Artist.of(name = "
-        fromRowBlock shouldNotContain "Artist(name = "
+        fromRowBlock.shouldContainEachAndNone(
+            present = listOf("Artist.of(name = "),
+            absent = listOf("Artist(name = ")
+        )
     }
 
     // internal entity reconstructed via a public secondary-constructor @PersistenceCreator
@@ -106,15 +107,16 @@ class PersistenceCreatorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("InternalTrackEntity_LirpTableDef.kt")
         val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
         // The creator takes only (id, title); the call must be by NAMED args limited to those two so
         // it binds to the secondary @PersistenceCreator (not positionally to the 3-arg primary ctor).
         // durationMs is omitted entirely — it has the default 0L.
-        fromRowBlock shouldContain "InternalTrackEntity(id = "
-        fromRowBlock shouldContain "title = "
-        fromRowBlock shouldNotContain "durationMs"
+        fromRowBlock.shouldContainEachAndNone(
+            present = listOf("InternalTrackEntity(id = ", "title = "),
+            absent = listOf("durationMs")
+        )
     }
 
     // a creator taking a reordered subset of the entity's params binds by name, not positionally
@@ -149,7 +151,7 @@ class PersistenceCreatorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("ReorderedCreatorEntity_LirpTableDef.kt")
         val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
         // Args emitted in the creator's declared order (second, id, first), each named.
@@ -188,7 +190,7 @@ class PersistenceCreatorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         result.messages shouldContain "not public"
     }
 
@@ -261,12 +263,13 @@ class PersistenceCreatorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("ConfigEmbeddableEntity_LirpTableDef.kt")
         val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
-        fromRowBlock shouldContain "host = "
-        fromRowBlock shouldNotContain "timeout = "
-        fromRowBlock shouldNotContain "timeout = null"
+        fromRowBlock.shouldContainEachAndNone(
+            present = listOf("host = "),
+            absent = listOf("timeout = ", "timeout = null")
+        )
     }
 
     // @PersistenceCreator wins over a public primary constructor
@@ -304,12 +307,14 @@ class PersistenceCreatorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("PublicCtorWithCreatorEntity_LirpTableDef.kt")
         val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
         // The companion factory wins even though the primary ctor is also public.
-        fromRowBlock shouldContain "Label.of("
-        fromRowBlock shouldNotContain "Label(name = "
+        fromRowBlock.shouldContainEachAndNone(
+            present = listOf("Label.of("),
+            absent = listOf("Label(name = ")
+        )
     }
 
     // multiple @PersistenceCreator on the same type produces a compilation error
@@ -406,7 +411,7 @@ class PersistenceCreatorProcessorTest : StringSpec({
             )
 
         // Codegen continues (fallback to primary ctor); the warn path does not abort.
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("NonPublicCtorEntity_LirpTableDef.kt")
         val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
         // Bare ctor call is used (no creator, so className is the call target).
@@ -446,7 +451,7 @@ class PersistenceCreatorProcessorTest : StringSpec({
             )
 
         // Warn only — codegen proceeds, no error.
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("InternalEntityInternalCreator_LirpTableDef.kt")
         content shouldContain "InternalEntityInternalCreator"
         result.messages shouldContain "not public"
@@ -488,14 +493,15 @@ class PersistenceCreatorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("BodyFlyweightEntity_LirpTableDef.kt")
         val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
         // Gap A: setter reconstruction routes through the factory, not the internal primary ctor.
-        fromRowBlock shouldContain "entity.label = test.FlyLabel.of(name = "
         // Gap B: the factory owner is fully qualified (no bare `FlyLabel.of` that would be unresolved).
-        fromRowBlock shouldNotContain "entity.label = FlyLabel.of"
-        fromRowBlock shouldNotContain "entity.label = test.FlyLabel(name = "
+        fromRowBlock.shouldContainEachAndNone(
+            present = listOf("entity.label = test.FlyLabel.of(name = "),
+            absent = listOf("entity.label = FlyLabel.of", "entity.label = test.FlyLabel(name = ")
+        )
     }
 
     // multiple @PersistenceCreator on a nested @Embeddable produces a compilation error naming both
@@ -613,7 +619,7 @@ class PersistenceCreatorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         result.messages shouldContain "not public"
         val content = result.generatedFileContent("InternalEmbeddableEntity_LirpTableDef.kt")
         content.substringAfter("override fun fromRow") shouldContain "test.Tag.of(value = "
@@ -648,7 +654,7 @@ class PersistenceCreatorProcessorTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         result.messages shouldContain "non-public primary constructor and no"
         val content = result.generatedFileContent("NoCreatorEmbeddableEntity_LirpTableDef.kt")
         content.substringAfter("override fun fromRow") shouldContain "test.Ratio(numerator = "

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/PersistencePropertyTypeHintTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/PersistencePropertyTypeHintTest.kt
@@ -17,10 +17,9 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
+import io.kotest.datatest.withData
 import io.kotest.matchers.string.shouldContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
@@ -34,40 +33,72 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 @OptIn(ExperimentalCompilerApi::class)
 class PersistencePropertyTypeHintTest : StringSpec({
 
-    "TableDefProcessor maps type=TEXT hint to ColumnType.TextType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "TextHintEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.PersistenceProperty
-
-                    @PersistenceMapping
-                    data class TextHintEntity(
-                        override val id: Int,
-                        @PersistenceProperty(type = "TEXT") val notes: String
-                    ) : ReactiveEntityBase<Int, TextHintEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = TextHintEntity(id, notes)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("TextHintEntity_LirpTableDef.kt") shouldContain "ColumnType.TextType"
+    data class TypeHintCase(
+        val name: String,
+        val entityName: String,
+        val annotationArgs: String,
+        val fieldName: String,
+        val fieldType: String,
+        val expectedColumnType: String
+    ) {
+        override fun toString() = name
     }
 
-    "TableDefProcessor maps type=INT hint to ColumnType.IntType" {
+    withData(
+        TypeHintCase(
+            "TableDefProcessor maps type=TEXT hint to ColumnType.TextType",
+            "TextHintEntity", """type = "TEXT"""", "notes", "String", "ColumnType.TextType"
+        ),
+        TypeHintCase(
+            "TableDefProcessor maps type=INT hint to ColumnType.IntType",
+            "IntHintEntity", """type = "INT"""", "count", "Long", "ColumnType.IntType"
+        ),
+        TypeHintCase(
+            "TableDefProcessor maps type=BIGINT hint to ColumnType.LongType",
+            "BigintHintEntity", """type = "BIGINT"""", "counter", "Int", "ColumnType.LongType"
+        ),
+        TypeHintCase(
+            "TableDefProcessor maps type=BOOLEAN hint to ColumnType.BooleanType",
+            "BoolHintEntity", """type = "BOOLEAN"""", "active", "Int", "ColumnType.BooleanType"
+        ),
+        TypeHintCase(
+            "TableDefProcessor maps type=DOUBLE hint to ColumnType.DoubleType",
+            "DoubleHintEntity", """type = "DOUBLE"""", "score", "String", "ColumnType.DoubleType"
+        ),
+        TypeHintCase(
+            "TableDefProcessor maps type=FLOAT hint to ColumnType.FloatType",
+            "FloatHintEntity", """type = "FLOAT"""", "ratio", "String", "ColumnType.FloatType"
+        ),
+        TypeHintCase(
+            "TableDefProcessor maps type=UUID hint to ColumnType.UuidType",
+            "UuidHintEntity", """type = "UUID"""", "externalRef", "String", "ColumnType.UuidType"
+        ),
+        TypeHintCase(
+            "TableDefProcessor maps type=DATE hint to ColumnType.DateType",
+            "DateHintEntity", """type = "DATE"""", "createdOn", "String", "ColumnType.DateType"
+        ),
+        TypeHintCase(
+            "TableDefProcessor maps type=DATETIME hint to ColumnType.DateTimeType",
+            "DatetimeHintEntity", """type = "DATETIME"""", "updatedAt", "String", "ColumnType.DateTimeType"
+        ),
+        TypeHintCase(
+            "TableDefProcessor maps type=DECIMAL hint to ColumnType.DecimalType with default precision and scale",
+            "DecimalDefaultHintEntity", """type = "DECIMAL"""", "amount", "String", "ColumnType.DecimalType(19, 2)"
+        ),
+        TypeHintCase(
+            "TableDefProcessor maps type=DECIMAL hint with explicit precision and scale",
+            "DecimalPrecisionHintEntity", """type = "DECIMAL", precision = 10, scale = 3""", "rate", "String", "ColumnType.DecimalType(10, 3)"
+        ),
+        TypeHintCase(
+            "TableDefProcessor maps type=VARCHAR with length to ColumnType.VarcharType",
+            "VarcharHintEntity", """type = "VARCHAR", length = 128""", "code", "String", "ColumnType.VarcharType(128)"
+        )
+    ) { case ->
         val result =
             KspTestSupport.compile(
                 TableDefProcessorProvider(),
                 SourceFile.kotlin(
-                    "IntHintEntity.kt",
+                    "${case.entityName}.kt",
                     """
                     package test
                     import net.transgressoft.lirp.entity.ReactiveEntityBase
@@ -75,300 +106,19 @@ class PersistencePropertyTypeHintTest : StringSpec({
                     import net.transgressoft.lirp.persistence.PersistenceProperty
 
                     @PersistenceMapping
-                    data class IntHintEntity(
+                    data class ${case.entityName}(
                         override val id: Int,
-                        @PersistenceProperty(type = "INT") val count: Long
-                    ) : ReactiveEntityBase<Int, IntHintEntity>() {
+                        @PersistenceProperty(${case.annotationArgs}) val ${case.fieldName}: ${case.fieldType}
+                    ) : ReactiveEntityBase<Int, ${case.entityName}>() {
                         override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = IntHintEntity(id, count)
+                        override fun clone() = ${case.entityName}(id, ${case.fieldName})
                     }
                     """
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("IntHintEntity_LirpTableDef.kt") shouldContain "ColumnType.IntType"
-    }
-
-    "TableDefProcessor maps type=BIGINT hint to ColumnType.LongType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "BigintHintEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.PersistenceProperty
-
-                    @PersistenceMapping
-                    data class BigintHintEntity(
-                        override val id: Int,
-                        @PersistenceProperty(type = "BIGINT") val counter: Int
-                    ) : ReactiveEntityBase<Int, BigintHintEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = BigintHintEntity(id, counter)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("BigintHintEntity_LirpTableDef.kt") shouldContain "ColumnType.LongType"
-    }
-
-    "TableDefProcessor maps type=BOOLEAN hint to ColumnType.BooleanType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "BoolHintEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.PersistenceProperty
-
-                    @PersistenceMapping
-                    data class BoolHintEntity(
-                        override val id: Int,
-                        @PersistenceProperty(type = "BOOLEAN") val active: Int
-                    ) : ReactiveEntityBase<Int, BoolHintEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = BoolHintEntity(id, active)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("BoolHintEntity_LirpTableDef.kt") shouldContain "ColumnType.BooleanType"
-    }
-
-    "TableDefProcessor maps type=DOUBLE hint to ColumnType.DoubleType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "DoubleHintEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.PersistenceProperty
-
-                    @PersistenceMapping
-                    data class DoubleHintEntity(
-                        override val id: Int,
-                        @PersistenceProperty(type = "DOUBLE") val score: String
-                    ) : ReactiveEntityBase<Int, DoubleHintEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = DoubleHintEntity(id, score)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("DoubleHintEntity_LirpTableDef.kt") shouldContain "ColumnType.DoubleType"
-    }
-
-    "TableDefProcessor maps type=FLOAT hint to ColumnType.FloatType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "FloatHintEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.PersistenceProperty
-
-                    @PersistenceMapping
-                    data class FloatHintEntity(
-                        override val id: Int,
-                        @PersistenceProperty(type = "FLOAT") val ratio: String
-                    ) : ReactiveEntityBase<Int, FloatHintEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = FloatHintEntity(id, ratio)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("FloatHintEntity_LirpTableDef.kt") shouldContain "ColumnType.FloatType"
-    }
-
-    "TableDefProcessor maps type=UUID hint to ColumnType.UuidType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "UuidHintEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.PersistenceProperty
-
-                    @PersistenceMapping
-                    data class UuidHintEntity(
-                        override val id: Int,
-                        @PersistenceProperty(type = "UUID") val externalRef: String
-                    ) : ReactiveEntityBase<Int, UuidHintEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = UuidHintEntity(id, externalRef)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("UuidHintEntity_LirpTableDef.kt") shouldContain "ColumnType.UuidType"
-    }
-
-    "TableDefProcessor maps type=DATE hint to ColumnType.DateType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "DateHintEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.PersistenceProperty
-
-                    @PersistenceMapping
-                    data class DateHintEntity(
-                        override val id: Int,
-                        @PersistenceProperty(type = "DATE") val createdOn: String
-                    ) : ReactiveEntityBase<Int, DateHintEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = DateHintEntity(id, createdOn)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("DateHintEntity_LirpTableDef.kt") shouldContain "ColumnType.DateType"
-    }
-
-    "TableDefProcessor maps type=DATETIME hint to ColumnType.DateTimeType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "DatetimeHintEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.PersistenceProperty
-
-                    @PersistenceMapping
-                    data class DatetimeHintEntity(
-                        override val id: Int,
-                        @PersistenceProperty(type = "DATETIME") val updatedAt: String
-                    ) : ReactiveEntityBase<Int, DatetimeHintEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = DatetimeHintEntity(id, updatedAt)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("DatetimeHintEntity_LirpTableDef.kt") shouldContain "ColumnType.DateTimeType"
-    }
-
-    "TableDefProcessor maps type=DECIMAL hint to ColumnType.DecimalType with default precision and scale" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "DecimalDefaultHintEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.PersistenceProperty
-
-                    @PersistenceMapping
-                    data class DecimalDefaultHintEntity(
-                        override val id: Int,
-                        @PersistenceProperty(type = "DECIMAL") val amount: String
-                    ) : ReactiveEntityBase<Int, DecimalDefaultHintEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = DecimalDefaultHintEntity(id, amount)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        // Default precision=19, scale=2 when not specified
-        result.generatedFileContent("DecimalDefaultHintEntity_LirpTableDef.kt") shouldContain "ColumnType.DecimalType(19, 2)"
-    }
-
-    "TableDefProcessor maps type=DECIMAL hint with explicit precision and scale" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "DecimalPrecisionHintEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.PersistenceProperty
-
-                    @PersistenceMapping
-                    data class DecimalPrecisionHintEntity(
-                        override val id: Int,
-                        @PersistenceProperty(type = "DECIMAL", precision = 10, scale = 3) val rate: String
-                    ) : ReactiveEntityBase<Int, DecimalPrecisionHintEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = DecimalPrecisionHintEntity(id, rate)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("DecimalPrecisionHintEntity_LirpTableDef.kt") shouldContain "ColumnType.DecimalType(10, 3)"
-    }
-
-    "TableDefProcessor maps type=VARCHAR with length to ColumnType.VarcharType" {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "VarcharHintEntity.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.PersistenceProperty
-
-                    @PersistenceMapping
-                    data class VarcharHintEntity(
-                        override val id: Int,
-                        @PersistenceProperty(type = "VARCHAR", length = 128) val code: String
-                    ) : ReactiveEntityBase<Int, VarcharHintEntity>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = VarcharHintEntity(id, code)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        result.generatedFileContent("VarcharHintEntity_LirpTableDef.kt") shouldContain "ColumnType.VarcharType(128)"
+        result.shouldSucceed()
+        result.generatedFileContent("${case.entityName}_LirpTableDef.kt") shouldContain case.expectedColumnType
     }
 
     "TableDefProcessor rejects type=VARCHAR without length" {
@@ -395,9 +145,7 @@ class PersistencePropertyTypeHintTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "requires length > 0"
-        result.messages shouldContain "code"
+        result.shouldFailWith("requires length > 0", "code")
     }
 
     "TableDefProcessor rejects unknown type hint" {
@@ -424,9 +172,7 @@ class PersistencePropertyTypeHintTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "Unknown @PersistenceProperty type hint"
-        result.messages shouldContain "CLOB"
+        result.shouldFailWith("Unknown @PersistenceProperty type hint", "CLOB")
     }
 
     "TableDefProcessor rejects precision/scale hint on String-based converter" {
@@ -461,9 +207,7 @@ class PersistencePropertyTypeHintTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "incompatible with converter"
-        result.messages shouldContain "precision/scale"
+        result.shouldFailWith("incompatible with converter", "precision/scale")
     }
 
     "TableDefProcessor rejects length hint on numeric-based converter" {
@@ -500,9 +244,7 @@ class PersistencePropertyTypeHintTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "incompatible with converter"
-        result.messages shouldContain "length"
+        result.shouldFailWith("incompatible with converter", "length")
     }
 
     "TableDefProcessor accepts type hint on converter column overriding the converter sqlType" {
@@ -537,11 +279,13 @@ class PersistencePropertyTypeHintTest : StringSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         // type hint overrides converter's sqlType expression
         val content = result.generatedFileContent("ConverterWithTypeHintEntity_LirpTableDef.kt")
-        content shouldContain "ColumnType.VarcharType(10)"
-        content shouldContain "test.CodeConverter.fromSql("
-        content shouldContain "test.CodeConverter.toSql("
+        content.shouldContainEach(
+            "ColumnType.VarcharType(10)",
+            "test.CodeConverter.fromSql(",
+            "test.CodeConverter.toSql("
+        )
     }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/PolymorphicRefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/PolymorphicRefProcessorTest.kt
@@ -17,13 +17,8 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.JvmCompilationResult
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
-import com.tschuchort.compiletesting.configureKsp
-import com.tschuchort.compiletesting.symbolProcessorProviders
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
@@ -143,55 +138,53 @@ internal class PolymorphicRefProcessorTest : FunSpec({
             """
         )
 
-    fun compileWithBothProcessors(vararg sources: SourceFile): JvmCompilationResult {
-        val compilation =
-            KotlinCompilation().apply {
-                this.sources = sources.toList()
-                inheritClassPath = true
-                // arm<K,E>() is an inline+reified function compiled with JVM target 21 in lirp-core.
-                // The test compilation must target the same version to inline the bytecode.
-                jvmTarget = "21"
-            }
-        compilation.configureKsp { this.withCompilation = true }
-        compilation.symbolProcessorProviders += TableDefProcessorProvider()
-        compilation.symbolProcessorProviders += ReactiveEntityRefProcessorProvider()
-        return compilation.compile()
-    }
+    // arm<K,E>() is an inline+reified function compiled with JVM target 21 in lirp-core.
+    // The test compilation must target the same version to inline the bytecode.
+    fun compileWithBothProcessors(vararg sources: SourceFile) =
+        KspTestSupport.compile(
+            providers = listOf(TableDefProcessorProvider(), ReactiveEntityRefProcessorProvider()),
+            sources = sources.toList(),
+            jvmTarget = "21"
+        )
 
     test("emits per-arm ForeignKeyDef entries in _LirpTableDef for a two-arm polymorphicAggregate") {
         val result = compileWithBothProcessors(twoArmEntitySource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("AudioContribution_LirpTableDef.kt")
-        content shouldContain "override fun foreignKeys(): List<ForeignKeyDef>"
-        content shouldContain "ForeignKeyDef(columnName = \"audio_item_id\""
-        content shouldContain "referencedTable = \"audio_item\""
-        content shouldContain "referencedColumn = \"id\""
-        content shouldContain "ForeignKeyDef(columnName = \"audio_playlist_id\""
-        content shouldContain "referencedTable = \"mutable_audio_playlist\""
+        content.shouldContainEach(
+            "override fun foreignKeys(): List<ForeignKeyDef>",
+            "ForeignKeyDef(columnName = \"audio_item_id\"",
+            "referencedTable = \"audio_item\"",
+            "referencedColumn = \"id\"",
+            "ForeignKeyDef(columnName = \"audio_playlist_id\"",
+            "referencedTable = \"mutable_audio_playlist\""
+        )
     }
 
     test("emits per-arm RefEntry in _LirpRefAccessor for a two-arm polymorphicAggregate") {
         val result = compileWithBothProcessors(twoArmEntitySource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("AudioContribution_LirpRefAccessor.kt")
-        // Item arm
-        content shouldContain "refName = \"target.item\""
-        content shouldContain """armDelegate("item").referenceId"""
-        content shouldContain """armDelegate("item") as AggregateRefDelegate<*, *>"""
-        // Playlist arm
-        content shouldContain "refName = \"target.playlist\""
-        content shouldContain """armDelegate("playlist").referenceId"""
-        content shouldContain """armDelegate("playlist") as AggregateRefDelegate<*, *>"""
-        // Arms do not bubble up
-        content shouldContain "bubbleUp = false"
+        content.shouldContainEach(
+            // Item arm
+            "refName = \"target.item\"",
+            """armDelegate("item").referenceId""",
+            """armDelegate("item") as AggregateRefDelegate<*, *>""",
+            // Playlist arm
+            "refName = \"target.playlist\"",
+            """armDelegate("playlist").referenceId""",
+            """armDelegate("playlist") as AggregateRefDelegate<*, *>""",
+            // Arms do not bubble up
+            "bubbleUp = false"
+        )
     }
 
     test("arm onDelete defaults to DETACH when not specified") {
         val result = compileWithBothProcessors(twoArmEntitySource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val tableDef = result.generatedFileContent("AudioContribution_LirpTableDef.kt")
         tableDef shouldContain "onDelete = CascadeAction.DETACH"
     }
@@ -230,7 +223,7 @@ internal class PolymorphicRefProcessorTest : FunSpec({
             )
         val result = compileWithBothProcessors(noneArmSource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("NoConstraintArm_LirpTableDef.kt")
         // NONE arms skip FK emission
         content shouldNotContain "override fun foreignKeys()"
@@ -239,31 +232,37 @@ internal class PolymorphicRefProcessorTest : FunSpec({
     test("three-arm polymorphicAggregate yields three FK entries and three RefEntry entries") {
         val result = compileWithBothProcessors(threeArmEntitySource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val tableDef = result.generatedFileContent("ThreeArmContribution_LirpTableDef.kt")
-        tableDef shouldContain "audio_track_id"
-        tableDef shouldContain "audio_album_id"
-        tableDef shouldContain "audio_artist_id"
-        tableDef shouldContain "audio_track"
-        tableDef shouldContain "audio_album"
-        tableDef shouldContain "audio_artist"
+        tableDef.shouldContainEach(
+            "audio_track_id",
+            "audio_album_id",
+            "audio_artist_id",
+            "audio_track",
+            "audio_album",
+            "audio_artist"
+        )
 
         val refAccessor = result.generatedFileContent("ThreeArmContribution_LirpRefAccessor.kt")
-        refAccessor shouldContain "refName = \"ref.alpha\""
-        refAccessor shouldContain "refName = \"ref.beta\""
-        refAccessor shouldContain "refName = \"ref.gamma\""
-        refAccessor shouldContain """armDelegate("alpha")"""
-        refAccessor shouldContain """armDelegate("beta")"""
-        refAccessor shouldContain """armDelegate("gamma")"""
+        refAccessor.shouldContainEach(
+            "refName = \"ref.alpha\"",
+            "refName = \"ref.beta\"",
+            "refName = \"ref.gamma\"",
+            """armDelegate("alpha")""",
+            """armDelegate("beta")""",
+            """armDelegate("gamma")"""
+        )
     }
 
     test("per-arm RefEntry delegateGetter reaches inner delegate via armDelegate") {
         val result = compileWithBothProcessors(twoArmEntitySource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("AudioContribution_LirpRefAccessor.kt")
-        content shouldContain "it.target.armDelegate("
-        content shouldContain ") as AggregateRefDelegate<*, *>"
+        content.shouldContainEach(
+            "it.target.armDelegate(",
+            ") as AggregateRefDelegate<*, *>"
+        )
     }
 
     test("positional onDelete cascade argument is honoured and emits the per-arm cascade action") {
@@ -300,13 +299,15 @@ internal class PolymorphicRefProcessorTest : FunSpec({
             )
         val result = compileWithBothProcessors(positionalSource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         // The arm is not dropped: it reaches both the FK table-def and the ref-accessor with CASCADE.
         val tableDef = result.generatedFileContent("PositionalArm_LirpTableDef.kt")
         tableDef shouldContain "onDelete = CascadeAction.CASCADE"
         val refAccessor = result.generatedFileContent("PositionalArm_LirpRefAccessor.kt")
-        refAccessor shouldContain "refName = \"ref.track\""
-        refAccessor shouldContain "cascadeAction = CascadeAction.CASCADE"
+        refAccessor.shouldContainEach(
+            "refName = \"ref.track\"",
+            "cascadeAction = CascadeAction.CASCADE"
+        )
     }
 
     test("this-qualified scalar in the arm lambda captures the backing scalar, not 'this'") {
@@ -343,7 +344,7 @@ internal class PolymorphicRefProcessorTest : FunSpec({
         val result = compileWithBothProcessors(qualifiedSource)
 
         // Before the fix this failed with "references unknown scalar 'this'".
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val tableDef = result.generatedFileContent("QualifiedScalar_LirpTableDef.kt")
         tableDef shouldContain "audio_track_id"
     }
@@ -390,8 +391,7 @@ internal class PolymorphicRefProcessorTest : FunSpec({
             )
         val result = compileWithBothProcessors(duplicateSource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "duplicate polymorphic arm label"
+        result.shouldFailWith("duplicate polymorphic arm label")
     }
 
     test("non-identifier arm label is rejected with a clear diagnostic") {
@@ -427,8 +427,7 @@ internal class PolymorphicRefProcessorTest : FunSpec({
             )
         val result = compileWithBothProcessors(badLabelSource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "not valid Kotlin identifiers"
+        result.shouldFailWith("not valid Kotlin identifiers")
     }
 
     test("six-arm and multiline-formatted declarations are not truncated by the scan window") {
@@ -513,11 +512,13 @@ internal class PolymorphicRefProcessorTest : FunSpec({
             )
         val result = compileWithBothProcessors(sixArmSource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         // The trailing arms past the old 12-line window still reach codegen.
         val refAccessor = result.generatedFileContent("SixArmContribution_LirpRefAccessor.kt")
-        refAccessor shouldContain "refName = \"ref.one\""
-        refAccessor shouldContain "refName = \"ref.six\""
+        refAccessor.shouldContainEach(
+            "refName = \"ref.one\"",
+            "refName = \"ref.six\""
+        )
         val sealed = result.generatedFileContent("SixArmContributionRefArm.kt")
         sealed shouldContain "data class Six(val entity: A6)"
     }
@@ -568,8 +569,7 @@ internal class PolymorphicRefProcessorTest : FunSpec({
 
         // The span walk skips the ')' inside the string literal, so the SECOND arm is still seen and
         // the first label is reported as a non-identifier rather than silently swallowing the rest.
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "not valid Kotlin identifiers"
+        result.shouldFailWith("not valid Kotlin identifiers")
     }
 
     test("aliased arm target import resolves to the aliased FQN") {
@@ -616,7 +616,7 @@ internal class PolymorphicRefProcessorTest : FunSpec({
             )
         val result = compileWithBothProcessors(aliasedTargetSource, aliasedConsumerSource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         // The arm binds to the aliased FQN's table, not to a wrong same-simple-name import.
         val tableDef = result.generatedFileContent("AliasedConsumer_LirpTableDef.kt")
         tableDef shouldContain "referencedTable = \"remote_track\""

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/PolymorphicSealedUnionGeneratorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/PolymorphicSealedUnionGeneratorTest.kt
@@ -17,15 +17,8 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.JvmCompilationResult
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
-import com.tschuchort.compiletesting.configureKsp
-import com.tschuchort.compiletesting.symbolProcessorProviders
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.string.shouldNotContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.DisplayName
 
@@ -150,41 +143,39 @@ internal class PolymorphicSealedUnionGeneratorTest : FunSpec({
             """
         )
 
-    fun compileWithTableDefProcessor(vararg sources: SourceFile): JvmCompilationResult {
-        val compilation =
-            KotlinCompilation().apply {
-                this.sources = sources.toList()
-                inheritClassPath = true
-                jvmTarget = "21"
-            }
-        compilation.configureKsp { this.withCompilation = true }
-        compilation.symbolProcessorProviders += TableDefProcessorProvider()
-        return compilation.compile()
-    }
+    fun compileWithTableDefProcessor(vararg sources: SourceFile) =
+        KspTestSupport.compile(TableDefProcessorProvider(), *sources, jvmTarget = "21")
 
     test("generates sealed class with one data-class subtype per arm for a two-arm entity") {
         val result = compileWithTableDefProcessor(twoArmEntitySource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("AudioContributionTargetArm.kt")
-        content shouldContain "sealed class AudioContributionTargetArm"
-        content shouldContain "data class Item(val entity: AudioItem) : AudioContributionTargetArm()"
-        content shouldContain "data class Playlist(val entity: MutableAudioPlaylist) : AudioContributionTargetArm()"
-        content shouldContain "fun PolymorphicResolution<AudioContributionTargetArm>.activeArm(): AudioContributionTargetArm"
+        content.shouldContainEach(
+            "sealed class AudioContributionTargetArm",
+            "data class Item(val entity: AudioItem) : AudioContributionTargetArm()",
+            "data class Playlist(val entity: MutableAudioPlaylist) : AudioContributionTargetArm()",
+            "fun PolymorphicResolution<AudioContributionTargetArm>.activeArm(): AudioContributionTargetArm"
+        )
     }
 
     test("generated activeArm() resolves label and entity in one scan and returns exact subtype") {
         val result = compileWithTableDefProcessor(twoArmEntitySource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("AudioContributionTargetArm.kt")
         // A single resolveActive() scan feeds both dispatch and the typed cast — no second
         // resolveArm() scan that could observe a different active arm (TOCTOU).
-        content shouldContain "val (label, entity) = this.resolveActive()"
-        content shouldContain """"item" -> AudioContributionTargetArm.Item(entity as AudioItem)"""
-        content shouldContain """"playlist" -> AudioContributionTargetArm.Playlist(entity as MutableAudioPlaylist)"""
-        content shouldNotContain "resolveArm("
-        content shouldContain "else -> error("
+        content.shouldContainEachAndNone(
+            present =
+                listOf(
+                    "val (label, entity) = this.resolveActive()",
+                    """"item" -> AudioContributionTargetArm.Item(entity as AudioItem)""",
+                    """"playlist" -> AudioContributionTargetArm.Playlist(entity as MutableAudioPlaylist)""",
+                    "else -> error("
+                ),
+            absent = listOf("resolveArm(")
+        )
     }
 
     test("exhaustive when over activeArm() compiles without else branch") {
@@ -252,19 +243,23 @@ internal class PolymorphicSealedUnionGeneratorTest : FunSpec({
             )
 
         val result = compileWithTableDefProcessor(consumerSource)
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
     }
 
     test("two polymorphicAggregate properties on one entity produce two distinct sealed files") {
         val result = compileWithTableDefProcessor(twoPropertiesEntitySource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val primaryContent = result.generatedFileContent("DualPolymorphicEntityPrimaryArm.kt")
         val secondaryContent = result.generatedFileContent("DualPolymorphicEntitySecondaryArm.kt")
-        primaryContent shouldContain "sealed class DualPolymorphicEntityPrimaryArm"
-        primaryContent shouldContain "fun PolymorphicResolution<DualPolymorphicEntityPrimaryArm>.activeArm()"
-        secondaryContent shouldContain "sealed class DualPolymorphicEntitySecondaryArm"
-        secondaryContent shouldContain "fun PolymorphicResolution<DualPolymorphicEntitySecondaryArm>.activeArm()"
+        primaryContent.shouldContainEach(
+            "sealed class DualPolymorphicEntityPrimaryArm",
+            "fun PolymorphicResolution<DualPolymorphicEntityPrimaryArm>.activeArm()"
+        )
+        secondaryContent.shouldContainEach(
+            "sealed class DualPolymorphicEntitySecondaryArm",
+            "fun PolymorphicResolution<DualPolymorphicEntitySecondaryArm>.activeArm()"
+        )
     }
 
     test("two distinct activeArm() extensions compile without conflict on a dual-property entity") {
@@ -349,6 +344,6 @@ internal class PolymorphicSealedUnionGeneratorTest : FunSpec({
             )
 
         val result = compileWithTableDefProcessor(consumerSource)
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
     }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ReactiveEntityRefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ReactiveEntityRefProcessorTest.kt
@@ -17,14 +17,11 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withTests
 import io.kotest.engine.names.WithDataTestName
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.string.shouldNotContain
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.DisplayName
 
@@ -149,12 +146,13 @@ internal class ReactiveEntityRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("InvoiceEntity_LirpRefAccessor.kt")
-        content shouldContain "override val entries: List<RefEntry<*, InvoiceEntity>>"
-        content shouldContain "refName = \"order\""
-        content shouldContain "idGetter = { it.orderId as Comparable<Any> }"
-        content shouldContain "override val collectionEntries: List<CollectionRefEntry<*, InvoiceEntity>> = emptyList()"
+        val content = result.shouldSucceed().generatedFileContent("InvoiceEntity_LirpRefAccessor.kt")
+        content.shouldContainEach(
+            "override val entries: List<RefEntry<*, InvoiceEntity>>",
+            "refName = \"order\"",
+            "idGetter = { it.orderId as Comparable<Any> }",
+            "override val collectionEntries: List<CollectionRefEntry<*, InvoiceEntity>> = emptyList()"
+        )
     }
 
     test("generates collectionEntries for entity with aggregateList property") {
@@ -187,14 +185,15 @@ internal class ReactiveEntityRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("PlaylistEntity_LirpRefAccessor.kt")
-        content shouldContain "override val collectionEntries: List<CollectionRefEntry<*, PlaylistEntity>>"
-        content shouldContain "refName = \"items\""
-        content shouldContain "idsGetter = { (it.items as AggregateCollectionRef<*, *>).referenceIds }"
-        content shouldContain "cascadeAction = CascadeAction.CASCADE"
-        content shouldContain "isOrdered = true"
-        content shouldContain "override val entries: List<RefEntry<*, PlaylistEntity>> = emptyList()"
+        val content = result.shouldSucceed().generatedFileContent("PlaylistEntity_LirpRefAccessor.kt")
+        content.shouldContainEach(
+            "override val collectionEntries: List<CollectionRefEntry<*, PlaylistEntity>>",
+            "refName = \"items\"",
+            "idsGetter = { (it.items as AggregateCollectionRef<*, *>).referenceIds }",
+            "cascadeAction = CascadeAction.CASCADE",
+            "isOrdered = true",
+            "override val entries: List<RefEntry<*, PlaylistEntity>> = emptyList()"
+        )
     }
 
     test("generates collectionEntries for entity with aggregateSet property") {
@@ -226,13 +225,14 @@ internal class ReactiveEntityRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("PlaylistGroupEntity_LirpRefAccessor.kt")
-        content shouldContain "override val collectionEntries: List<CollectionRefEntry<*, PlaylistGroupEntity>>"
-        content shouldContain "refName = \"playlists\""
-        content shouldContain "idsGetter = { (it.playlists as AggregateCollectionRef<*, *>).referenceIds }"
-        content shouldContain "isOrdered = false"
-        content shouldContain "cascadeAction = CascadeAction.NONE"
+        val content = result.shouldSucceed().generatedFileContent("PlaylistGroupEntity_LirpRefAccessor.kt")
+        content.shouldContainEach(
+            "override val collectionEntries: List<CollectionRefEntry<*, PlaylistGroupEntity>>",
+            "refName = \"playlists\"",
+            "idsGetter = { (it.playlists as AggregateCollectionRef<*, *>).referenceIds }",
+            "isOrdered = false",
+            "cascadeAction = CascadeAction.NONE"
+        )
     }
 
     test("generates both entries and collectionEntries for entity with mixed @ToOneAggregate and @ToManyAggregates refs") {
@@ -281,19 +281,20 @@ internal class ReactiveEntityRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("AlbumEntity_LirpRefAccessor.kt")
+        val content = result.shouldSucceed().generatedFileContent("AlbumEntity_LirpRefAccessor.kt")
         // To-one ref entry
-        content shouldContain "override val entries: List<RefEntry<*, AlbumEntity>>"
-        content shouldContain "refName = \"artist\""
-        content shouldContain "idGetter = { it.artistId as Comparable<Any> }"
-        content shouldContain "bubbleUp = true"
         // Collection ref entry
-        content shouldContain "override val collectionEntries: List<CollectionRefEntry<*, AlbumEntity>>"
-        content shouldContain "refName = \"tracks\""
-        content shouldContain "idsGetter = { (it.tracks as AggregateCollectionRef<*, *>).referenceIds }"
-        content shouldContain "isOrdered = true"
-        content shouldContain "cascadeAction = CascadeAction.CASCADE"
+        content.shouldContainEach(
+            "override val entries: List<RefEntry<*, AlbumEntity>>",
+            "refName = \"artist\"",
+            "idGetter = { it.artistId as Comparable<Any> }",
+            "bubbleUp = true",
+            "override val collectionEntries: List<CollectionRefEntry<*, AlbumEntity>>",
+            "refName = \"tracks\"",
+            "idsGetter = { (it.tracks as AggregateCollectionRef<*, *>).referenceIds }",
+            "isOrdered = true",
+            "cascadeAction = CascadeAction.CASCADE"
+        )
     }
 
     data class BubbleUpCase(
@@ -338,9 +339,7 @@ internal class ReactiveEntityRefProcessorTest : FunSpec({
                     )
                 )
 
-            result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-            result.messages shouldContain "bubbleUp"
-            result.messages shouldContain "not supported"
+            result.shouldFailWith("bubbleUp", "not supported")
         }
     }
 
@@ -381,8 +380,7 @@ internal class ReactiveEntityRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("MixedCollectionEntity_LirpRefAccessor.kt")
+        val content = result.shouldSucceed().generatedFileContent("MixedCollectionEntity_LirpRefAccessor.kt")
         // Split by CollectionRefEntry blocks and verify each refName is paired with its isOrdered
         val entryBlocks = content.split("CollectionRefEntry(").drop(1)
         val orderedBlock = entryBlocks.first { it.contains("refName = \"orderedRefs\"") }
@@ -428,10 +426,11 @@ internal class ReactiveEntityRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("PartialAnnotationEntity_LirpRefAccessor.kt")
-        content shouldContain "refName = \"annotatedRefs\""
-        content shouldNotContain "ignoredRefs"
+        val content = result.shouldSucceed().generatedFileContent("PartialAnnotationEntity_LirpRefAccessor.kt")
+        content.shouldContainEachAndNone(
+            present = listOf("refName = \"annotatedRefs\""),
+            absent = listOf("ignoredRefs")
+        )
     }
 
     test("generates \$-separated accessor name for 1-level inner class entity") {
@@ -466,11 +465,12 @@ internal class ReactiveEntityRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Outer\$RefEntity_LirpRefAccessor.kt")
-        content shouldContain "`Outer\$RefEntity_LirpRefAccessor`"
-        content shouldContain "LirpRefAccessor<Outer.RefEntity>"
-        content shouldContain "InnerEntity::class.java"
+        val content = result.shouldSucceed().generatedFileContent("Outer\$RefEntity_LirpRefAccessor.kt")
+        content.shouldContainEach(
+            "`Outer\$RefEntity_LirpRefAccessor`",
+            "LirpRefAccessor<Outer.RefEntity>",
+            "InnerEntity::class.java"
+        )
     }
 
     test("generates \$-separated accessor name for 3-level nested entity") {
@@ -506,11 +506,12 @@ internal class ReactiveEntityRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("A\$B\$C_LirpRefAccessor.kt")
-        content shouldContain "`A\$B\$C_LirpRefAccessor`"
-        content shouldContain "LirpRefAccessor<A.B.C>"
-        content shouldContain "RefEntity::class.java"
+        val content = result.shouldSucceed().generatedFileContent("A\$B\$C_LirpRefAccessor.kt")
+        content.shouldContainEach(
+            "`A\$B\$C_LirpRefAccessor`",
+            "LirpRefAccessor<A.B.C>",
+            "RefEntity::class.java"
+        )
     }
 
     test("top-level entity accessor generation unchanged after inner class support") {
@@ -543,11 +544,12 @@ internal class ReactiveEntityRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("TopLevelEntity_LirpRefAccessor.kt")
-        content shouldContain "`TopLevelEntity_LirpRefAccessor`"
-        content shouldContain "LirpRefAccessor<TopLevelEntity>"
-        content shouldContain "TargetEntity::class.java"
+        val content = result.shouldSucceed().generatedFileContent("TopLevelEntity_LirpRefAccessor.kt")
+        content.shouldContainEach(
+            "`TopLevelEntity_LirpRefAccessor`",
+            "LirpRefAccessor<TopLevelEntity>",
+            "TargetEntity::class.java"
+        )
     }
 
     test("generates collectionEntries for entity with mutableAggregateList returning MutableList") {
@@ -580,14 +582,15 @@ internal class ReactiveEntityRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("MutablePlaylistEntity_LirpRefAccessor.kt")
-        content shouldContain "override val collectionEntries: List<CollectionRefEntry<*, MutablePlaylistEntity>>"
-        content shouldContain "refName = \"items\""
-        content shouldContain "idsGetter = { (it.items as AggregateCollectionRef<*, *>).referenceIds }"
-        content shouldContain "cascadeAction = CascadeAction.CASCADE"
-        content shouldContain "isOrdered = true"
-        content shouldContain "override val entries: List<RefEntry<*, MutablePlaylistEntity>> = emptyList()"
+        val content = result.shouldSucceed().generatedFileContent("MutablePlaylistEntity_LirpRefAccessor.kt")
+        content.shouldContainEach(
+            "override val collectionEntries: List<CollectionRefEntry<*, MutablePlaylistEntity>>",
+            "refName = \"items\"",
+            "idsGetter = { (it.items as AggregateCollectionRef<*, *>).referenceIds }",
+            "cascadeAction = CascadeAction.CASCADE",
+            "isOrdered = true",
+            "override val entries: List<RefEntry<*, MutablePlaylistEntity>> = emptyList()"
+        )
     }
 
     test("ReactiveEntityRefProcessor emits compile error when @ToManyAggregates is placed on aggregate{} delegate val") {

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/TableDefProcessorTest.kt
@@ -17,7 +17,6 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -56,12 +55,13 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("MinimalEntity_LirpTableDef.kt")
-        content shouldContain "tableName: String = \"minimal_entity\""
-        content shouldContain "ColumnType.IntType"
-        content shouldContain "primaryKey = true"
-        content shouldContain "object MinimalEntity_LirpTableDef : SqlTableDef<MinimalEntity>"
+        val content = result.shouldSucceed().generatedFileContent("MinimalEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "tableName: String = \"minimal_entity\"",
+            "ColumnType.IntType",
+            "primaryKey = true",
+            "object MinimalEntity_LirpTableDef : SqlTableDef<MinimalEntity>"
+        )
     }
 
     test("generates _LirpTableDef with annotation overrides for table name and column config") {
@@ -89,14 +89,15 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("ProductEntity_LirpTableDef.kt")
-        content shouldContain "tableName: String = \"products\""
-        content shouldContain "name = \"full_name\""
-        content shouldContain "ColumnType.VarcharType(100)"
-        content shouldContain "name = \"description\""
-        content shouldContain "ColumnType.TextType"
-        content shouldContain "ColumnType.LongType"
+        val content = result.shouldSucceed().generatedFileContent("ProductEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "tableName: String = \"products\"",
+            "name = \"full_name\"",
+            "ColumnType.VarcharType(100)",
+            "name = \"description\"",
+            "ColumnType.TextType",
+            "ColumnType.LongType"
+        )
     }
 
     test("maps reactiveProperty delegate to declared type") {
@@ -123,10 +124,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("ReactiveEntity_LirpTableDef.kt")
-        content shouldContain "name = \"mutable_label\""
-        content shouldContain "ColumnType.TextType"
+        val content = result.shouldSucceed().generatedFileContent("ReactiveEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "name = \"mutable_label\"",
+            "ColumnType.TextType"
+        )
     }
 
     test("excludes @PersistenceIgnore properties from generated descriptor") {
@@ -154,11 +156,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("EntityWithIgnored_LirpTableDef.kt")
-        content shouldContain "name = \"name\""
-        content shouldNotContain "transient_data"
-        content shouldNotContain "transientData"
+        val content = result.shouldSucceed().generatedFileContent("EntityWithIgnored_LirpTableDef.kt")
+        content.shouldContainEachAndNone(
+            present = listOf("name = \"name\""),
+            absent = listOf("transient_data", "transientData")
+        )
     }
 
     test("triggers on @PersistenceProperty without class-level @PersistenceMapping") {
@@ -183,10 +185,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("ImplicitEntity_LirpTableDef.kt")
-        content shouldContain "tableName: String = \"implicit_entity\""
-        content shouldContain "name = \"label\""
+        val content = result.shouldSucceed().generatedFileContent("ImplicitEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "tableName: String = \"implicit_entity\"",
+            "name = \"label\""
+        )
     }
 
     test("generates SqlTableDef implementation for entity with all-mutable non-PK properties") {
@@ -208,12 +211,13 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("MutableEntity_LirpTableDef.kt")
-        content shouldContain "object MutableEntity_LirpTableDef : SqlTableDef<MutableEntity>"
-        content shouldContain "import net.transgressoft.lirp.persistence.sql.SqlTableDef"
-        content shouldContain "import org.jetbrains.exposed.v1.core.ResultRow"
-        content shouldContain "import org.jetbrains.exposed.v1.core.Table"
+        val content = result.shouldSucceed().generatedFileContent("MutableEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "object MutableEntity_LirpTableDef : SqlTableDef<MutableEntity>",
+            "import net.transgressoft.lirp.persistence.sql.SqlTableDef",
+            "import org.jetbrains.exposed.v1.core.ResultRow",
+            "import org.jetbrains.exposed.v1.core.Table"
+        )
     }
 
     test("generates fromRow that constructs entity with id and sets mutable properties") {
@@ -235,15 +239,19 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("EntityWithFromRow_LirpTableDef.kt")
-        content shouldContain "override fun fromRow(row: ResultRow, table: Table): EntityWithFromRow"
-        content shouldContain "val entity = EntityWithFromRow("
-        content shouldContain "entity.name ="
-        content shouldContain "entity.active ="
-        content shouldContain "return entity"
-        // Non-reactive @PersistenceMapping classes have no withEventsDisabled — must not be wrapped.
-        content shouldNotContain "withEventsDisabled"
+        val content = result.shouldSucceed().generatedFileContent("EntityWithFromRow_LirpTableDef.kt")
+        content.shouldContainEachAndNone(
+            present =
+                listOf(
+                    "override fun fromRow(row: ResultRow, table: Table): EntityWithFromRow",
+                    "val entity = EntityWithFromRow(",
+                    "entity.name =",
+                    "entity.active =",
+                    "return entity"
+                ),
+            // Non-reactive @PersistenceMapping classes have no withEventsDisabled — must not be wrapped.
+            absent = listOf("withEventsDisabled")
+        )
     }
 
     test("generates fromRow that hydrates a reactive entity inside withEventsDisabled") {
@@ -268,15 +276,16 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("ReactiveFromRowEntity_LirpTableDef.kt")
+        val content = result.shouldSucceed().generatedFileContent("ReactiveFromRowEntity_LirpTableDef.kt")
         // Hydration of a reactive entity must not emit mutation events — emitting during load would
         // schedule a stray write-back of the just-loaded values that races the repository's mutation
         // subscription (observed as an intermittently-lost update). The body-declared reactive
         // setters are therefore wrapped in withEventsDisabled.
-        content shouldContain "entity.withEventsDisabled {"
-        content shouldContain "entity.name ="
-        content shouldContain "entity.score ="
+        content.shouldContainEach(
+            "entity.withEventsDisabled {",
+            "entity.name =",
+            "entity.score ="
+        )
     }
 
     test("generates toParams that returns all column-value pairs including PK") {
@@ -298,12 +307,13 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("EntityWithToParams_LirpTableDef.kt")
-        content shouldContain "override fun toParams(entity: EntityWithToParams, table: Table): Map<Column<*>, Any?>"
-        content shouldContain "cols[\"id\"]!! to entity.id"
-        content shouldContain "cols[\"description\"]!! to entity.description"
-        content shouldContain "cols[\"count\"]!! to entity.count"
+        val content = result.shouldSucceed().generatedFileContent("EntityWithToParams_LirpTableDef.kt")
+        content.shouldContainEach(
+            "override fun toParams(entity: EntityWithToParams, table: Table): Map<Column<*>, Any?>",
+            "cols[\"id\"]!! to entity.id",
+            "cols[\"description\"]!! to entity.description",
+            "cols[\"count\"]!! to entity.count"
+        )
     }
 
     test("generates SqlTableDef when every non-PK column is a primary-constructor val") {
@@ -322,13 +332,14 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("ImmutableEntity_LirpTableDef.kt")
-        content shouldContain "object ImmutableEntity_LirpTableDef : SqlTableDef<ImmutableEntity>"
-        // fromRow rebuilds the entity through the primary constructor (both args are ctor params).
-        content shouldContain "val entity = ImmutableEntity("
-        // applyRow has no mutable non-PK columns to reassign — emits the documented no-op branch.
-        content shouldContain "No mutable non-PK columns"
+        val content = result.shouldSucceed().generatedFileContent("ImmutableEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "object ImmutableEntity_LirpTableDef : SqlTableDef<ImmutableEntity>",
+            // fromRow rebuilds the entity through the primary constructor (both args are ctor params).
+            "val entity = ImmutableEntity(",
+            // applyRow has no mutable non-PK columns to reassign — emits the documented no-op branch.
+            "No mutable non-PK columns"
+        )
         // Critically: applyRow MUST NOT attempt `entity.name =` reassignment on the val column.
         val applyRowBlock = content.substringAfter("override fun applyRow").substringBefore("override fun ")
         applyRowBlock shouldNotContain "entity.name ="
@@ -352,12 +363,13 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("ImportCheckEntity_LirpTableDef.kt")
-        content shouldContain "import net.transgressoft.lirp.persistence.sql.SqlTableDef"
-        content shouldContain "import org.jetbrains.exposed.v1.core.Column"
-        content shouldContain "import org.jetbrains.exposed.v1.core.ResultRow"
-        content shouldContain "import org.jetbrains.exposed.v1.core.Table"
+        val content = result.shouldSucceed().generatedFileContent("ImportCheckEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "import net.transgressoft.lirp.persistence.sql.SqlTableDef",
+            "import org.jetbrains.exposed.v1.core.Column",
+            "import org.jetbrains.exposed.v1.core.ResultRow",
+            "import org.jetbrains.exposed.v1.core.Table"
+        )
     }
 
     test("generates correct enum handling as String in fromRow and toParams") {
@@ -380,11 +392,12 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("EntityWithEnum_LirpTableDef.kt")
-        content shouldContain "ColumnType.EnumType"
-        content shouldContain "enumValueOf<Status>"
-        content shouldContain "entity.status.name"
+        val content = result.shouldSucceed().generatedFileContent("EntityWithEnum_LirpTableDef.kt")
+        content.shouldContainEach(
+            "ColumnType.EnumType",
+            "enumValueOf<Status>",
+            "entity.status.name"
+        )
     }
 
     test("reports KSP error for unsupported property type") {
@@ -411,8 +424,7 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "Unsupported column type"
+        result.shouldFailWith("Unsupported column type")
     }
 
     test("generates UUID primary key column for entity with UUID id") {
@@ -437,13 +449,14 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("UuidKeyEntity_LirpTableDef.kt")
-        content shouldContain "ColumnType.UuidType"
-        content shouldContain "primaryKey = true"
-        content shouldContain "tableName: String = \"uuid_key_entity\""
-        content shouldContain "SqlTableDef<UuidKeyEntity>"
-        content shouldContain "toJavaUuid()"
+        val content = result.shouldSucceed().generatedFileContent("UuidKeyEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "ColumnType.UuidType",
+            "primaryKey = true",
+            "tableName: String = \"uuid_key_entity\"",
+            "SqlTableDef<UuidKeyEntity>",
+            "toJavaUuid()"
+        )
     }
 
     test("generates nullable columns for entity with all nullable non-PK properties") {
@@ -466,12 +479,13 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("NullableEntity_LirpTableDef.kt")
-        content shouldContain "name = \"name\""
-        content shouldContain "nullable = true"
-        content shouldContain "name = \"score\""
-        content shouldContain "name = \"active\""
+        val content = result.shouldSucceed().generatedFileContent("NullableEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "name = \"name\"",
+            "nullable = true",
+            "name = \"score\"",
+            "name = \"active\""
+        )
     }
 
     test("generates SqlTableDef for entity mixing ctor-param val and body-level var properties") {
@@ -492,13 +506,14 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("MixedEntity_LirpTableDef.kt")
-        content shouldContain "object MixedEntity_LirpTableDef : SqlTableDef<MixedEntity>"
-        content shouldContain "name = \"read_only\""
-        content shouldContain "name = \"mutable\""
-        // fromRow constructs the entity passing readOnly through the primary constructor.
-        content shouldContain "val entity = MixedEntity("
+        val content = result.shouldSucceed().generatedFileContent("MixedEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "object MixedEntity_LirpTableDef : SqlTableDef<MixedEntity>",
+            "name = \"read_only\"",
+            "name = \"mutable\"",
+            // fromRow constructs the entity passing readOnly through the primary constructor.
+            "val entity = MixedEntity("
+        )
         // applyRow reassigns only the mutable body-level var; the immutable ctor-val is skipped.
         val applyRowBlock = content.substringAfter("override fun applyRow").substringBefore("override fun ")
         applyRowBlock shouldContain "entity.mutable ="
@@ -529,18 +544,20 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("CtorValReactive_LirpTableDef.kt")
+        val content = result.shouldSucceed().generatedFileContent("CtorValReactive_LirpTableDef.kt")
         content shouldContain "object CtorValReactive_LirpTableDef : SqlTableDef<CtorValReactive>"
         val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
-        // Both id and label are ctor params, so fromRow passes them positionally to the constructor.
-        fromRowBlock shouldContain "val entity = CtorValReactive("
-        fromRowBlock shouldContain "entity.notes ="
-        // The ctor-val `label` must never appear on the left-hand side of an assignment.
-        fromRowBlock shouldNotContain "entity.label ="
+        fromRowBlock.shouldContainEachAndNone(
+            // Both id and label are ctor params, so fromRow passes them positionally to the constructor.
+            present = listOf("val entity = CtorValReactive(", "entity.notes ="),
+            // The ctor-val `label` must never appear on the left-hand side of an assignment.
+            absent = listOf("entity.label =")
+        )
         val applyRowBlock = content.substringAfter("override fun applyRow").substringBefore("override fun ")
-        applyRowBlock shouldContain "entity.notes ="
-        applyRowBlock shouldNotContain "entity.label ="
+        applyRowBlock.shouldContainEachAndNone(
+            present = listOf("entity.notes ="),
+            absent = listOf("entity.label =")
+        )
     }
 
     test("still falls back to LirpTableDef when a non-ctor non-PK property is immutable") {
@@ -563,10 +580,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("BodyValEntity_LirpTableDef.kt")
-        content shouldContain "object BodyValEntity_LirpTableDef : LirpTableDef<BodyValEntity>"
-        content shouldNotContain "SqlTableDef"
+        val content = result.shouldSucceed().generatedFileContent("BodyValEntity_LirpTableDef.kt")
+        content.shouldContainEachAndNone(
+            present = listOf("object BodyValEntity_LirpTableDef : LirpTableDef<BodyValEntity>"),
+            absent = listOf("SqlTableDef")
+        )
     }
 
     test("generates correct descriptor for UUID PK entity with @PersistenceIgnore field") {
@@ -593,13 +611,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("UuidIgnoreEntity_LirpTableDef.kt")
-        content shouldContain "ColumnType.UuidType"
-        content shouldContain "primaryKey = true"
-        content shouldContain "name = \"name\""
-        content shouldNotContain "transient_field"
-        content shouldNotContain "transientField"
+        val content = result.shouldSucceed().generatedFileContent("UuidIgnoreEntity_LirpTableDef.kt")
+        content.shouldContainEachAndNone(
+            present = listOf("ColumnType.UuidType", "primaryKey = true", "name = \"name\""),
+            absent = listOf("transient_field", "transientField")
+        )
     }
 
     test("generates SqlTableDef via resolver detection without KSP options") {
@@ -624,11 +640,12 @@ internal class TableDefProcessorTest : FunSpec({
         // No options passed — resolver-only detection
         val result = KspTestSupport.compile(TableDefProcessorProvider(), source)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("ResolverDetectedEntity_LirpTableDef.kt")
-        content shouldContain "SqlTableDef<ResolverDetectedEntity>"
-        content shouldContain "override fun fromRow(row: ResultRow, table: Table): ResolverDetectedEntity"
-        content shouldContain "override fun toParams(entity: ResolverDetectedEntity, table: Table)"
+        val content = result.shouldSucceed().generatedFileContent("ResolverDetectedEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "SqlTableDef<ResolverDetectedEntity>",
+            "override fun fromRow(row: ResultRow, table: Table): ResolverDetectedEntity",
+            "override fun toParams(entity: ResolverDetectedEntity, table: Table)"
+        )
     }
 
     test("documents monorepo behavior: resolver still generates SqlTableDef without options") {
@@ -653,7 +670,7 @@ internal class TableDefProcessorTest : FunSpec({
             )
         val result = KspTestSupport.compile(TableDefProcessorProvider(), source, options = emptyMap())
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         // In monorepo, resolver finds SqlTableDef — so SqlTableDef is still generated
         val content = result.generatedFileContent("FallbackEntity_LirpTableDef.kt")
         content shouldContain "SqlTableDef<FallbackEntity>"
@@ -689,27 +706,28 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("NullableTypesEntity_LirpTableDef.kt")
-        content shouldContain "SqlTableDef<NullableTypesEntity>"
-        content shouldContain "@OptIn(ExperimentalUuidApi::class)"
-        // Nullable UUID conversions
-        content shouldContain "as? kotlin.uuid.Uuid)?.toJavaUuid()"
-        content shouldContain "entity.parentId?.toKotlinUuid()"
-        // Non-null UUID PK conversion
-        content shouldContain "as kotlin.uuid.Uuid).toJavaUuid()"
-        content shouldContain "entity.id.toKotlinUuid()"
-        // Nullable LocalDate conversions
-        content shouldContain "as? kotlinx.datetime.LocalDate)?.toJavaLocalDate()"
-        content shouldContain "entity.startDate?.toKotlinLocalDate()"
-        // Nullable LocalDateTime conversions
-        content shouldContain "as? kotlinx.datetime.LocalDateTime)?.toJavaLocalDateTime()"
-        content shouldContain "entity.modifiedAt?.toKotlinLocalDateTime()"
-        // Nullable enum conversions
-        content shouldContain """as? String)?.let { enumValueOf<Status>(it) }"""
-        content shouldContain "entity.status?.name"
-        // Nullable String
-        content shouldContain "as? String"
+        val content = result.shouldSucceed().generatedFileContent("NullableTypesEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "SqlTableDef<NullableTypesEntity>",
+            "@OptIn(ExperimentalUuidApi::class)",
+            // Nullable UUID conversions
+            "as? kotlin.uuid.Uuid)?.toJavaUuid()",
+            "entity.parentId?.toKotlinUuid()",
+            // Non-null UUID PK conversion
+            "as kotlin.uuid.Uuid).toJavaUuid()",
+            "entity.id.toKotlinUuid()",
+            // Nullable LocalDate conversions
+            "as? kotlinx.datetime.LocalDate)?.toJavaLocalDate()",
+            "entity.startDate?.toKotlinLocalDate()",
+            // Nullable LocalDateTime conversions
+            "as? kotlinx.datetime.LocalDateTime)?.toJavaLocalDateTime()",
+            "entity.modifiedAt?.toKotlinLocalDateTime()",
+            // Nullable enum conversions
+            """as? String)?.let { enumValueOf<Status>(it) }""",
+            "entity.status?.name",
+            // Nullable String
+            "as? String"
+        )
     }
 
     test("generates BigDecimal import and correct column type for DecimalType properties") {
@@ -736,14 +754,15 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("DecimalEntity_LirpTableDef.kt")
-        content shouldContain "SqlTableDef<DecimalEntity>"
-        content shouldContain "import java.math.BigDecimal"
-        content shouldContain "ColumnType.DecimalType(10, 2)"
-        content shouldContain "ColumnType.DecimalType(14, 4)"
-        content shouldContain "as BigDecimal"
-        content shouldContain "as? BigDecimal"
+        val content = result.shouldSucceed().generatedFileContent("DecimalEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "SqlTableDef<DecimalEntity>",
+            "import java.math.BigDecimal",
+            "ColumnType.DecimalType(10, 2)",
+            "ColumnType.DecimalType(14, 4)",
+            "as BigDecimal",
+            "as? BigDecimal"
+        )
     }
 
     test("generates correct ordered multi-param constructor call in fromRow") {
@@ -772,12 +791,13 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("MultiParamEntity_LirpTableDef.kt")
-        content shouldContain "SqlTableDef<MultiParamEntity>"
-        // Constructor args in declaration order: id first, tenantId second
-        content shouldContain "val entity = MultiParamEntity("
-        content shouldContain "entity.name ="
+        val content = result.shouldSucceed().generatedFileContent("MultiParamEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "SqlTableDef<MultiParamEntity>",
+            // Constructor args in declaration order: id first, tenantId second
+            "val entity = MultiParamEntity(",
+            "entity.name ="
+        )
         // In fromRow, tenantId must be in the constructor call (not a setter) since it's a ctor param.
         val fromRowBlock = content.substringAfter("override fun fromRow").substringBefore("override fun ")
         fromRowBlock shouldNotContain "entity.tenantId ="
@@ -802,12 +822,12 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("UnmappedCtorEntity_LirpTableDef.kt")
-        // Should fall back to LirpTableDef since transientParam is excluded from columns
-        content shouldContain "LirpTableDef<UnmappedCtorEntity>"
-        content shouldNotContain "SqlTableDef"
-        content shouldNotContain "fromRow"
+        val content = result.shouldSucceed().generatedFileContent("UnmappedCtorEntity_LirpTableDef.kt")
+        content.shouldContainEachAndNone(
+            // Should fall back to LirpTableDef since transientParam is excluded from columns
+            present = listOf("LirpTableDef<UnmappedCtorEntity>"),
+            absent = listOf("SqlTableDef", "fromRow")
+        )
     }
 
     test("generates isVersion = true in ColumnDef for a valid @Version property") {
@@ -832,8 +852,7 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("VersionedEntity_LirpTableDef.kt")
+        val content = result.shouldSucceed().generatedFileContent("VersionedEntity_LirpTableDef.kt")
         content shouldContain "isVersion = true"
         // The id column should still carry isVersion = false
         val idColumnLine = content.lines().first { it.contains("name = \"id\"") }
@@ -863,11 +882,12 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("VersionedEntity2_LirpTableDef.kt")
-        content shouldContain "override fun applyRow(entity: VersionedEntity2, row: ResultRow, table: Table)"
-        content shouldContain "entity.name ="
-        content shouldContain "entity.version ="
+        val content = result.shouldSucceed().generatedFileContent("VersionedEntity2_LirpTableDef.kt")
+        content.shouldContainEach(
+            "override fun applyRow(entity: VersionedEntity2, row: ResultRow, table: Table)",
+            "entity.name =",
+            "entity.version ="
+        )
         // The id (PK) should NOT appear in applyRow assignments
         val applyRowBlock = content.substringAfter("override fun applyRow").substringBefore("\n    }")
         applyRowBlock shouldNotContain "entity.id ="
@@ -895,8 +915,7 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "must be of type 'Long'"
+        result.shouldFailWith("must be of type 'Long'")
     }
 
     test("rejects @Version on a val property") {
@@ -921,8 +940,7 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "must be declared with 'var'"
+        result.shouldFailWith("must be declared with 'var'")
     }
 
     test("rejects multiple @Version properties on one class") {
@@ -948,8 +966,7 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "multiple @Version properties"
+        result.shouldFailWith("multiple @Version properties")
     }
 
     test("rejects @Version on a non-delegated property") {
@@ -974,8 +991,7 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "must use the 'reactiveProperty' delegate"
+        result.shouldFailWith("must use the 'reactiveProperty' delegate")
     }
 
     test("entity without @Version has isVersion = false on all columns") {
@@ -999,10 +1015,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Unversioned_LirpTableDef.kt")
-        content shouldNotContain "isVersion = true"
-        content shouldContain "isVersion = false"
+        val content = result.shouldSucceed().generatedFileContent("Unversioned_LirpTableDef.kt")
+        content.shouldContainEachAndNone(
+            present = listOf("isVersion = false"),
+            absent = listOf("isVersion = true")
+        )
     }
 
     test("generates bumpVersion override for entity with @Version") {
@@ -1027,12 +1044,13 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("BumpCheck_LirpTableDef.kt")
-        content shouldContain "override fun bumpVersion(entity: BumpCheck, newVersion: Long)"
-        content shouldContain "entity.version = newVersion"
-        content shouldContain "override fun versionOf(entity: BumpCheck): Long"
-        content shouldContain "return entity.version"
+        val content = result.shouldSucceed().generatedFileContent("BumpCheck_LirpTableDef.kt")
+        content.shouldContainEach(
+            "override fun bumpVersion(entity: BumpCheck, newVersion: Long)",
+            "entity.version = newVersion",
+            "override fun versionOf(entity: BumpCheck): Long",
+            "return entity.version"
+        )
     }
 
     test("does NOT generate bumpVersion override for entity without @Version") {
@@ -1056,10 +1074,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("NoBump_LirpTableDef.kt")
-        content shouldNotContain "override fun bumpVersion"
-        content shouldNotContain "override fun versionOf"
+        val content = result.shouldSucceed().generatedFileContent("NoBump_LirpTableDef.kt")
+        content.shouldContainEachAndNone(
+            present = emptyList(),
+            absent = listOf("override fun bumpVersion", "override fun versionOf")
+        )
     }
 
     // ---- Junction tables and FK constraints (#144) ----
@@ -1097,18 +1116,19 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val junction = result.generatedFileContent("Playlist_Tracks_LirpJunctionTableDef.kt")
-        junction shouldContain "object Playlist_Tracks_LirpJunctionTableDef : JunctionTableDef"
-        junction shouldContain "tableName: String = \"playlist_tracks\""
-        junction shouldContain "parentTableName: String = \"playlist\""
-        junction shouldContain "itemTableName: String = \"track\""
-        junction shouldContain "isOrdered: Boolean = true"
-        junction shouldContain "JunctionColumnDef(name = \"parent_id\""
-        junction shouldContain "JunctionColumnDef(name = \"item_id\""
-        junction shouldContain "JunctionColumnDef(name = \"position\""
-        junction shouldContain "parentFkOnDelete: CascadeAction = CascadeAction.CASCADE"
-        junction shouldContain "itemFkOnDelete: CascadeAction = CascadeAction.DETACH"
+        val junction = result.shouldSucceed().generatedFileContent("Playlist_Tracks_LirpJunctionTableDef.kt")
+        junction.shouldContainEach(
+            "object Playlist_Tracks_LirpJunctionTableDef : JunctionTableDef",
+            "tableName: String = \"playlist_tracks\"",
+            "parentTableName: String = \"playlist\"",
+            "itemTableName: String = \"track\"",
+            "isOrdered: Boolean = true",
+            "JunctionColumnDef(name = \"parent_id\"",
+            "JunctionColumnDef(name = \"item_id\"",
+            "JunctionColumnDef(name = \"position\"",
+            "parentFkOnDelete: CascadeAction = CascadeAction.CASCADE",
+            "itemFkOnDelete: CascadeAction = CascadeAction.DETACH"
+        )
     }
 
     test("emits unordered junction descriptor without position column for aggregateSet") {
@@ -1143,10 +1163,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val junction = result.generatedFileContent("Album_Tags_LirpJunctionTableDef.kt")
-        junction shouldContain "isOrdered: Boolean = false"
-        junction shouldNotContain "position"
+        val junction = result.shouldSucceed().generatedFileContent("Album_Tags_LirpJunctionTableDef.kt")
+        junction.shouldContainEachAndNone(
+            present = listOf("isOrdered: Boolean = false"),
+            absent = listOf("position")
+        )
     }
 
     test("attaches RESTRICT foreign key to @ToOneAggregate scalar") {
@@ -1180,13 +1201,14 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Order_LirpTableDef.kt")
-        content shouldContain "override fun foreignKeys(): List<ForeignKeyDef>"
-        content shouldContain "ForeignKeyDef(columnName = \"customer_id\""
-        content shouldContain "referencedTable = \"customer\""
-        content shouldContain "referencedColumn = \"id\""
-        content shouldContain "onDelete = CascadeAction.RESTRICT"
+        val content = result.shouldSucceed().generatedFileContent("Order_LirpTableDef.kt")
+        content.shouldContainEach(
+            "override fun foreignKeys(): List<ForeignKeyDef>",
+            "ForeignKeyDef(columnName = \"customer_id\"",
+            "referencedTable = \"customer\"",
+            "referencedColumn = \"id\"",
+            "onDelete = CascadeAction.RESTRICT"
+        )
     }
 
     test("rejects DETACH on non-nullable @ToOneAggregate scalar at compile time") {
@@ -1220,8 +1242,7 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "requires a nullable backing scalar"
+        result.shouldFailWith("requires a nullable backing scalar")
     }
 
     test("allows DETACH on nullable @ToOneAggregate scalar and emits SET_NULL semantics") {
@@ -1255,10 +1276,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Site_LirpTableDef.kt")
-        content shouldContain "ForeignKeyDef(columnName = \"region_id\""
-        content shouldContain "onDelete = CascadeAction.DETACH"
+        val content = result.shouldSucceed().generatedFileContent("Site_LirpTableDef.kt")
+        content.shouldContainEach(
+            "ForeignKeyDef(columnName = \"region_id\"",
+            "onDelete = CascadeAction.DETACH"
+        )
     }
 
     test("emits SET_NULL FK for nullable @ToOneAggregate scalar with DETACH action") {
@@ -1286,10 +1308,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Tenant_LirpTableDef.kt")
-        content shouldContain "ForeignKeyDef(columnName = \"parent_tenant_id\""
-        content shouldContain "onDelete = CascadeAction.DETACH"
+        val content = result.shouldSucceed().generatedFileContent("Tenant_LirpTableDef.kt")
+        content.shouldContainEach(
+            "ForeignKeyDef(columnName = \"parent_tenant_id\"",
+            "onDelete = CascadeAction.DETACH"
+        )
     }
 
     // ---- Junction accessor wiring on _LirpTableDef (#144 / FK-04, plan 53-03a) ----
@@ -1326,12 +1349,13 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Playlist_LirpTableDef.kt")
-        content shouldContain "import net.transgressoft.lirp.persistence.sql.JunctionAccessor"
-        content shouldContain "import net.transgressoft.lirp.persistence.sql.JunctionTableDef"
-        content shouldContain "override val junctionTableDefs: List<JunctionTableDef>"
-        content shouldContain "Playlist_Tracks_LirpJunctionTableDef"
+        val content = result.shouldSucceed().generatedFileContent("Playlist_LirpTableDef.kt")
+        content.shouldContainEach(
+            "import net.transgressoft.lirp.persistence.sql.JunctionAccessor",
+            "import net.transgressoft.lirp.persistence.sql.JunctionTableDef",
+            "override val junctionTableDefs: List<JunctionTableDef>",
+            "Playlist_Tracks_LirpJunctionTableDef"
+        )
     }
 
     test("_LirpTableDef overrides junctionAccessors with idsOf returning the backing field") {
@@ -1366,12 +1390,13 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Playlist_LirpTableDef.kt")
-        content shouldContain "override val junctionAccessors: List<JunctionAccessor<Playlist>>"
-        content shouldContain "object : JunctionAccessor<Playlist>"
-        content shouldContain "override val descriptor: JunctionTableDef = Playlist_Tracks_LirpJunctionTableDef"
-        content shouldContain "override fun idsOf(entity: Playlist): Collection<Any> = entity.trackIds"
+        val content = result.shouldSucceed().generatedFileContent("Playlist_LirpTableDef.kt")
+        content.shouldContainEach(
+            "override val junctionAccessors: List<JunctionAccessor<Playlist>>",
+            "object : JunctionAccessor<Playlist>",
+            "override val descriptor: JunctionTableDef = Playlist_Tracks_LirpJunctionTableDef",
+            "override fun idsOf(entity: Playlist): Collection<Any> = entity.trackIds"
+        )
     }
 
     test("_LirpTableDef overrides applyJunctionRows wrapping mutation in withEventsDisabled") {
@@ -1406,12 +1431,13 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Playlist_LirpTableDef.kt")
-        content shouldContain "override fun applyJunctionRows("
-        content shouldContain "entity.withEventsDisabled"
-        content shouldContain "Playlist_Tracks_LirpJunctionTableDef ->"
-        content shouldContain "entity.trackIds = ids.filterIsInstance<Int>()"
+        val content = result.shouldSucceed().generatedFileContent("Playlist_LirpTableDef.kt")
+        content.shouldContainEach(
+            "override fun applyJunctionRows(",
+            "entity.withEventsDisabled",
+            "Playlist_Tracks_LirpJunctionTableDef ->",
+            "entity.trackIds = ids.filterIsInstance<Int>()"
+        )
     }
 
     test("_LirpTableDef does NOT override junction members when entity has no collection aggregates") {
@@ -1434,11 +1460,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Plain_LirpTableDef.kt")
-        content shouldNotContain "junctionTableDefs"
-        content shouldNotContain "junctionAccessors"
-        content shouldNotContain "applyJunctionRows"
+        val content = result.shouldSucceed().generatedFileContent("Plain_LirpTableDef.kt")
+        content.shouldContainEachAndNone(
+            present = emptyList(),
+            absent = listOf("junctionTableDefs", "junctionAccessors", "applyJunctionRows")
+        )
     }
 
     test("KSP-emitted _LirpTableDef applies junction rows at runtime without firing MutationEvents") {
@@ -1473,7 +1499,7 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
 
         val cl = result.classLoader
         val playlistClass = cl.loadClass("test.RuntimePlaylist")
@@ -1563,9 +1589,7 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "KSP[FK-04]"
-        result.messages shouldContain "must be a 'var List<K>'"
+        result.shouldFailWith("KSP[FK-04]", "must be a 'var List<K>'")
     }
 
     // ---- Short / Byte column-type inference (#207-B2) ----
@@ -1590,8 +1614,7 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("InternalPersisted_LirpTableDef.kt")
+        val content = result.shouldSucceed().generatedFileContent("InternalPersisted_LirpTableDef.kt")
         content shouldContain "internal object InternalPersisted_LirpTableDef"
     }
 
@@ -1617,11 +1640,12 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("InternalMultiProp_LirpTableDef.kt")
-        content shouldContain "internal object InternalMultiProp_LirpTableDef"
-        content shouldContain "name = \"name\""
-        content shouldContain "name = \"score\""
+        val content = result.shouldSucceed().generatedFileContent("InternalMultiProp_LirpTableDef.kt")
+        content.shouldContainEach(
+            "internal object InternalMultiProp_LirpTableDef",
+            "name = \"name\"",
+            "name = \"score\""
+        )
     }
 
     test("TableDefProcessor fails compilation for private-nested entity with @PersistenceMapping") {
@@ -1646,9 +1670,10 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
-        result.messages shouldContain "must be public or internal"
-        result.messages shouldContain "Private and protected entities cannot have accessible generated code"
+        result.shouldFailWith(
+            "must be public or internal",
+            "Private and protected entities cannot have accessible generated code"
+        )
     }
 
     test("TableDefProcessor maps kotlin.Short to ColumnType.IntType and emits .toShort() narrowing in fromRow") {
@@ -1672,11 +1697,12 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("ShortEntity_LirpTableDef.kt")
-        content shouldContain "name = \"year\", type = ColumnType.IntType"
-        content shouldContain "as Number).toShort()"
-        content shouldContain "entity.year.toInt()"
+        val content = result.shouldSucceed().generatedFileContent("ShortEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "name = \"year\", type = ColumnType.IntType",
+            "as Number).toShort()",
+            "entity.year.toInt()"
+        )
     }
 
     test("TableDefProcessor maps kotlin.Byte to ColumnType.IntType and emits .toByte() narrowing in fromRow") {
@@ -1700,11 +1726,12 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("ByteEntity_LirpTableDef.kt")
-        content shouldContain "name = \"flag\", type = ColumnType.IntType"
-        content shouldContain "as Number).toByte()"
-        content shouldContain "entity.flag.toInt()"
+        val content = result.shouldSucceed().generatedFileContent("ByteEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "name = \"flag\", type = ColumnType.IntType",
+            "as Number).toByte()",
+            "entity.flag.toInt()"
+        )
     }
 
     test("TableDefProcessor maps nullable kotlin.Short to nullable ColumnType.IntType with safe narrowing") {
@@ -1728,11 +1755,12 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("NullableShortEntity_LirpTableDef.kt")
-        content shouldContain "name = \"year\", type = ColumnType.IntType, nullable = true"
-        content shouldContain "as? Number)?.toShort()"
-        content shouldContain "entity.year?.toInt()"
+        val content = result.shouldSucceed().generatedFileContent("NullableShortEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "name = \"year\", type = ColumnType.IntType, nullable = true",
+            "as? Number)?.toShort()",
+            "entity.year?.toInt()"
+        )
     }
 
     test("TableDefProcessor maps nullable kotlin.Byte to nullable ColumnType.IntType with safe narrowing") {
@@ -1756,11 +1784,12 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("NullableByteEntity_LirpTableDef.kt")
-        content shouldContain "name = \"flag\", type = ColumnType.IntType, nullable = true"
-        content shouldContain "as? Number)?.toByte()"
-        content shouldContain "entity.flag?.toInt()"
+        val content = result.shouldSucceed().generatedFileContent("NullableByteEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            "name = \"flag\", type = ColumnType.IntType, nullable = true",
+            "as? Number)?.toByte()",
+            "entity.flag?.toInt()"
+        )
     }
 
     test("TableDefProcessor excludes @kotlinx.serialization.Transient mirror and generates delegate-backed column for lirp+kotlinx+reactive-delegate entity") {
@@ -1793,12 +1822,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("AudioItem_LirpTableDef.kt")
-        content shouldContain "\"title\""
-        content shouldContain "\"display_name\""
-        content shouldNotContain "titleProperty"
-        content shouldNotContain "title_property"
+        val content = result.shouldSucceed().generatedFileContent("AudioItem_LirpTableDef.kt")
+        content.shouldContainEachAndNone(
+            present = listOf("\"title\"", "\"display_name\""),
+            absent = listOf("titleProperty", "title_property")
+        )
         result.messages shouldNotContain "Unsupported column type"
     }
 
@@ -1827,20 +1855,21 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("MixedIntegersEntity_LirpTableDef.kt")
-        // All three columns resolve to IntType.
-        content shouldContain "name = \"a\", type = ColumnType.IntType"
-        content shouldContain "name = \"b\", type = ColumnType.IntType"
-        content shouldContain "name = \"c\", type = ColumnType.IntType"
-        // The Int branch must NOT pick up Short/Byte narrowing.
-        content shouldContain "entity.a = row[table.columns.first { it.name == \"a\" }] as Int"
-        content shouldContain "cols[\"a\"]!! to entity.a"
-        // Short/Byte still get the narrowing/widening treatment.
-        content shouldContain "as Number).toShort()"
-        content shouldContain "as Number).toByte()"
-        content shouldContain "entity.b.toInt()"
-        content shouldContain "entity.c.toInt()"
+        val content = result.shouldSucceed().generatedFileContent("MixedIntegersEntity_LirpTableDef.kt")
+        content.shouldContainEach(
+            // All three columns resolve to IntType.
+            "name = \"a\", type = ColumnType.IntType",
+            "name = \"b\", type = ColumnType.IntType",
+            "name = \"c\", type = ColumnType.IntType",
+            // The Int branch must NOT pick up Short/Byte narrowing.
+            "entity.a = row[table.columns.first { it.name == \"a\" }] as Int",
+            "cols[\"a\"]!! to entity.a",
+            // Short/Byte still get the narrowing/widening treatment.
+            "as Number).toShort()",
+            "as Number).toByte()",
+            "entity.b.toInt()",
+            "entity.c.toInt()"
+        )
     }
 
     // ---- Deferral — terminal diagnostic for permanently-unresolved types (#219) ----
@@ -1887,7 +1916,7 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         result.messages shouldNotContain "still unresolved after final round"
     }
 
@@ -1919,11 +1948,12 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("MutableAudioItem_LirpTableDef.kt")
-        content shouldContain "object MutableAudioItem_LirpTableDef : SqlTableDef<test.AudioItem>"
-        content shouldContain "override fun fromRow(row: ResultRow, table: Table): test.AudioItem"
-        content shouldContain "entityRef as MutableAudioItem"
+        val content = result.shouldSucceed().generatedFileContent("MutableAudioItem_LirpTableDef.kt")
+        content.shouldContainEach(
+            "object MutableAudioItem_LirpTableDef : SqlTableDef<test.AudioItem>",
+            "override fun fromRow(row: ResultRow, table: Table): test.AudioItem",
+            "entityRef as MutableAudioItem"
+        )
     }
 
     test("TableDefProcessor resolves R through an intermediate reactive base class") {
@@ -1954,11 +1984,12 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("ConcreteMedia_LirpTableDef.kt")
-        content shouldContain "object ConcreteMedia_LirpTableDef : SqlTableDef<test.MediaItem>"
-        content shouldContain "override fun fromRow(row: ResultRow, table: Table): test.MediaItem"
-        content shouldContain "entityRef as ConcreteMedia"
+        val content = result.shouldSucceed().generatedFileContent("ConcreteMedia_LirpTableDef.kt")
+        content.shouldContainEach(
+            "object ConcreteMedia_LirpTableDef : SqlTableDef<test.MediaItem>",
+            "override fun fromRow(row: ResultRow, table: Table): test.MediaItem",
+            "entityRef as ConcreteMedia"
+        )
     }
 
     test("TableDefProcessor falls back to concrete class typing when R is not resolvable") {
@@ -1979,10 +2010,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("PlainMapped_LirpTableDef.kt")
-        content shouldContain "object PlainMapped_LirpTableDef : SqlTableDef<PlainMapped>"
-        content shouldNotContain "entityRef as"
+        val content = result.shouldSucceed().generatedFileContent("PlainMapped_LirpTableDef.kt")
+        content.shouldContainEachAndNone(
+            present = listOf("object PlainMapped_LirpTableDef : SqlTableDef<PlainMapped>"),
+            absent = listOf("entityRef as")
+        )
     }
 
     test("TableDefProcessor types the descriptor on the class itself for a self-referential reactive entity") {
@@ -2006,12 +2038,16 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("SelfReactive_LirpTableDef.kt")
-        content shouldContain "object SelfReactive_LirpTableDef : SqlTableDef<SelfReactive>"
-        content shouldContain "override fun fromRow(row: ResultRow, table: Table): SelfReactive"
-        // R == class: no downcast alias is emitted, preserving the original byte-identical layout.
-        content shouldNotContain "entityRef as"
+        val content = result.shouldSucceed().generatedFileContent("SelfReactive_LirpTableDef.kt")
+        content.shouldContainEachAndNone(
+            present =
+                listOf(
+                    "object SelfReactive_LirpTableDef : SqlTableDef<SelfReactive>",
+                    "override fun fromRow(row: ResultRow, table: Table): SelfReactive"
+                ),
+            // R == class: no downcast alias is emitted, preserving the original byte-identical layout.
+            absent = listOf("entityRef as")
+        )
     }
 
     test("TableDefProcessor skips generation when R stays an unsubstituted type parameter on a generic entity") {
@@ -2067,10 +2103,11 @@ internal class TableDefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("StringTagged_LirpTableDef.kt")
-        content shouldContain "object StringTagged_LirpTableDef : SqlTableDef<test.Tagged<kotlin.String>>"
-        content shouldContain "override fun fromRow(row: ResultRow, table: Table): test.Tagged<kotlin.String>"
-        content shouldContain "entityRef as StringTagged"
+        val content = result.shouldSucceed().generatedFileContent("StringTagged_LirpTableDef.kt")
+        content.shouldContainEach(
+            "object StringTagged_LirpTableDef : SqlTableDef<test.Tagged<kotlin.String>>",
+            "override fun fromRow(row: ResultRow, table: Table): test.Tagged<kotlin.String>",
+            "entityRef as StringTagged"
+        )
     }
 })

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ToOneAggregateRefProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ToOneAggregateRefProcessorTest.kt
@@ -17,7 +17,6 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldNotContain
@@ -70,14 +69,15 @@ internal class ToOneAggregateRefProcessorTest : FunSpec({
     test("ReactiveEntityRefProcessor generates RefEntry for entity with @ToOneAggregate scalar") {
         val result = KspTestSupport.compile(ReactiveEntityRefProcessorProvider(), vehicleAndCompanySource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Vehicle_LirpRefAccessor.kt")
-        content shouldContain "refName = \"company\""
-        content shouldContain "idGetter = { it.companyId as Comparable<Any>? }"
-        content shouldContain "referencedClass = Company::class.java"
-        content shouldContain "cascadeAction = CascadeAction.DETACH"
-        content shouldContain "bubbleUp = false"
-        content shouldContain "getOrComputeToOneRef(\"company\""
+        val content = result.shouldSucceed().generatedFileContent("Vehicle_LirpRefAccessor.kt")
+        content.shouldContainEach(
+            "refName = \"company\"",
+            "idGetter = { it.companyId as Comparable<Any>? }",
+            "referencedClass = Company::class.java",
+            "cascadeAction = CascadeAction.DETACH",
+            "bubbleUp = false",
+            "getOrComputeToOneRef(\"company\""
+        )
     }
 
     test("ReactiveEntityRefProcessor generates RefEntry with bubbleUp=true when specified") {
@@ -110,17 +110,17 @@ internal class ToOneAggregateRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Album_LirpRefAccessor.kt")
-        content shouldContain "refName = \"artist\""
-        content shouldContain "bubbleUp = true"
+        val content = result.shouldSucceed().generatedFileContent("Album_LirpRefAccessor.kt")
+        content.shouldContainEach(
+            "refName = \"artist\"",
+            "bubbleUp = true"
+        )
     }
 
     test("ReactiveEntityRefProcessor infers optional reference from nullable scalar") {
         val result = KspTestSupport.compile(ReactiveEntityRefProcessorProvider(), vehicleAndCompanySource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Vehicle_LirpRefAccessor.kt")
+        val content = result.shouldSucceed().generatedFileContent("Vehicle_LirpRefAccessor.kt")
         // Nullable scalar UUID? — idGetter uses null-safe cast so null FK returns null (not NPE)
         content shouldContain "idGetter = { it.companyId as Comparable<Any>? }"
     }
@@ -155,10 +155,11 @@ internal class ToOneAggregateRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Track_LirpRefAccessor.kt")
-        content shouldContain "refName = \"playlist\""
-        content shouldContain "idGetter = { it.playlistId as Comparable<Any> }"
+        val content = result.shouldSucceed().generatedFileContent("Track_LirpRefAccessor.kt")
+        content.shouldContainEach(
+            "refName = \"playlist\"",
+            "idGetter = { it.playlistId as Comparable<Any> }"
+        )
     }
 
     test("ReactiveEntityRefProcessor emits diagnostic (a) when target lacks @PersistenceMapping") {
@@ -334,8 +335,7 @@ internal class ToOneAggregateRefProcessorTest : FunSpec({
     test("ReactiveEntityRefProcessor emits null-safe idGetter for optional FK scalar") {
         val result = KspTestSupport.compile(ReactiveEntityRefProcessorProvider(), vehicleAndCompanySource)
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Vehicle_LirpRefAccessor.kt")
+        val content = result.shouldSucceed().generatedFileContent("Vehicle_LirpRefAccessor.kt")
         // Optional scalar UUID? must use null-safe cast so idGetter returns null for null FK
         content shouldContain "idGetter = { it.companyId as Comparable<Any>? }"
     }
@@ -370,8 +370,7 @@ internal class ToOneAggregateRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Concert_LirpRefAccessor.kt")
+        val content = result.shouldSucceed().generatedFileContent("Concert_LirpRefAccessor.kt")
         // Non-nullable scalar Int must use non-null cast
         content shouldContain "idGetter = { it.venueId as Comparable<Any> }"
     }
@@ -410,14 +409,15 @@ internal class ToOneAggregateRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("AudioPlaylist_LirpRefAccessor.kt")
-        content shouldContain "refName = \"audioTrack\""
-        content shouldContain "idGetter = { it.audioTrack.referenceId }"
-        content shouldContain "delegateGetter = { it.audioTrack as AggregateRefDelegate<*, *> }"
-        content shouldContain "referencedClass = AudioTrack::class.java"
-        content shouldContain "bubbleUp = false"
-        content shouldContain "cascadeAction = CascadeAction.DETACH"
+        val content = result.shouldSucceed().generatedFileContent("AudioPlaylist_LirpRefAccessor.kt")
+        content.shouldContainEach(
+            "refName = \"audioTrack\"",
+            "idGetter = { it.audioTrack.referenceId }",
+            "delegateGetter = { it.audioTrack as AggregateRefDelegate<*, *> }",
+            "referencedClass = AudioTrack::class.java",
+            "bubbleUp = false",
+            "cascadeAction = CascadeAction.DETACH"
+        )
     }
 
     test("ReactiveEntityRefProcessor does not generate extension accessor for @ToOneAggregate delegate val") {
@@ -454,7 +454,7 @@ internal class ToOneAggregateRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         // No _LirpToOneExtAccessor file should be generated for delegate-val form
         val generatedNames = result.generatedNames()
         generatedNames shouldNotContain "TrackPlaylist_LirpToOneExtAccessor.kt"
@@ -496,8 +496,7 @@ internal class ToOneAggregateRefProcessorTest : FunSpec({
             )
 
         // Must compile without error (no Id suffix required for delegate-val form)
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("MusicLibrary_LirpRefAccessor.kt")
+        val content = result.shouldSucceed().generatedFileContent("MusicLibrary_LirpRefAccessor.kt")
         content shouldContain "refName = \"featuredItem\""
     }
 
@@ -535,11 +534,12 @@ internal class ToOneAggregateRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("BubblePlaylist_LirpRefAccessor.kt")
-        content shouldContain "bubbleUp = true"
-        content shouldContain "refName = \"track\""
-        content shouldContain "idGetter = { it.track.referenceId }"
+        val content = result.shouldSucceed().generatedFileContent("BubblePlaylist_LirpRefAccessor.kt")
+        content.shouldContainEach(
+            "bubbleUp = true",
+            "refName = \"track\"",
+            "idGetter = { it.track.referenceId }"
+        )
     }
 
     test("ReactiveEntityRefProcessor emits error when @ToOneAggregate target mismatches delegate entity type") {
@@ -639,15 +639,16 @@ internal class ToOneAggregateRefProcessorTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("Vehicle_LirpRefAccessor.kt")
+        val content = result.shouldSucceed().generatedFileContent("Vehicle_LirpRefAccessor.kt")
         // companyId stays a scalar FK: scalar cast idGetter, not the delegate's `referenceId` form
         // (a misclassification would emit `idGetter = { it.companyId.referenceId }` instead).
-        content shouldContain "refName = \"company\""
-        content shouldContain "idGetter = { it.companyId as Comparable<Any> }"
         // audioTrack is correctly the delegate-val.
-        content shouldContain "refName = \"audioTrack\""
-        content shouldContain "idGetter = { it.audioTrack.referenceId }"
+        content.shouldContainEach(
+            "refName = \"company\"",
+            "idGetter = { it.companyId as Comparable<Any> }",
+            "refName = \"audioTrack\"",
+            "idGetter = { it.audioTrack.referenceId }"
+        )
     }
 
     test("delegate-val detection regex matches every by-delegation form, with or without a space before the brace") {

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ToOneAggregateTableDefTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/ToOneAggregateTableDefTest.kt
@@ -17,11 +17,9 @@
 
 package net.transgressoft.lirp.ksp
 
-import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
+import io.kotest.datatest.withData
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.DisplayName
 
@@ -37,117 +35,127 @@ import org.junit.jupiter.api.DisplayName
 @DisplayName("ToOneAggregateTableDef")
 internal class ToOneAggregateTableDefTest : FunSpec({
 
-    test("TableDefProcessor emits ForeignKeyDef for entity with @ToOneAggregate scalar") {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "VehicleOrder.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.CascadeAction
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.ToOneAggregate
-
-                    @PersistenceMapping
-                    class Company(override val id: Int) : ReactiveEntityBase<Int, Company>() {
-                        var name: String by reactiveProperty("")
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = Company(id)
-                    }
-
-                    @PersistenceMapping
-                    class VehicleOrder(override val id: Long, companyId: Int) : ReactiveEntityBase<Long, VehicleOrder>() {
-                        @ToOneAggregate(target = Company::class, onDelete = CascadeAction.RESTRICT)
-                        var companyId: Int by reactiveProperty(companyId)
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = VehicleOrder(id, companyId)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("VehicleOrder_LirpTableDef.kt")
-        content shouldContain "override fun foreignKeys(): List<ForeignKeyDef>"
-        content shouldContain "ForeignKeyDef(columnName = \"company_id\""
-        content shouldContain "referencedTable = \"company\""
-        content shouldContain "referencedColumn = \"id\""
+    data class FkActionCase(
+        val name: String,
+        val fileName: String,
+        val source: String,
+        val generatedFile: String,
+        val expected: List<String>
+    ) {
+        override fun toString() = name
     }
 
-    test("TableDefProcessor emits ForeignKeyDef with correct onDelete action for @ToOneAggregate") {
+    withData(
+        FkActionCase(
+            name = "TableDefProcessor emits ForeignKeyDef for entity with @ToOneAggregate scalar",
+            fileName = "VehicleOrder.kt",
+            source =
+                """
+                package test
+                import net.transgressoft.lirp.entity.CascadeAction
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+                import net.transgressoft.lirp.persistence.ToOneAggregate
+
+                @PersistenceMapping
+                class Company(override val id: Int) : ReactiveEntityBase<Int, Company>() {
+                    var name: String by reactiveProperty("")
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = Company(id)
+                }
+
+                @PersistenceMapping
+                class VehicleOrder(override val id: Long, companyId: Int) : ReactiveEntityBase<Long, VehicleOrder>() {
+                    @ToOneAggregate(target = Company::class, onDelete = CascadeAction.RESTRICT)
+                    var companyId: Int by reactiveProperty(companyId)
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = VehicleOrder(id, companyId)
+                }
+                """,
+            generatedFile = "VehicleOrder_LirpTableDef.kt",
+            expected =
+                listOf(
+                    "override fun foreignKeys(): List<ForeignKeyDef>",
+                    "ForeignKeyDef(columnName = \"company_id\"",
+                    "referencedTable = \"company\"",
+                    "referencedColumn = \"id\""
+                )
+        ),
+        FkActionCase(
+            name = "TableDefProcessor emits ForeignKeyDef with correct onDelete action for @ToOneAggregate",
+            fileName = "AlbumTrack.kt",
+            source =
+                """
+                package test
+                import net.transgressoft.lirp.entity.CascadeAction
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+                import net.transgressoft.lirp.persistence.ToOneAggregate
+
+                @PersistenceMapping
+                class AudioAlbum(override val id: Int) : ReactiveEntityBase<Int, AudioAlbum>() {
+                    var title: String by reactiveProperty("")
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = AudioAlbum(id)
+                }
+
+                @PersistenceMapping
+                class AlbumTrack(override val id: Long, albumId: Int) : ReactiveEntityBase<Long, AlbumTrack>() {
+                    @ToOneAggregate(target = AudioAlbum::class, onDelete = CascadeAction.CASCADE)
+                    var albumId: Int by reactiveProperty(albumId)
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = AlbumTrack(id, albumId)
+                }
+                """,
+            generatedFile = "AlbumTrack_LirpTableDef.kt",
+            expected =
+                listOf(
+                    "ForeignKeyDef(columnName = \"album_id\"",
+                    "onDelete = CascadeAction.CASCADE"
+                )
+        ),
+        FkActionCase(
+            name = "TableDefProcessor emits ForeignKeyDef with SET_NULL semantics for nullable @ToOneAggregate scalar",
+            fileName = "OptionalRef.kt",
+            source =
+                """
+                package test
+                import net.transgressoft.lirp.entity.CascadeAction
+                import net.transgressoft.lirp.entity.ReactiveEntityBase
+                import net.transgressoft.lirp.persistence.PersistenceMapping
+                import net.transgressoft.lirp.persistence.ToOneAggregate
+                import java.util.UUID
+
+                @PersistenceMapping
+                class Distributor(override val id: UUID) : ReactiveEntityBase<UUID, Distributor>() {
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = Distributor(id)
+                }
+
+                @PersistenceMapping
+                class AudioItem(override val id: UUID, distributorId: UUID?) : ReactiveEntityBase<UUID, AudioItem>() {
+                    @ToOneAggregate(target = Distributor::class, onDelete = CascadeAction.DETACH)
+                    var distributorId: UUID? by reactiveProperty(distributorId)
+                    override val uniqueId: String get() = "${'$'}id"
+                    override fun clone() = AudioItem(id, distributorId)
+                }
+                """,
+            generatedFile = "AudioItem_LirpTableDef.kt",
+            expected =
+                listOf(
+                    "ForeignKeyDef(columnName = \"distributor_id\"",
+                    "onDelete = CascadeAction.DETACH"
+                )
+        )
+    ) { case ->
         val result =
             KspTestSupport.compile(
                 TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "AlbumTrack.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.CascadeAction
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.ToOneAggregate
-
-                    @PersistenceMapping
-                    class AudioAlbum(override val id: Int) : ReactiveEntityBase<Int, AudioAlbum>() {
-                        var title: String by reactiveProperty("")
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = AudioAlbum(id)
-                    }
-
-                    @PersistenceMapping
-                    class AlbumTrack(override val id: Long, albumId: Int) : ReactiveEntityBase<Long, AlbumTrack>() {
-                        @ToOneAggregate(target = AudioAlbum::class, onDelete = CascadeAction.CASCADE)
-                        var albumId: Int by reactiveProperty(albumId)
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = AlbumTrack(id, albumId)
-                    }
-                    """
-                )
+                SourceFile.kotlin(case.fileName, case.source)
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("AlbumTrack_LirpTableDef.kt")
-        content shouldContain "ForeignKeyDef(columnName = \"album_id\""
-        content shouldContain "onDelete = CascadeAction.CASCADE"
-    }
-
-    test("TableDefProcessor emits ForeignKeyDef with SET_NULL semantics for nullable @ToOneAggregate scalar") {
-        val result =
-            KspTestSupport.compile(
-                TableDefProcessorProvider(),
-                SourceFile.kotlin(
-                    "OptionalRef.kt",
-                    """
-                    package test
-                    import net.transgressoft.lirp.entity.CascadeAction
-                    import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.PersistenceMapping
-                    import net.transgressoft.lirp.persistence.ToOneAggregate
-                    import java.util.UUID
-
-                    @PersistenceMapping
-                    class Distributor(override val id: UUID) : ReactiveEntityBase<UUID, Distributor>() {
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = Distributor(id)
-                    }
-
-                    @PersistenceMapping
-                    class AudioItem(override val id: UUID, distributorId: UUID?) : ReactiveEntityBase<UUID, AudioItem>() {
-                        @ToOneAggregate(target = Distributor::class, onDelete = CascadeAction.DETACH)
-                        var distributorId: UUID? by reactiveProperty(distributorId)
-                        override val uniqueId: String get() = "${'$'}id"
-                        override fun clone() = AudioItem(id, distributorId)
-                    }
-                    """
-                )
-            )
-
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        val content = result.generatedFileContent("AudioItem_LirpTableDef.kt")
-        content shouldContain "ForeignKeyDef(columnName = \"distributor_id\""
-        content shouldContain "onDelete = CascadeAction.DETACH"
+        result.shouldSucceed()
+        result.generatedFileContent(case.generatedFile).shouldContainEach(*case.expected.toTypedArray())
     }
 
     test("TableDefProcessor emits ForeignKeyDef targeting the lambda scalar for delegate-val @ToOneAggregate") {
@@ -187,10 +195,12 @@ internal class ToOneAggregateTableDefTest : FunSpec({
                 )
             )
 
-        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        result.shouldSucceed()
         val content = result.generatedFileContent("AudioRelease_LirpTableDef.kt")
         // FK column must reference the backing scalar `label_id`, not the delegate name `label`.
-        content shouldContain "ForeignKeyDef(columnName = \"label_id\""
-        content shouldContain "referencedTable = \"audio_label\""
+        content.shouldContainEach(
+            "ForeignKeyDef(columnName = \"label_id\"",
+            "referencedTable = \"audio_label\""
+        )
     }
 })

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/CombinedKspRobustnessIT.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/CombinedKspRobustnessIT.kt
@@ -17,6 +17,7 @@
 
 package net.transgressoft.lirp.persistence.sql
 
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.awaitSubscriptionReady
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.assertions.nondeterministic.eventuallyConfig
@@ -26,7 +27,6 @@ import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.delay
 
 /**
  * Polling config for cross-dialect persistence assertions. A mutation is persisted asynchronously
@@ -39,19 +39,6 @@ private val persistedRowPoll =
         duration = 30.seconds
         interval = 200.milliseconds
     }
-
-/**
- * Warm-up pause that lets a freshly constructed or freshly populated repository's per-entity
- * persistence subscription start collecting before the first reactive mutation.
- *
- * Each entity is subscribed on a launched collector coroutine; until that coroutine reaches its
- * `collect`, the entity's event publisher has a registered subscriber count but no active collector.
- * A mutation emitted in that window is delivered to a `replay = 0` flow with no live collector and is
- * dropped — the update never reaches the debounced SQL flush, so a later read polls forever and the
- * assertion times out. Pausing before the first mutation closes the window. Mirrors the SharedFlow
- * collector-warmup convention documented in CONTRIBUTING.md.
- */
-private suspend fun awaitSubscriptionReady() = delay(50.milliseconds)
 
 /**
  * Joint cross-dialect canary asserting that the three KSP robustness fixes from issue #207

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SoftDeleteSqlIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SoftDeleteSqlIntegrationTest.kt
@@ -18,6 +18,7 @@
 package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.persistence.query.query
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.awaitSubscriptionReady
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.assertions.nondeterministic.eventuallyConfig
@@ -30,7 +31,6 @@ import io.kotest.matchers.optional.shouldNotBePresent
 import io.kotest.matchers.shouldBe
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.delay
 
 /**
  * Polling config for soft-delete persistence assertions. Reactive mutation events are dispatched
@@ -42,16 +42,6 @@ private val persistedRowPoll =
         duration = 30.seconds
         interval = 200.milliseconds
     }
-
-/**
- * Pause that lets a freshly constructed or freshly populated repository's per-entity
- * persistence subscription start collecting before the first reactive mutation.
- *
- * Each entity is subscribed on a launched collector coroutine; until that coroutine reaches its
- * `collect`, a mutation emitted in that window is dropped (replay = 0, no live collector).
- * Pausing before the first mutation closes the window.
- */
-private suspend fun awaitSubscriptionReady() = delay(50.milliseconds)
 
 /**
  * Cross-dialect integration tests verifying the soft-delete persistence contract for

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryConverterIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryConverterIntegrationTest.kt
@@ -18,7 +18,8 @@
 package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
-import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
 import java.nio.file.Paths
@@ -32,10 +33,10 @@ import java.time.Duration
  * Each dialect runs two scenarios: a non-null round-trip exercising both [PathConverter] and
  * [DurationConverter], and a nullable round-trip preserving `null` through write and read.
  */
-internal class SqlRepositoryConverterIntegrationTest : StringSpec({
+internal class SqlRepositoryConverterIntegrationTest : FunSpec({
 
-    databases.forEach { db ->
-        "SqlRepository round-trips ConverterFixtureEntity with non-null converter-routed fields on ${db.name}" {
+    withData(databases) { db ->
+        test("SqlRepository round-trips ConverterFixtureEntity with non-null converter-routed fields") {
             DatabaseTestSupport.withDatabaseTest(db, ConverterFixtureEntity_LirpTableDef) { ds ->
                 val originalPath = Paths.get("/tmp/song.mp3")
                 val originalCover = Paths.get("/tmp/cover.png")
@@ -65,7 +66,7 @@ internal class SqlRepositoryConverterIntegrationTest : StringSpec({
             }
         }
 
-        "SqlRepository preserves null in a nullable converter-routed column on ${db.name}" {
+        test("SqlRepository preserves null in a nullable converter-routed column") {
             DatabaseTestSupport.withDatabaseTest(db, ConverterFixtureEntity_LirpTableDef) { ds ->
                 val originalPath = Paths.get("/tmp/song.mp3")
                 val originalLength = Duration.ofSeconds(60)

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryDdlIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryDdlIntegrationTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.withDatabaseTest
+import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withTests
 import io.kotest.matchers.optional.shouldBePresent
@@ -71,17 +72,19 @@ internal class SqlRepositoryDdlIntegrationTest : FunSpec({
                 repo.add(entity)
 
                 repo.findById(1).shouldBePresent {
-                    it.longVal shouldBe 123456789L
-                    it.textVal shouldBe "hello text"
-                    it.boolVal shouldBe true
-                    it.doubleVal shouldBe 3.14
-                    it.floatVal shouldBe 2.71f
-                    it.uuidVal shouldBe uuid
-                    it.dateVal shouldBe date
-                    it.dateTimeVal shouldBe dateTime
-                    it.varcharVal shouldBe "varchar value"
-                    it.decimalVal shouldBe BigDecimal("99.99")
-                    it.enumVal shouldBe "ACTIVE"
+                    assertSoftly {
+                        it.longVal shouldBe 123456789L
+                        it.textVal shouldBe "hello text"
+                        it.boolVal shouldBe true
+                        it.doubleVal shouldBe 3.14
+                        it.floatVal shouldBe 2.71f
+                        it.uuidVal shouldBe uuid
+                        it.dateVal shouldBe date
+                        it.dateTimeVal shouldBe dateTime
+                        it.varcharVal shouldBe "varchar value"
+                        it.decimalVal shouldBe BigDecimal("99.99")
+                        it.enumVal shouldBe "ACTIVE"
+                    }
                 }
 
                 repo.close()

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEventIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEventIntegrationTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.CrudEvent.Type.UPDATE
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.awaitSubscriptionReady
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.withDatabaseTest
 import io.kotest.assertions.nondeterministic.eventually
@@ -30,9 +31,7 @@ import org.junit.jupiter.api.DisplayName
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.delay
 
 /**
  * Integration tests for [SqlRepository] event emission against PostgreSQL, MySQL 8.0, and MariaDB 11.
@@ -50,7 +49,7 @@ internal class SqlRepositoryEventIntegrationTest : FunSpec({
                 val repo = SqlRepository(dataSource, TestPersonTableDef)
                 val received = AtomicReference<CrudEvent.Type?>()
                 repo.subscribe { event -> received.set(event.type) }
-                delay(50.milliseconds) // let SharedFlow collector coroutine start
+                awaitSubscriptionReady()
 
                 repo.add(TestPerson(1).apply { firstName = "Alice" })
 
@@ -70,7 +69,7 @@ internal class SqlRepositoryEventIntegrationTest : FunSpec({
                 val received = AtomicReference<CrudEvent.Type?>()
                 // Subscribe before add so the collector coroutine is running when DELETE fires
                 repo.subscribe { event -> received.set(event.type) }
-                delay(50.milliseconds) // let SharedFlow collector coroutine start
+                awaitSubscriptionReady()
 
                 val person = TestPerson(2).apply { firstName = "Bob" }
                 repo.add(person)
@@ -92,7 +91,7 @@ internal class SqlRepositoryEventIntegrationTest : FunSpec({
                 val eventTypes = Collections.synchronizedList(mutableListOf<CrudEvent.Type>())
                 // Subscribe before add so the collector coroutine is running when DELETE fires
                 repo.subscribe { event -> eventTypes.add(event.type) }
-                delay(50.milliseconds) // let SharedFlow collector coroutine start
+                awaitSubscriptionReady()
 
                 repo.add(TestPerson(3).apply { firstName = "Carol" })
                 repo.clear()
@@ -115,7 +114,7 @@ internal class SqlRepositoryEventIntegrationTest : FunSpec({
                 val mutationReceived = AtomicBoolean(false)
                 val person = repo.findById(4).get()
                 person.subscribe { mutationReceived.set(true) }
-                delay(50.milliseconds) // let SharedFlow collector coroutine start
+                awaitSubscriptionReady()
 
                 person.firstName = "Changed"
 
@@ -140,7 +139,7 @@ internal class SqlRepositoryEventIntegrationTest : FunSpec({
                 val mutationReceived = AtomicBoolean(false)
                 val person = repo.findById(5).get()
                 person.subscribe { mutationReceived.set(true) }
-                delay(50.milliseconds) // let SharedFlow collector coroutine start
+                awaitSubscriptionReady()
 
                 person.firstName = "Evelyn"
 

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryForeignKeyIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryForeignKeyIntegrationTest.kt
@@ -18,7 +18,6 @@
 package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
-import com.zaxxer.hikari.HikariDataSource
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withTests
@@ -42,30 +41,6 @@ import java.sql.SQLException
  */
 @DisplayName("SqlRepository Foreign Keys Integration")
 internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
-
-    /**
-     * Drops all FK-related tables in dependency order so the next iteration starts clean. Errors
-     * for tables that don't exist yet are swallowed — tests run against fresh databases on every
-     * dialect except SQLite (which gets a fresh tempfile per [HikariDataSource]) so the drops are
-     * mostly defensive.
-     */
-    fun resetSchema(dataSource: HikariDataSource) {
-        // Drop child tables before parents to avoid FK violations during teardown. Junction first,
-        // then parents (the FK lives on the junction → parent edge), then children.
-        for (sql in listOf(
-            "DROP TABLE IF EXISTS fk_parent_children",
-            "DROP TABLE IF EXISTS fk_parents",
-            "DROP TABLE IF EXISTS fk_children"
-        )) {
-            try {
-                dataSource.connection.use { conn ->
-                    conn.createStatement().use { stmt -> stmt.execute(sql) }
-                }
-            } catch (_: SQLException) {
-                // ignore — table may not exist on a fresh database
-            }
-        }
-    }
 
     /**
      * Asserts that [block] throws a SQL foreign-key violation. The dialect-specific error codes
@@ -103,7 +78,7 @@ internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
         withTests(databases) { db ->
             val dataSource = db.buildDataSource()
             try {
-                resetSchema(dataSource)
+                DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
                 FkScalarFkInstaller.setupRestrict(dataSource)
 
                 val childRepo = SqlRepository(dataSource, FkChildTableDef)
@@ -145,7 +120,7 @@ internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
         withTests(databases) { db ->
             val dataSource = db.buildDataSource()
             try {
-                resetSchema(dataSource)
+                DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
                 FkScalarFkInstaller.setupCascade(dataSource)
 
                 val childRepo = SqlRepository(dataSource, FkChildTableDef)
@@ -184,7 +159,7 @@ internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
         withTests(databases) { db ->
             val dataSource = db.buildDataSource()
             try {
-                resetSchema(dataSource)
+                DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
                 FkScalarFkInstaller.setupDetach(dataSource)
 
                 val childRepo = SqlRepository(dataSource, FkChildTableDef)
@@ -224,7 +199,7 @@ internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
         withTests(databases) { db ->
             val dataSource = db.buildDataSource()
             try {
-                resetSchema(dataSource)
+                DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
                 FkScalarFkInstaller.setupNone(dataSource)
 
                 val parentRepo = SqlRepository(dataSource, FkParentTableDef)
@@ -253,7 +228,7 @@ internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
         withTests(databases) { db ->
             val dataSource = db.buildDataSource()
             try {
-                resetSchema(dataSource)
+                DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
                 // Use the NONE schema to keep the scalar FK out of the way — we only care about
                 // junction CASCADE here.
                 FkScalarFkInstaller.setupNone(dataSource)
@@ -305,7 +280,7 @@ internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
         withTests(databases) { db ->
             val dataSource = db.buildDataSource()
             try {
-                resetSchema(dataSource)
+                DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
                 FkScalarFkInstaller.setupNone(dataSource)
 
                 val childRepo = SqlRepository(dataSource, FkChildTableDef)

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryForeignKeyIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryForeignKeyIntegrationTest.kt
@@ -18,6 +18,7 @@
 package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
+import com.zaxxer.hikari.HikariDataSource
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withTests
@@ -41,6 +42,11 @@ import java.sql.SQLException
  */
 @DisplayName("SqlRepository Foreign Keys Integration")
 internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
+
+    // Drops the FK-linked tables (children/junction before parents) so each case starts clean.
+    // Keeps the table list in one place across the cases that reset the schema.
+    fun resetSchema(dataSource: HikariDataSource) =
+        DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
 
     /**
      * Asserts that [block] throws a SQL foreign-key violation. The dialect-specific error codes
@@ -78,7 +84,7 @@ internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
         withTests(databases) { db ->
             val dataSource = db.buildDataSource()
             try {
-                DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
+                resetSchema(dataSource)
                 FkScalarFkInstaller.setupRestrict(dataSource)
 
                 val childRepo = SqlRepository(dataSource, FkChildTableDef)
@@ -120,7 +126,7 @@ internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
         withTests(databases) { db ->
             val dataSource = db.buildDataSource()
             try {
-                DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
+                resetSchema(dataSource)
                 FkScalarFkInstaller.setupCascade(dataSource)
 
                 val childRepo = SqlRepository(dataSource, FkChildTableDef)
@@ -159,7 +165,7 @@ internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
         withTests(databases) { db ->
             val dataSource = db.buildDataSource()
             try {
-                DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
+                resetSchema(dataSource)
                 FkScalarFkInstaller.setupDetach(dataSource)
 
                 val childRepo = SqlRepository(dataSource, FkChildTableDef)
@@ -199,7 +205,7 @@ internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
         withTests(databases) { db ->
             val dataSource = db.buildDataSource()
             try {
-                DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
+                resetSchema(dataSource)
                 FkScalarFkInstaller.setupNone(dataSource)
 
                 val parentRepo = SqlRepository(dataSource, FkParentTableDef)
@@ -228,7 +234,7 @@ internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
         withTests(databases) { db ->
             val dataSource = db.buildDataSource()
             try {
-                DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
+                resetSchema(dataSource)
                 // Use the NONE schema to keep the scalar FK out of the way — we only care about
                 // junction CASCADE here.
                 FkScalarFkInstaller.setupNone(dataSource)
@@ -280,7 +286,7 @@ internal class SqlRepositoryForeignKeyIntegrationTest : FunSpec({
         withTests(databases) { db ->
             val dataSource = db.buildDataSource()
             try {
-                DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
+                resetSchema(dataSource)
                 FkScalarFkInstaller.setupNone(dataSource)
 
                 val childRepo = SqlRepository(dataSource, FkChildTableDef)

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryJunctionOrphanIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryJunctionOrphanIntegrationTest.kt
@@ -41,22 +41,6 @@ import org.junit.jupiter.api.DisplayName
 @DisplayName("SqlRepository Junction Orphan Integration")
 class SqlRepositoryJunctionOrphanIntegrationTest : StringSpec({
 
-    fun resetSchema(dataSource: HikariDataSource) {
-        // DROP TABLE IF EXISTS already handles the "table missing" case across PostgreSQL, MySQL,
-        // MariaDB and SQLite, so any propagated SQLException is a real setup failure that must
-        // surface — silently swallowing it would mask schema corruption and let regression tests
-        // pass for the wrong reason.
-        for (sql in listOf(
-            "DROP TABLE IF EXISTS fk_parent_children",
-            "DROP TABLE IF EXISTS fk_parents",
-            "DROP TABLE IF EXISTS fk_children"
-        )) {
-            dataSource.connection.use { conn ->
-                conn.createStatement().use { stmt -> stmt.execute(sql) }
-            }
-        }
-    }
-
     fun junctionRowCount(dataSource: HikariDataSource, parentIdFilter: Int? = null): Long {
         val where = if (parentIdFilter != null) " WHERE parent_id = $parentIdFilter" else ""
         return dataSource.connection.use { conn ->
@@ -72,7 +56,7 @@ class SqlRepositoryJunctionOrphanIntegrationTest : StringSpec({
     "[SqlRepositoryJunctionOrphan] clear path removes junction rows before parent table when FKs not yet installed" {
         val dataSource = PostgresContainerSupport.buildDataSource()
         try {
-            resetSchema(dataSource)
+            DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
             // No FK install on the scalar column either — keep the scenario focused on junction.
             FkScalarFkInstaller.setupNone(dataSource)
 
@@ -120,7 +104,7 @@ class SqlRepositoryJunctionOrphanIntegrationTest : StringSpec({
     "[SqlRepositoryJunctionOrphan] remove path removes junction rows for the deleted id only" {
         val dataSource = PostgresContainerSupport.buildDataSource()
         try {
-            resetSchema(dataSource)
+            DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
             FkScalarFkInstaller.setupNone(dataSource)
 
             val childRepo = SqlRepository(dataSource, FkChildTableDef)
@@ -156,7 +140,7 @@ class SqlRepositoryJunctionOrphanIntegrationTest : StringSpec({
     "[SqlRepositoryJunctionOrphan] installJunctionForeignKeys succeeds after clear and remove" {
         val dataSource = PostgresContainerSupport.buildDataSource()
         try {
-            resetSchema(dataSource)
+            DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
             FkScalarFkInstaller.setupNone(dataSource)
 
             val childRepo = SqlRepository(dataSource, FkChildTableDef)

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryOptimisticLockingIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryOptimisticLockingIntegrationTest.kt
@@ -27,12 +27,9 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withTests
 import io.kotest.matchers.shouldBe
 import org.jetbrains.exposed.v1.core.Column
-import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.selectAll
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
 import org.junit.jupiter.api.DisplayName
 import java.util.Collections
@@ -53,20 +50,12 @@ import kotlin.time.Duration.Companion.seconds
 @DisplayName("SqlRepository Optimistic Locking Integration")
 internal class SqlRepositoryOptimisticLockingIntegrationTest : FunSpec({
 
-    // Helper — opens a short-lived Exposed transaction against [dataSource] using the same
-    // [tableDef] the repo uses, so a "third writer" can bump a row's version independently.
-    fun <T> rawTransaction(dataSource: HikariDataSource, tableDef: SqlTableDef<*>, block: Table.() -> T): T {
-        val db = Database.connect(dataSource)
-        val exposed = ExposedTableInterpreter().interpret(tableDef)
-        return transaction(db) { exposed.table.block() }
-    }
-
     // Polls the DB directly until the row with [id] has [minVersion] or higher. Used to
     // synchronize against repo debounce flushes before racing / third-party writes.
     suspend fun awaitVersionedInDb(dataSource: HikariDataSource, id: Int, minVersion: Long = 0L) {
         eventually(10.seconds) {
             val version =
-                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                DatabaseTestSupport.rawTransaction(dataSource, TestVersionedPersonTableDef) {
                     @Suppress("UNCHECKED_CAST")
                     selectAll()
                         .where { (columns.first { it.name == "id" } as Column<Int>) eq id }
@@ -84,7 +73,7 @@ internal class SqlRepositoryOptimisticLockingIntegrationTest : FunSpec({
     suspend fun awaitUnversionedInDb(dataSource: HikariDataSource, id: Int) {
         eventually(10.seconds) {
             val count =
-                rawTransaction(dataSource, TestPersonTableDef) {
+                DatabaseTestSupport.rawTransaction(dataSource, TestPersonTableDef) {
                     @Suppress("UNCHECKED_CAST")
                     selectAll()
                         .where { (columns.first { it.name == "id" } as Column<Int>) eq id }
@@ -120,7 +109,7 @@ internal class SqlRepositoryOptimisticLockingIntegrationTest : FunSpec({
                 awaitVersionedInDb(dataSource, 1)
 
                 // Third-party writer commits its UPDATE and bumps version to 1.
-                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                DatabaseTestSupport.rawTransaction(dataSource, TestVersionedPersonTableDef) {
                     @Suppress("UNCHECKED_CAST")
                     update({ (columns.first { it.name == "id" } as Column<Int>) eq 1 }) { row ->
                         @Suppress("UNCHECKED_CAST")
@@ -175,7 +164,7 @@ internal class SqlRepositoryOptimisticLockingIntegrationTest : FunSpec({
 
                 // Third-party writer commits a concurrent change and bumps version to 1 BEFORE our
                 // local mutations' debounce fires.
-                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                DatabaseTestSupport.rawTransaction(dataSource, TestVersionedPersonTableDef) {
                     @Suppress("UNCHECKED_CAST")
                     update({ (columns.first { it.name == "id" } as Column<Int>) eq 2 }) { row ->
                         @Suppress("UNCHECKED_CAST")
@@ -221,7 +210,7 @@ internal class SqlRepositoryOptimisticLockingIntegrationTest : FunSpec({
                 awaitVersionedInDb(dataSource, 3)
 
                 // Third-party writer bumps the version BEFORE our delete fires.
-                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                DatabaseTestSupport.rawTransaction(dataSource, TestVersionedPersonTableDef) {
                     @Suppress("UNCHECKED_CAST")
                     update({ (columns.first { it.name == "id" } as Column<Int>) eq 3 }) { row ->
                         @Suppress("UNCHECKED_CAST")
@@ -265,7 +254,7 @@ internal class SqlRepositoryOptimisticLockingIntegrationTest : FunSpec({
                     // Seed versioned repo then force a conflict via third-party writer.
                     versioned.add(TestVersionedPerson(1).apply { firstName = "V" })
                     awaitVersionedInDb(versionedDs, 1)
-                    rawTransaction(versionedDs, TestVersionedPersonTableDef) {
+                    DatabaseTestSupport.rawTransaction(versionedDs, TestVersionedPersonTableDef) {
                         @Suppress("UNCHECKED_CAST")
                         update({ (columns.first { it.name == "id" } as Column<Int>) eq 1 }) { row ->
                             @Suppress("UNCHECKED_CAST")
@@ -287,7 +276,7 @@ internal class SqlRepositoryOptimisticLockingIntegrationTest : FunSpec({
 
                     // Overwrite the unversioned row externally, then mutate locally — no conflict
                     // ever fires because the unversioned repo does not check AND version=?.
-                    rawTransaction(unversionedDs, TestPersonTableDef) {
+                    DatabaseTestSupport.rawTransaction(unversionedDs, TestPersonTableDef) {
                         @Suppress("UNCHECKED_CAST")
                         update({ (columns.first { it.name == "id" } as Column<Int>) eq 9 }) { row ->
                             @Suppress("UNCHECKED_CAST")
@@ -330,7 +319,7 @@ internal class SqlRepositoryOptimisticLockingIntegrationTest : FunSpec({
                 (1..5).forEach { id -> awaitVersionedInDb(dataSource, id) }
 
                 // Bump id=3's version externally so its versioned DELETE will fail.
-                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                DatabaseTestSupport.rawTransaction(dataSource, TestVersionedPersonTableDef) {
                     @Suppress("UNCHECKED_CAST")
                     update({ (columns.first { it.name == "id" } as Column<Int>) eq 3 }) { row ->
                         @Suppress("UNCHECKED_CAST")
@@ -430,7 +419,7 @@ internal class SqlRepositoryOptimisticLockingIntegrationTest : FunSpec({
                 awaitVersionedInDb(dataSource, 11)
 
                 // Third-party writer bumps id=10's version so our local update will conflict.
-                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                DatabaseTestSupport.rawTransaction(dataSource, TestVersionedPersonTableDef) {
                     @Suppress("UNCHECKED_CAST")
                     update({ (columns.first { it.name == "id" } as Column<Int>) eq 10 }) { row ->
                         @Suppress("UNCHECKED_CAST")
@@ -456,7 +445,7 @@ internal class SqlRepositoryOptimisticLockingIntegrationTest : FunSpec({
                     repo.findById(11).isPresent shouldBe false
                 }
                 // Raw DB check — id=11 row really was deleted; id=10 reflects third-party state.
-                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                DatabaseTestSupport.rawTransaction(dataSource, TestVersionedPersonTableDef) {
                     @Suppress("UNCHECKED_CAST")
                     val row11Count = selectAll().where { (columns.first { it.name == "id" } as Column<Int>) eq 11 }.count()
                     row11Count shouldBe 0L
@@ -488,7 +477,7 @@ internal class SqlRepositoryOptimisticLockingIntegrationTest : FunSpec({
                 awaitVersionedInDb(dataSource, 20)
 
                 // Third-party DELETE — our local UPDATE will hit canonicalRow == null (Case 1).
-                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                DatabaseTestSupport.rawTransaction(dataSource, TestVersionedPersonTableDef) {
                     deleteWhere {
                         @Suppress("UNCHECKED_CAST")
                         (columns.first { it.name == "id" } as Column<Int>) eq 20

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryQueryDslIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryQueryDslIntegrationTest.kt
@@ -28,6 +28,7 @@ import net.transgressoft.lirp.persistence.query.lte
 import net.transgressoft.lirp.persistence.query.not
 import net.transgressoft.lirp.persistence.query.or
 import net.transgressoft.lirp.persistence.query.query
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.awaitSubscriptionReady
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
@@ -40,9 +41,7 @@ import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.DisplayName as JunitDisplayName
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.delay
 
 /**
  * Integration tests for the Query DSL against [SqlRepository] on PostgreSQL, MySQL, MariaDB, and SQLite.
@@ -758,7 +757,7 @@ internal class SqlRepositoryQueryDslIntegrationTest : FunSpec({
                     repo.activateEvents(CrudEvent.Type.READ)
                     val readCount = AtomicInteger(0)
                     repo.subscribe(CrudEvent.Type.READ) { readCount.incrementAndGet() }
-                    delay(50.milliseconds) // let SharedFlow collector coroutine start
+                    awaitSubscriptionReady()
 
                     val sequence = repo.query { where { TestPerson::firstName eq "A" } }
 

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryRawConstructorIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryRawConstructorIntegrationTest.kt
@@ -26,6 +26,7 @@ import net.transgressoft.lirp.persistence.LirpRawInitializer
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.withDatabaseTest
 import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withTests
@@ -319,9 +320,11 @@ internal class SqlRepositoryRawConstructorIntegrationTest : FunSpec({
                     // LirpRawInitializer rather than re-inserting a partially hydrated instance.
                     eventually(5.seconds) {
                         val recovered = repo.findById(7).orElseThrow()
-                        recovered.tag shouldBe "tag-7"
-                        recovered.version shouldBe 1L
-                        recovered.note shouldBe "note-7"
+                        assertSoftly {
+                            recovered.tag shouldBe "tag-7"
+                            recovered.version shouldBe 1L
+                            recovered.note shouldBe "note-7"
+                        }
                     }
                 } finally {
                     repo.close()

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryRawInitLoadTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryRawInitLoadTest.kt
@@ -18,8 +18,10 @@
 package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.event.CrudEvent
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.PERSISTED_ROW_POLL
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.databases
 import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.withDatabaseTest
+import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withTests
 import io.kotest.matchers.shouldBe
@@ -105,10 +107,12 @@ internal class SqlRepositoryRawInitLoadTest : FunSpec({
                 val first = repo.findById(0).orElseThrow()
                 first.age = 99
 
-                // Allow the reactive event dispatch to settle.
-                Thread.sleep(100)
-                mutationEvents.size shouldBe 1
-                mutationEvents.first() shouldNotBe ""
+                // Poll until the async reactive dispatch delivers the single mutation event, rather
+                // than racing it with a fixed sleep.
+                eventually(PERSISTED_ROW_POLL) {
+                    mutationEvents.size shouldBe 1
+                    mutationEvents.first() shouldNotBe ""
+                }
 
                 repo.close()
             }

--- a/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryVersioningJunctionIntegrationTest.kt
+++ b/lirp-sql/src/integrationTest/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryVersioningJunctionIntegrationTest.kt
@@ -25,7 +25,6 @@ import io.kotest.datatest.withTests
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.DisplayName
-import java.sql.SQLException
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -37,22 +36,6 @@ import kotlin.time.Duration.Companion.seconds
  */
 @DisplayName("SqlRepository Versioning x Junction Integration")
 internal class SqlRepositoryVersioningJunctionIntegrationTest : FunSpec({
-
-    fun resetSchema(dataSource: HikariDataSource) {
-        for (sql in listOf(
-            "DROP TABLE IF EXISTS fk_parent_children",
-            "DROP TABLE IF EXISTS fk_parents",
-            "DROP TABLE IF EXISTS fk_children"
-        )) {
-            try {
-                dataSource.connection.use { conn ->
-                    conn.createStatement().use { stmt -> stmt.execute(sql) }
-                }
-            } catch (_: SQLException) {
-                // ignore — table may not exist on a fresh database
-            }
-        }
-    }
 
     fun queryParentVersion(dataSource: HikariDataSource, parentId: Int): Long =
         dataSource.connection.use { conn ->
@@ -76,7 +59,7 @@ internal class SqlRepositoryVersioningJunctionIntegrationTest : FunSpec({
         parentName: String,
         childIds: List<Int>
     ) {
-        resetSchema(dataSource)
+        DatabaseTestSupport.dropTables(dataSource, "fk_parent_children", "fk_parents", "fk_children")
         FkScalarFkInstaller.setupNone(dataSource)
 
         val childRepo = SqlRepository(dataSource, FkChildTableDef)

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlRepositoryTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlRepositoryTest.kt
@@ -20,15 +20,14 @@ package net.transgressoft.lirp.persistence.sql
 import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.persistence.RegistryBase
 import net.transgressoft.lirp.persistence.fx.FxToolkitInit
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.awaitSubscriptionReady
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.delay
 
 /**
  * SQL persistence tests for entities combining fx scalar delegates ([fxString], [fxInteger],
@@ -246,7 +245,7 @@ internal class FxSqlRepositoryTest : StringSpec({
         entityRepo.add(entity)
 
         entityRepo.subscribe { event -> received.set(event.type) }
-        delay(50.milliseconds)
+        awaitSubscriptionReady()
 
         entity.nameProperty.set("Updated")
 

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlRepositoryTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/FxSqlRepositoryTest.kt
@@ -36,6 +36,8 @@ import kotlin.time.Duration.Companion.seconds
  */
 internal class FxSqlRepositoryTest : StringSpec({
 
+    extension(IsolatedReactiveScope)
+
     fun freshJdbcUrl() = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
 
     beforeSpec {

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/ReactiveEmbeddedSqlTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/ReactiveEmbeddedSqlTest.kt
@@ -42,6 +42,8 @@ import kotlin.time.Duration.Companion.seconds
  */
 internal class ReactiveEmbeddedSqlTest : StringSpec({
 
+    extension(IsolatedReactiveScope)
+
     fun freshJdbcUrl() = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
 
     "ReactiveEmbeddedFixtureEntity round-trips body-declared @Embedded leaf values on H2" {

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SoftDeleteSqlTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SoftDeleteSqlTest.kt
@@ -34,6 +34,8 @@ import io.kotest.matchers.shouldBe
  */
 internal class SoftDeleteSqlTest : StringSpec({
 
+    extension(IsolatedReactiveScope)
+
     val tableDef = SoftDeletableVersionedTrack_LirpTableDef
 
     "SoftDeleteSqlTest soft-delete persists deleted_at via UPDATE and does not hard-delete the row" {

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryBulkLoadTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryBulkLoadTest.kt
@@ -45,6 +45,8 @@ import javax.sql.DataSource
  */
 class SqlRepositoryBulkLoadTest : StringSpec({
 
+    extension(IsolatedReactiveScope)
+
     fun freshJdbcUrl() = "jdbc:h2:mem:bulkload-${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
 
     fun newDataSource(jdbcUrl: String): HikariDataSource {

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEntityForeignKeyInstallTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEntityForeignKeyInstallTest.kt
@@ -51,6 +51,8 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 class SqlRepositoryEntityForeignKeyInstallTest : StringSpec({
 
+    extension(IsolatedReactiveScope)
+
     val nextId = AtomicInteger(0)
 
     "installEntityForeignKeys with RESTRICT prevents deleting a referenced child row" {

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEntityForeignKeyInstallTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryEntityForeignKeyInstallTest.kt
@@ -24,7 +24,6 @@ import net.transgressoft.lirp.persistence.ColumnType
 import net.transgressoft.lirp.persistence.LirpRawInitializer
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
-import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
@@ -47,8 +46,8 @@ import java.util.concurrent.atomic.AtomicInteger
  * via direct JDBC. `Int` keys avoid `java.util.UUID` vs `kotlin.uuid.Uuid` plumbing noise that
  * is orthogonal to the FK install contract under test.
  *
- * Persistence waits use kotest's [eventually] to poll the DB rather than fixed `delay(...)` sleeps,
- * keeping the suite deterministic under CI jitter.
+ * Persistence waits poll the DB via [DatabaseTestSupport.awaitRowPresent] rather than fixed
+ * `delay(...)` sleeps, keeping the suite deterministic under CI jitter.
  */
 class SqlRepositoryEntityForeignKeyInstallTest : StringSpec({
 
@@ -63,11 +62,11 @@ class SqlRepositoryEntityForeignKeyInstallTest : StringSpec({
 
             val childId = nextId.incrementAndGet()
             childRepo.add(ScalarFkChild(childId).apply { name = "linked" })
-            awaitRowPresent(ds, "fk_scalar_children", childId)
+            DatabaseTestSupport.awaitRowPresent(ds, "fk_scalar_children", childId)
 
             val parentId = nextId.incrementAndGet()
             parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
-            awaitRowPresent(ds, "fk_scalar_parents", parentId)
+            DatabaseTestSupport.awaitRowPresent(ds, "fk_scalar_parents", parentId)
 
             shouldThrow<java.sql.SQLException> {
                 ds.connection.use { conn ->
@@ -92,11 +91,11 @@ class SqlRepositoryEntityForeignKeyInstallTest : StringSpec({
 
             val childId = nextId.incrementAndGet()
             childRepo.add(ScalarFkChild(childId).apply { name = "doomed" })
-            awaitRowPresent(ds, "fk_scalar_children", childId)
+            DatabaseTestSupport.awaitRowPresent(ds, "fk_scalar_children", childId)
 
             val parentId = nextId.incrementAndGet()
             parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
-            awaitRowPresent(ds, "fk_scalar_parents", parentId)
+            DatabaseTestSupport.awaitRowPresent(ds, "fk_scalar_parents", parentId)
 
             ds.connection.use { conn ->
                 conn.createStatement().use { stmt ->
@@ -125,11 +124,11 @@ class SqlRepositoryEntityForeignKeyInstallTest : StringSpec({
 
             val childId = nextId.incrementAndGet()
             childRepo.add(ScalarFkChild(childId).apply { name = "to-be-orphaned" })
-            awaitRowPresent(ds, "fk_scalar_children", childId)
+            DatabaseTestSupport.awaitRowPresent(ds, "fk_scalar_children", childId)
 
             val parentId = nextId.incrementAndGet()
             parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
-            awaitRowPresent(ds, "fk_scalar_parents", parentId)
+            DatabaseTestSupport.awaitRowPresent(ds, "fk_scalar_parents", parentId)
 
             ds.connection.use { conn ->
                 conn.createStatement().use { stmt ->
@@ -163,11 +162,11 @@ class SqlRepositoryEntityForeignKeyInstallTest : StringSpec({
 
             val childId = nextId.incrementAndGet()
             childRepo.add(ScalarFkChild(childId).apply { name = "still-linked" })
-            awaitRowPresent(ds, "fk_scalar_children", childId)
+            DatabaseTestSupport.awaitRowPresent(ds, "fk_scalar_children", childId)
 
             val parentId = nextId.incrementAndGet()
             parentRepo.add(ScalarFkParent(parentId).apply { this.childId = childId })
-            awaitRowPresent(ds, "fk_scalar_parents", parentId)
+            DatabaseTestSupport.awaitRowPresent(ds, "fk_scalar_parents", parentId)
 
             shouldThrow<java.sql.SQLException> {
                 ds.connection.use { conn ->
@@ -189,7 +188,7 @@ class SqlRepositoryEntityForeignKeyInstallTest : StringSpec({
 
             val childId = nextId.incrementAndGet()
             childRepo.add(ScalarFkChild(childId).apply { name = "standalone" })
-            awaitRowPresent(ds, "fk_scalar_children", childId)
+            DatabaseTestSupport.awaitRowPresent(ds, "fk_scalar_children", childId)
 
             childRepo.findById(childId).shouldBePresent { it.name shouldBe "standalone" }
         } finally {
@@ -205,20 +204,6 @@ private fun freshDataSource(): HikariDataSource {
             maximumPoolSize = 4
         }
     return HikariDataSource(cfg)
-}
-
-// Polls the DB directly until a row with the given primary key appears, with a generous timeout.
-// Replaces fixed `delay(...)` sleeps so the suite stays deterministic under CI jitter.
-private suspend fun awaitRowPresent(ds: HikariDataSource, tableName: String, id: Int) {
-    eventually(DatabaseTestSupport.PERSISTED_ROW_POLL) {
-        ds.connection.use { conn ->
-            conn.createStatement().use { stmt ->
-                val rs = stmt.executeQuery("SELECT COUNT(*) FROM $tableName WHERE id = $id")
-                rs.next()
-                require(rs.getInt(1) == 1) { "row id=$id not yet visible in $tableName" }
-            }
-        }
-    }
 }
 
 // Closes resources in reverse-of-acquisition order, swallowing per-resource failures so a leak

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryRecoveryFailedTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryRecoveryFailedTest.kt
@@ -45,6 +45,8 @@ import kotlin.time.Duration.Companion.seconds
  */
 class SqlRepositoryRecoveryFailedTest : StringSpec({
 
+    extension(IsolatedReactiveScope)
+
     fun freshJdbcUrl() = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
 
     /** Reflectively reads the `db` field of a [SqlRepository] for direct DDL execution in tests. */

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryRecoveryFailedTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryRecoveryFailedTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.event.StandardCrudEvent
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.awaitSubscriptionReady
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -28,9 +29,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.delay
 
 /**
  * Regression tests for #201: `SqlRepository.writePending` must not silently swallow
@@ -79,7 +78,7 @@ class SqlRepositoryRecoveryFailedTest : StringSpec({
         val repo = SqlRepository(freshJdbcUrl(), TestVersionedPersonTableDef)
         val received = CopyOnWriteArrayList<CrudEvent<*, *>>()
         repo.subscribe { event -> received.add(event) }
-        delay(50.milliseconds)
+        awaitSubscriptionReady()
 
         // Seed the retry queue at the escalation threshold so a single failed retry escalates.
         staleIdsOf(repo)[999] = newStaleEntry(expectedVersion = 5L, attempts = SqlRepository.MAX_RECOVERY_ATTEMPTS)

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryTest.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.persistence.sql
 
 import net.transgressoft.lirp.event.CrudEvent
 import net.transgressoft.lirp.persistence.RegistryBase
+import net.transgressoft.lirp.persistence.sql.DatabaseTestSupport.awaitSubscriptionReady
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.kotest.assertions.nondeterministic.eventually
@@ -88,7 +89,7 @@ internal class SqlRepositoryTest : StringSpec({
         val repo = SqlRepository(freshJdbcUrl(), TestPersonTableDef)
         val received = AtomicReference<CrudEvent.Type?>()
         repo.subscribe { event -> received.set(event.type) }
-        delay(50.milliseconds) // let SharedFlow collector coroutine start
+        awaitSubscriptionReady()
 
         repo.add(TestPerson(1).apply { firstName = "Bob" })
 
@@ -128,7 +129,7 @@ internal class SqlRepositoryTest : StringSpec({
         val received = AtomicReference<CrudEvent.Type?>()
         // Subscribe before add so the subscriber coroutine is active before events are emitted
         repo.subscribe { event -> received.set(event.type) }
-        delay(50.milliseconds) // let SharedFlow collector coroutine start
+        awaitSubscriptionReady()
 
         repo.add(person)
         repo.remove(person)

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepositoryTest.kt
@@ -42,6 +42,8 @@ import kotlinx.coroutines.delay
  */
 internal class SqlRepositoryTest : StringSpec({
 
+    extension(IsolatedReactiveScope)
+
     /** Returns a unique JDBC URL for an isolated H2 in-memory database per test. */
     fun freshJdbcUrl() = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
 

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlTransactionTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlTransactionTest.kt
@@ -41,7 +41,6 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
@@ -212,17 +211,14 @@ internal class SqlTransactionTest : StringSpec() {
                 }
 
                 // DB-level: the sibling Bob write must NOT be in the DB (full rollback required).
-                val exposedTable = ExposedTableInterpreter().interpret(TestVersionedPersonTableDef)
-                val db = Database.connect(dataSource)
                 val bobFirstNameInDb =
-                    transaction(db) {
-                        exposedTable.table
-                            .selectAll()
-                            .where { (exposedTable.table.columns.first { it.name == "id" } as Column<Int>) eq 11 }
+                    DatabaseTestSupport.rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                        selectAll()
+                            .where { (columns.first { it.name == "id" } as Column<Int>) eq 11 }
                             .singleOrNull()
                             ?.let { row ->
                                 @Suppress("UNCHECKED_CAST")
-                                row[exposedTable.table.columns.first { it.name == "first_name" } as Column<String>]
+                                row[columns.first { it.name == "first_name" } as Column<String>]
                             }
                     }
                 // Bob's DB row must remain "Bob" — the entire DB transaction was rolled back.

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlTransactionTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlTransactionTest.kt
@@ -30,7 +30,6 @@ import net.transgressoft.lirp.persistence.RegistryBase
 import net.transgressoft.lirp.persistence.TransactionBuffer
 import net.transgressoft.lirp.persistence.TransactionConflictException
 import net.transgressoft.lirp.persistence.transaction
-import com.zaxxer.hikari.HikariDataSource
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -74,16 +73,6 @@ private fun Table.audioItemTitleColumn(): Column<String> = columns.first { it.na
 @DisplayName("SqlRepository transaction commit contract (H2)")
 internal class SqlTransactionTest : StringSpec() {
 
-    /**
-     * Opens a short-lived Exposed transaction against [dataSource] to simulate a third-party writer
-     * that bumps a row's version independently of the repository's debounce pipeline.
-     */
-    fun <T> rawTransaction(dataSource: HikariDataSource, tableDef: SqlTableDef<*>, block: Table.() -> T): T {
-        val db = Database.connect(dataSource)
-        val exposed = ExposedTableInterpreter().interpret(tableDef)
-        return transaction(db) { exposed.table.block() }
-    }
-
     init {
 
         afterEach {
@@ -111,7 +100,7 @@ internal class SqlTransactionTest : StringSpec() {
 
                 // DB-level assertion via rawTransaction (bypasses the in-memory cache).
                 val titleInDb =
-                    rawTransaction(dataSource, AudioItemSqlTableDef) {
+                    DatabaseTestSupport.rawTransaction(dataSource, AudioItemSqlTableDef) {
                         selectAll()
                             .where { audioItemIdColumn() eq 1 }
                             .singleOrNull()
@@ -137,7 +126,7 @@ internal class SqlTransactionTest : StringSpec() {
 
                 // DB-level: raw query confirms the row was committed.
                 val titleInDb =
-                    rawTransaction(dataSource, AudioItemSqlTableDef) {
+                    DatabaseTestSupport.rawTransaction(dataSource, AudioItemSqlTableDef) {
                         selectAll()
                             .where { audioItemIdColumn() eq 50 }
                             .singleOrNull()
@@ -167,7 +156,7 @@ internal class SqlTransactionTest : StringSpec() {
 
                 // DB-level: raw query confirms the row is gone.
                 val rowInDb =
-                    rawTransaction(dataSource, AudioItemSqlTableDef) {
+                    DatabaseTestSupport.rawTransaction(dataSource, AudioItemSqlTableDef) {
                         selectAll()
                             .where { audioItemIdColumn() eq 51 }
                             .singleOrNull()
@@ -194,7 +183,7 @@ internal class SqlTransactionTest : StringSpec() {
             val repo = SqlRepository<Int, TestVersionedPerson>(dataSource, TestVersionedPersonTableDef)
             try {
                 // Third-party writer bumps Alice's DB version to 1. The in-memory entity keeps version=0.
-                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                DatabaseTestSupport.rawTransaction(dataSource, TestVersionedPersonTableDef) {
                     @Suppress("UNCHECKED_CAST")
                     update({ (columns.first { it.name == "id" } as Column<Int>) eq 10 }) { row ->
                         @Suppress("UNCHECKED_CAST")
@@ -280,7 +269,7 @@ internal class SqlTransactionTest : StringSpec() {
                 transaction(repo) { _ -> }
 
                 // Bump the DB row's version externally. The in-memory entity keeps version=0.
-                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                DatabaseTestSupport.rawTransaction(dataSource, TestVersionedPersonTableDef) {
                     @Suppress("UNCHECKED_CAST")
                     update({ (columns.first { it.name == "id" } as Column<Int>) eq 1 }) { row ->
                         @Suppress("UNCHECKED_CAST")
@@ -495,7 +484,7 @@ internal class SqlTransactionTest : StringSpec() {
                 transaction(repo) { _ -> }
 
                 // Bump the DB row's version externally. In-memory entity keeps version=0.
-                rawTransaction(dataSource, TestVersionedPersonTableDef) {
+                DatabaseTestSupport.rawTransaction(dataSource, TestVersionedPersonTableDef) {
                     @Suppress("UNCHECKED_CAST")
                     update({ (columns.first { it.name == "id" } as Column<Int>) eq 99 }) { row ->
                         @Suppress("UNCHECKED_CAST")
@@ -545,7 +534,7 @@ internal class SqlTransactionTest : StringSpec() {
 
                 // DB-level: exactly one row with the updated title.
                 val titleInDb =
-                    rawTransaction(dataSource, AudioItemSqlTableDef) {
+                    DatabaseTestSupport.rawTransaction(dataSource, AudioItemSqlTableDef) {
                         selectAll().where { audioItemIdColumn() eq 60 }.singleOrNull()
                             ?.let { it[audioItemTitleColumn()] }
                     }
@@ -570,7 +559,7 @@ internal class SqlTransactionTest : StringSpec() {
 
                 // DB-level: no row written.
                 val rowInDb =
-                    rawTransaction(dataSource, AudioItemSqlTableDef) {
+                    DatabaseTestSupport.rawTransaction(dataSource, AudioItemSqlTableDef) {
                         selectAll().where { audioItemIdColumn() eq 61 }.singleOrNull()
                     }
                 rowInDb shouldBe null

--- a/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlVersionClobberTest.kt
+++ b/lirp-sql/src/test/kotlin/net/transgressoft/lirp/persistence/sql/SqlVersionClobberTest.kt
@@ -38,6 +38,8 @@ import java.util.UUID
 @io.kotest.core.annotation.DisplayName("SqlWritePipeline version-clobber regression")
 internal class SqlVersionClobberTest : StringSpec({
 
+    extension(IsolatedReactiveScope)
+
     fun freshJdbcUrl() = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
 
     /** Reflectively reads the `db` field of a [SqlRepository] for direct DDL in tests. */

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DatabaseTestSupport.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DatabaseTestSupport.kt
@@ -20,8 +20,10 @@ package net.transgressoft.lirp.persistence.sql
 import net.transgressoft.lirp.event.ReactiveScope
 import com.zaxxer.hikari.HikariDataSource
 import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.assertions.withClue
 import io.kotest.engine.names.WithDataTestName
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
@@ -178,7 +180,10 @@ object DatabaseTestSupport {
             conn.createStatement().use { stmt ->
                 val rs = stmt.executeQuery("SELECT COUNT(*) FROM $table WHERE id = $id")
                 rs.next()
-                require(rs.getInt(1) == 1) { "row id=$id not yet visible in $table" }
+                // Assert with a Kotest matcher, not require(): eventually only retries on AssertionError,
+                // so an IllegalArgumentException from require() would abort the poll on the first miss
+                // instead of waiting for the row to land.
+                withClue("row id=$id not yet visible in $table") { rs.getInt(1) shouldBe 1 }
             }
         }
     }
@@ -232,38 +237,48 @@ object DatabaseTestSupport {
         }
 
     /**
-     * Runs [block] with a fresh [HikariDataSource] from [db], dropping [tableDef] beforehand
-     * for isolation. The data source is always closed in a finally block, even if the test fails.
+     * Runs [block] with [ReactiveScope]'s flow and I/O scopes swapped for fresh, per-test isolated
+     * scopes, restoring the previous scopes afterwards.
+     *
+     * The production ioScope is JVM-global and single-threaded; a slow or contended flush would
+     * otherwise queue every other repository's flush behind it on that one shared thread, starving
+     * the async write a test is verifying (reproducible on any dialect, including in-memory H2, and
+     * most visible under a loaded CI runner). A fresh scope per test keeps one test's flush from
+     * blocking another. The scopes mirror production parallelism exactly — ioScope stays
+     * single-threaded so the global write-serialization guarantee is preserved — they are merely
+     * isolated, not widened. This relies on the consuming specs running sequentially, so the global
+     * swap is never concurrent.
      */
-    inline fun withDatabaseTest(db: DbConfig, tableDef: SqlTableDef<*>, block: (HikariDataSource) -> Unit) {
-        // Isolate the reactive scopes per test. The production ioScope is JVM-global and
-        // single-threaded; under the integration suite a slow dialect's blocking flush would
-        // otherwise queue every other repository's flush behind it on that one shared thread,
-        // starving the async write under verification (reproducible on any dialect, including
-        // in-memory H2, and on master). A fresh scope per test keeps one test's flush from blocking
-        // another. The scopes mirror the production parallelism exactly — ioScope stays
-        // single-threaded so the global write-serialization guarantee that
-        // SqlRepositoryConcurrencyIntegrationTest relies on is preserved — they are merely isolated,
-        // not widened. The scope is cancelled and the defaults restored afterwards; this relies on
-        // the integration specs running sequentially, so the global swap is never concurrent.
+    inline fun <T> withIsolatedReactiveScope(block: () -> T): T {
         val isolatedFlowScope = CoroutineScope(Dispatchers.Default.limitedParallelism(4) + SupervisorJob())
         val isolatedIoScope = CoroutineScope(Dispatchers.IO.limitedParallelism(1) + SupervisorJob())
         val previousFlowScope = ReactiveScope.flowScope
         val previousIoScope = ReactiveScope.ioScope
         ReactiveScope.flowScope = isolatedFlowScope
         ReactiveScope.ioScope = isolatedIoScope
-        val dataSource = db.buildDataSource()
         try {
-            dropTable(dataSource, tableDef)
-            block(dataSource)
+            return block()
         } finally {
+            isolatedFlowScope.cancel()
+            isolatedIoScope.cancel()
+            ReactiveScope.flowScope = previousFlowScope
+            ReactiveScope.ioScope = previousIoScope
+        }
+    }
+
+    /**
+     * Runs [block] with a fresh [HikariDataSource] from [db], dropping [tableDef] beforehand
+     * for isolation and running under [withIsolatedReactiveScope]. The data source is always closed
+     * in a finally block, even if the test fails.
+     */
+    inline fun withDatabaseTest(db: DbConfig, tableDef: SqlTableDef<*>, block: (HikariDataSource) -> Unit) {
+        withIsolatedReactiveScope {
+            val dataSource = db.buildDataSource()
             try {
-                dataSource.close()
+                dropTable(dataSource, tableDef)
+                block(dataSource)
             } finally {
-                isolatedFlowScope.cancel()
-                isolatedIoScope.cancel()
-                ReactiveScope.flowScope = previousFlowScope
-                ReactiveScope.ioScope = previousIoScope
+                dataSource.close()
             }
         }
     }

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DatabaseTestSupport.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/DatabaseTestSupport.kt
@@ -22,16 +22,19 @@ import com.zaxxer.hikari.HikariDataSource
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.engine.names.WithDataTestName
 import io.kotest.matchers.nulls.shouldNotBeNull
+import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.sql.SQLException
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 
 /**
  * Database configuration for data-driven integration tests.
@@ -149,6 +152,59 @@ object DatabaseTestSupport {
         assert: (R) -> Unit
     ) = eventually(timeout) {
         reader().use { assert(it) }
+    }
+
+    /**
+     * Waits a short warm-up window for a freshly-registered `SharedFlow` collector coroutine to begin
+     * collecting before the test emits the mutation it wants observed.
+     *
+     * A subscription registered immediately before a mutation can miss it because the collector
+     * coroutine has not started; this brief settle absorbs that handoff. It is deliberately NOT
+     * [awaitRow]: it waits on in-JVM collector readiness, not on a durable write.
+     */
+    suspend fun awaitSubscriptionReady(warmup: Duration = 50.milliseconds) = delay(warmup)
+
+    /**
+     * Polls until a row with [id] is present in [table], or [timeout] elapses. A presence-only
+     * companion to [awaitRow] for tests that assert a durable write landed without inspecting columns.
+     */
+    suspend fun awaitRowPresent(
+        dataSource: HikariDataSource,
+        table: String,
+        id: Int,
+        timeout: Duration = PERSISTED_ROW_POLL
+    ) = eventually(timeout) {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("SELECT COUNT(*) FROM $table WHERE id = $id")
+                rs.next()
+                require(rs.getInt(1) == 1) { "row id=$id not yet visible in $table" }
+            }
+        }
+    }
+
+    /**
+     * Drops each table in [tableNames] with `DROP TABLE IF EXISTS`, isolating a test's schema from
+     * leftovers of a previous run. Order matters for FK-linked tables: pass children/junctions before
+     * parents. A propagated [SQLException] is a real setup failure and is intentionally not swallowed.
+     */
+    fun dropTables(dataSource: HikariDataSource, vararg tableNames: String) {
+        for (name in tableNames) {
+            dataSource.connection.use { conn ->
+                conn.createStatement().use { stmt -> stmt.execute("DROP TABLE IF EXISTS $name") }
+            }
+        }
+    }
+
+    /**
+     * Runs [block] as an Exposed transaction bound to [tableDef]'s interpreted table, returning its
+     * result. Lets a test read or mutate persisted rows directly via the Exposed DSL without standing
+     * up a full [SqlRepository].
+     */
+    fun <T> rawTransaction(dataSource: HikariDataSource, tableDef: SqlTableDef<*>, block: Table.() -> T): T {
+        val db = Database.connect(dataSource)
+        val exposed = ExposedTableInterpreter().interpret(tableDef)
+        return transaction(db) { exposed.table.block() }
     }
 
     private fun readRowById(dataSource: HikariDataSource, table: String, id: Any, columns: Array<out String>): Map<String, Any?>? =

--- a/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/IsolatedReactiveScope.kt
+++ b/lirp-sql/src/testFixtures/kotlin/net/transgressoft/lirp/persistence/sql/IsolatedReactiveScope.kt
@@ -1,0 +1,43 @@
+/******************************************************************************
+ *     Copyright (C) 2026  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.persistence.sql
+
+import io.kotest.core.extensions.SpecExtension
+import io.kotest.core.spec.Spec
+
+/**
+ * Kotest [SpecExtension] that runs a spec with [DatabaseTestSupport.withIsolatedReactiveScope] in
+ * effect, so its debounced writes and reactive-event delivery use fresh per-spec scopes instead of
+ * the JVM-global single-thread `ioScope` shared by every other spec.
+ *
+ * Persistence-assertion specs poll a durable write with `eventually`/`awaitRow`. When they run on
+ * the shared global scope, a slow or backed-up flush from another spec — most visible under a loaded
+ * CI runner — can starve the write past the poll window and fail the assertion intermittently. This
+ * extension gives each such spec its own scope, cancelled when the spec ends, so no leftover flush
+ * can queue behind it. Apply it to any `src/test` spec that asserts on debounced persistence.
+ *
+ *     class SomePersistenceTest : StringSpec({
+ *         extension(IsolatedReactiveScope)
+ *         "..." { /* debounced write + eventually { ... } */ }
+ *     })
+ */
+object IsolatedReactiveScope : SpecExtension {
+    override suspend fun intercept(spec: Spec, execute: suspend (Spec) -> Unit) {
+        DatabaseTestSupport.withIsolatedReactiveScope { execute(spec) }
+    }
+}

--- a/scripts/flaky-hunt.sh
+++ b/scripts/flaky-hunt.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# flaky-hunt.sh — run the full test suite repeatedly to surface intermittent
+# failures and hangs (notably the historic cross-thread transaction deadlock)
+# before they reach master.
+#
+# The suite passes in module isolation but a rare locking interleaving could
+# hang the full run only under load; a single green run therefore does not prove
+# determinism. This script re-runs the suite N times, forcing re-execution each
+# time, and captures JVM thread dumps if a run exceeds its wall-clock budget so a
+# hang is diagnosable instead of an opaque timeout.
+#
+# Usage:
+#   scripts/flaky-hunt.sh [iterations] [per-run-timeout-seconds]
+#
+# Defaults: 10 iterations, 900s per run. Override via args or the ITERATIONS /
+# RUN_TIMEOUT environment variables. Stress tests run as part of the suite.
+#
+# Exit status: 0 if every run passed; non-zero on the first failing or hung run.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || exit 1
+
+ITERATIONS="${1:-${ITERATIONS:-10}}"
+RUN_TIMEOUT="${2:-${RUN_TIMEOUT:-900}}"
+GRADLE="${GRADLE:-./gradlew}"
+
+echo "flaky-hunt: $ITERATIONS run(s) of '$GRADLE test', ${RUN_TIMEOUT}s budget each"
+
+dump_threads() {
+    command -v jstack >/dev/null 2>&1 || { echo "jstack unavailable — skipping thread dump"; return; }
+    command -v jps >/dev/null 2>&1 || { echo "jps unavailable — skipping thread dump"; return; }
+    for pid in $(jps -q); do
+        echo "--- jstack $pid ---"
+        jstack "$pid" 2>/dev/null || true
+    done
+}
+
+for i in $(seq 1 "$ITERATIONS"); do
+    echo "===== run $i/$ITERATIONS ($(date '+%H:%M:%S')) ====="
+    timeout "$RUN_TIMEOUT" "$GRADLE" test --rerun-tasks
+    rc=$?
+    if [ "$rc" = "124" ]; then
+        echo "!!! run $i exceeded ${RUN_TIMEOUT}s — likely a deadlock. Thread dumps follow."
+        dump_threads
+        echo "!!! flaky-hunt FAILED: hang on run $i"
+        exit 124
+    elif [ "$rc" != "0" ]; then
+        echo "!!! flaky-hunt FAILED: run $i exited $rc"
+        exit "$rc"
+    fi
+    echo "run $i passed"
+done
+
+echo "flaky-hunt: all $ITERATIONS run(s) passed"

--- a/scripts/flaky-hunt.sh
+++ b/scripts/flaky-hunt.sh
@@ -39,7 +39,9 @@ dump_threads() {
 
 for i in $(seq 1 "$ITERATIONS"); do
     echo "===== run $i/$ITERATIONS ($(date '+%H:%M:%S')) ====="
-    timeout "$RUN_TIMEOUT" "$GRADLE" test --rerun-tasks
+    # -k escalates to SIGKILL 30s after the initial SIGTERM so a wedged JVM cannot keep the
+    # run alive past its budget; a hang still yields exit 124 and the thread-dump path below.
+    timeout -k 30 "$RUN_TIMEOUT" "$GRADLE" test --rerun-tasks
     rc=$?
     if [ "$rc" = "124" ]; then
         echo "!!! run $i exceeded ${RUN_TIMEOUT}s — likely a deadlock. Thread dumps follow."


### PR DESCRIPTION
## Summary

This branch groups a concurrency-robustness fix, a small KSP cleanup, and a repository-wide test-craftsmanship pass. No public API changes; production behaviour is unchanged except for the transaction flush-lock hardening described below. All unit suites are green (1,848 tests across the six modules) and ktlint passes.

Closes #312
Closes #313

## Concurrency: bound the transaction flush-lock (#312)

The `transaction { }` commit path acquired the repository flush lock with an unbounded `lock()`. A flush that never releases it — a stuck backing-store write, or a lock leaked by an earlier transaction — could block the caller forever and, in the test suite, hang the whole JVM (the intermittent full-suite hang that passed in module isolation).

- Acquisition is now bounded: `tryLockFlush(timeout)` waits at most a generous window (60s, far above any legitimate flush) and, on expiry, aborts the transaction with a diagnostic `LirpTransactionException` instead of hanging. This converts the deadlock class from a silent hang into a fast, observable failure at the locking level. Added a regression test.
- Replaced fixed `Thread.sleep` waits that raced async reactive-event delivery with `eventually` polling in the JSON and SQL raw-init tests.
- Added `scripts/flaky-hunt.sh` (re-runs the full suite N times, thread-dumps on hang) and a manually-triggered `flaky hunt` CI workflow; documented both. Corrected a stale note claiming stress tests are excluded by default — they run by default and stay on in CI.

The single canonical `Stress` tag already lives in lirp-core testFixtures and is consumed by all modules; no duplicates to remove.

## KSP: centralize generated-accessor name suffixes (#313)

Routed the last two raw generated-name suffix literals (`_LirpJunctionTableDef`, `_LirpReactivePropertyAccessor`) through the shared `LirpGenNames` object so producer-side codegen has a single source of truth. Suffix string values are unchanged, so generated code is byte-identical. Also corrected the `LirpGenNames`/`KspAccessorLoader` KDoc to document the intentional producer/runtime-consumer mirror (lirp-core keeps its own copy rather than depending on the compile-only lirp-ksp module).

## Test-craftsmanship pass (all modules)

Pure test-code quality work — no production change, test counts preserved, coverage held. Foundation-first: a shared helper/matcher landed once per module's test support, then adopted across call sites, with clear copy-paste cascades parametrized via `withData`.

- **lirp-ksp** — multi-provider `KspTestSupport.compile()` + `jvmTarget`; `shouldSucceed`/`shouldFailWith`/`shouldContainEach` matchers replacing the exit-code + repeated-`shouldContain` roulette; migrated the hand-rolled `KotlinCompilation` files; parametrized type-matrix cascades. (~350 fewer lines.)
- **lirp-sql** — hoisted `awaitSubscriptionReady`, `awaitRowPresent`, `dropTables`, and `rawTransaction` into `DatabaseTestSupport`, deduplicating the per-file copies and inline waits; `databases.forEach` → `withData`; `assertSoftly` for independent field checks.
- **lirp-core** — `EventRecorder.awaitCount` plus entity-level `record()/recordAsync()` overloads, replacing the `AtomicReference` + `CountDownLatch` await roulette; migrated count-only collectors; assorted quick wins.
- **lirp-fx** — one-time JavaFX toolkit init via `beforeProject()` (dropping 16 per-spec init blocks); list/set change matchers (`shouldBeSingleAdd`/`shouldBeAddOf`, …); parametrized converter/JSON/scalar cascades.
- **lirp-api** — parametrized the symmetric column-converter round-trips.

Deliberately untouched to avoid masking behaviour: stress-test barriers, the distinct cascade-mode behaviours, sync-negative tests, the synchronous-transport publisher section, FX-thread dispatch tests, multi-segment change walks, and dialect-specific integration tests.

## Testing

- `gradle test ktlintCheck` — green across all modules (1,848 unit tests, 0 failures).
- `gradle :lirp-sql:integrationTest` — a representative subset run against Testcontainers (PostgreSQL/MySQL/MariaDB/SQLite/H2) is green, exercising the hoisted SQL helpers.
- The transaction regression test proves the flush-lock now fails fast rather than hanging.

## Follow-ups (not in this PR)

- Rename the generic placeholder entities in the query-package tests to the canonical music-domain fixtures.
- Extract a Gradle TestKit helper for the plugin test; add an `awaitFxEvent` helper for the FX-thread dispatch tests.