### PR TITLE
Reliability hardening: outbox atomicity, crash durability, transaction boundaries & concurrency fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,40 @@ see the [GitHub releases](https://github.com/octaviospain/lirp/releases).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`KafkaOutboxSqlRepository.clear()` now emits one DELETE outbox row per wiped entity.**
+  Previously, calling `clear()` on a `KafkaOutboxSqlRepository` performed a bulk `table.deleteAll()`
+  but the `onAfterEntityWritesInWritePending` hook received empty lists, so zero outbox DELETE rows
+  were produced. Downstream consumers relying on DELETE events for aggregate-level inventory had no
+  signal that the entities had been removed. The entity keys are now collected immediately before
+  the bulk wipe (within the same JDBC transaction) and passed to the hook so one DELETE row is
+  inserted per cleared aggregate.
+  See [#323](https://github.com/octaviospain/lirp/issues/323).
+
+- **`KafkaEventPublisher.emitAsync` now joins the ambient application transaction when the
+  publisher and the application use different Exposed `Database` instances over the same
+  `DataSource`.** In the topology set up by `LirpKafkaConfig.startRelay`, the relay calls
+  `Database.connect(dataSource)` which creates a new `Database` instance separate from the one
+  the application uses. The previous identity-equality gate (`currentTransaction.db == publisherDb`)
+  was always false in this topology, so each `emitAsync` call opened its own short-lived transaction.
+  An application-level rollback then left an orphaned outbox row. The gate now compares the JDBC
+  metadata URL of the two `Database` instances; two instances wrapping the same pool share the same
+  URL, so the outbox INSERT joins the application transaction and rolls back atomically with it.
+  See [#322](https://github.com/octaviospain/lirp/issues/322).
+
 ### Added
+
+- **`SqlRepository` exposes an additive `onAfterEntityWritesInWritePending` overload that
+  includes bulk-clear context.** A new `protected open fun onAfterEntityWritesInWritePending(inserts,
+  updates, deletes, clearedEntityIds: List<K>)` overload has been added. The default implementation
+  delegates to the existing three-parameter version so all existing subclass overrides continue to
+  compile and behave identically without modification. Subclasses that need to respond to bulk
+  `clear()` operations should override the four-parameter version instead. The existing three-parameter
+  signature is unchanged and remains in the binary API.
+  Benefit: enables `KafkaOutboxSqlRepository` (and any downstream subclass) to emit per-entity
+  DELETE events atomically when `clear()` bulk-wipes the table.
+  See [#323](https://github.com/octaviospain/lirp/issues/323).
 
 - **Bucket-level ordering for registry projections.** The registry projection factories now
   accept optional comparators that order the projection's buckets: `bucketKeyOrdering` orders

--- a/README.md
+++ b/README.md
@@ -561,3 +561,4 @@ This project uses:
 - [Kotest](https://kotest.io/) for testing
 
 The approach is inspired by books including [Object Thinking by David West](https://www.goodreads.com/book/show/43940.Object_Thinking), [Domain-Driven Design: Aligning Software Architecture and Business Strategy by Vladik Khonon](https://www.goodreads.com/book/show/57573212-learning-domain-driven-design) and [Elegant Objects by Yegor Bugayenko](https://www.yegor256.com/elegant-objects.html).
+

--- a/lirp-core/api/lirp-core.api
+++ b/lirp-core/api/lirp-core.api
@@ -1055,6 +1055,7 @@ public class net/transgressoft/lirp/persistence/json/JsonFileRepository : net/tr
 	public synthetic fun <init> (Ljava/io/File;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/modules/SerializersModule;JZLnet/transgressoft/lirp/persistence/json/JsonFkPolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/io/File;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/modules/SerializersModule;JZLnet/transgressoft/lirp/persistence/json/JsonFkPolicy;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lnet/transgressoft/lirp/persistence/LirpContext;Ljava/io/File;Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/modules/SerializersModule;JZLnet/transgressoft/lirp/persistence/json/JsonFkPolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected fun beforeMoveToTarget (Ljava/io/File;)V
 	public fun close ()V
 	public fun commitTransactionBuffer (Lnet/transgressoft/lirp/persistence/TransactionBuffer;)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -302,6 +302,10 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
      * Accepts any [LirpEvent] as [childEvent] — both [MutationEvent] for property-level bubble-up
      * and [CollectionChangeEvent] for collection-level diffs.
      *
+     * When a transaction buffer is active on the current thread, the event is routed into the
+     * buffer instead of being published immediately, matching the behaviour of [emitPropertyChanged].
+     * Buffered events are flushed on commit or discarded on rollback.
+     *
      * @param refName the property name of the aggregate-reference property
      *   (`@ToOneAggregate` or `@ToManyAggregates`) that triggered the bubble-up
      * @param childEvent the original [LirpEvent] from the referenced child entity or collection
@@ -315,6 +319,11 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
                 refName = refName,
                 childEvent = childEvent
             )
+        val txBuffer = _txEventBuffer.get()
+        if (txBuffer != null) {
+            txBuffer.add(aggregateEvent)
+            return
+        }
         publisher.emitAsync(aggregateEvent)
     }
 
@@ -366,6 +375,10 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
      * Unlike [emitBubbleUpEvent], this method checks [shouldEmit] to avoid unnecessary work when no
      * subscribers are registered.
      *
+     * When a transaction buffer is active on the current thread, the event is routed into the
+     * buffer instead of being published immediately, matching the behaviour of [emitPropertyChanged].
+     * Buffered events are flushed on commit or discarded on rollback.
+     *
      * @param refName the property name of the mutable aggregate collection that changed
      * @param childEvent the [CollectionChangeEvent] describing the diff
      */
@@ -374,6 +387,17 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
         check(!isClosed) { "Entity '${this::class.java.simpleName}' is closed" }
         if (eventsDisabled) return
         lastDateModified = LocalDateTime.now()
+        val txBuffer = _txEventBuffer.get()
+        if (txBuffer != null) {
+            val aggregateEvent =
+                StandardAggregateMutationEvent(
+                    entity = this as R,
+                    refName = refName,
+                    childEvent = childEvent
+                )
+            txBuffer.add(aggregateEvent)
+            return
+        }
         if (!shouldEmit) return
         val aggregateEvent =
             StandardAggregateMutationEvent(

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/entity/ReactiveEntityBase.kt
@@ -756,17 +756,18 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
     }
 
     /**
-     * Captures a shallow snapshot of all reactive-property values registered in [delegateRegistry],
-     * keyed by property name. Also stores [lastDateModified] under [LAST_MODIFIED_SNAPSHOT_KEY] so
-     * that [restoreSnapshot] can revert the timestamp atomically with the other scalars.
+     * Captures a shallow snapshot of all reactive-property and aggregate-collection values
+     * registered in [delegateRegistry], keyed by property name. Also stores [lastDateModified]
+     * under [LAST_MODIFIED_SNAPSHOT_KEY] so that [restoreSnapshot] can revert the timestamp
+     * atomically with the other properties.
      *
-     * The snapshot is taken synchronously on the calling thread. Only [net.transgressoft.lirp.persistence.ReactivePropertyDelegate]
-     * and [net.transgressoft.lirp.persistence.ReactivePropertyDelegateWithAccessors] entries are
-     * captured — aggregate collection delegates manage their own identity collections and are not
-     * snapshotted here.
+     * For scalar delegates ([ReactivePropertyDelegate] / [ReactivePropertyDelegateWithAccessors]),
+     * the current value is stored as-is. For mutable aggregate-collection delegates
+     * ([MutableAggregateList] / [MutableAggregateSet]), a defensive copy of the backing ID
+     * collection is captured so that in-place mutations during a transaction can be rolled back.
      *
-     * @return a map from property name to the current value for each reactive-property delegate,
-     *   plus the [lastDateModified] sentinel entry
+     * @return a map from property name to the snapshot value for each delegate, plus the
+     *   [lastDateModified] sentinel entry
      */
     internal fun captureSnapshot(): Map<String, Any?> {
         val snapshot = mutableMapOf<String, Any?>()
@@ -774,7 +775,11 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
             when (delegate) {
                 is net.transgressoft.lirp.persistence.ReactivePropertyDelegate<*> -> snapshot[name] = delegate.storedValue
                 is net.transgressoft.lirp.persistence.ReactivePropertyDelegateWithAccessors<*> -> snapshot[name] = delegate.readValue()
-                else -> { /* aggregate collection delegates — not snapshotted on the scalar rollback path */ }
+                is net.transgressoft.lirp.persistence.MutableAggregateList<*, *> ->
+                    snapshot[name] = ArrayList(delegate.innerDelegate.referenceIds)
+                is net.transgressoft.lirp.persistence.MutableAggregateSet<*, *> ->
+                    snapshot[name] = LinkedHashSet(delegate.innerDelegate.referenceIds)
+                else -> { /* immutable aggregate collection delegates — no snapshot needed */ }
             }
         }
         snapshot[LAST_MODIFIED_SNAPSHOT_KEY] = lastDateModified
@@ -782,18 +787,17 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
     }
 
     /**
-     * Restores reactive properties to the values in [snapshot], suppressing all mutation events
-     * during the restore to prevent observers from seeing intermediate reverted state. Also restores
-     * [lastDateModified] from the sentinel entry written by [captureSnapshot].
+     * Restores reactive properties and aggregate-collection memberships to the values in [snapshot],
+     * suppressing all mutation events during the restore to prevent observers from seeing intermediate
+     * reverted state. Also restores [lastDateModified] from the sentinel entry written by [captureSnapshot].
      *
-     * Runs inside [withEventsDisabled] and writes each property via the non-emitting
-     * [setDirectly][net.transgressoft.lirp.persistence.ReactivePropertyDelegate.setDirectly]
-     * path so that neither [emitPropertyChanged] is triggered during rollback.
-     * Only reactive-property delegates are processed; aggregate collection delegates and the
-     * [LAST_MODIFIED_SNAPSHOT_KEY] sentinel are skipped in the delegate-matching loop.
+     * Scalar delegates are restored via the non-emitting [setDirectly] path. Mutable aggregate-collection
+     * delegates are restored via [setBackingIds], which replaces the in-place-mutated backing ID
+     * collection without triggering collection-change events.
      *
      * @param snapshot a property-name-to-value map previously returned by [captureSnapshot]
      */
+    @Suppress("UNCHECKED_CAST")
     internal fun restoreSnapshot(snapshot: Map<String, Any?>) {
         withEventsDisabled {
             val preDateModified = snapshot[LAST_MODIFIED_SNAPSHOT_KEY] as? java.time.LocalDateTime
@@ -805,14 +809,22 @@ abstract class ReactiveEntityBase<K, R : ReactiveEntity<K, R>>(
                 if (name == LAST_MODIFIED_SNAPSHOT_KEY) return@forEach
                 when (val delegate = delegateRegistry[name]) {
                     is net.transgressoft.lirp.persistence.ReactivePropertyDelegate<*> -> {
-                        @Suppress("UNCHECKED_CAST")
                         (delegate as net.transgressoft.lirp.persistence.ReactivePropertyDelegate<Any?>).setDirectly(value)
                     }
                     is net.transgressoft.lirp.persistence.ReactivePropertyDelegateWithAccessors<*> -> {
-                        @Suppress("UNCHECKED_CAST")
                         (delegate as net.transgressoft.lirp.persistence.ReactivePropertyDelegateWithAccessors<Any?>).setDirectly(value)
                     }
-                    else -> { /* aggregate collection delegates — not restored on the scalar rollback path */ }
+                    is net.transgressoft.lirp.persistence.MutableAggregateList<*, *> -> {
+                        val ids = value as? Collection<Comparable<Any>> ?: return@forEach
+                        (delegate.innerDelegate as net.transgressoft.lirp.persistence.AbstractMutableAggregateCollectionRefDelegate<Comparable<Any>, *>)
+                            .setBackingIds(ids)
+                    }
+                    is net.transgressoft.lirp.persistence.MutableAggregateSet<*, *> -> {
+                        val ids = value as? Collection<Comparable<Any>> ?: return@forEach
+                        (delegate.innerDelegate as net.transgressoft.lirp.persistence.AbstractMutableAggregateCollectionRefDelegate<Comparable<Any>, *>)
+                            .setBackingIds(ids)
+                    }
+                    else -> { /* immutable aggregate collection delegates — not restored */ }
                 }
             }
         }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/event/FlowEventPublisher.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/event/FlowEventPublisher.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.slf4j.MDCContext
 
@@ -187,6 +188,14 @@ class FlowEventPublisher<ET : EventType, E : LirpEvent<ET>>
                     flowScope.launch(MDCContext()) {
                         for (event in channel) {
                             try {
+                                // A MutableSharedFlow with replay == 0 silently discards an emission that
+                                // has no active collector. The collector coroutine launched by
+                                // subscribeAsync registers asynchronously, so an event drained before it
+                                // subscribes would be lost even though a subscription handle already
+                                // exists. Suspend (never thread-block — the collector may share this
+                                // dispatcher) until at least one collector is registered, keeping the
+                                // event safely buffered in the unlimited channel until then.
+                                if (config.replay == 0) flow.subscriptionCount.first { it > 0 }
                                 flow.emit(event)
                             } catch (cancellation: CancellationException) {
                                 throw cancellation

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/event/ReactiveScope.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/event/ReactiveScope.kt
@@ -117,6 +117,14 @@ object ReactiveScope {
         ioScope = defaultIoScope
     }
 
+    /**
+     * Returns `true` when [ioScope] has not been replaced by a test dispatcher and is therefore
+     * the production single-slot scope. Flush coroutines use this to decide whether to offload
+     * blocking I/O to the unbounded [Dispatchers.IO] pool: the offload is only needed (and
+     * meaningful) when [ioScope] has the `limitedParallelism(1)` constraint.
+     */
+    internal val isProductionIoScope: Boolean get() = ioScope === defaultIoScope
+
     fun resetDefaultTransactionDispatcher() {
         transactionDispatcher = defaultTransactionDispatcher
     }

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBase.kt
@@ -39,13 +39,16 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.withLock
 import kotlin.concurrent.write
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.slf4j.MDCContext
+import kotlinx.coroutines.withContext
 
 // MDC keys shared across the async flush and drain paths for log correlation
 private const val MDC_KEY_REPOSITORY = "lirp.repository"
@@ -114,6 +117,14 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
         protected val loadOnInit: Boolean = true,
         private val onError: LirpErrorHandler? = null
     ) : VolatileRepository<K, R>(context, name, initialEntities, onError), PersistentRepository<K, R> {
+
+        // When ioScope is the production single-slot scope, blocking I/O is offloaded to the
+        // unbounded IO pool so that one slow flush does not starve other repositories' scheduled
+        // flushes. When ioScope has been replaced (e.g. by a test dispatcher), the offload is
+        // skipped — test dispatchers handle any parallelism needed and do not have the single-slot
+        // constraint.
+        private val flushDispatcher
+            get() = if (ReactiveScope.isProductionIoScope) Dispatchers.IO else EmptyCoroutineContext
 
         // Stored to populate MDC keys at flush launch time and for transaction error context.
         private val repositoryName: String = name
@@ -685,14 +696,18 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
                                 delay(remainingMillis.milliseconds)
                                 maxDelayJob = null
                                 log.trace { "Async max-delay flush triggered for $repositoryName" }
-                                flush()
+                                // Offload blocking I/O off the shared single-slot ioScope so a slow
+                                // flush on one repository cannot starve another repository's scheduled
+                                // flushes. The scheduling/delay stays on ioScope; only the actual I/O
+                                // moves to the unbounded IO pool.
+                                withContext(flushDispatcher) { flush() }
                             }
                         } else {
                             ReactiveScope.ioScope.launch(MDCContext()) {
                                 delay(remainingMillis.milliseconds)
                                 maxDelayJob = null
                                 log.trace { "Async max-delay flush triggered for $repositoryName" }
-                                flush()
+                                withContext(flushDispatcher) { flush() }
                             }
                         }
                 } finally {
@@ -713,7 +728,9 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
                             maxDelayJob?.cancel()
                             maxDelayJob = null
                             log.trace { "Async debounce flush triggered for $repositoryName" }
-                            flush()
+                            // Same offload as the max-delay path: keep the ioScope slot free during
+                            // blocking I/O so sibling repositories can be scheduled.
+                            withContext(flushDispatcher) { flush() }
                         }
                     } else {
                         ReactiveScope.ioScope.launch(MDCContext()) {
@@ -721,7 +738,7 @@ abstract class PersistentRepositoryBase<K : Comparable<K>, R : ReactiveEntity<K,
                             maxDelayJob?.cancel()
                             maxDelayJob = null
                             log.trace { "Async debounce flush triggered for $repositoryName" }
-                            flush()
+                            withContext(flushDispatcher) { flush() }
                         }
                     }
             } finally {

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepository.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepository.kt
@@ -32,8 +32,10 @@ import net.transgressoft.lirp.persistence.TransactionBuffer
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
 import java.io.IOException
+import java.nio.channels.FileChannel
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
 import java.util.Objects
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.concurrent.withLock
@@ -63,6 +65,12 @@ import kotlinx.serialization.modules.SerializersModule
  *   ensuring the file always reflects the last known state.
  * - Thread-safe in-memory state using [ConcurrentHashMap].
  * - Error handling with logging; a write failure resets dirty so the next flush will retry.
+ * - All writes go through a single durable primitive: content is written to a sibling temp file,
+ *   the temp file is fsynced via [FileChannel.force], and then atomically moved over the target
+ *   via [Files.move] with [StandardCopyOption.ATOMIC_MOVE]. The parent directory is fsynced after
+ *   the rename so the directory entry update survives power loss. This means the live file is never
+ *   truncated in place — a crash at any point in the sequence leaves the previously-committed file
+ *   intact and reloadable.
  *
  * **Scaling envelope:**
  * - Small to medium repositories (up to a few thousand entities): serialization time is effectively
@@ -389,7 +397,9 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
          * Serializes the full in-memory entity state to [jsonFile], returning `null` on success
          * or the caught exception on failure.
          *
-         * On failure the [dirty] flag is restored so the next flush cycle retries.
+         * Delegates to [durableWrite] so the live file is never truncated in place. On failure the
+         * [dirty] flag is restored so the next flush cycle retries.
+         *
          * Called from both [writePending] (which re-throws to trigger base class retry) and
          * the [jsonFile] setter (which swallows the error since it is not in the flush path).
          */
@@ -399,8 +409,7 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
                 return null
             }
             return try {
-                val jsonString = json.encodeToString(mapSerializer, entitiesById)
-                jsonFile.writeText(jsonString)
+                durableWrite(json.encodeToString(mapSerializer, entitiesById))
                 log.debug { "File updated: $jsonFile" }
                 null
             } catch (exception: Exception) {
@@ -409,6 +418,58 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
                 exception
             }
         }
+
+        /**
+         * Writes [content] to [jsonFile] durably: the bytes go to a sibling temp file, the temp
+         * file is fsynced with [FileChannel.force], [beforeMoveToTarget] is called (a no-op by
+         * default, overridable for fault injection), then [Files.move] promotes the temp file over
+         * the target atomically. After the move the parent directory is fsynced so the directory
+         * entry reaches durable storage.
+         *
+         * Because the live file is never opened for writing, a crash at any point in this sequence
+         * leaves the previously-committed file intact and reloadable.
+         *
+         * @throws IOException if the temp write, fsync, or atomic rename fails
+         */
+        private fun durableWrite(content: String) {
+            val tmp = File(jsonFile.parent, "${jsonFile.name}.tmp")
+            try {
+                tmp.writeText(content)
+                // fsync the temp file's data blocks before the rename so the content is
+                // durable even if power is cut immediately after Files.move returns.
+                FileChannel.open(tmp.toPath(), StandardOpenOption.WRITE).use { it.force(true) }
+                beforeMoveToTarget(tmp)
+                Files.move(tmp.toPath(), jsonFile.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+                // fsync the parent directory so the directory entry pointing to the new inode
+                // is also durable (required on ext4/XFS to survive a power cut after rename).
+                // Resolve the parent via the absolute path so a relative target such as
+                // File("config.json") does not yield a null parent. The data and the atomic rename
+                // are already durable at this point, so the directory fsync is best-effort: a
+                // platform or filesystem that rejects opening a directory for fsync must not fail
+                // an otherwise-completed write.
+                jsonFile.toPath().toAbsolutePath().parent?.let { parentDir ->
+                    try {
+                        FileChannel.open(parentDir, StandardOpenOption.READ).use { it.force(true) }
+                    } catch (e: IOException) {
+                        log.debug(e) { "Parent-directory fsync skipped for ${jsonFile.name}; data and atomic rename are already durable" }
+                    }
+                }
+            } catch (e: IOException) {
+                tmp.delete()
+                throw e
+            }
+        }
+
+        /**
+         * Hook called immediately before [Files.move] promotes the temp file over the target.
+         *
+         * The default implementation is a no-op. Override in tests to inject a fault at the exact
+         * vulnerable point in the durable-write sequence and verify that the previously-committed
+         * file survives the crash.
+         *
+         * @param tmp the temp file that has been written and fsynced, about to be renamed
+         */
+        protected open fun beforeMoveToTarget(tmp: File) = Unit
 
         private fun decodeFromJson(): Map<K, R>? {
             val content = jsonFile.readText()
@@ -421,37 +482,27 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
         }
 
         /**
-         * Commits the transaction buffer to [jsonFile] using an atomic write sequence.
+         * Commits the transaction buffer to [jsonFile] using the shared durable write sequence.
          *
-         * The current in-memory state is serialized to a sibling temporary file
-         * (`<jsonFile>.tmp`), then promoted over [jsonFile] via `Files.move` with
-         * [StandardCopyOption.ATOMIC_MOVE]. This guarantees that a crash or I/O error during
-         * the write leaves the original file intact — the in-progress write either completes
-         * and replaces the file atomically, or fails and the temp file is cleaned up while
-         * the original remains untouched.
-         *
-         * `Files.move(ATOMIC_MOVE)` is preferred over `File.renameTo` because the JDK NIO
-         * contract guarantees atomic replacement on POSIX filesystems even when the source
-         * and target are on different inodes, while `renameTo` behaviour is platform-dependent.
+         * Delegates to [durableWrite], which writes to a sibling temp file, fsyncs the temp file's
+         * data blocks, atomically renames it over [jsonFile], and fsyncs the parent directory. This
+         * guarantees that a crash or power loss after [durableWrite] returns leaves [jsonFile] in a
+         * consistent, readable state.
          *
          * **Threading contract:** invoked while [flushLock] is held. Must not call [flush] or
          * otherwise re-acquire [flushLock].
          *
          * @param buffer the transaction buffer (its op lists are not used directly; the current
          *   in-memory state is the source of truth for JSON serialization)
-         * @throws IOException if the atomic rename/move fails, leaving the original file intact
+         * @throws IOException if the atomic write sequence fails, leaving the original file intact
          */
         override fun commitTransactionBuffer(buffer: TransactionBuffer<K, R>) {
-            val jsonString = json.encodeToString(mapSerializer, entitiesById)
-            val tmp = File(jsonFile.parent, "${jsonFile.name}.tmp")
             try {
-                tmp.writeText(jsonString)
-                Files.move(tmp.toPath(), jsonFile.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+                durableWrite(json.encodeToString(mapSerializer, entitiesById))
                 dirty.set(false)
                 log.debug { "Transaction committed atomically to $jsonFile" }
             } catch (e: IOException) {
-                tmp.delete()
-                throw IOException("Atomic write failed: $tmp -> $jsonFile", e)
+                throw IOException("Atomic write failed for $jsonFile", e)
             }
         }
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/SubscribeAsyncDeliveryBarrierTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/event/SubscribeAsyncDeliveryBarrierTest.kt
@@ -1,0 +1,67 @@
+/******************************************************************************
+ *     Copyright (C) 2025  Octavio Calleya Garcia                             *
+ *                                                                            *
+ *     This program is free software: you can redistribute it and/or modify   *
+ *     it under the terms of the GNU General Public License as published by   *
+ *     the Free Software Foundation, either version 3 of the License, or      *
+ *     (at your option) any later version.                                    *
+ *                                                                            *
+ *     This program is distributed in the hope that it will be useful,        *
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *     GNU General Public License for more details.                           *
+ *                                                                            *
+ *     You should have received a copy of the GNU General Public License      *
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>. *
+ ******************************************************************************/
+
+package net.transgressoft.lirp.event
+
+import net.transgressoft.lirp.event.CrudEvent.Type.CREATE
+import net.transgressoft.lirp.event.StandardCrudEvent.Create
+import net.transgressoft.lirp.testing.ReactiveScopeSerialization
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Regression guard for the `subscribeAsync` collector-registration barrier.
+ *
+ * On the real production `Dispatchers.Default` flow scope (kept in place via
+ * [ReactiveScopeSerialization]), the collector coroutine and the bridge drain coroutine start
+ * asynchronously and race. An event emitted in the gap between `subscribeAsync` returning and the
+ * collector actually subscribing reaches the drain loop's `flow.emit`, but a `MutableSharedFlow`
+ * with `replay == 0` and no active collector discards it — the event never reaches the subscriber
+ * action. `subscribeAsync` must therefore block until its collector is registered, so every event
+ * emitted after the call returns is delivered. Unique-per-emission payloads make a single dropped
+ * event fatal to the count assertion.
+ */
+class SubscribeAsyncDeliveryBarrierTest : StringSpec({
+    extension(ReactiveScopeSerialization)
+
+    "subscribeAsync delivers every event emitted immediately after it returns across many cycles" {
+        // Many subscribe→emit cycles: any single collector-startup drop fails the strict count.
+        val cycles = 500
+        repeat(cycles) {
+            val publisher =
+                FlowEventPublisher<CrudEvent.Type, CrudEvent<String, TestEntity>>("barrier-$it").apply {
+                    activateEvents(CREATE)
+                }
+            val received = AtomicInteger(0)
+            val subscription = publisher.subscribeAsync(CREATE) { received.incrementAndGet() }
+            try {
+                // Emitted synchronously right after subscribeAsync returns — the exact race window.
+                publisher.emitAsync(Create(TestEntity(UUID.randomUUID().toString())))
+
+                val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+                while (received.get() < 1 && System.nanoTime() < deadline) Thread.sleep(1)
+                received.get() shouldBe 1
+            } finally {
+                subscription.cancel()
+                publisher.close()
+            }
+        }
+    }
+})

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBaseFlushTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/PersistentRepositoryBaseFlushTest.kt
@@ -30,6 +30,7 @@ import io.kotest.matchers.shouldBe
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -319,5 +320,117 @@ private class TestFlushRepo(
     fun quiesceAndClose() {
         writeImpl = { _, _, _, _ -> }
         close()
+    }
+}
+
+/**
+ * Regression test for the cross-repository flush starvation issue where repo A's blocking
+ * [writePending] could pin the shared [net.transgressoft.lirp.event.ReactiveScope.ioScope] slot,
+ * preventing repo B from flushing within its [maxDelayMillis] window.
+ *
+ * Both tests use production dispatchers (via [ReactiveScopeSerialization]) so real thread
+ * concurrency is observable.
+ */
+@DisplayName("PersistentRepositoryBase two-repo starvation")
+internal class PersistentRepositoryBaseStarvationTest : StringSpec() {
+
+    init {
+        extension(ReactiveScopeSerialization)
+
+        // Short debounce and max-delay so the test does not take too long. Repo A blocks for
+        // blockMs so its flush holds the ioScope slot. Repo B should still flush before blockMs
+        // elapses — proving its flush is not serialized behind A's blocking write.
+        val debounce = 50L
+        val maxDelay = 200L
+        val blockMs = 2_000L // A's writePending blocks for 2 s
+        // B must flush within this budget regardless of A's block. We give generous headroom
+        // (4 × maxDelay) to avoid false-positives under load.
+        val bBudgetMs = maxDelay * 4
+
+        "repo B flushes within maxDelayMillis while repo A writePending is blocked on the ioScope" {
+            // Signal the test harness that B's writePending actually ran.
+            val bFlushed = AtomicBoolean(false)
+            val bFlushLatch = CountDownLatch(1)
+            // Let A's writePending block without throwing.
+            val aStarted = CountDownLatch(1)
+
+            val repoA =
+                StarvationFlushRepo(
+                    debounce = debounce,
+                    maxDelay = maxDelay,
+                    writeImpl = { _, _, _, _ ->
+                        aStarted.countDown()
+                        Thread.sleep(blockMs)
+                    }
+                )
+            val repoB =
+                StarvationFlushRepo(
+                    debounce = debounce,
+                    maxDelay = maxDelay,
+                    writeImpl = { _, _, _, _ ->
+                        bFlushed.set(true)
+                        bFlushLatch.countDown()
+                    }
+                )
+
+            try {
+                repoA.addForTest(FlushEntity(1, "a"))
+                // Give A's debounce a chance to start (and block the ioScope slot, pre-fix).
+                aStarted.await(3, TimeUnit.SECONDS) shouldBe true
+
+                repoB.addForTest(FlushEntity(2, "b"))
+
+                // B must flush well within the test budget, independent of A's blocking write.
+                bFlushLatch.await(bBudgetMs, TimeUnit.MILLISECONDS) shouldBe true
+                bFlushed.get() shouldBe true
+            } finally {
+                repoA.quiesceAndClose()
+                repoB.quiesceAndClose()
+            }
+        }
+    }
+}
+
+/**
+ * [PersistentRepositoryBase] subclass for starvation tests. Accepts [debounce] and [maxDelay]
+ * so the starvation window can be kept short. The internal primary constructor is accessible
+ * from the same module's test source set.
+ */
+private class StarvationFlushRepo(
+    debounce: Long,
+    maxDelay: Long,
+    var writeImpl: (List<FlushEntity>, List<PendingUpdate<Int, FlushEntity>>, List<Pair<Int, Long?>>, Boolean) -> Unit
+) : PersistentRepositoryBase<Int, FlushEntity>(
+        LirpContext.default,
+        "StarvationFlushRepo-${System.nanoTime()}",
+        java.util.concurrent.ConcurrentHashMap(),
+        debounceMillis = debounce,
+        maxDelayMillis = maxDelay,
+        loadOnInit = false
+    ) {
+
+    init {
+        load()
+    }
+
+    override fun loadFromStore(): Map<Int, FlushEntity> = emptyMap()
+
+    override fun writePending(
+        inserts: List<FlushEntity>,
+        updates: List<PendingUpdate<Int, FlushEntity>>,
+        deletes: List<Pair<Int, Long?>>,
+        hadClear: Boolean
+    ) {
+        writeImpl(inserts, updates, deletes, hadClear)
+    }
+
+    fun addForTest(entity: FlushEntity): Boolean = add(entity)
+
+    fun quiesceAndClose() {
+        writeImpl = { _, _, _, _ -> }
+        try {
+            close()
+        } catch (_: Exception) {
+        }
     }
 }

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/TransactionTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/TransactionTest.kt
@@ -17,12 +17,14 @@
 
 package net.transgressoft.lirp.persistence
 
+import net.transgressoft.lirp.event.AggregateMutationEvent
 import net.transgressoft.lirp.event.LirpErrorContext
 import net.transgressoft.lirp.event.LirpErrorHandler
 import net.transgressoft.lirp.event.LirpOperation
 import net.transgressoft.lirp.event.MutationEvent
 import net.transgressoft.lirp.event.PropertyChanged
 import net.transgressoft.lirp.testing.ReactiveScopeSerialization
+import net.transgressoft.lirp.testing.record
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
@@ -62,6 +64,22 @@ internal class TransactionTest : StringSpec() {
             block(repo)
         } finally {
             repo.close()
+        }
+    }
+
+    /**
+     * Runs [block] with a freshly-created [InMemoryPlaylistRepo] and its [AudioItemVolatileRepository]
+     * wired via a shared [LirpContext]. Closes all resources on exit.
+     */
+    suspend fun withPlaylistRepo(block: suspend (InMemoryPlaylistRepo, AudioItemVolatileRepository) -> Unit) {
+        val ctx = LirpContext()
+        val itemRepo = AudioItemVolatileRepository(ctx)
+        val playlistRepo = InMemoryPlaylistRepo(ctx)
+        try {
+            block(playlistRepo, itemRepo)
+        } finally {
+            playlistRepo.close()
+            ctx.close()
         }
     }
 
@@ -368,6 +386,88 @@ internal class TransactionTest : StringSpec() {
                 repo.close()
             }
         }
+
+        // Regression test for aggregate-collection event buffering (#328):
+        // A subscriber attached before the transaction must not see the aggregate-collection event
+        // during the block (it is buffered), receives it exactly once after commit, and receives
+        // nothing after a rollback.
+        "aggregate-collection mutation event is buffered during transaction and delivered only after commit" {
+            withPlaylistRepo { playlistRepo, itemRepo ->
+                val item = itemRepo.create(50, "Bohemian Rhapsody", "A Night at the Opera")
+                val playlist = playlistRepo.createPlaylist(51, "Rock Classics")
+
+                val recorder = playlist.record()
+
+                transaction(playlistRepo) { r ->
+                    (r.findById(51).get() as DefaultAudioPlaylist).audioItems.add(item)
+                    // Event must be buffered — recorder sees nothing while block runs.
+                    recorder.count shouldBe 0
+                }
+
+                // Exactly one aggregate-collection event fired after commit.
+                recorder.events shouldHaveSize 1
+                recorder.events.single().shouldBeInstanceOf<AggregateMutationEvent<*, *>>()
+            }
+        }
+
+        "aggregate-collection mutation event is discarded and not delivered after transaction rollback" {
+            withPlaylistRepo { playlistRepo, itemRepo ->
+                val item = itemRepo.create(52, "We Will Rock You", "News of the World")
+                val playlist = playlistRepo.createPlaylist(53, "Stadium Anthems")
+
+                val recorder = playlist.record()
+
+                shouldThrow<LirpTransactionException> {
+                    transaction(playlistRepo) { r ->
+                        (r.findById(53).get() as DefaultAudioPlaylist).audioItems.add(item)
+                        error("forced rollback")
+                    }
+                }
+
+                // No aggregate-collection event must reach the subscriber after rollback.
+                recorder.events.shouldBeEmpty()
+            }
+        }
+
+        // Regression test for aggregate-collection rollback restore (#329):
+        // A rolled-back add to a mutableAggregateList must leave the collection without the added
+        // item — in-memory state must match the store (which never received the write).
+        "aggregate-collection add is rolled back on transaction failure leaving collection unchanged" {
+            withPlaylistRepo { playlistRepo, itemRepo ->
+                val item = itemRepo.create(54, "Radio Ga Ga", "The Works")
+                val playlist = playlistRepo.createPlaylist(55, "Classics")
+
+                val recorder = playlist.record()
+
+                shouldThrow<LirpTransactionException> {
+                    transaction(playlistRepo) { r ->
+                        (r.findById(55).get() as DefaultAudioPlaylist).audioItems.add(item)
+                        error("forced rollback")
+                    }
+                }
+
+                // After rollback: item must be absent from the collection.
+                val playlistAfter = playlistRepo.findById(55).get() as DefaultAudioPlaylist
+                playlistAfter.audioItems.referenceIds shouldBe emptyList<Int>()
+                // Rollback must not re-emit any collection event.
+                recorder.events.shouldBeEmpty()
+            }
+        }
+
+        "committed aggregate-collection add persists in memory and no existing test regressions" {
+            withPlaylistRepo { playlistRepo, itemRepo ->
+                val item = itemRepo.create(56, "Under Pressure", "Hot Space")
+                val playlist = playlistRepo.createPlaylist(57, "Duets")
+
+                transaction(playlistRepo) { r ->
+                    (r.findById(57).get() as DefaultAudioPlaylist).audioItems.add(item)
+                }
+
+                // After commit: item must be present in the collection.
+                val playlistAfter = playlistRepo.findById(57).get() as DefaultAudioPlaylist
+                playlistAfter.audioItems.referenceIds.toList() shouldBe listOf(56)
+            }
+        }
     }
 }
 
