### PR TITLE
JDK 25 Toolchain Adoption

### DIFF
--- a/.github/workflows/branch-pr.yml
+++ b/.github/workflows/branch-pr.yml
@@ -18,10 +18,10 @@ jobs:
                 with:
                     fetch-depth: 0
 
-            -   name: Set up JDK 21
+            -   name: Set up JDK 25
                 uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
                 with:
-                    java-version: 21
+                    java-version: 25
                     distribution: 'zulu'
                     java-package: 'jdk+fx'
 

--- a/.github/workflows/flaky-hunt.yml
+++ b/.github/workflows/flaky-hunt.yml
@@ -28,10 +28,10 @@ jobs:
                     fetch-depth: 0
                     persist-credentials: false
 
-            -   name: Set up JDK 21
+            -   name: Set up JDK 25
                 uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
                 with:
-                    java-version: 21
+                    java-version: 25
                     distribution: 'zulu'
                     java-package: 'jdk+fx'
 

--- a/.github/workflows/manual-pr-build.yml
+++ b/.github/workflows/manual-pr-build.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           ref: refs/pull/${{ github.event.inputs.pr_number }}/merge
           fetch-depth: 0
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'zulu'
           java-package: 'jdk+fx'
       - name: Cache Gradle packages

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,10 +18,10 @@ jobs:
                 with:
                     fetch-depth: 0
 
-            -   name: Set up JDK 21
+            -   name: Set up JDK 25
                 uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
                 with:
-                    java-version: 21
+                    java-version: 25
                     distribution: 'zulu'
                     java-package: 'jdk+fx'
 

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -23,10 +23,10 @@ jobs:
         steps:
             -   uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-            -   name: Set up JDK 21
+            -   name: Set up JDK 25
                 uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
                 with:
-                    java-version: 21
+                    java-version: 25
                     distribution: 'zulu'
                     java-package: 'jdk+fx'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,10 @@ jobs:
                     git config --global user.name "github-actions"
                     git remote set-url origin "https://x-access-token:$PAT_TOKEN@github.com/$REPO.git"
 
-            -   name: Set up JDK 21
+            -   name: Set up JDK 25
                 uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
                 with:
-                    java-version: 21
+                    java-version: 25
                     distribution: 'zulu'
                     java-package: 'jdk+fx'
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,10 +12,10 @@ jobs:
                 with:
                     fetch-depth: 0
 
-            -   name: Set up JDK 21
+            -   name: Set up JDK 25
                 uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
                 with:
-                    java-version: 21
+                    java-version: 25
                     distribution: 'zulu'
                     java-package: 'jdk+fx'
 

--- a/README.md
+++ b/README.md
@@ -420,6 +420,8 @@ Benchmarks run with JMH 1.37 on OpenJDK 21.0.10, 13th Gen Intel Core i7-13700, 6
 
 `findById()` at 27 ns is against the in-memory `ConcurrentHashMap` — the SQL and JSON repositories skip the round-trip entirely. For operation-level persistence timing details and full benchmark methodology, see [Performance Benchmarks](https://github.com/octaviospain/lirp/wiki/Performance-Benchmarks).
 
+**JDK 25 footprint tip:** applications running on JDK 25 can reduce LIRP's resident memory by ~11% by enabling [`-XX:+UseCompactObjectHeaders`](https://openjdk.org/jeps/519) on their own JVM. The flag shrinks each object header from 12 to 8 bytes (JEP 519, product flag — no unlock needed); because LIRP keeps the full working set in a `ConcurrentHashMap`, the saving scales with entity count. The flag is incompatible with ZGC on x64; G1 (the default collector) works correctly with it.
+
 ## Logging
 
 LIRP uses [SLF4J](https://www.slf4j.org/) via [kotlin-logging](https://github.com/oshai/kotlin-logging) and ships **no logging configuration in its published jars**. Add your preferred SLF4J binding (`logback-classic`, `log4j-slf4j2-impl`, etc.) to your application; LIRP will use it automatically.

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 tasks.named('jar') {
@@ -201,14 +201,18 @@ subprojects {
     }
 
     kotlin {
-        jvmToolchain(21)
+        jvmToolchain(25)
     }
 
     tasks.withType(KotlinJvmCompile).configureEach {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_21)
-            freeCompilerArgs.add('-Xjsr305=strict')
+            freeCompilerArgs.addAll('-Xjsr305=strict', '-Xjdk-release=21')
         }
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        options.release = 21
     }
 
     sonar {
@@ -229,6 +233,9 @@ subprojects {
         useJUnitPlatform()
         testLogging {
             events 'passed', 'skipped', 'failed'
+        }
+        if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+            jvmArgs '-XX:+UseCompactObjectHeaders'
         }
     }
 

--- a/lirp-benchmark/build.gradle
+++ b/lirp-benchmark/build.gradle
@@ -63,6 +63,12 @@ jmh {
         // reachable from an entity graph on this JDK; the magic-field-offset fallback restores sizing.
         '-Djol.magicFieldOffset=true'
     ]
+    // Compact Object Headers reduce the per-object header from 12 to 8 bytes on JDK 25
+    // (JEP 519, product flag, no UnlockExperimentalVMOptions needed).
+    // Uses add() so this composes with any earlier jvmArgsAppend assignment (e.g. async-profiler).
+    if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+        jvmArgsAppend.add('-XX:+UseCompactObjectHeaders')
+    }
 }
 
 // Post-process JMH results.json into CSV files and a rendered Performance-Benchmarks.md.