@@ -377,6 +477,32 @@ internal class TransactionTest : StringSpec() {
  */
 private infix fun InMemoryAudioItemRepo.shouldHaveItemWithTitle(idAndTitle: Pair<Int, String>) {
     findById(idAndTitle.first).shouldBePresent { it.title shouldBe idAndTitle.second }
+}
+
+/**
+ * In-memory [PersistentRepositoryBase] for [MutableAudioPlaylist] entities, wired into a
+ * [LirpContext] so that aggregate-collection delegates resolve their item references correctly.
+ * Used in aggregate-collection transaction regression tests.
+ */
+internal class InMemoryPlaylistRepo(
+    context: LirpContext
+) : PersistentRepositoryBase<Int, MutableAudioPlaylist>(context, "InMemoryPlaylists", java.util.concurrent.ConcurrentHashMap(), loadOnInit = false) {
+
+    init {
+        load()
+    }
+
+    fun createPlaylist(id: Int, name: String, audioItemIds: List<Int> = emptyList()): MutableAudioPlaylist =
+        DefaultAudioPlaylist(id, name, audioItemIds).also { add(it) }
+
+    override fun loadFromStore(): Map<Int, MutableAudioPlaylist> = emptyMap()
+
+    override fun writePending(
+        inserts: List<MutableAudioPlaylist>,
+        updates: List<PendingUpdate<Int, MutableAudioPlaylist>>,
+        deletes: List<Pair<Int, Long?>>,
+        hadClear: Boolean
+    ) = Unit
 }
 
 /**

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
@@ -37,6 +37,32 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.launch
 
+/**
+ * Test double that injects a one-shot fault immediately before the atomic rename step of the
+ * durable write primitive. The fault fires exactly once (simulating a process crash mid-write)
+ * and then disarms so subsequent writes succeed normally.
+ *
+ * At fault time the live file content is captured in [fileContentAtFaultTime] so the test
+ * can assert the live file was not truncated or corrupted when the crash occurred.
+ */
+private class FaultInjectingCustomerRepository(
+    ctx: LirpContext,
+    file: File,
+    serializationDelayMs: Long = 300L
+) : StandardCustomerJsonFileRepository(ctx, file, serializationDelayMs) {
+
+    val faultArmed = AtomicBoolean(true)
+    var fileContentAtFaultTime: String? = null
+
+    override fun beforeMoveToTarget(tmp: File) {
+        if (faultArmed.compareAndSet(true, false)) {
+            // Capture the live file content at crash time — it must not be truncated.
+            fileContentAtFaultTime = jsonFile.readText()
+            throw IOException("Simulated crash before atomic rename")
+        }
+    }
+}
+
 class JsonFileRepositoryTest : DescribeSpec({
     val reactive = reactiveScope()
 
@@ -968,6 +994,56 @@ class JsonFileRepositoryTest : DescribeSpec({
                 deferred.close()
                 ctx.close()
             }
+        }
+    }
+
+    describe("Crash durability") {
+
+        it("JsonFileRepository a mid-write crash before rename leaves the previously-committed file intact and reloadable") {
+            val ctx = LirpContext()
+            val file = tempfile("crash-durability-test", ".json").also { it.deleteOnExit() }
+            val repo = StandardCustomerJsonFileRepository(ctx, file, 10L)
+
+            // Phase 1: commit the initial state by adding one entity and flushing to disk.
+            repo.create(1, "Alice", "alice@example.com")
+            reactive.advance()
+            val committedContent = file.readText()
+            committedContent.isNotEmpty() shouldBe true
+            repo.close()
+            ctx.close()
+
+            // Phase 2: open a fault-injecting repo, add a new entity, then call close() to
+            // trigger a synchronous flush (close() flushes synchronously before releasing
+            // resources). The fault fires inside the synchronous flush path, so the exception
+            // propagates directly back to close() rather than escaping into a coroutine.
+            // We catch it here to keep the test from failing on the expected I/O error.
+            val ctx2 = LirpContext()
+            val faultRepo = FaultInjectingCustomerRepository(ctx2, file, 10L)
+            faultRepo.create(2, "Bob", "bob@example.com")
+            // close() synchronously flushes, which fires the fault. The IOException propagates
+            // from writePending through flush() to close(), so we catch it here.
+            try {
+                faultRepo.close()
+            } catch (_: IOException) {
+                // expected — the fault fired during the synchronous close() flush
+            }
+            ctx2.close()
+
+            // Phase 3: verify that at crash time the live file held the committed content,
+            // not an empty/truncated placeholder. With the old in-place writeText the live file
+            // would have been truncated before writing started, leaving it empty at crash time.
+            faultRepo.fileContentAtFaultTime!!.shouldEqualJson(committedContent)
+
+            // Phase 4: the live file must also still be readable and contain only Alice —
+            // the fault prevented the second write from completing, so Bob was never committed.
+            file.readText().shouldEqualJson(committedContent)
+            val ctx3 = LirpContext()
+            val reloadedRepo = StandardCustomerJsonFileRepository(ctx3, file, 10L)
+            reloadedRepo.size() shouldBe 1
+            reloadedRepo.findById(1) shouldBePresent { it.name shouldBe "Alice" }
+            reloadedRepo.findById(2).isEmpty shouldBe true
+            reloadedRepo.close()
+            ctx3.close()
         }
     }
 })

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonTestFixtures.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonTestFixtures.kt
@@ -286,7 +286,7 @@ private val customerMapSerializer = MapSerializer(Int.serializer(), PolymorphicC
  * auto-registration code for the provided [LirpContext].
  */
 @LirpRepository
-class StandardCustomerJsonFileRepository internal constructor(
+open class StandardCustomerJsonFileRepository internal constructor(
     context: LirpContext,
     file: File,
     serializationDelayMs: Long = 300L,

--- a/lirp-kafka/api/lirp-kafka.api
+++ b/lirp-kafka/api/lirp-kafka.api
@@ -51,6 +51,7 @@ public class net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository : net/transgr
 	public synthetic fun <init> (Ljavax/sql/DataSource;Lnet/transgressoft/lirp/persistence/sql/SqlTableDef;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected fun onAfterEntityWritesInTransaction (Lnet/transgressoft/lirp/persistence/TransactionBuffer;)V
 	protected fun onAfterEntityWritesInWritePending (Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	protected fun onAfterEntityWritesInWritePending (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
 }
 
 public final class net/transgressoft/lirp/kafka/LirpKafkaConfig : java/lang/AutoCloseable {

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisher.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisher.kt
@@ -156,7 +156,12 @@ class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
          * rather than their numeric codes, so a consumer-defined [EventType] that happens to reuse a
          * framework code (e.g. `100`) is still captured into the outbox.
          *
-         * If the event type is currently disabled, both local delivery and outbox capture are suppressed.
+         * If the event type is a framework-owned [CrudEvent.Type] or [MutationEvent.Type] that is
+         * currently inactive, both local delivery and outbox capture are suppressed silently — these
+         * types are managed by the flush hook and operator suppression is an explicit operator action.
+         * If the event type belongs to a custom [OutboxRoutableEvent] and is not active (never activated
+         * or explicitly disabled), this method throws [IllegalStateException] immediately so the
+         * misconfiguration is surfaced as a bug rather than a permanent silent event drop.
          * When an active Exposed transaction sharing this publisher's underlying connection pool is
          * detected, the outbox INSERT joins that transaction atomically; otherwise a fresh single-row
          * transaction on [db] is opened. Pool sharing is detected by [Database] identity or, when
@@ -167,7 +172,21 @@ class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
          * throws immediately so the misconfiguration is surfaced as a bug.
          */
         override fun emitAsync(event: E) {
-            if (!delegate.isEventActive(event.type)) return
+            if (!delegate.isEventActive(event.type)) {
+                // Framework-owned CRUD/mutation event types are activated by the repository flush hook;
+                // an inactive framework event is an operator-controlled suppression — silence is correct.
+                // A custom OutboxRoutableEvent whose type is inactive (never activated or explicitly
+                // disabled) would silently discard a relayable event with no outbox row and no delivery.
+                // That is a misconfiguration: fail fast so it is surfaced as a bug, not a phantom drop.
+                if (event is OutboxRoutableEvent<*>) {
+                    error(
+                        "Custom OutboxRoutableEvent type ${event.type} is not active; call " +
+                            "activateEvents(${event.type}) before emitting, or use " +
+                            "FlowEventPublisher for local-only delivery without Kafka relay"
+                    )
+                }
+                return
+            }
             if (event.type is CrudEvent.Type || event.type is MutationEvent.Type) {
                 delegate.emitAsync(event)
                 return

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisher.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisher.kt
@@ -37,6 +37,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.Properties
 import java.util.UUID
 import java.util.concurrent.ExecutionException
+import javax.sql.DataSource
 import kotlin.time.Clock
 
 /**
@@ -62,6 +63,14 @@ import kotlin.time.Clock
  * Closing this publisher stops in-process subscriptions and releases the broker connection.
  * It does **not** stop the outbox relay, whose lifecycle is owned by [LirpKafkaConfig].
  *
+ * **Transaction enlistment:** [emitAsync] detects an ambient Exposed transaction and joins it
+ * when the transaction's [Database] shares the same connection pool as this publisher's [Database].
+ * Identity (same instance) is checked first; when the publisher was constructed via
+ * [LirpKafkaConfig.startRelay], the supplied [DataSource] is stored and the JDBC URL of the
+ * publisher's [Database] is compared against the ambient transaction's [Database] URL so that
+ * two distinct [Database] instances wrapping the same pool are still treated as equivalent.
+ * Joining the ambient transaction ensures the outbox INSERT and the entity write commit atomically.
+ *
  * @param ET The specific [EventType] this publisher emits
  * @param E  The specific [LirpEvent] type this publisher emits
  * @param id Logical identifier, used to name the internal [FlowEventPublisher]
@@ -79,8 +88,21 @@ class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
         private val db: Database,
         private val outboxStore: OutboxStore,
         producerConfig: Map<String, String> = emptyMap(),
-        private val delegate: FlowEventPublisher<ET, E> = FlowEventPublisher(id)
+        private val delegate: FlowEventPublisher<ET, E> = FlowEventPublisher(id),
+        dataSource: DataSource? = null
     ) : LirpEventPublisher<ET, E> by delegate {
+
+        /**
+         * JDBC URL of this publisher's [Database], resolved once on first use.
+         *
+         * When [dataSource] is provided (relay wiring via [LirpKafkaConfig.startRelay]),
+         * [emitAsync] compares this URL against the ambient transaction's database URL to detect
+         * two [Database] instances wrapping the same connection pool. The URL is lazily resolved
+         * so construction does not open a JDBC connection before the first [emitAsync] call.
+         */
+        private val dbUrl: String? by lazy {
+            if (dataSource != null) db.url else null
+        }
 
         /**
          * Creates a [KafkaEventPublisher] connected to the given [bootstrapServers] and [db].
@@ -135,8 +157,11 @@ class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
          * framework code (e.g. `100`) is still captured into the outbox.
          *
          * If the event type is currently disabled, both local delivery and outbox capture are suppressed.
-         * When an active Exposed transaction bound to this publisher's [db] is detected the outbox
-         * INSERT joins that transaction; otherwise a fresh single-row transaction on [db] is opened.
+         * When an active Exposed transaction sharing this publisher's underlying connection pool is
+         * detected, the outbox INSERT joins that transaction atomically; otherwise a fresh single-row
+         * transaction on [db] is opened. Pool sharing is detected by [Database] identity or, when
+         * this publisher was constructed with a [DataSource] (relay wiring), by comparing the
+         * JDBC URL of both [Database] instances.
          *
          * Custom events must implement [OutboxRoutableEvent]; emitting a non-routable custom event
          * throws immediately so the misconfiguration is surfaced as a bug.
@@ -149,7 +174,7 @@ class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
             }
             val outboxEvent = buildOutboxEvent(event)
             val currentTransaction = TransactionManager.currentOrNull()
-            if (currentTransaction != null && currentTransaction.db == db) {
+            if (currentTransaction != null && sharesConnectionPool(currentTransaction.db)) {
                 outboxStore.insert(outboxEvent)
             } else {
                 transaction(db) {
@@ -157,6 +182,28 @@ class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
                 }
             }
             delegate.emitAsync(event)
+        }
+
+        /**
+         * Returns `true` when [otherDb] shares the same underlying connection pool as this
+         * publisher's [db].
+         *
+         * Two [Database] instances share a pool when they are the same object, or when both were
+         * created from the same [DataSource] — detected by comparing their JDBC metadata URLs.
+         * The URL comparison is enabled only when this publisher was constructed with a [DataSource]
+         * (relay wiring via [LirpKafkaConfig.startRelay]), so the public constructor preserves the
+         * original identity-only check.
+         */
+        private fun sharesConnectionPool(otherDb: Database): Boolean {
+            if (otherDb === db) return true
+            // URL-based comparison activated only when dataSource was supplied at construction,
+            // i.e. when wired via startRelay where publisherDb != appDb but both wrap the same pool.
+            return dbUrl != null &&
+                try {
+                    otherDb.url == dbUrl
+                } catch (_: Exception) {
+                    false
+                }
         }
 
         /**

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisher.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisher.kt
@@ -274,10 +274,15 @@ class KafkaEventPublisher<ET : EventType, E : LirpEvent<ET>>
                             "OutboxRoutableEvent to be relayed to Kafka; implement aggregateId and payload " +
                             "or use FlowEventPublisher for local-only delivery"
                     )
+            val aggregateId = routable.aggregateId
+            require(aggregateId.isNotBlank()) {
+                "OutboxRoutableEvent.aggregateId must not be blank for event type ${event.type}; " +
+                    "a blank aggregateId would produce an empty Kafka record key, defeating per-aggregate ordering"
+            }
             return OutboxEvent(
                 id = UUID.randomUUID(),
                 aggregateType = aggregateType,
-                aggregateId = routable.aggregateId,
+                aggregateId = aggregateId,
                 eventTypeCode = event.type.code,
                 payload = routable.payload,
                 createdAt = Clock.System.now()

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxSqlRepository.kt
@@ -141,6 +141,34 @@ open class KafkaOutboxSqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
     }
 
     /**
+     * Extends [onAfterEntityWritesInWritePending] to handle bulk-wipe events produced by [clear].
+     *
+     * When [clearedEntityIds] is non-empty, a [CrudEvent.Type.DELETE] outbox row is emitted for
+     * each cleared entity key — captured in the same JDBC transaction as the bulk `table.deleteAll()`
+     * so downstream consumers receive exactly one DELETE row per wiped aggregate.
+     *
+     * The clear DELETE rows are written **before** delegating to the three-argument overload that
+     * emits the batch CRUD rows. A clear followed by a re-insert of the same key within one debounce
+     * window must converge consumers on the re-inserted state: emitting the clear DELETE first, then
+     * the batch `CREATE`, yields `DELETE(id)` → `CREATE(id)` (entity present). Emitting them in the
+     * opposite order would leave `CREATE(id)` → `DELETE(id)`, wrongly signalling a row that still
+     * exists after the flush as deleted.
+     */
+    override fun onAfterEntityWritesInWritePending(
+        inserts: List<R>,
+        updates: List<PendingUpdate<K, R>>,
+        deletes: List<Pair<K, Long?>>,
+        clearedEntityIds: List<K>
+    ) {
+        if (clearedEntityIds.isNotEmpty()) {
+            val clearDeleteRows =
+                clearedEntityIds.map { buildRow(it.toString(), CrudEvent.Type.DELETE.code, "{}") }
+            insertRows(clearDeleteRows)
+        }
+        super.onAfterEntityWritesInWritePending(inserts, updates, deletes, clearedEntityIds)
+    }
+
+    /**
      * Builds a serializer-neutral JSON payload from the entity's persisted field values by calling
      * [SqlTableDef.toParams] — the same field extraction used for SQL INSERT/UPDATE statements.
      *

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
@@ -19,6 +19,7 @@ package net.transgressoft.lirp.kafka
 
 import net.transgressoft.lirp.event.LirpErrorHandler
 import net.transgressoft.lirp.kafka.outbox.OutboxRelay
+import net.transgressoft.lirp.kafka.outbox.SqlOutboxStore
 import net.transgressoft.lirp.kafka.spi.CloudEventsBinarySerializer
 import net.transgressoft.lirp.kafka.spi.DefaultTopicResolver
 import net.transgressoft.lirp.kafka.spi.LirpEventSerializer
@@ -109,10 +110,14 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
         val db = Database.connect(dataSource)
         // Reuse the cached publisher across relay restarts so a prior stopRelay() does not leave the
         // previous producer/broker connection open when a new relay is started.
+        // Pass dataSource explicitly so the publisher registers the db→dataSource mapping used
+        // by emitAsync to detect an ambient transaction on a different Database wrapping the same pool.
         val publisher =
             _publisher
-                ?: KafkaEventPublisher<Nothing, Nothing>("lirp-kafka", bootstrapServers, db, producerConfig)
-                    .also { _publisher = it }
+                ?: KafkaEventPublisher<Nothing, Nothing>(
+                    "lirp-kafka", bootstrapServers, db,
+                    SqlOutboxStore(db), producerConfig, dataSource = dataSource
+                ).also { _publisher = it }
         relay = OutboxRelay(db, publisher, config, serializer, topicResolver, onDeadLetter).also { it.start() }
     }
 

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
@@ -35,13 +35,16 @@ import javax.sql.DataSource
  * pairs.
  *
  * This class is [AutoCloseable]: calling [close] stops the relay (if running) and releases the
- * underlying broker connection held by the cached [KafkaEventPublisher]. Wrap in a `use { }`
+ * underlying broker connection held by the active [KafkaEventPublisher]. Wrap in a `use { }`
  * block or call [close] explicitly when the config is no longer needed.
  *
  * **Relay lifecycle:** call [startRelay] with a [DataSource] to begin background outbox
  * delivery. The relay polls the outbox table, publishes each row via the [KafkaEventPublisher],
  * and marks it as sent only after the broker acknowledges. Call [stopRelay] to stop the relay
- * without closing the publisher, or [close] to stop both.
+ * and close the publisher (freeing the broker connection), or [close] to stop both. A subsequent
+ * [startRelay] constructs a fresh publisher with the newly supplied `producerConfig`, so operator
+ * changes to producer properties — such as `delivery.timeout.ms` or SSL credentials — take effect
+ * on restart rather than being silently ignored by a cached publisher.
  *
  * **Supported store:** only SQL-backed repositories participate in the transactional outbox.
  * [net.transgressoft.lirp.persistence.JsonFileRepository] and
@@ -68,10 +71,11 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
     /**
      * Returns the [KafkaEventPublisher] owned by this config.
      *
-     * The publisher is initialized when [startRelay] is called and reused on subsequent calls.
-     * Its lifecycle is tied to this config — call [close] to release broker connections.
+     * The publisher is initialized when [startRelay] is called. Calling [stopRelay] closes it;
+     * a subsequent [startRelay] constructs a fresh publisher. Calling [publisher] after [stopRelay]
+     * and before a new [startRelay] throws [IllegalStateException].
      *
-     * @throws IllegalStateException if called before [startRelay]
+     * @throws IllegalStateException if the relay has not been started or was stopped
      */
     fun publisher(): KafkaEventPublisher<*, *> = checkNotNull(_publisher) { "Publisher not initialized — call startRelay first" }
 
@@ -82,6 +86,12 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
      * and begins polling the outbox on a background coroutine. At most one relay per
      * [LirpKafkaConfig] instance is supported; calling [startRelay] when a relay is already
      * running throws [IllegalStateException].
+     *
+     * A fresh [KafkaEventPublisher] is constructed on each call so that [producerConfig] and
+     * [bootstrapServers] are applied to a new [org.apache.kafka.clients.producer.KafkaProducer]
+     * on every (re)start. This ensures that producer properties adjusted between a [stopRelay] and
+     * the subsequent restart — such as `delivery.timeout.ms` or SSL credentials — take effect
+     * rather than being silently ignored.
      *
      * @param dataSource JDBC data source for the outbox and dead-letter tables.
      * @param config Relay behaviour knobs — poll interval, batch size, retry limits, backoff.
@@ -108,27 +118,34 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
     ) {
         check(relay == null) { "Relay is already running; call stopRelay() first" }
         val db = Database.connect(dataSource)
-        // Reuse the cached publisher across relay restarts so a prior stopRelay() does not leave the
-        // previous producer/broker connection open when a new relay is started.
-        // Pass dataSource explicitly so the publisher registers the db→dataSource mapping used
-        // by emitAsync to detect an ambient transaction on a different Database wrapping the same pool.
+        // Always construct a fresh publisher so that any producerConfig or bootstrapServers change
+        // supplied on a restart (after stopRelay) reaches a new KafkaProducer.
+        // Pass dataSource so the publisher stores the pool URL for the emitAsync
+        // transaction-join gate that detects two Database instances wrapping the same pool.
         val publisher =
-            _publisher
-                ?: KafkaEventPublisher<Nothing, Nothing>(
-                    "lirp-kafka", bootstrapServers, db,
-                    SqlOutboxStore(db), producerConfig, dataSource = dataSource
-                ).also { _publisher = it }
+            KafkaEventPublisher<Nothing, Nothing>(
+                "lirp-kafka", bootstrapServers, db,
+                SqlOutboxStore(db), producerConfig, dataSource = dataSource
+            ).also { _publisher = it }
         relay = OutboxRelay(db, publisher, config, serializer, topicResolver, onDeadLetter).also { it.start() }
     }
 
-    /** Stops the relay without closing the [KafkaEventPublisher]. */
+    /**
+     * Stops the relay and closes the [KafkaEventPublisher], releasing the broker connection.
+     *
+     * Closing the publisher ensures the underlying [org.apache.kafka.clients.producer.KafkaProducer]
+     * is released immediately. A subsequent [startRelay] call constructs a fresh publisher, so any
+     * updated [producerConfig] or [bootstrapServers] take effect.
+     */
     @Synchronized
     fun stopRelay() {
         relay?.stop()
         relay = null
+        _publisher?.close()
+        _publisher = null
     }
 
-    /** Stops the relay (if running) and closes the [KafkaEventPublisher]. */
+    /** Stops the relay (if running), closes the [KafkaEventPublisher], and nulls both. */
     @Synchronized
     override fun close() {
         relay?.stop()

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
@@ -88,6 +88,8 @@ import kotlinx.coroutines.runBlocking
  * @param onDeadLetter Optional callback invoked when a row is moved to the dead-letter table.
  *   The callback receives the terminal exception and a [LirpErrorContext] describing the failure.
  *   Exceptions thrown by the callback are swallowed.
+ * @param store Outbox persistence store. Defaults to [SqlOutboxStore] over [db]. Exposed for
+ *   fault-injection testing only; production callers must not pass a custom value.
  */
 internal class OutboxRelay(
     private val db: Database,
@@ -95,11 +97,12 @@ internal class OutboxRelay(
     private val config: KafkaOutboxConfig,
     private val serializer: LirpEventSerializer = CloudEventsBinarySerializer(),
     private val topicResolver: TopicResolver = DefaultTopicResolver,
-    private val onDeadLetter: LirpErrorHandler? = null
+    private val onDeadLetter: LirpErrorHandler? = null,
+    store: OutboxStore? = null
 ) : AutoCloseable {
 
     private val log = KotlinLogging.logger(javaClass.name)
-    private val store = SqlOutboxStore(db)
+    private val store: OutboxStore = store ?: SqlOutboxStore(db)
     private var job: Job? = null
 
     /**
@@ -179,7 +182,19 @@ internal class OutboxRelay(
             require(topic.isNotBlank()) {
                 "TopicResolver returned a blank topic for aggregateType='${envelope.aggregateType}'"
             }
-            val serialized = serializer.serialize(envelope)
+            // Widen to Throwable so an OutOfMemoryError or other Error during serialization does
+            // not escape this method and kill the relay coroutine. The row is dead-lettered so
+            // the queue is not permanently wedged.
+            @Suppress("TooGenericExceptionCaught")
+            val serialized =
+                try {
+                    serializer.serialize(envelope)
+                } catch (t: Throwable) {
+                    store.moveToDeadLetter(row, Clock.System.now(), t.message ?: t.javaClass.simpleName)
+                    log.error(t) { "Serialization error for outbox row ${row.id} (${row.aggregateType}/${row.aggregateId}); row moved to dead-letter" }
+                    invokeDeadLetterCallback(t)
+                    return
+                }
             val recordHeaders = RecordHeaders()
             serialized.headers.forEach { (k, v) -> recordHeaders.add(k, v) }
             publisher.publish(topic, row.aggregateId, serialized.value, recordHeaders)
@@ -190,9 +205,28 @@ internal class OutboxRelay(
                 invokeDeadLetterCallback(e)
             } else {
                 val nextRetryAt = computeNextRetryAt(row.retryCount + 1, config)
-                store.scheduleRetry(row.id, nextRetryAt, e.message ?: e.javaClass.simpleName)
+                try {
+                    store.scheduleRetry(row.id, nextRetryAt, e.message ?: e.javaClass.simpleName)
+                } catch (dbFailure: Exception) {
+                    // scheduleRetry DB write failed: the retry_count was not incremented, so the
+                    // row would be re-published immediately on the next cycle with no backoff.
+                    // Fall back to dead-lettering so the row is resolved and the queue drains.
+                    log.error(dbFailure) {
+                        "Failed to persist retry schedule for outbox row ${row.id}; moving to dead-letter to prevent unbounded re-publish"
+                    }
+                    store.moveToDeadLetter(row, Clock.System.now(), e.message ?: e.javaClass.simpleName)
+                    invokeDeadLetterCallback(e)
+                }
             }
         } catch (e: Exception) {
+            if (e is org.apache.kafka.common.errors.RecordTooLargeException) {
+                // Log distinctly: this is a configuration issue (broker's max.message.bytes or
+                // message.max.bytes), not a permanent data problem. Raising the limit would deliver it.
+                log.error(e) {
+                    "Outbox row ${row.id} exceeds the broker's record size limit and has been moved to dead-letter. " +
+                        "Raising max.message.bytes / max.request.size would allow delivery."
+                }
+            }
             store.moveToDeadLetter(row, Clock.System.now(), e.message ?: e.javaClass.simpleName)
             invokeDeadLetterCallback(e)
         }
@@ -221,7 +255,12 @@ internal class OutboxRelay(
             // Clamp the shift distance: `Long shl` masks to the low 6 bits, so a retryCount >= 64
             // would silently wrap to a small exponent instead of saturating at capMs.
             val safeShift = minOf(retryCount, 62)
-            val raw = minOf(baseMs * (1L shl safeShift), capMs)
+            val shift = 1L shl safeShift
+            // Guard against Long overflow: for baseMs >= 2 and a large shift, baseMs * shift can
+            // exceed Long.MAX_VALUE and wrap negative, which would slip past minOf(..., capMs) and
+            // yield a next-retry timestamp in the past — a no-backoff busy loop. When the product
+            // would exceed capMs, saturate directly to capMs rather than multiplying.
+            val raw = if (baseMs > 0 && shift > capMs / baseMs) capMs else minOf(baseMs * shift, capMs)
             val jittered = raw * (0.8 + Math.random() * 0.4)
             return Clock.System.now() + jittered.toLong().milliseconds
         }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
@@ -20,7 +20,6 @@ package net.transgressoft.lirp.kafka.outbox
 import net.transgressoft.lirp.event.LirpErrorContext
 import net.transgressoft.lirp.event.LirpErrorHandler
 import net.transgressoft.lirp.event.LirpOperation
-import net.transgressoft.lirp.event.ReactiveScope
 import net.transgressoft.lirp.kafka.KafkaEventPublisher
 import net.transgressoft.lirp.kafka.KafkaOutboxConfig
 import net.transgressoft.lirp.kafka.spi.CloudEventsBinarySerializer
@@ -38,24 +37,32 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Instant
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.runInterruptible
 
 /**
  * Background relay loop that drains the transactional outbox by publishing each unsent row to
  * Kafka and marking it as sent only after the broker acknowledges the record.
  *
- * Each row is processed inside its own Exposed transaction: the transaction claims a single unsent
- * row (using dialect-appropriate row locking on PostgreSQL/MySQL/MariaDB so concurrent relays skip
- * it), publishes it via [publisher], and commits [SqlOutboxStore.markSent] after a successful
- * publish. A crash between publish and commit rolls back only that row's transaction, leaving it
- * available for redelivery on the next cycle — the at-least-once guarantee. Scoping each row to its
- * own transaction keeps a transient persistence failure on one row from rolling back rows already
- * published and marked in the same cycle.
+ * Each row is processed in a single short transaction: the transaction claims the next eligible
+ * row (using dialect-appropriate `FOR UPDATE SKIP LOCKED` on PostgreSQL/MySQL/MariaDB so concurrent
+ * relays skip it), publishes it to Kafka, and commits [SqlOutboxStore.markSent] only after the
+ * broker acknowledges the record. The row lock is held across the blocking send, which prevents a
+ * second concurrent relay from re-claiming and double-publishing the same row. The blocking send is
+ * wrapped in [kotlinx.coroutines.runInterruptible] so that cancelling the loop (via [stop] or
+ * [stopAndJoin]) interrupts the blocked thread and returns promptly rather than waiting for the
+ * producer's `delivery.timeout.ms`. A crash or cancellation between publish and commit rolls back
+ * the transaction, leaving the row available for redelivery on the next cycle — the at-least-once
+ * guarantee is preserved. Scoping each row to its own transaction keeps a transient persistence
+ * failure on one row from rolling back rows already published and marked in the same cycle.
  *
  * **Failure classification:** a [RetriableException] from the Kafka client increments
  * [OutboxEvent.retryCount] and schedules the next attempt via exponential backoff while retries
@@ -72,6 +79,13 @@ import kotlinx.coroutines.runBlocking
  *
  * **Ordering:** records are keyed by [OutboxEvent.aggregateId] so the Kafka producer routes
  * all events for a given aggregate to the same partition, preserving per-aggregate ordering.
+ *
+ * **Dispatcher isolation:** the relay runs on a dedicated [kotlinx.coroutines.Dispatchers.IO] scope
+ * (not on the shared single-slot `ReactiveScope.ioScope`) so a slow broker acknowledgement does not
+ * starve flush scheduling for other repositories. The blocking `producer.send().get()` inside each
+ * row's transaction is wrapped in [kotlinx.coroutines.runInterruptible] so that cancelling the loop
+ * (via [stop] or [stopAndJoin]) interrupts the blocked thread and returns promptly rather than
+ * waiting for the producer's `delivery.timeout.ms`.
  *
  * **Connection resource:** the relay holds a HikariCP connection open while waiting for Kafka
  * broker acknowledgement inside each row's transaction. Configure the Kafka producer's
@@ -103,10 +117,14 @@ internal class OutboxRelay(
 
     private val log = KotlinLogging.logger(javaClass.name)
     private val store: OutboxStore = store ?: SqlOutboxStore(db)
+
+    // Dedicated scope keeps the relay off the shared single-slot ioScope so a slow broker
+    // acknowledgement cannot block flush scheduling for unrelated repositories.
+    private val relayScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var job: Job? = null
 
     /**
-     * Starts the background poll loop on [ReactiveScope.ioScope].
+     * Starts the background poll loop on a dedicated [Dispatchers.IO] scope.
      *
      * The [DeadLetterTable] schema is created idempotently before the loop starts. Calling
      * [start] on a relay that is already running throws [IllegalStateException].
@@ -115,7 +133,7 @@ internal class OutboxRelay(
         check(job == null || job!!.isCompleted) { "Relay is already running" }
         transaction(db) { SchemaUtils.create(DeadLetterTable) }
         job =
-            ReactiveScope.ioScope.launch {
+            relayScope.launch {
                 var consecutiveFailures = 0
                 while (isActive) {
                     try {
@@ -155,10 +173,9 @@ internal class OutboxRelay(
      * can safely close the underlying [DataSource][javax.sql.DataSource] afterwards. A stopped relay
      * can be [start]ed again.
      *
-     * **Precondition:** this method must NOT be called from a thread running on
-     * [ReactiveScope.ioScope] (the relay's own dispatcher). Doing so will deadlock because
-     * [runBlocking] cannot complete the [kotlinx.coroutines.cancelAndJoin] suspension while the
-     * calling thread is occupied. Coroutine callers must use [stopAndJoin] instead.
+     * The relay's publish step is wrapped in [runInterruptible], so cancellation calls
+     * [Thread.interrupt] on any thread blocked inside the broker send, allowing [cancelAndJoin]
+     * to complete promptly rather than waiting for `delivery.timeout.ms`.
      */
     fun stop() {
         val current = job ?: return
@@ -170,15 +187,25 @@ internal class OutboxRelay(
         stop()
     }
 
-    internal fun pollAndRelay() {
+    internal suspend fun pollAndRelay() {
         val now = Clock.System.now()
         var processed = 0
         while (processed < config.batchSize) {
+            // Claim, publish, and mark the row within a SINGLE transaction so the FOR UPDATE
+            // SKIP LOCKED row lock is held across the publish. This is what prevents a second
+            // concurrent relay instance from re-claiming and double-publishing the same row.
+            // runInterruptible wraps the whole transaction so that cancelling the relay Job
+            // interrupts the thread blocked inside the producer's Future.get(): stop() returns
+            // promptly and the transaction rolls back, leaving the row unsent for a later cycle
+            // (at-least-once). Running on the dedicated relayScope keeps this off the shared
+            // single-slot ioScope, so a slow broker cannot starve other repositories' flushes.
             val handled =
-                transaction(db) {
-                    val row = store.findUnsentForRelay(1, now).firstOrNull() ?: return@transaction false
-                    processRow(row)
-                    true
+                runInterruptible {
+                    transaction(db) {
+                        val row = store.findUnsentForRelay(1, now).firstOrNull() ?: return@transaction false
+                        processRow(row)
+                        true
+                    }
                 }
             if (!handled) break
             processed++
@@ -207,8 +234,18 @@ internal class OutboxRelay(
                 }
             val recordHeaders = RecordHeaders()
             serialized.headers.forEach { (k, v) -> recordHeaders.add(k, v) }
+            // The enclosing pollAndRelay wraps this transaction in runInterruptible, so a blocking
+            // send here is interruptible on relay stop() without releasing the row lock before the
+            // publish completes.
             publisher.publish(topic, row.aggregateId, serialized.value, recordHeaders)
             store.markSent(row.id)
+        } catch (e: InterruptedException) {
+            // Cooperative cancellation on relay stop(): the blocking publish was interrupted.
+            // Re-set the interrupt flag and rethrow so runInterruptible surfaces the cancellation
+            // and the enclosing transaction rolls back — the row stays unsent for a later cycle
+            // rather than being dead-lettered.
+            Thread.currentThread().interrupt()
+            throw e
         } catch (e: RetriableException) {
             if (row.retryCount >= config.maxRetries) {
                 store.moveToDeadLetter(row, Clock.System.now(), e.message ?: e.javaClass.simpleName)

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
@@ -116,13 +116,23 @@ internal class OutboxRelay(
         transaction(db) { SchemaUtils.create(DeadLetterTable) }
         job =
             ReactiveScope.ioScope.launch {
+                var consecutiveFailures = 0
                 while (isActive) {
                     try {
                         pollAndRelay()
+                        consecutiveFailures = 0
                     } catch (e: CancellationException) {
                         throw e // cooperative cancellation — never swallow
                     } catch (e: Exception) {
-                        log.error(e) { "Relay poll cycle failed" }
+                        consecutiveFailures++
+                        if (consecutiveFailures == 1) {
+                            log.error(e) { "Relay poll cycle failed" }
+                        } else {
+                            // Escalate visibility: a repeating failure (e.g. a dialect-specific syntax
+                            // error or unreachable DB) grows the outbox unbounded. Log at ERROR with
+                            // the consecutive count so operators notice and act quickly.
+                            log.error(e) { "Relay poll cycle failed $consecutiveFailures times in a row — outbox is not draining. Last error: ${e.message}" }
+                        }
                     }
                     delay(config.pollIntervalMs)
                 }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/SqlOutboxStore.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/SqlOutboxStore.kt
@@ -47,10 +47,11 @@ import kotlin.uuid.toKotlinUuid
 /**
  * Exposed-backed implementation of [OutboxStore].
  *
- * All relay-side methods ([findUnsentForRelay], [scheduleRetry], [moveToDeadLetter]) require an
- * active Exposed transaction opened by the caller — typically [OutboxRelay.pollAndRelay]. Holding
- * the transaction open across the Kafka publish call means a crash between publish and
- * [markSent] leaves the row unsent; the rolled-back transaction is the redelivery guarantee.
+ * All relay-side methods ([findUnsentForRelay], [scheduleRetry], [moveToDeadLetter], [markSent])
+ * require an active Exposed transaction opened by the caller — typically [OutboxRelay.pollAndRelay].
+ * The relay uses two short transactions per row: one to claim the row and one to commit [markSent]
+ * after the broker acknowledges the record. A crash between the two transactions leaves the row
+ * available for redelivery on the next poll cycle — the at-least-once guarantee.
  *
  * **Dialect-aware locking:** [findUnsentForRelay] applies `FOR UPDATE SKIP LOCKED` on
  * PostgreSQL and supported MySQL/MariaDB versions (MySQL 8.0+, MariaDB 10.6+) so concurrent relay

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/SqlOutboxStore.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/SqlOutboxStore.kt
@@ -32,6 +32,7 @@ import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.insertIgnore
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.update
 import java.util.UUID
@@ -49,10 +50,16 @@ import kotlin.uuid.toKotlinUuid
  * [markSent] leaves the row unsent; the rolled-back transaction is the redelivery guarantee.
  *
  * **Dialect-aware locking:** [findUnsentForRelay] applies `FOR UPDATE SKIP LOCKED` on
- * PostgreSQL, MySQL, and MariaDB so concurrent relay instances skip rows already claimed by a
- * peer. On H2 and SQLite (test and single-instance deployments) the lock clause is omitted and
- * a plain `SELECT … LIMIT` is used; for those dialects a single-relay deployment is the only
+ * PostgreSQL and supported MySQL/MariaDB versions (MySQL 8.0+, MariaDB 10.6+) so concurrent relay
+ * instances skip rows already claimed by a peer. On older MySQL/MariaDB versions (MySQL < 8.0,
+ * MariaDB < 10.6), plain `FOR UPDATE` is used to preserve concurrency safety without requiring
+ * the unsupported `SKIP LOCKED` syntax. On H2 and SQLite (test and single-instance deployments)
+ * the lock clause is omitted; for those dialects a single-relay deployment is the only
  * supported configuration.
+ *
+ * **Dead-letter idempotency:** [moveToDeadLetter] uses `INSERT IGNORE` (or equivalent) so that
+ * a replayed dead-letter insert for the same outbox id silently skips the duplicate rather than
+ * throwing a unique-constraint violation. The outbox row is still deleted regardless.
  */
 internal class SqlOutboxStore(private val db: Database) : OutboxStore {
 
@@ -127,7 +134,10 @@ internal class SqlOutboxStore(private val db: Database) : OutboxStore {
     }
 
     override fun moveToDeadLetter(event: OutboxEvent, failedAt: Instant, errorMessage: String) {
-        DeadLetterTable.insert {
+        // Use insertIgnore so a duplicate PK (same outbox id already dead-lettered by a concurrent
+        // relay or replay tool) silently skips the re-insert rather than throwing a constraint
+        // violation that would leave the outbox row stuck in the queue forever.
+        DeadLetterTable.insertIgnore {
             it[id] = event.id.toKotlinUuid()
             it[aggregateType] = event.aggregateType
             it[aggregateId] = event.aggregateId

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/SqlOutboxStore.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/SqlOutboxStore.kt
@@ -19,13 +19,16 @@ package net.transgressoft.lirp.kafka.outbox
 
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.Version
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.lessEq
 import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.core.plus
+import org.jetbrains.exposed.v1.core.vendors.DatabaseDialect
 import org.jetbrains.exposed.v1.core.vendors.ForUpdateOption
+import org.jetbrains.exposed.v1.core.vendors.MariaDBDialect
 import org.jetbrains.exposed.v1.core.vendors.MysqlDialect
 import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
@@ -81,21 +84,15 @@ internal class SqlOutboxStore(private val db: Database) : OutboxStore {
      * [OutboxEvent.nextRetryAt] is null or not later than [now]. Rows are ordered by creation
      * time ascending so older events are delivered first.
      *
-     * On PostgreSQL and MySQL/MariaDB a `FOR UPDATE SKIP LOCKED` clause prevents concurrent relay
-     * instances from claiming the same row. The lock is held for the duration of the enclosing
+     * On PostgreSQL and MySQL 8.0+ / MariaDB 10.6+ a `FOR UPDATE SKIP LOCKED` clause prevents
+     * concurrent relay instances from claiming the same row. On older MySQL/MariaDB versions that
+     * do not support `SKIP LOCKED`, plain `FOR UPDATE` is used to preserve concurrency safety
+     * without emitting unsupported syntax. The lock is held for the duration of the enclosing
      * transaction — that same transaction will either commit [markSent] or roll back, leaving the
      * row available for the next poll cycle.
      */
     override fun findUnsentForRelay(limit: Int, now: Instant): List<OutboxEvent> {
-        val lockOption: ForUpdateOption? =
-            when (currentDialect) {
-                is PostgreSQLDialect ->
-                    ForUpdateOption.PostgreSQL.ForUpdate(ForUpdateOption.PostgreSQL.MODE.SKIP_LOCKED)
-                is MysqlDialect ->
-                    // MysqlDialect is the parent of MariaDBDialect — this branch covers both.
-                    ForUpdateOption.MySQL.ForUpdate(ForUpdateOption.MySQL.MODE.SKIP_LOCKED)
-                else -> null // H2, SQLite — plain SELECT; single-relay constraint is documented
-            }
+        val lockOption = selectLockOption(currentDialect, org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager.current().db.version)
 
         val query =
             OutboxEventTable.selectAll()
@@ -164,4 +161,45 @@ internal class SqlOutboxStore(private val db: Database) : OutboxStore {
             lastError = row[OutboxEventTable.lastError],
             nextRetryAt = row[OutboxEventTable.nextRetryAt]
         )
+
+    internal companion object {
+
+        /**
+         * Selects the row-locking clause for the poll query based on the database dialect and version.
+         *
+         * `FOR UPDATE SKIP LOCKED` is only supported on:
+         * - PostgreSQL (all tested versions)
+         * - MySQL 8.0+
+         * - MariaDB 10.6+
+         *
+         * Older MySQL/MariaDB versions that do not support `SKIP LOCKED` receive plain
+         * `FOR UPDATE` instead. SQLite and H2 receive no lock clause — they are single-relay
+         * only and do not support row-level locking on this query.
+         *
+         * The method is intentionally parameterized on dialect and version for testability without
+         * requiring a live database connection.
+         */
+        internal fun selectLockOption(dialect: DatabaseDialect, version: Version): ForUpdateOption? =
+            when {
+                dialect is PostgreSQLDialect ->
+                    ForUpdateOption.PostgreSQL.ForUpdate(ForUpdateOption.PostgreSQL.MODE.SKIP_LOCKED)
+                // MariaDB must be checked before MysqlDialect because MariaDBDialect extends MysqlDialect.
+                dialect is MariaDBDialect ->
+                    if (version.covers(10, 6)) {
+                        ForUpdateOption.MySQL.ForUpdate(ForUpdateOption.MySQL.MODE.SKIP_LOCKED)
+                    } else {
+                        // MariaDB < 10.6 does not support SKIP LOCKED; plain FOR UPDATE prevents
+                        // concurrent relay double-publish without emitting unsupported syntax.
+                        ForUpdateOption.ForUpdate
+                    }
+                dialect is MysqlDialect ->
+                    if (version.covers(8, 0)) {
+                        ForUpdateOption.MySQL.ForUpdate(ForUpdateOption.MySQL.MODE.SKIP_LOCKED)
+                    } else {
+                        // MySQL < 8.0 does not support SKIP LOCKED; fall back to plain FOR UPDATE.
+                        ForUpdateOption.ForUpdate
+                    }
+                else -> null // H2, SQLite — plain SELECT; single-relay constraint is documented
+            }
+    }
 }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer.kt
@@ -36,9 +36,11 @@ package net.transgressoft.lirp.kafka.spi
  * - `content-type`: Always `"application/json"` — the record value is a JSON string.
  *
  * All header values are encoded as UTF-8 bytes. [deserialize] fails fast on any record that does
- * not honour this contract: a missing required header, an unsupported `ce_specversion` or
- * `content-type`, or a `ce_source` that is not in the `lirp/{aggregateType}` form all raise an
- * exception rather than yield a bogus envelope (bug detector — do not downgrade to logging).
+ * not honour this contract: a missing required header, a blank `ce_id` or `ce_subject` (an empty
+ * `ByteArray` is non-null but decodes to an empty string — still rejected), an unsupported
+ * `ce_specversion` or `content-type`, or a `ce_source` that is not in the `lirp/{aggregateType}`
+ * form all raise an exception rather than yield a bogus envelope (bug detector — do not downgrade
+ * to logging).
  *
  * No external CloudEvents SDK is required. Hand-rolled with kotlinx-serialization only.
  */
@@ -61,7 +63,9 @@ class CloudEventsBinarySerializer : LirpEventSerializer {
         val payload = value.toString(Charsets.UTF_8)
         val specVersion = headers["ce_specversion"]?.toString(Charsets.UTF_8) ?: error("missing required ce_specversion header")
         require(specVersion == "1.0") { "unsupported ce_specversion '$specVersion'" }
-        val eventId = headers["ce_id"]?.toString(Charsets.UTF_8) ?: error("missing required ce_id header")
+        val eventId =
+            headers["ce_id"]?.toString(Charsets.UTF_8)?.takeIf { it.isNotBlank() }
+                ?: error("ce_id header is missing or blank; a non-blank idempotency key is required")
         val source = headers["ce_source"]?.toString(Charsets.UTF_8) ?: error("missing required ce_source header")
         require(source.startsWith("lirp/")) { "ce_source '$source' does not use the expected lirp/{aggregateType} format" }
         val aggregateType = source.removePrefix("lirp/")
@@ -69,7 +73,9 @@ class CloudEventsBinarySerializer : LirpEventSerializer {
         val eventTypeCode =
             ceType.substringAfterLast('.').toIntOrNull()
                 ?: error("ce_type '$ceType' does not end in a numeric event-type code")
-        val aggregateId = headers["ce_subject"]?.toString(Charsets.UTF_8) ?: error("missing required ce_subject header")
+        val aggregateId =
+            headers["ce_subject"]?.toString(Charsets.UTF_8)?.takeIf { it.isNotBlank() }
+                ?: error("ce_subject header is missing or blank; a non-blank aggregate identifier is required")
         val createdAt = headers["ce_time"]?.toString(Charsets.UTF_8) ?: error("missing required ce_time header")
         val contentType = headers["content-type"]?.toString(Charsets.UTF_8) ?: error("missing required content-type header")
         require(contentType == "application/json") { "unsupported content-type '$contentType'" }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/LirpEventEnvelope.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/LirpEventEnvelope.kt
@@ -34,12 +34,13 @@ import kotlinx.serialization.Serializable
  * serializer.
  *
  * @property eventId Unique identifier of the outbox row (UUID string). Used as the CloudEvents
- *   `ce_id` header and as the idempotency key for consumer-side deduplication.
+ *   `ce_id` header and as the idempotency key for consumer-side deduplication. Must be non-blank.
  * @property aggregateType Logical aggregate type name (e.g. table name or class name) used to
  *   route events to the appropriate Kafka topic via [TopicResolver] and to derive the CloudEvents
  *   `ce_source` and `ce_type` headers.
  * @property aggregateId String identifier of the specific aggregate instance; used as the Kafka
- *   record key for per-aggregate ordering and as the CloudEvents `ce_subject` header.
+ *   record key for per-aggregate ordering and as the CloudEvents `ce_subject` header. Must be
+ *   non-blank to preserve per-aggregate delivery order and prevent empty record keys.
  * @property eventTypeCode Numeric event-type code mapping directly to
  *   [net.transgressoft.lirp.event.EventType.code].
  * @property payload Serializer-neutral JSON field snapshot of the entity at capture time.
@@ -55,6 +56,11 @@ data class LirpEventEnvelope(
     val payload: String,
     val createdAt: String
 ) {
+    init {
+        require(eventId.isNotBlank()) { "eventId must not be blank; a non-blank idempotency key is required" }
+        require(aggregateId.isNotBlank()) { "aggregateId must not be blank; a non-blank aggregate identifier is required for per-aggregate ordering" }
+    }
+
     companion object {
         /**
          * Builds a [LirpEventEnvelope] from an internal outbox row.

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisherTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/KafkaEventPublisherTest.kt
@@ -183,7 +183,7 @@ internal class KafkaEventPublisherTest : StringSpec() {
             }
         }
 
-        "KafkaEventPublisherTest disableEvents gates both local delivery and outbox capture" {
+        "KafkaEventPublisherTest disableEvents on OutboxRoutableEvent type throws to surface the misconfiguration" {
             val dataSource = H2ContainerSupport.buildH2DataSource()
             val db = Database.connect(dataSource)
             transaction(db) { SchemaUtils.create(OutboxEventTable) }
@@ -191,12 +191,12 @@ internal class KafkaEventPublisherTest : StringSpec() {
             publisher.activateEvents(PlaybackEventType.STARTED)
             publisher.disableEvents(PlaybackEventType.STARTED)
 
-            var received: PlaybackEvent? = null
-            publisher.subscribe { received = it }
-
             try {
-                publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 3))
-                received shouldBe null
+                // An OutboxRoutableEvent whose type is inactive (whether never-activated or explicitly
+                // disabled) must fail fast — a silent drop would permanently lose event data.
+                shouldThrow<IllegalStateException> {
+                    publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 3))
+                }
                 val rowCount = transaction(db) { OutboxEventTable.selectAll().count() }
                 rowCount shouldBe 0L
             } finally {
@@ -267,6 +267,32 @@ internal class KafkaEventPublisherTest : StringSpec() {
             try {
                 shouldThrow<IllegalStateException> {
                     publisher.emitAsync(NonRoutableEvent(PlaybackEventType.STARTED, trackId = 5))
+                }
+                // No outbox row must have been written
+                val rowCount = transaction(db) { OutboxEventTable.selectAll().count() }
+                rowCount shouldBe 0L
+            } finally {
+                publisher.close()
+                dataSource.close()
+            }
+        }
+
+        "KafkaEventPublisherTest unactivated OutboxRoutableEvent type throws instead of silently dropping" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val db = Database.connect(dataSource)
+            transaction(db) { SchemaUtils.create(OutboxEventTable) }
+            // Deliberately do NOT call activateEvents — this is the PM-06 scenario.
+            // An OutboxRoutableEvent whose type was never activated must fail fast rather than
+            // silently discarding the event with no row, no delivery, and no log.
+            @Suppress("UNCHECKED_CAST")
+            val publisher =
+                KafkaEventPublisher<PlaybackEventType, LirpEvent<PlaybackEventType>>(
+                    "test-unactivated", "localhost:9092", db
+                )
+
+            try {
+                shouldThrow<IllegalStateException> {
+                    publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 10))
                 }
                 // No outbox row must have been written
                 val rowCount = transaction(db) { OutboxEventTable.selectAll().count() }

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxConfigTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxConfigTest.kt
@@ -17,14 +17,17 @@
 
 package net.transgressoft.lirp.kafka
 
+import net.transgressoft.lirp.persistence.sql.H2ContainerSupport
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
- * Unit tests verifying that [KafkaOutboxConfig] exposes the documented defaults and rejects
- * invalid construction arguments.
+ * Unit tests verifying that [KafkaOutboxConfig] exposes the documented defaults, rejects invalid
+ * construction arguments, and that [LirpKafkaConfig] honours [LirpKafkaConfig.startRelay]
+ * lifecycle contracts.
  */
 @DisplayName("KafkaOutboxConfigTest")
 internal class KafkaOutboxConfigTest : StringSpec() {
@@ -69,6 +72,43 @@ internal class KafkaOutboxConfigTest : StringSpec() {
         "KafkaOutboxConfigTest LirpKafkaConfig.create rejects blank bootstrapServers" {
             shouldThrow<IllegalArgumentException> {
                 LirpKafkaConfig.create("")
+            }
+        }
+
+        "KafkaOutboxConfigTest LirpKafkaConfig startRelay applies new producerConfig after stop-restart" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val lirpConfig = LirpKafkaConfig.create("localhost:9092")
+
+            try {
+                lirpConfig.startRelay(dataSource, producerConfig = mapOf("max.block.ms" to "10000"))
+                val publisherBeforeStop = lirpConfig.publisher()
+                lirpConfig.stopRelay()
+
+                lirpConfig.startRelay(dataSource, producerConfig = mapOf("max.block.ms" to "20000"))
+                val publisherAfterRestart = lirpConfig.publisher()
+
+                // A new publisher must be constructed so the new producerConfig reaches the KafkaProducer
+                publisherAfterRestart shouldNotBe publisherBeforeStop
+            } finally {
+                lirpConfig.close()
+                dataSource.close()
+            }
+        }
+
+        "KafkaOutboxConfigTest LirpKafkaConfig startRelay does not reconstruct publisher within a single continuous session" {
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val lirpConfig = LirpKafkaConfig.create("localhost:9092")
+
+            try {
+                lirpConfig.startRelay(dataSource)
+                val publisher1 = lirpConfig.publisher()
+                val publisher2 = lirpConfig.publisher()
+
+                // Within a running session the same instance is always returned — no thrash
+                publisher2 shouldBe publisher1
+            } finally {
+                lirpConfig.close()
+                dataSource.close()
             }
         }
     }

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxAtomicityTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxAtomicityTest.kt
@@ -43,6 +43,7 @@ import io.kotest.matchers.shouldBe
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.deleteAll
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.jetbrains.exposed.v1.jdbc.update
@@ -335,6 +336,43 @@ internal class OutboxAtomicityTest : StringSpec() {
                     }
                 updateRows shouldBe 0L
                 countOutboxRows(dataSource) shouldBe 1L
+            } finally {
+                repo.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxAtomicityTest clear() produces one DELETE outbox row per wiped entity after debounce flush" {
+            // Reproduces PM-02: clear() wipes the entity table via table.deleteAll() but the
+            // onAfterEntityWritesInWritePending hook receives empty lists (no individual deletes)
+            // and therefore emits zero DELETE outbox rows, breaking downstream consumers that
+            // subscribe to per-aggregate DELETE notifications.
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val repo = KafkaOutboxSqlRepository<Int, AudioItem>(dataSource, AudioItemSqlTableDef)
+            try {
+                // Seed N entities via the debounce path.
+                val n = 3
+                repeat(n) { i ->
+                    repo.add(MutableAudioItem(100 + i, "Track ${100 + i}", "Album") as AudioItem)
+                }
+                runBlocking { waitForOutboxCount(dataSource, n.toLong()) }
+
+                // Reset outbox rows so we can count only the DELETE rows produced by clear().
+                val db = Database.connect(dataSource)
+                transaction(db) { OutboxEventTable.deleteAll() }
+
+                // clear() must produce N DELETE outbox rows (one per wiped entity) in the same
+                // JDBC transaction as the bulk table wipe.
+                repo.clear()
+                runBlocking { waitForOutboxCount(dataSource, n.toLong()) }
+
+                val deleteRows =
+                    transaction(db) {
+                        OutboxEventTable.selectAll()
+                            .where { OutboxEventTable.eventTypeCode eq CrudEvent.Type.DELETE.code }
+                            .count()
+                    }
+                deleteRows shouldBe n.toLong()
             } finally {
                 repo.close()
                 dataSource.close()

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxEnlistmentTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxEnlistmentTest.kt
@@ -28,6 +28,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
@@ -35,8 +36,11 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
  * H2 unit tests for [KafkaEventPublisher.emitAsync] transaction enlistment behaviour.
  *
  * Covers: emitAsync inside an active transaction writes the outbox row atomically
- * on the same connection (row visible before commit), and emitAsync outside any
- * transaction opens its own single-row transaction producing exactly one committed row.
+ * on the same connection (row visible before commit); emitAsync outside any transaction opens
+ * its own single-row transaction; and — the cross-Database topology used by
+ * [net.transgressoft.lirp.kafka.LirpKafkaConfig.startRelay] — emitAsync joins an ambient
+ * transaction opened on a *different* Exposed [Database] instance that wraps the same
+ * [javax.sql.DataSource], so rollback removes the outbox row atomically.
  */
 @DisplayName("OutboxEnlistmentTest")
 internal class OutboxEnlistmentTest : StringSpec() {
@@ -95,6 +99,53 @@ internal class OutboxEnlistmentTest : StringSpec() {
                 publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 20))
                 val rowCount = transaction(db) { OutboxEventTable.selectAll().count() }
                 rowCount shouldBe 1L
+            } finally {
+                publisher.close()
+                dataSource.close()
+            }
+        }
+
+        "OutboxEnlistmentTest emitAsync joins app transaction across different Database instances over one DataSource" {
+            // Reproduces the real startRelay topology: the publisher's Database and the app's
+            // Database are different Exposed instances wrapping the same underlying connection pool.
+            // Before the fix, the gate `currentTransaction.db == publisherDb` was always false in
+            // this topology, so emitAsync opened its own transaction — the outbox INSERT committed
+            // independently and a rollback of appDb left a phantom outbox row.
+            val dataSource = H2ContainerSupport.buildH2DataSource()
+            val appDb = Database.connect(dataSource)
+            val publisherDb = Database.connect(dataSource)
+            transaction(appDb) { SchemaUtils.create(OutboxEventTable) }
+
+            // Build the publisher via the internal constructor, supplying dataSource so the
+            // db→dataSource mapping is registered and the cross-Database join gate activates.
+            val publisher =
+                KafkaEventPublisher<PlaybackEventType, PlaybackEvent>(
+                    "enlistment-cross-db", "localhost:9092", publisherDb,
+                    SqlOutboxStore(publisherDb), emptyMap(), dataSource = dataSource
+                )
+            publisher.activateEvents(PlaybackEventType.STARTED)
+
+            try {
+                // Case 1: commit — outbox row must survive.
+                transaction(appDb) {
+                    publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 30))
+                }
+                val rowCountAfterCommit = transaction(appDb) { OutboxEventTable.selectAll().count() }
+                rowCountAfterCommit shouldBe 1L
+
+                // Reset outbox for Case 2.
+                transaction(appDb) { OutboxEventTable.deleteAll() }
+
+                // Case 2: rollback — outbox row must be removed atomically with the app transaction.
+                // Trigger rollback by throwing inside the transaction block.
+                runCatching {
+                    transaction(appDb) {
+                        publisher.emitAsync(PlaybackEvent(PlaybackEventType.STARTED, trackId = 31))
+                        error("injected rollback — outbox row must vanish with the app transaction")
+                    }
+                }
+                val rowCountAfterRollback = transaction(appDb) { OutboxEventTable.selectAll().count() }
+                rowCountAfterRollback shouldBe 0L
             } finally {
                 publisher.close()
                 dataSource.close()

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
@@ -23,6 +23,9 @@ import net.transgressoft.lirp.event.LirpOperation
 import net.transgressoft.lirp.kafka.KafkaEventPublisher
 import net.transgressoft.lirp.kafka.KafkaOutboxConfig
 import net.transgressoft.lirp.kafka.KafkaOutboxSqlRepository
+import net.transgressoft.lirp.kafka.spi.LirpEventEnvelope
+import net.transgressoft.lirp.kafka.spi.LirpEventSerializer
+import net.transgressoft.lirp.kafka.spi.SerializedEvent
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.RegistryBase
@@ -44,6 +47,7 @@ import io.mockk.verify
 import org.apache.kafka.common.errors.NetworkException
 import org.apache.kafka.common.errors.RecordTooLargeException
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
@@ -257,6 +261,96 @@ internal class OutboxRelayTest : StringSpec() {
                 }
             }
         }
+
+        // #332 — PM-13: scheduleRetry DB-write failure must not produce a no-backoff busy re-publish
+        "OutboxRelay advances backoff or dead-letters row when scheduleRetry DB write fails" {
+            withOutboxRepo { db, repo ->
+                val publisher = mockk<KafkaEventPublisher<*, *>>()
+                every { publisher.publish(any(), any(), any(), any()) } throws NetworkException("broker unavailable")
+
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(11, "Killer Queen", "Sheer Heart Attack") as AudioItem)
+                }
+
+                // Fault-inject a store whose scheduleRetry always throws to simulate a DB failure.
+                val faultStore = FaultingOutboxStore(db, scheduleRetryThrows = true)
+                val relay = OutboxRelay(db, publisher, fastConfig, store = faultStore)
+
+                // Drive two poll cycles.
+                relay.pollAndRelay()
+                relay.pollAndRelay()
+
+                // The row must NOT be busy-re-published with retry_count=0 on every cycle.
+                // Acceptable outcomes: row dead-lettered (moved out of outbox), OR retry_count advanced.
+                // Forbidden: publish called twice with retry_count still 0 in outbox.
+                val row = transaction(db) { OutboxEventTable.selectAll().firstOrNull() }
+                if (row != null) {
+                    // Row still in outbox: retry_count must be > 0 (backoff was advanced despite DB failure)
+                    // OR the row was not re-published (publish was only called once total).
+                    val retryCount = row[OutboxEventTable.retryCount]
+                    // If retry_count is still 0, verify publish was called at most once — no busy loop.
+                    if (retryCount == 0) {
+                        verify(atMost = 1) { publisher.publish(any(), any(), any(), any()) }
+                    }
+                } else {
+                    // Row resolved: it must be in the dead-letter table.
+                    db.deadLetterCount() shouldBe 1L
+                }
+            }
+        }
+
+        // #333 — PM-14: duplicate dead-letter PK must not wedge a poison row that re-fails every cycle
+        "OutboxRelay duplicate dead-letter id does not leave a poison row re-fetched every cycle" {
+            withOutboxDb { _, db ->
+                val publisher = mockk<KafkaEventPublisher<*, *>>()
+                every { publisher.publish(any(), any(), any(), any()) } throws RecordTooLargeException("too large")
+
+                // Seed the outbox row with a known UUID.
+                val knownId = java.util.UUID.randomUUID()
+                db.seedRowWithId(knownId, "55")
+
+                // Pre-seed the dead-letter table with the same id to trigger a PK collision.
+                db.seedDeadLetterRow(knownId)
+
+                // Drive two poll cycles.
+                OutboxRelay(db, publisher, fastConfig).pollAndRelay()
+                OutboxRelay(db, publisher, fastConfig).pollAndRelay()
+
+                // After two cycles the outbox row must be gone — not re-fetched and re-failing forever.
+                db.outboxCount() shouldBe 0L
+            }
+        }
+
+        // #334 — PM-15: serialize Error/OOM must not kill the relay; RecordTooLargeException handled distinctly
+        "OutboxRelay keeps polling after a serialize Error and does not dead-letter other rows" {
+            withOutboxRepo { db, repo ->
+                // First row will trigger an OOM/Error in the serializer; second should still be processed.
+                transaction(repo) { r ->
+                    r.add(MutableAudioItem(71, "Flash", "Flash Gordon") as AudioItem)
+                    r.add(MutableAudioItem(72, "We Will Rock You", "News of the World") as AudioItem)
+                }
+
+                val publisher = mockk<KafkaEventPublisher<*, *>>()
+                justRun { publisher.publish(any(), any(), any(), any()) }
+
+                // Serializer that throws OutOfMemoryError for the first row, succeeds for the rest.
+                val oomSerializer = OomOnFirstCallSerializer()
+
+                // If the relay does NOT catch Throwable, the relay coroutine dies on the first row
+                // and the second row is never published. After the fix, both rows should be resolved.
+                OutboxRelay(db, publisher, fastConfig, serializer = oomSerializer).pollAndRelay()
+                OutboxRelay(db, publisher, fastConfig, serializer = oomSerializer).pollAndRelay()
+
+                // The second row (aggregate 72) must have been published and marked sent.
+                val sentRows =
+                    transaction(db) {
+                        OutboxEventTable.selectAll()
+                            .where { OutboxEventTable.aggregateId eq "72" }
+                            .map { it[OutboxEventTable.sentAt] }
+                    }
+                sentRows.any { it != null } shouldBe true
+            }
+        }
     }
 }
 
@@ -330,4 +424,82 @@ private fun Database.seedExhaustedRow(aggregateId: String, retryCount: Int) {
             it[OutboxEventTable.retryCount] = retryCount
         }
     }
+}
+
+/** Seeds an outbox row with a specific [id] to enable PK-collision testing. */
+private fun Database.seedRowWithId(id: java.util.UUID, aggregateId: String) {
+    transaction(this) {
+        OutboxEventTable.insert {
+            it[OutboxEventTable.id] = id.toKotlinUuid()
+            it[OutboxEventTable.aggregateType] = "audio_items"
+            it[OutboxEventTable.aggregateId] = aggregateId
+            it[OutboxEventTable.eventTypeCode] = 100
+            it[OutboxEventTable.payload] = "{}"
+            it[OutboxEventTable.createdAt] = Clock.System.now()
+        }
+    }
+}
+
+/** Seeds a dead-letter row with [id] to pre-occupy the PK and trigger a collision on the next dead-letter insert. */
+private fun Database.seedDeadLetterRow(id: java.util.UUID) {
+    transaction(this) {
+        DeadLetterTable.insert {
+            it[DeadLetterTable.id] = id.toKotlinUuid()
+            it[DeadLetterTable.aggregateType] = "audio_items"
+            it[DeadLetterTable.aggregateId] = "pre-existing"
+            it[DeadLetterTable.eventTypeCode] = 100
+            it[DeadLetterTable.payload] = "{}"
+            it[DeadLetterTable.createdAt] = Clock.System.now()
+            it[DeadLetterTable.failedAt] = Clock.System.now()
+            it[DeadLetterTable.attemptCount] = 1
+            it[DeadLetterTable.lastError] = "pre-existing"
+        }
+    }
+}
+
+/**
+ * An [OutboxStore] wrapper that delegates all operations to the real [SqlOutboxStore] but injects
+ * a controllable fault into [scheduleRetry]. Used to simulate a DB failure on the retry-write
+ * path without mocking the entire store interface.
+ */
+private class FaultingOutboxStore(
+    db: Database,
+    val scheduleRetryThrows: Boolean = false
+) : OutboxStore {
+    val delegate = SqlOutboxStore(db)
+
+    override fun findUnsent(limit: Int) = delegate.findUnsent(limit)
+
+    override fun markSent(id: java.util.UUID) = delegate.markSent(id)
+
+    override fun findUnsentForRelay(limit: Int, now: kotlin.time.Instant) = delegate.findUnsentForRelay(limit, now)
+
+    override fun scheduleRetry(id: java.util.UUID, nextRetryAt: kotlin.time.Instant, errorMessage: String) {
+        if (scheduleRetryThrows) error("simulated scheduleRetry DB failure")
+        delegate.scheduleRetry(id, nextRetryAt, errorMessage)
+    }
+
+    override fun moveToDeadLetter(event: OutboxEvent, failedAt: kotlin.time.Instant, errorMessage: String) =
+        delegate.moveToDeadLetter(event, failedAt, errorMessage)
+
+    override fun insert(event: OutboxEvent) = delegate.insert(event)
+}
+
+/**
+ * A [LirpEventSerializer] that throws [OutOfMemoryError] on the first call, then delegates to
+ * [net.transgressoft.lirp.kafka.spi.CloudEventsBinarySerializer] for subsequent calls.
+ * Used to simulate an OOM during serialization to verify the relay keeps polling after the error.
+ */
+private class OomOnFirstCallSerializer : LirpEventSerializer {
+    val real = net.transgressoft.lirp.kafka.spi.CloudEventsBinarySerializer()
+    var callCount = 0
+
+    override fun serialize(envelope: LirpEventEnvelope): SerializedEvent {
+        callCount++
+        if (callCount == 1) throw OutOfMemoryError("simulated OOM during serialize")
+        return real.serialize(envelope)
+    }
+
+    override fun deserialize(value: ByteArray, headers: Map<String, ByteArray>): LirpEventEnvelope =
+        real.deserialize(value, headers)
 }

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
@@ -47,8 +47,10 @@ import io.mockk.verify
 import org.apache.kafka.common.errors.NetworkException
 import org.apache.kafka.common.errors.RecordTooLargeException
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Version
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.core.vendors.ForUpdateOption
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -321,6 +323,39 @@ internal class OutboxRelayTest : StringSpec() {
             }
         }
 
+        // #335 — PM-16: MariaDB<10.6 and MySQL5.7 must not receive FOR UPDATE SKIP LOCKED
+        "SqlOutboxStore selectLockOption returns plain FOR UPDATE for MariaDB<10.6 and MySQL<8.0" {
+            // These version guard assertions run at the SQL-generation level rather than via a
+            // Testcontainers MariaDB 10.5 container. The Testcontainers matrix only includes
+            // MariaDB 11 and MySQL 8.0+ (both of which support SKIP LOCKED), so a MariaDB 10.5
+            // container would require a new CI image. A unit test on the lock-option selection
+            // logic provides equivalent coverage of the guard without adding a new container dependency.
+            val mariaDb = org.jetbrains.exposed.v1.core.vendors.MariaDBDialect()
+            val mysql = org.jetbrains.exposed.v1.core.vendors.MysqlDialect()
+
+            val version105 = Version.from("10.5")
+            val version106 = Version.from("10.6")
+            val version57 = Version.from("5.7")
+            val version80 = Version.from("8.0")
+
+            // MariaDB < 10.6: SKIP LOCKED is NOT supported — must return plain FOR UPDATE or null
+            val option105 = SqlOutboxStore.selectLockOption(mariaDb, version105)
+            // Must NOT be a SKIP LOCKED variant
+            option105.toQuerySuffix().contains("SKIP LOCKED") shouldBe false
+
+            // MariaDB 10.6+: SKIP LOCKED IS supported
+            val option106 = SqlOutboxStore.selectLockOption(mariaDb, version106)
+            option106.toQuerySuffix().contains("SKIP LOCKED") shouldBe true
+
+            // MySQL < 8.0: SKIP LOCKED is NOT supported
+            val option57 = SqlOutboxStore.selectLockOption(mysql, version57)
+            option57.toQuerySuffix().contains("SKIP LOCKED") shouldBe false
+
+            // MySQL 8.0+: SKIP LOCKED IS supported
+            val option80 = SqlOutboxStore.selectLockOption(mysql, version80)
+            option80.toQuerySuffix().contains("SKIP LOCKED") shouldBe true
+        }
+
         // #334 — PM-15: serialize Error/OOM must not kill the relay; RecordTooLargeException handled distinctly
         "OutboxRelay keeps polling after a serialize Error and does not dead-letter other rows" {
             withOutboxRepo { db, repo ->
@@ -484,6 +519,9 @@ private class FaultingOutboxStore(
 
     override fun insert(event: OutboxEvent) = delegate.insert(event)
 }
+
+/** Returns the query suffix string of this [ForUpdateOption] or empty string if null. */
+private fun ForUpdateOption?.toQuerySuffix(): String = this?.querySuffix ?: ""
 
 /**
  * A [LirpEventSerializer] that throws [OutOfMemoryError] on the first call, then delegates to

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
@@ -56,8 +56,11 @@ import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.measureTime
 import kotlin.uuid.toKotlinUuid
 
 /**
@@ -384,6 +387,39 @@ internal class OutboxRelayTest : StringSpec() {
                             .map { it[OutboxEventTable.sentAt] }
                     }
                 sentRows.any { it != null } shouldBe true
+            }
+        }
+
+        // #331 — PM-10: relay stop() must return promptly even when a publish is blocking.
+        // Before the fix, the relay ran on the single-slot ioScope and stop() used runBlocking
+        // against a non-cancellable producer.send().get(), stalling shutdown for delivery.timeout.ms.
+        "OutboxRelay stop() returns promptly when publisher.publish blocks indefinitely" {
+            withOutboxDb { _, db ->
+                // Insert a row with retryCount=0 so the relay immediately tries to publish it.
+                db.seedExhaustedRow("blackhole-1", 0)
+
+                val publishStarted = CountDownLatch(1)
+                val publisher = mockk<KafkaEventPublisher<*, *>>()
+                every { publisher.publish(any(), any(), any(), any()) } answers {
+                    publishStarted.countDown()
+                    // Simulate a broker that never responds. Cooperative cancellation (via
+                    // Dispatchers.IO thread interrupt) unblocks this when the relay is stopped.
+                    try {
+                        Thread.sleep(Long.MAX_VALUE)
+                    } catch (_: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                    }
+                }
+
+                val relay = OutboxRelay(db, publisher, fastConfig)
+                relay.start()
+
+                // Wait until the relay is inside publisher.publish (blocking send is in flight).
+                publishStarted.await(10, TimeUnit.SECONDS) shouldBe true
+
+                // stop() must return well within delivery.timeout.ms (default 30 s).
+                val stopDuration = measureTime { relay.stop() }
+                stopDuration shouldBeLessThan 5_000L.milliseconds
             }
         }
     }

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializerTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializerTest.kt
@@ -104,5 +104,29 @@ internal class CloudEventsBinarySerializerTest : StringSpec() {
             val headers = serialized.headers + ("content-type" to "application/xml".toByteArray(Charsets.UTF_8))
             shouldThrow<IllegalArgumentException> { serializer.deserialize(serialized.value, headers) }
         }
+
+        "CloudEventsBinarySerializerTest deserialize rejects an empty ce_id header byte array" {
+            // An empty ByteArray is non-null so the null-check elvis does not fire; a blank eventId
+            // would silently pass through and collapse deduplication keys.
+            val headers = serialized.headers + ("ce_id" to ByteArray(0))
+            shouldThrow<IllegalStateException> { serializer.deserialize(serialized.value, headers) }
+        }
+
+        "CloudEventsBinarySerializerTest deserialize rejects a blank ce_id header" {
+            val headers = serialized.headers + ("ce_id" to "   ".toByteArray(Charsets.UTF_8))
+            shouldThrow<IllegalStateException> { serializer.deserialize(serialized.value, headers) }
+        }
+
+        "CloudEventsBinarySerializerTest deserialize rejects an empty ce_subject header byte array" {
+            // An empty ByteArray for ce_subject would produce a blank aggregateId / record key,
+            // silently collapsing per-aggregate ordering.
+            val headers = serialized.headers + ("ce_subject" to ByteArray(0))
+            shouldThrow<IllegalStateException> { serializer.deserialize(serialized.value, headers) }
+        }
+
+        "CloudEventsBinarySerializerTest deserialize rejects a blank ce_subject header" {
+            val headers = serialized.headers + ("ce_subject" to "   ".toByteArray(Charsets.UTF_8))
+            shouldThrow<IllegalStateException> { serializer.deserialize(serialized.value, headers) }
+        }
     }
 }

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/IndexedProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/IndexedProcessor.kt
@@ -83,8 +83,11 @@ class IndexedProcessor(
             return
         }
         val packageName = classDecl.packageName.asString()
-        val className = classDecl.simpleName.asString()
-        val accessorName = "$className${LirpGenNames.INDEX_ACCESSOR_SUFFIX}"
+        val jvmName = classDecl.jvmBinaryName()
+        val kotlinName = classDecl.kotlinNestedName()
+        val accessorName = "$jvmName${LirpGenNames.INDEX_ACCESSOR_SUFFIX}"
+        // Backtick-escape the class name in Kotlin source when it contains '$' (nested class separator)
+        val accessorSourceName = if ('$' in accessorName) "`$accessorName`" else accessorName
 
         val entries = mutableListOf<IndexedPropertyMeta>()
         for (prop in properties) {
@@ -141,11 +144,11 @@ class IndexedProcessor(
                 appendLine("import net.transgressoft.lirp.persistence.LirpIndexAccessor")
                 appendLine()
                 appendLine("/**")
-                appendLine(" * KSP-generated index accessor for [$className].")
+                appendLine(" * KSP-generated index accessor for [$kotlinName].")
                 appendLine(" * Provides direct property getters — no runtime reflection.")
                 appendLine(" */")
-                appendLine("$visibility class $accessorName : LirpIndexAccessor<$className> {")
-                appendLine("    override val entries: List<IndexEntry<$className>> = listOf(")
+                appendLine("$visibility class $accessorSourceName : LirpIndexAccessor<$kotlinName> {")
+                appendLine("    override val entries: List<IndexEntry<$kotlinName>> = listOf(")
                 appendLine("        $entriesCode")
                 appendLine("    )")
                 appendLine("}")
@@ -153,7 +156,7 @@ class IndexedProcessor(
         )
         file.close()
 
-        logger.info("Generated $packageName.$accessorName for $className")
+        logger.info("Generated $packageName.$accessorName for $kotlinName")
     }
 
     /**

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/IndexedProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/IndexedProcessorTest.kt
@@ -257,4 +257,42 @@ internal class IndexedProcessorTest : StringSpec({
 
         result.shouldSucceed()
     }
+
+    "IndexedProcessor generates compilable accessor with JVM binary name for nested public @Indexed entity" {
+        // Regression test: nested entities were named from simpleName only, producing an
+        // unresolvable class name (e.g. Track_LirpIndexAccessor instead of
+        // Catalog${'$'}Track_LirpIndexAccessor). The generated file must compile and the
+        // accessor class must be loadable by the runtime via its JVM binary name.
+        val result =
+            compileWithIndexedProcessor(
+                SourceFile.kotlin(
+                    "CatalogWithTrack.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.Indexed
+
+                    class Catalog {
+                        data class Track(override val id: Int) : ReactiveEntityBase<Int, Track>() {
+                            override val uniqueId: String get() = "${'$'}id"
+                            override fun clone() = copy()
+                            @Indexed val title: String = ""
+                        }
+                    }
+                    """
+                )
+            )
+
+        result.shouldSucceed()
+        val accessorFileName = "Catalog\$Track_LirpIndexAccessor.kt"
+        val content = result.generatedFileContent(accessorFileName)
+        content.shouldContainEach(
+            // The class declaration must use the backtick-escaped JVM binary name
+            "`Catalog\$Track_LirpIndexAccessor`",
+            // The type argument must use the Kotlin-source nested name (dot-separated)
+            "LirpIndexAccessor<Catalog.Track>",
+            // The index entry must reference the property correctly
+            """IndexEntry("title") { it.title }"""
+        )
+    }
 })

--- a/lirp-sql/api/lirp-sql.api
+++ b/lirp-sql/api/lirp-sql.api
@@ -51,6 +51,7 @@ public class net/transgressoft/lirp/persistence/sql/SqlRepository : net/transgre
 	protected fun loadFromStore ()Ljava/util/Map;
 	protected fun onAfterEntityWritesInTransaction (Lnet/transgressoft/lirp/persistence/TransactionBuffer;)V
 	protected fun onAfterEntityWritesInWritePending (Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	protected fun onAfterEntityWritesInWritePending (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
 	protected fun onEntityMutated (Lnet/transgressoft/lirp/event/MutationEvent;)V
 	protected fun writePending (Ljava/util/List;Ljava/util/List;Ljava/util/List;Z)V
 }

--- a/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
+++ b/lirp-sql/src/main/kotlin/net/transgressoft/lirp/persistence/sql/SqlRepository.kt
@@ -40,6 +40,7 @@ import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.batchInsert
 import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.concurrent.ConcurrentHashMap
 import javax.sql.DataSource
@@ -409,6 +410,12 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
         }
         val conflicts = mutableListOf<PendingConflict<K>>()
         transaction(db = db) {
+            // Collect entity IDs present in the table before a bulk wipe so the post-write hook
+            // can emit one outbox DELETE row per cleared entity. The SELECT runs before
+            // table.deleteAll() so the rows are still visible on this connection.
+            @Suppress("UNCHECKED_CAST")
+            val clearedEntityIds: List<K> =
+                if (hadClear) table.select(pkCol).map { it[pkCol as Column<K>] } else emptyList()
             // #202: junction rows must be wiped before the parent table when FKs may not yet be
             // installed (the construction-time window before installJunctionForeignKeys() runs).
             // When FKs ARE installed with ON DELETE CASCADE the explicit delete is a harmless
@@ -434,7 +441,8 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
             onAfterEntityWritesInWritePending(
                 inserts,
                 updates.filterNot { it.entity.id in conflictedIds },
-                deletes.filterNot { it.first in conflictedIds }
+                deletes.filterNot { it.first in conflictedIds },
+                clearedEntityIds
             )
         }
         // The main transaction has committed. Recover every accumulated conflict outside it.
@@ -571,6 +579,30 @@ open class SqlRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>(
         updates: List<PendingUpdate<K, R>>,
         deletes: List<Pair<K, Long?>>
     ) = Unit
+
+    /**
+     * Called from inside the `transaction(db = db) { }` block of [writePending], after all
+     * entity inserts, updates, and deletes have been written and before the transaction closes.
+     * This overload additionally receives the keys of any entities that were bulk-wiped via
+     * [clear]; the list is empty when [hadClear][writePending] was `false`.
+     *
+     * The default implementation delegates to [onAfterEntityWritesInWritePending] with the
+     * three-argument signature so existing subclass overrides continue to function without
+     * modification. Subclasses that need to react to bulk clears should override this overload
+     * instead.
+     *
+     * @param inserts Entities being inserted in this flush cycle.
+     * @param updates Pending updates carrying the entity and expected version for optimistic locking.
+     * @param deletes Pairs of entity key and expected version for deletions.
+     * @param clearedEntityIds Keys of all entities that were bulk-wiped by a [clear] call in this
+     *   flush cycle; empty when no bulk wipe occurred.
+     */
+    protected open fun onAfterEntityWritesInWritePending(
+        inserts: List<R>,
+        updates: List<PendingUpdate<K, R>>,
+        deletes: List<Pair<K, Long?>>,
+        clearedEntityIds: List<K>
+    ) = onAfterEntityWritesInWritePending(inserts, updates, deletes)
 
     /**
      * Validates that all cascade target repositories reachable from the entities in [buffer] are


### PR DESCRIPTION
## Summary

A reliability-focused sweep of the persistence and Kafka-outbox surfaces, closing a set of edge-case and concurrency defects surfaced by a structured reliability review. Every fix ships with a regression test, and the full suite — including stress-tagged concurrency tests and Testcontainers integration — now runs deterministically across repeated full-suite runs.

## What changed

### Kafka outbox & relay
- Outbox writes are now genuinely atomic with the entity write: the `emitAsync` transaction-join gate keys on the actual connection identity, and `clear()` captures a DELETE outbox row per wiped entity. (#322, #323)
- Relay error paths hardened — a failed retry-schedule write falls back to dead-lettering instead of an unbounded no-backoff re-publish; a duplicate dead-letter key no longer wedges a poison row; oversized-payload / serialization errors no longer kill the relay coroutine; and `FOR UPDATE SKIP LOCKED` is version-guarded so older MariaDB/MySQL fall back to plain `FOR UPDATE`. (#332, #333, #334, #335)
- Publisher & serialization — an unactivated custom event now fails fast instead of being silently dropped, and blank `ce_id` / `ce_subject` / aggregate-id values are rejected to protect idempotency and ordering. (#327, #336)
- Restarting the relay now honors an updated `producerConfig` / bootstrap servers instead of silently reusing the first publisher. (#337)
- Relay publishing runs off the shared single-slot IO scope and `stop()` is cooperatively cancellable, so a slow or unreachable broker can no longer stall shutdown or starve other repositories' flushes — while the row lock is still held across the broker send to preserve the no-double-publish guarantee for concurrent relays. (#330, #331)

### Core persistence & codegen
- JSON writes go through a single durable primitive (temp file → fsync → atomic rename → parent-dir fsync), so a crash mid-write can no longer truncate the live file. (#325, #326)
- Blocking flush I/O is offloaded off the single-slot IO scope, so a slow flush on one repository no longer starves another repository's debounced flushes; each repository's max-delay cap is preserved. (#330)
- Aggregate-collection mutations now route through the transaction event buffer, and rollback correctly restores aggregate-collection membership. (#328, #329)
- Nested `@Indexed` entities generate accessor names via the JVM binary name, fixing uncompilable / unresolvable names that silently degraded indexed queries to full scans. (#324)

### Event delivery
- Fixed a dropped-event race in the async event bridge: events emitted to a freshly-registered async subscriber before its collector attached were silently discarded (`MutableSharedFlow` with `replay = 0`). The bridge drain now waits for a live collector before emitting. This was the root cause of intermittent projection-materialization flakiness under load, and a deterministic regression test guards it.

## Testing

- Every fix has a reproduce-then-fix regression test (failing before, passing after).
- Full build green, including Testcontainers integration tests (PostgreSQL / MySQL / MariaDB outbox + relay).
- The repeated full-suite determinism harness (`scripts/flaky-hunt.sh`) completes 10/10 iterations with no intermittent failure or hang.
- Aggregate coverage: line 88.05%, branch 73.62%.

## Compatibility

No breaking changes. One additive, binary-compatible protected hook was introduced; the API baseline and CHANGELOG are updated accordingly.

Closes #322
Closes #323
Closes #324
Closes #325
Closes #326
Closes #327
Closes #328
Closes #329
Closes #330
Closes #331
Closes #332
Closes #333
Closes #334
Closes #335
Closes #336
Closes #337