### PR DESCRIPTION
Closes #351

## Summary

Moves the Gradle build, test, and JMH benchmark tasks to a **JDK 25 toolchain** while holding the compiled bytecode target at **JVM 21**. This is a non-breaking change: the ABI is unchanged (`apiCheck` reports no diff) and the consumer runtime floor is unaffected.

The motivation is LIRP's in-memory-first design — every repository holds its full dataset resident in a `ConcurrentHashMap`, so JDK 25's Compact Object Headers (JEP 519, 12→8 byte header) reduce the footprint of every resident entity/node. The flag is enabled on our test and benchmark JVMs to shrink the resident-dataset footprint and speed up runs; a consumer-facing note documents how to opt in.

## Changes

- **`build.gradle`** — `jvmToolchain(25)` at root and subprojects; `jvmTarget` stays `JVM_21`. Added `-Xjdk-release=21` (Kotlin) and `options.release = 21` (JavaCompile) so no JDK 25 `java.*` API can leak into target-21 bytecode. Added a version-guarded `-XX:+UseCompactObjectHeaders` to the shared subprojects `test` JVM args.
- **`lirp-benchmark/build.gradle`** — added the same compact-header flag to the JMH fork JVM using an additive `jvmArgsAppend.add(...)`, so it composes with the async-profiler branch and preserves JOL's `--add-opens` / `-Djol.magicFieldOffset=true` args.
- **CI (7 workflows)** — `branch-pr`, `master`, `flaky-hunt`, `sonar`, `manual-pr-build`, `release`, `osv-scanner` bumped to `java-version: 25`, keeping the Zulu `jdk+fx` distribution (JavaFX is required by `lirp-fx`) and the pinned `actions/setup-java` SHA unchanged. `dependency-review.yml` provisions no Java and is untouched.
- **Docs** — `README.md` gains a consumer note recommending `-XX:+UseCompactObjectHeaders` on JDK 25 (with the ZGC caveat and a JEP 519 link). The wiki performance page records the measured footprint delta.

## Measured footprint delta (both runs on JDK 25)

Two JDK 25 JMH runs (flag off vs on) isolate the header effect from the JDK-version effect. JOL deep-graph measurement shows a consistent **~11.4% resident-heap reduction** per entity graph (e.g. 65,792 → 58,248 bytes at 0 subscribers). At 50,000 resident entities this is on the order of hundreds of MB saved.

## Verification

- `gradle build ktlintCheck apiCheck` — green, **no ABI diff** (bytecode still targets JVM 21).
- Full test suite (H2 unit) + `:lirp-sql:integrationTest` (Testcontainers: PostgreSQL/MySQL/MariaDB) — pass on JDK 25.
- `:lirp-fx:test` — passes on JDK 25 (openjfx-monocle 21.0.2 headless confirmed working).
- Coverage: line **88.04%** / branch **73.65%** — above the recorded floor (line ≥ 87.79%, branch ≥ 72.66%).
- `scripts/flaky-hunt.sh 5` — all 5 full-suite iterations pass, no intermittent hang.

Local runs used BellSoft Liberica JDK 25. This PR's CI is the first confirmation that the pinned `actions/setup-java` SHA resolves **Azul Zulu 25 `jdk+fx`** without error; watch the `branch-pr` and `sonar` checks. Fallback if Zulu 25 `jdk+fx` fails to resolve: switch the affected workflows to `distribution: 'liberica'`.

## Breaking changes

None. `jvmTarget` remains 21, so the ABI and the consumer runtime floor are unchanged.
