### PR TITLE
Resolve deferred tech-debt backlog across JSON serialization, KSP/FxScalar codegen, and Kafka outbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,33 @@ see the [GitHub releases](https://github.com/octaviospain/lirp/releases).
 
 ### Fixed
 
+- **SQLite deployments no longer fail immediately with `SQLITE_BUSY` when an entity-save runs
+  concurrently with the outbox relay.** SQLite serialises writers, so the relay holding its
+  write transaction across the Kafka publish window blocked any concurrent `INSERT` from a
+  `KafkaOutboxSqlRepository` flush. The default SQLite busy-timeout of 0 ms meant the INSERT
+  threw `SQLITE_BUSY` immediately. `KafkaOutboxConfig` now exposes a `sqliteBusyTimeoutMs`
+  field (default 3 000 ms) that is applied pool-wide via `HikariDataSource.connectionInitSql`
+  before the first connection is borrowed, so every pooled connection receives the
+  `PRAGMA busy_timeout` and capture INSERTs can retry within that window. The relay transaction
+  structure and error propagation are unchanged; non-SQLite data sources are unaffected.
+  See [#340](https://github.com/octaviospain/lirp/issues/340).
+
+### Added
+
+- **`KafkaOutboxConfig.sqliteBusyTimeoutMs` — configurable SQLite write-lock retry window.**
+  A new `Long` field with a default of 3 000 ms controls how long SQLite connections will wait
+  to acquire a write lock before returning `SQLITE_BUSY`. Set it to 0 to restore the original
+  no-wait behaviour or raise it for deployments where the relay holds the transaction open for
+  longer (e.g. high-latency Kafka brokers). The field is validated non-negative at construction.
+
+  **Migration:** the field carries a default value and is the last parameter in the data class, so
+  existing **source** call sites that construct `KafkaOutboxConfig` positionally or by name compile
+  unchanged after a recompile. This is **not binary-compatible**, however: adding a constructor
+  parameter changes the generated JVM constructor descriptor, so code compiled against an earlier
+  version must be **recompiled** against this release (a pre-compiled caller would otherwise fail at
+  runtime with `NoSuchMethodError`). No source changes are needed for callers that use named
+  parameters or `KafkaOutboxConfig.DEFAULT`. See [#340](https://github.com/octaviospain/lirp/issues/340).
+
 - **`KafkaOutboxSqlRepository.clear()` now emits one DELETE outbox row per wiped entity.**
   Previously, calling `clear()` on a `KafkaOutboxSqlRepository` performed a bulk `table.deleteAll()`
   but the `onAfterEntityWritesInWritePending` hook received empty lists, so zero outbox DELETE rows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ see the [GitHub releases](https://github.com/octaviospain/lirp/releases).
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **`LirpEntitySerializer` now fails fast when a required reactive-property field is missing from
+  persisted JSON.** Previously, a `by reactiveProperty(...)` field absent from the stored JSON was
+  silently loaded at its constructor default — making schema changes invisible and producing
+  partially-migrated entities without any diagnostic. The serializer now throws immediately with a
+  message listing the missing field names. This aligns with how missing constructor parameters already
+  behave (kotlinx.serialization throws on a required constructor field), making the contract
+  consistent across both serialization paths.
+
+  **Who is affected:** deployments that added a `by reactiveProperty(...)` field to an entity class
+  **without** migrating existing JSON files. On load the serializer will now throw instead of
+  silently defaulting the new field.
+
+  **Migration options:**
+
+  1. **Migrate persisted JSON** — run a one-time script that reads each stored JSON file and adds the
+     new field with its desired default value before upgrading the application.
+
+  2. **Use a constructor parameter with a default** — if the field can be treated as an optional
+     constructor argument, declare it as `val myField: T = default` in the primary constructor
+     rather than as a `by reactiveProperty(default)` delegate. Constructor parameters with defaults
+     are not affected by this change (kotlinx.serialization handles optional constructor params
+     natively).
+
+  See [#343](https://github.com/octaviospain/lirp/issues/343).
+
 ### Fixed
 
 - **SQLite deployments no longer fail immediately with `SQLITE_BUSY` when an entity-save runs

--- a/README.md
+++ b/README.md
@@ -468,6 +468,16 @@ val repo = SqlRepository<Int, Album>(
 Individual subscriptions can also carry an independent error handler via
 `subscribeAsync(action, onError)`, independent of the repository-level handler.
 
+## Upgrading from v3.2.0
+
+The next release contains a **breaking change** in JSON deserialization. `LirpEntitySerializer` now
+fails fast (throws `IllegalStateException`) when a required `by reactiveProperty(...)` field is
+missing from persisted JSON, rather than silently defaulting it. Deployments that added a reactive
+property without migrating existing JSON files will see an exception on load.
+
+See **[CHANGELOG.md](CHANGELOG.md)** for the full migration guide and the two available
+migration paths (JSON file migration or converting to a default-valued constructor parameter).
+
 ## Upgrading to v3.2.0
 
 Version 3.2.0 adds the optional `lirp-kafka` module for transactional-outbox Kafka publishing. All

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepository.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepository.kt
@@ -122,6 +122,10 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
 
         private val log = KotlinLogging.logger(javaClass.name)
 
+        // Instance-unique suffix appended to the temp file name so that two repositories over the
+        // same file each write to a distinct temp path and cannot clobber each other's in-flight write.
+        private val tmpSuffix = java.util.UUID.randomUUID().toString().take(8)
+
         final override var jsonFile: File = file
             set(value) {
                 require(value.exists().and(value.canWrite()).and(value.extension == "json").and(value.readText().isEmpty())) {
@@ -432,7 +436,7 @@ open class JsonFileRepository<K : Comparable<K>, R : ReactiveEntity<K, R>>
          * @throws IOException if the temp write, fsync, or atomic rename fails
          */
         private fun durableWrite(content: String) {
-            val tmp = File(jsonFile.parent, "${jsonFile.name}.tmp")
+            val tmp = File(jsonFile.parent, "${jsonFile.name}.$tmpSuffix.tmp")
             try {
                 tmp.writeText(content)
                 // fsync the temp file's data blocks before the rename so the content is

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
@@ -70,6 +70,16 @@ import kotlinx.serialization.serializer
  * to the behavior of consumers that register no contextual serializers. This mirrors the
  * `ColumnConverter` escape hatch the SQL persistence layer already offers.
  *
+ * **Schema migration contract:** when a reactive property (declared with `by reactiveProperty(...)`)
+ * is absent from the persisted JSON being loaded, deserialization fails immediately with an error.
+ * This enforces a consistent, explicit schema-migration contract: any JSON produced before the property
+ * was added must be migrated before the new version of the entity class is deployed, or the property
+ * must be declared as a constructor parameter with a default value so it is serialized under the
+ * constructor-parameter path. Adding a constructor parameter without a default likewise throws at
+ * deserialization when the field is missing (standard kotlinx.serialization behaviour for required
+ * constructor parameters). Use data migration or a default-valued constructor parameter to maintain
+ * backward compatibility when the schema evolves.
+ *
  * Usage: pass a sample entity instance to the [lirpSerializer] factory function to build
  * the serializer, then use it with [MapSerializer] when constructing a [JsonFileRepository]:
  * ```kotlin
@@ -394,6 +404,21 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
 
         val decoded = decodeElements(composite, paramByIndex, delegateByIndex)
         composite.endStructure(descriptor)
+
+        // Fail-fast on missing required reactive-property fields: a reactive property absent from
+        // persisted JSON is never silently defaulted. Callers must migrate their JSON or declare
+        // the property as a default-valued constructor parameter before deploying the new entity class.
+        val missingFields =
+            delegateInfos
+                .filterIsInstance<DelegateInfo.ReactivePropertyKsp>()
+                .filter { it.name !in decoded.reactiveValues && it.name !in constructorDelegateParams }
+        if (missingFields.isNotEmpty()) {
+            error(
+                "Missing required JSON field(s) ${missingFields.map { it.name }} " +
+                    "for ${kClass.simpleName}. Migrate the persisted JSON or convert the property " +
+                    "to a default-valued constructor parameter before loading."
+            )
+        }
 
         // Merge reactive delegate values that are also constructor params (e.g. `name`)
         val mergedParamValues = decoded.paramValues.toMutableMap()

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
@@ -251,16 +251,18 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
         delegate: AggregateCollectionRef<*, *>,
         prop: kotlin.reflect.KProperty1<E, *>?
     ): KSerializer<Any?> {
-        // Prefer live IDs type when the collection is non-empty — most reliable source
+        // Prefer the declared return type first (e.g. MutableAggregateList<Int, AudioItem> -> Int),
+        // so the resolved serializer is stable regardless of whether the collection is populated.
+        val idKType = prop?.returnType?.arguments?.getOrNull(0)?.type
+        if (idKType != null) {
+            return serializersModule.serializer(idKType)
+        }
+        // Fallback: reflect from the runtime class of the first live ID. Only reached when the member
+        // property's declared return type is star-projected, making the first type argument unresolvable.
         val liveIds = delegate.referenceIds
         if (liveIds.isNotEmpty()) {
             val firstId = liveIds.first()
             return serializer(firstId::class, emptyList(), false)
-        }
-        // Fall back to the first type argument of the property's return type (e.g. List<Int> -> Int)
-        val idKType = prop?.returnType?.arguments?.getOrNull(0)?.type
-        if (idKType != null) {
-            return serializer(idKType)
         }
         error(
             "Could not determine aggregate ID type for property '${prop?.name}' on ${kClass.simpleName}. " +

--- a/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
+++ b/lirp-core/src/main/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializer.kt
@@ -287,8 +287,9 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
     /**
      * Resolves the value-level serializer for an [FxScalarPropertyDelegate] in the reflection
      * fallback path. The delegate wraps a JavaFX property whose underlying value type is determined
-     * from the property return type name; falls back to the current value's runtime type when the
-     * property type isn't recognized.
+     * from the property return type name; falls back to the declared payload type argument when
+     * the property type isn't recognized, and only reflects the live value's runtime type as a
+     * last resort when no declared type information is available.
      */
     private fun resolveFxScalarSerializer(
         delegate: FxScalarPropertyDelegate,
@@ -307,6 +308,16 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
                 if (typeArg != null) serializersModule.serializer(typeArg) else serializer<String?>()
             }
             else -> {
+                // Resolve from the declared property return type first — avoids defaulting to
+                // String? when the sample value is null for a non-String FxScalar delegate.
+                if (prop != null) {
+                    val typeArg = prop.returnType.arguments.firstOrNull()?.type
+                    if (typeArg != null) return serializersModule.serializer(typeArg)
+                    // No type argument: attempt resolution via the declared return type itself.
+                    return serializersModule.serializer(prop.returnType)
+                }
+                // Last resort: reflect from the live value's runtime type. Only reached when prop
+                // is null (should not occur in practice but retained for safety).
                 val value = delegate.javaClass.getMethod("get").invoke(delegate)
                 if (value != null) serializersModule.serializer(value::class.createType()) else serializer<String?>()
             }
@@ -502,10 +513,17 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
      *
      * Returns `null` when no generated accessor exists (the entity's module did not apply lirp-ksp,
      * or the entity carries no reactive-property delegates), or when the accessor's constructor
-     * fails — for example when the entity has a property whose type requires a contextual serializer
-     * (such as `java.time.Instant`) that is not available at construction time. In that case the
-     * caller substitutes [reflectionReactivePropertyAccessor], which resolves serializers through
-     * the supplied [serializersModule] and therefore honours contextual registrations.
+     * throws. Two distinct failure modes are distinguished:
+     *
+     * - **Constructor threw a serialization error:** the expected case when a reactive property's
+     *   type (e.g. `java.time.Instant`) requires a contextual serializer that inline `serializer<T>()`
+     *   cannot resolve at construction time. `newInstance()` wraps it in [InvocationTargetException];
+     *   only a wrapped `SerializationException` is treated as expected and logged at DEBUG. The caller
+     *   substitutes [reflectionReactivePropertyAccessor] which honours [serializersModule] entries.
+     * - **Constructor threw anything else, or reflective access failed ([ReflectiveOperationException]):**
+     *   an unexpected codegen regression such as a renamed constructor or a visibility change. Logged
+     *   at WARN so the failure is auditable above DEBUG; the reflection fallback still takes over so
+     *   the entity remains usable.
      */
     @Suppress("UNCHECKED_CAST")
     private fun tryLoadReactivePropertyAccessor(): LirpReactivePropertyAccessor<E>? =
@@ -519,14 +537,28 @@ class LirpEntitySerializer<E : ReactiveEntityBase<*, *>>(
             accessorClass.getDeclaredConstructor().newInstance() as LirpReactivePropertyAccessor<E>
         } catch (_: ClassNotFoundException) {
             null
+        } catch (e: java.lang.reflect.InvocationTargetException) {
+            // newInstance() wraps every constructor exception in InvocationTargetException, so the
+            // wrapped cause must be inspected: only a SerializationException is the expected
+            // contextual-serializer case (a reactive property's type, e.g. java.time.Instant, needs a
+            // contextual serializer that inline serializer<T>() cannot resolve at construction time).
+            // Any other cause is an unexpected codegen bug and must not hide at DEBUG.
+            if (e.targetException is kotlinx.serialization.SerializationException) {
+                log.debug(e) { "KSP accessor for ${kClass.simpleName} constructor threw (contextual-serializer type); falling back to reflection accessor" }
+            } else {
+                log.warn(e) {
+                    "KSP accessor for ${kClass.simpleName} constructor threw unexpectedly (${e.targetException?.javaClass?.simpleName}) — check that lirp-ksp generated code is up to date"
+                }
+            }
+            null
         } catch (e: ReflectiveOperationException) {
-            // The accessor class exists but its constructor threw. This is expected when a reactive
-            // property's type (e.g. java.time.Instant) is not natively serializable and the
-            // inline serializer<T>() call in the generated accessor fails at construction time.
-            // Fall through to reflectionReactivePropertyAccessor so the serializersModule contextual
-            // entries are used. Log at DEBUG so genuine codegen regressions (NoSuchMethodException,
-            // InstantiationException, etc.) are visible without changing normal behaviour.
-            log.debug(e) { "KSP accessor for ${kClass.simpleName} failed to instantiate; falling back to reflection accessor" }
+            // Unexpected: NoSuchMethodException, InstantiationException, or IllegalAccessException —
+            // not the contextual-serializer case. This may indicate stale lirp-ksp generated code
+            // (e.g. a renamed constructor or a visibility change). Surface at WARN so a genuine
+            // codegen regression is not invisible above DEBUG.
+            log.warn(e) {
+                "KSP accessor for ${kClass.simpleName} failed to load due to a reflective operation error — check that lirp-ksp generated code is up to date"
+            }
             null
         }
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/JsonFileRepositoryTest.kt
@@ -20,6 +20,7 @@ import io.kotest.engine.spec.tempfile
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -323,6 +324,58 @@ class JsonFileRepositoryTest : DescribeSpec({
             val reloadedRepo = StandardCustomerJsonFileRepository(jsonFile)
             reloadedRepo.size() shouldBe inMemorySize
             reloadedRepo.close()
+        }
+
+        // Regression: #344 — two repositories over the same file must use distinct temp paths so
+        // concurrent writes do not clobber each other's in-flight temp file. Without the instance-unique
+        // suffix, the last writer atomically renames the other's temp, silently discarding its changes.
+        it("two repositories over the same file produce valid JSON after concurrent mutations").config(tags = setOf(Stress)) {
+            val sharedFile = tempfile("shared-two-repo-test", ".json").also { it.deleteOnExit() }
+            val ctx1 = LirpContext()
+            val ctx2 = LirpContext()
+            val repo1 = StandardCustomerJsonFileRepository(ctx1, sharedFile, 10L)
+            val repo2 = StandardCustomerJsonFileRepository(ctx2, sharedFile, 10L)
+
+            // Write disjoint entity sets from both repos concurrently — each flush goes through
+            // its own instance-unique temp path, so the renames cannot clobber each other.
+            (1..10).forEach { id -> repo1.create(id, "Repo1-Customer-$id", "r1c$id@example.com") }
+            (101..110).forEach { id -> repo2.create(id, "Repo2-Customer-$id", "r2c$id@example.com") }
+
+            // Launch concurrent mutations from both repos
+            reactive.scope.launch {
+                repeat(5) { i ->
+                    launch {
+                        (1..10).forEach { id ->
+                            (repo1.findById(id).orElse(null) as? StandardCustomer)?.updateName("R1-Name-$i-$id")
+                        }
+                    }
+                    launch {
+                        (101..110).forEach { id ->
+                            (repo2.findById(id).orElse(null) as? StandardCustomer)?.updateName("R2-Name-$i-$id")
+                        }
+                    }
+                }
+            }
+            reactive.advance()
+
+            repo1.close()
+            repo2.close()
+            ctx1.close()
+            ctx2.close()
+
+            // The file must contain valid JSON — no truncation or corruption from clobbered temp files.
+            // One repo's close() wins the final rename; the important invariant is the file is parseable.
+            val finalContent = sharedFile.readText()
+            finalContent.isNotEmpty() shouldBe true
+            // Verify it parses as JSON without throwing (a truncated or corrupted write would throw here)
+            val ctx3 = LirpContext()
+            val reloaded = StandardCustomerJsonFileRepository(ctx3, sharedFile, 10L)
+            // Last-writer-wins on the shared target file, so the reload holds one repo's full set
+            // (10 entities) — never a truncated or corrupted subset. That lower bound is the real
+            // invariant the instance-unique temp path protects.
+            reloaded.size() shouldBeGreaterThanOrEqual 10
+            reloaded.close()
+            ctx3.close()
         }
     }
 

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializerTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializerTest.kt
@@ -23,12 +23,18 @@ import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.DefaultAudioPlaylist
 import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
 import net.transgressoft.lirp.persistence.LirpDelegate
+import net.transgressoft.lirp.persistence.LirpReactivePropertyAccessor
 import net.transgressoft.lirp.persistence.MutableAggregateList
 import net.transgressoft.lirp.persistence.MutableAggregateSet
+import net.transgressoft.lirp.persistence.ReactivePropertyEntry
 import net.transgressoft.lirp.persistence.mutableAggregateList
+import net.transgressoft.lirp.testing.LogCapture
+import ch.qos.logback.classic.Level
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
@@ -396,6 +402,25 @@ class LirpEntitySerializerTest : StringSpec({
         }
     }
 
+    // Regression: #341 — FxScalar null-sample must resolve from declared payload type, not default to String?
+    "LirpEntitySerializer resolves Rating FxScalar serializer from declared type when sample value is null" {
+        // RatingEntity starts with rating=null. Before the fix, resolveFxScalarSerializer would
+        // fall through to delegate.get() == null and return serializer<String?>(), corrupting the payload.
+        // After the fix, it resolves from prop.returnType (Rating?) via the contextual module.
+        val module = SerializersModule { contextual(Rating::class, RatingSerializer) }
+        val sample = RatingEntity(0) // rating is null at construction — exercises the null-sample path
+        val serializer = lirpSerializer(sample, module) // must not default to String? serializer
+
+        val entity = RatingEntity(1).apply { rating = Rating(5) }
+        val jsonStr = json.encodeToString(serializer, entity)
+        jsonStr shouldContain "\"rating\""
+        jsonStr shouldContain "5"
+
+        val decoded = json.decodeFromString(serializer, jsonStr)
+        decoded.id shouldBe 1
+        decoded.rating shouldBe Rating(5)
+    }
+
     // Regression: #342 — empty aggregate collection must not crash serializer construction
     "LirpEntitySerializer does not throw when built from a DefaultAudioPlaylist sample with an empty audioItems collection" {
         // This is the first-run scenario: the sample entity has no items yet. Before the fix,
@@ -403,6 +428,56 @@ class LirpEntitySerializerTest : StringSpec({
         // collection fail with "Could not determine aggregate ID type".
         val emptySample = DefaultAudioPlaylist(0, "")
         lirpSerializer(emptySample) // must not throw
+    }
+
+    // Regression: #339 — unexpected accessor load failure (IllegalAccessException, not InvocationTargetException)
+    // must surface at WARN, not be swallowed at DEBUG.
+    "LirpEntitySerializer logs a WARN when KSP accessor constructor throws a non-InvocationTargetException ReflectiveOperationException" {
+        // WarnTriggerEntity_LirpReactivePropertyAccessor is a Kotlin object whose private singleton
+        // constructor causes getDeclaredConstructor().newInstance() to throw IllegalAccessException —
+        // a ReflectiveOperationException that is NOT InvocationTargetException.
+        // After the fix, this is routed to the WARN catch arm.
+        val capture = LogCapture()
+        capture.attach(
+            "net.transgressoft.lirp.persistence.json.LirpEntitySerializer",
+            Level.WARN
+        )
+        try {
+            lirpSerializer(WarnTriggerEntity(0)) // triggers tryLoadReactivePropertyAccessor
+        } finally {
+            val warnLogs = capture.logs.filter { it.level == "WARN" }
+            warnLogs.shouldNotBeEmpty()
+            warnLogs.any { it.message.contains("reflective operation error") }.shouldBeTrue()
+            capture.detach()
+        }
+    }
+
+    // Regression: #339 — a constructor failure wrapped in InvocationTargetException whose cause is NOT
+    // a SerializationException is an unexpected codegen bug and must surface at WARN, not hide at DEBUG.
+    "LirpEntitySerializer logs a WARN when the KSP accessor constructor throws a non-serialization error" {
+        val capture = LogCapture()
+        capture.attach("net.transgressoft.lirp.persistence.json.LirpEntitySerializer", Level.WARN)
+        try {
+            lirpSerializer(BuggyAccessorEntity(0)) // constructor throws IllegalStateException
+        } finally {
+            val warnLogs = capture.logs.filter { it.level == "WARN" }
+            warnLogs.any { it.message.contains("constructor threw unexpectedly") }.shouldBeTrue()
+            capture.detach()
+        }
+    }
+
+    // Regression: #339 — the expected contextual-serializer case (constructor throws a
+    // SerializationException) stays at DEBUG and must NOT emit a WARN.
+    "LirpEntitySerializer stays quiet at WARN when the KSP accessor constructor throws a SerializationException" {
+        val capture = LogCapture()
+        capture.attach("net.transgressoft.lirp.persistence.json.LirpEntitySerializer", Level.WARN)
+        try {
+            lirpSerializer(SerErrorEntity(0)) // constructor throws SerializationException (expected)
+        } finally {
+            val warnLogs = capture.logs.filter { it.level == "WARN" }
+            warnLogs.none { it.message.contains("constructor threw") }.shouldBeTrue()
+            capture.detach()
+        }
     }
 
     // Regression: #338 — aggregate-ID serializer must be derived from the declared type, not the
@@ -430,13 +505,193 @@ class LirpEntitySerializerTest : StringSpec({
  * FxScalarPropertyDelegate without get()/set() — triggers requireMethod error during serializer init.
  */
 private class BrokenFxScalarDelegate : FxScalarPropertyDelegate, LirpDelegate {
-    override fun bindMutationCallback(callback: (Any?, Any?, () -> Unit) -> Unit) {}
+    override fun bindMutationCallback(callback: (Any?, Any?, () -> Unit) -> Unit) = Unit
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures for #341: FxScalar null-sample declared-type resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * A non-String domain value type used as the FxScalar payload in #341 regression tests.
+ * Not `@Serializable` — resolved via a contextual module.
+ */
+class Rating(val value: Int) {
+    override fun equals(other: Any?) = this === other || (other is Rating && value == other.value)
+
+    override fun hashCode() = value
+}
+
+/**
+ * Minimal [KSerializer] for [Rating], registered contextually in tests that need
+ * to round-trip a non-String FxScalar payload.
+ */
+object RatingSerializer : KSerializer<Rating> {
+    override val descriptor = buildClassSerialDescriptor("Rating") { element<Int>("value") }
+
+    override fun serialize(encoder: Encoder, value: Rating) {
+        encoder.encodeStructure(descriptor) {
+            encodeIntElement(descriptor, 0, value.value)
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): Rating =
+        decoder.decodeStructure(descriptor) {
+            var v = 0
+            while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    0 -> v = decodeIntElement(descriptor, 0)
+                    CompositeDecoder.DECODE_DONE -> break
+                    else -> error("Unexpected index $index")
+                }
+            }
+            Rating(v)
+        }
+}
+
+/**
+ * A custom [FxScalarPropertyDelegate] whose payload type is [Rating] (non-String).
+ *
+ * The delegate's `get()` returns null at sample-entity construction time, exercising
+ * the null-sample code path in `resolveFxScalarSerializer`. Before the fix, this null
+ * return triggered `serializer<String?>()`, corrupting a non-String payload. The delegate
+ * implements property-delegation protocol so the entity can declare it via `by` — giving
+ * `resolveFxScalarSerializer` a non-null `prop` with the correct declared type, enabling
+ * resolution from `prop.returnType.arguments` instead of the live sample value.
+ */
+class NullableRatingFxDelegate : FxScalarPropertyDelegate, LirpDelegate {
+    var backing: Rating? = null
+
+    fun get(): Rating? = backing
+
+    fun set(value: Rating?) {
+        backing = value
+    }
+
+    operator fun getValue(thisRef: Any?, property: kotlin.reflect.KProperty<*>): Rating? = backing
+
+    operator fun setValue(thisRef: Any?, property: kotlin.reflect.KProperty<*>, value: Rating?) {
+        backing = value
+    }
+
+    override fun bindMutationCallback(callback: (Any?, Any?, () -> Unit) -> Unit) = Unit
+}
+
+/**
+ * Entity whose FxScalar delegate carries a [Rating] payload that starts null at construction.
+ *
+ * The property type `NullableRatingFxDelegate` does not end in any recognized suffix
+ * (`StringProperty`, `ObjectProperty`, etc.), so `resolveFxScalarSerializer` falls into the
+ * `else` branch. With a non-null `prop` and a type argument of [Rating], the fix resolves
+ * the serializer from the declared type rather than the null sample value.
+ */
+class RatingEntity(override val id: Int) : ReactiveEntityBase<Int, RatingEntity>() {
+    var rating: Rating? by NullableRatingFxDelegate()
+    override val uniqueId: String get() = id.toString()
+
+    override fun clone(): RatingEntity =
+        RatingEntity(id).also { it.withEventsDisabled { it.rating = rating } }
+
+    override fun equals(other: Any?) = this === other || (other is RatingEntity && id == other.id && rating == other.rating)
+
+    override fun hashCode() = 31 * id + (rating?.hashCode() ?: 0)
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures for #339: codegen-regression WARN surface
+// ---------------------------------------------------------------------------
+
+/**
+ * A private entity whose KSP accessor ([WarnTriggerEntity_LirpReactivePropertyAccessor]) is a
+ * Kotlin `object` singleton defined in this test file. Since KSP skips private entity classes,
+ * there is no generation conflict. When [LirpEntitySerializer] calls
+ * `getDeclaredConstructor().newInstance()` on the object class, the JVM throws
+ * [IllegalAccessException] (private singleton constructor — not wrapped in
+ * [java.lang.reflect.InvocationTargetException]), so the narrowed catch routes it to WARN.
+ */
+private class WarnTriggerEntity(override val id: Int) : ReactiveEntityBase<Int, WarnTriggerEntity>() {
+    var label by reactiveProperty("warn-test")
+    override val uniqueId: String get() = id.toString()
+
+    override fun clone(): WarnTriggerEntity =
+        WarnTriggerEntity(id).also { it.withEventsDisabled { it.label = label } }
+
+    override fun equals(other: Any?) =
+        this === other || (other is WarnTriggerEntity && id == other.id && label == other.label)
+
+    override fun hashCode() = 31 * id + label.hashCode()
 }
 
 /**
  * A non-FxScalar, non-aggregate LirpDelegate with no matching member property — triggers requireNotNull error.
  */
 private class OrphanReactiveDelegate : LirpDelegate
+
+/**
+ * A Kotlin `object` that acts as a fake accessor for [WarnTriggerEntity]. Kotlin objects have a
+ * private no-arg constructor, so `getDeclaredConstructor().newInstance()` throws
+ * [IllegalAccessException] — a [ReflectiveOperationException] that is NOT
+ * [java.lang.reflect.InvocationTargetException]. This routes to the WARN catch arm in
+ * [LirpEntitySerializer.tryLoadReactivePropertyAccessor], simulating an unexpected codegen
+ * regression without requiring bytecode manipulation.
+ */
+@Suppress("unused", "ClassName")
+private object WarnTriggerEntity_LirpReactivePropertyAccessor : LirpReactivePropertyAccessor<WarnTriggerEntity> {
+    override val entries: List<ReactivePropertyEntry<WarnTriggerEntity>> = emptyList()
+}
+
+/**
+ * Entity whose accessor constructor throws a [SerializationException] — the expected
+ * contextual-serializer case. `newInstance()` wraps it in
+ * [java.lang.reflect.InvocationTargetException] with a `SerializationException` cause, which stays at
+ * DEBUG and falls back to reflection without a WARN.
+ */
+private class SerErrorEntity(override val id: Int) : ReactiveEntityBase<Int, SerErrorEntity>() {
+    var label by reactiveProperty("ser")
+    override val uniqueId: String get() = id.toString()
+
+    override fun clone(): SerErrorEntity = SerErrorEntity(id).also { it.withEventsDisabled { it.label = label } }
+
+    override fun equals(other: Any?) =
+        this === other || (other is SerErrorEntity && id == other.id && label == other.label)
+
+    override fun hashCode() = 31 * id + label.hashCode()
+}
+
+@Suppress("unused", "ClassName")
+private class SerErrorEntity_LirpReactivePropertyAccessor : LirpReactivePropertyAccessor<SerErrorEntity> {
+    init {
+        throw SerializationException("simulated contextual-serializer resolution failure")
+    }
+
+    override val entries: List<ReactivePropertyEntry<SerErrorEntity>> = emptyList()
+}
+
+/**
+ * Entity whose accessor constructor throws a non-serialization [IllegalStateException] — an
+ * unexpected codegen bug. `newInstance()` wraps it in [java.lang.reflect.InvocationTargetException]
+ * with a non-`SerializationException` cause, which must surface at WARN rather than hide at DEBUG.
+ */
+private class BuggyAccessorEntity(override val id: Int) : ReactiveEntityBase<Int, BuggyAccessorEntity>() {
+    var label by reactiveProperty("bug")
+    override val uniqueId: String get() = id.toString()
+
+    override fun clone(): BuggyAccessorEntity = BuggyAccessorEntity(id).also { it.withEventsDisabled { it.label = label } }
+
+    override fun equals(other: Any?) =
+        this === other || (other is BuggyAccessorEntity && id == other.id && label == other.label)
+
+    override fun hashCode() = 31 * id + label.hashCode()
+}
+
+@Suppress("unused", "ClassName")
+private class BuggyAccessorEntity_LirpReactivePropertyAccessor : LirpReactivePropertyAccessor<BuggyAccessorEntity> {
+    init {
+        error("simulated codegen regression")
+    }
+
+    override val entries: List<ReactivePropertyEntry<BuggyAccessorEntity>> = emptyList()
+}
 
 /** Injects a fake delegate into an entity's delegate registry via reflection. */
 private fun injectDelegate(entity: ReactiveEntityBase<*, *>, name: String, delegate: LirpDelegate) {

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializerTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializerTest.kt
@@ -499,6 +499,32 @@ class LirpEntitySerializerTest : StringSpec({
         decoded.id shouldBe 2
         decoded.audioItems.referenceIds.toList() shouldBe listOf(30, 40)
     }
+
+    // Regression: #343 (Option B — fail-fast) — a persisted JSON that is missing a required
+    // reactive-property field must fail immediately on load rather than silently defaulting.
+    "LirpEntitySerializer throws when decoding JSON that is missing a required reactive property field" {
+        // SimpleDelegate has 'id' (constructor param) and 'name' (reactive property).
+        // Craft JSON with only the constructor param — 'name' is absent.
+        val serializer = lirpSerializer(SimpleDelegate(0))
+        val jsonMissingName = """{"id":1}"""
+        val exception =
+            shouldThrow<IllegalStateException> {
+                json.decodeFromString(serializer, jsonMissingName)
+            }
+        exception.message shouldContain "Missing required JSON field"
+        exception.message shouldContain "name"
+    }
+
+    // Regression: #343 — valid JSON that contains all fields must still round-trip normally
+    // (existing, fully-populated persisted data is unaffected by the fail-fast enforcement).
+    "LirpEntitySerializer round-trips a SimpleDelegate entity with all fields present" {
+        val original = SimpleDelegate(5).apply { name = "Valid" }
+        val serializer = lirpSerializer(original)
+        val jsonStr = json.encodeToString(serializer, original)
+        val decoded = json.decodeFromString(serializer, jsonStr)
+        decoded.id shouldBe 5
+        decoded.name shouldBe "Valid"
+    }
 })
 
 /**

--- a/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializerTest.kt
+++ b/lirp-core/src/test/kotlin/net/transgressoft/lirp/persistence/json/LirpEntitySerializerTest.kt
@@ -20,6 +20,7 @@ package net.transgressoft.lirp.persistence.json
 import net.transgressoft.lirp.entity.ReactiveEntityBase
 import net.transgressoft.lirp.persistence.AbstractMutableAggregateCollectionRefDelegate
 import net.transgressoft.lirp.persistence.AudioItem
+import net.transgressoft.lirp.persistence.DefaultAudioPlaylist
 import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
 import net.transgressoft.lirp.persistence.LirpDelegate
 import net.transgressoft.lirp.persistence.MutableAggregateList
@@ -393,6 +394,35 @@ class LirpEntitySerializerTest : StringSpec({
         shouldThrow<SerializationException> {
             lirpSerializer(WaypointEntity(1))
         }
+    }
+
+    // Regression: #342 — empty aggregate collection must not crash serializer construction
+    "LirpEntitySerializer does not throw when built from a DefaultAudioPlaylist sample with an empty audioItems collection" {
+        // This is the first-run scenario: the sample entity has no items yet. Before the fix,
+        // the declared-type fallback was only reached after the live-IDs check, making an empty
+        // collection fail with "Could not determine aggregate ID type".
+        val emptySample = DefaultAudioPlaylist(0, "")
+        lirpSerializer(emptySample) // must not throw
+    }
+
+    // Regression: #338 — aggregate-ID serializer must be derived from the declared type, not the
+    // runtime class of the first live ID, so a serializer built on one sample round-trips another.
+    "LirpEntitySerializer built from a populated DefaultAudioPlaylist sample round-trips a second playlist's audioItem IDs" {
+        val populatedSample = DefaultAudioPlaylist(1, "Sample")
+        populatedSample.setDelegateIds("audioItems", listOf(10, 20))
+
+        val serializer = lirpSerializer(populatedSample)
+
+        // A second entity whose IDs were not present when the serializer was built must still
+        // encode and decode without coercion or loss — proving resolution is from the declared
+        // type (Int), not the runtime class of ID 10 or 20.
+        val other = DefaultAudioPlaylist(2, "Other")
+        other.setDelegateIds("audioItems", listOf(30, 40))
+
+        val jsonStr = json.encodeToString(serializer, other)
+        val decoded = json.decodeFromString(serializer, jsonStr)
+        decoded.id shouldBe 2
+        decoded.audioItems.referenceIds.toList() shouldBe listOf(30, 40)
     }
 })
 

--- a/lirp-kafka/api/lirp-kafka.api
+++ b/lirp-kafka/api/lirp-kafka.api
@@ -23,21 +23,23 @@ public final class net/transgressoft/lirp/kafka/KafkaEventPublisher : net/transg
 public final class net/transgressoft/lirp/kafka/KafkaOutboxConfig {
 	public static final field Companion Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig$Companion;
 	public fun <init> ()V
-	public fun <init> (JIIJJ)V
-	public synthetic fun <init> (JIIJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JIIJJJ)V
+	public synthetic fun <init> (JIIJJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component2 ()I
 	public final fun component3 ()I
 	public final fun component4 ()J
 	public final fun component5 ()J
-	public final fun copy (JIIJJ)Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;
-	public static synthetic fun copy$default (Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;JIIJJILjava/lang/Object;)Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;
+	public final fun component6 ()J
+	public final fun copy (JIIJJJ)Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;
+	public static synthetic fun copy$default (Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;JIIJJJILjava/lang/Object;)Lnet/transgressoft/lirp/kafka/KafkaOutboxConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBatchSize ()I
 	public final fun getMaxRetries ()I
 	public final fun getPollIntervalMs ()J
 	public final fun getRetryBaseDelayMs ()J
 	public final fun getRetryMaxDelayMs ()J
+	public final fun getSqliteBusyTimeoutMs ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/lirp-kafka/build.gradle
+++ b/lirp-kafka/build.gradle
@@ -25,13 +25,14 @@ dependencies {
     implementation libs.coroutines.core
     implementation libs.kotlin.logging
     implementation libs.serialization.json
+    implementation libs.hikari
 
     testImplementation platform(libs.junit.bom)
     testImplementation libs.bundles.kotest
     testImplementation libs.coroutines.test
     testImplementation libs.junit.jupiter
     testImplementation libs.h2
-    testImplementation libs.hikari
+    testImplementation libs.sqlite
     testImplementation testFixtures(project(':lirp-core'))
     testImplementation testFixtures(project(':lirp-sql'))
     testImplementation libs.mockk

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxConfig.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/KafkaOutboxConfig.kt
@@ -46,13 +46,20 @@ package net.transgressoft.lirp.kafka
  * @property retryMaxDelayMs Upper bound in milliseconds for the exponential backoff delay. The
  *   computed retry delay is capped at this value regardless of the attempt count. Must be
  *   greater than or equal to [retryBaseDelayMs].
+ * @property sqliteBusyTimeoutMs Milliseconds SQLite will wait to acquire a write lock before
+ *   returning `SQLITE_BUSY` when a concurrent entity-save INSERT contends with the relay's
+ *   write transaction. Applied pool-wide via `PRAGMA busy_timeout` on every HikariCP connection
+ *   at relay startup; has no effect on non-SQLite data sources. SQLite serialises writers, so
+ *   a single-relay deployment is the only supported configuration — this knob provides a
+ *   retry window for capture INSERTs, not concurrent relay instances. Must be non-negative.
  */
 data class KafkaOutboxConfig(
     val pollIntervalMs: Long = 500L,
     val batchSize: Int = 100,
     val maxRetries: Int = 5,
     val retryBaseDelayMs: Long = 1_000L,
-    val retryMaxDelayMs: Long = 60_000L
+    val retryMaxDelayMs: Long = 60_000L,
+    val sqliteBusyTimeoutMs: Long = 3_000L
 ) {
     init {
         require(pollIntervalMs > 0) { "pollIntervalMs must be positive, was $pollIntervalMs" }
@@ -62,6 +69,7 @@ data class KafkaOutboxConfig(
         require(retryMaxDelayMs >= retryBaseDelayMs) {
             "retryMaxDelayMs ($retryMaxDelayMs) must be >= retryBaseDelayMs ($retryBaseDelayMs)"
         }
+        require(sqliteBusyTimeoutMs >= 0) { "sqliteBusyTimeoutMs must be non-negative, was $sqliteBusyTimeoutMs" }
     }
 
     companion object {

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
@@ -124,9 +124,11 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
         // This gives concurrent entity-save capture INSERTs a retry window while the relay
         // holds its write transaction, avoiding immediate SQLITE_BUSY with the 0 ms default.
         // The guard is scoped to HikariDataSource + jdbc:sqlite URLs so non-SQLite sources
-        // and non-HikariCP pools are unaffected.
+        // and non-HikariCP pools are unaffected. A caller-supplied connectionInitSql is
+        // preserved by appending the PRAGMA rather than overwriting it.
         if (dataSource is HikariDataSource && dataSource.jdbcUrl?.startsWith("jdbc:sqlite") == true) {
-            dataSource.connectionInitSql = "PRAGMA busy_timeout=${config.sqliteBusyTimeoutMs}"
+            dataSource.connectionInitSql =
+                sqliteBusyTimeoutInitSql(dataSource.connectionInitSql, config.sqliteBusyTimeoutMs)
         }
         val db = Database.connect(dataSource)
         // Always construct a fresh publisher so that any producerConfig or bootstrapServers change
@@ -164,4 +166,18 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
         _publisher?.close()
         _publisher = null
     }
+}
+
+/**
+ * Computes the SQLite `connectionInitSql` for a HikariCP pool, appending the `busy_timeout` PRAGMA to
+ * any caller-supplied init SQL rather than overwriting it. A pre-configured statement (for example
+ * `PRAGMA journal_mode=WAL`) is preserved and the PRAGMA is chained after it.
+ */
+internal fun sqliteBusyTimeoutInitSql(existingInitSql: String?, busyTimeoutMs: Long): String {
+    val busyTimeoutPragma = "PRAGMA busy_timeout=$busyTimeoutMs"
+    if (existingInitSql.isNullOrBlank()) return busyTimeoutPragma
+    // Idempotent across restarts: a relay stopped and started again on the same HikariDataSource
+    // already carries the PRAGMA in its connectionInitSql; re-appending would grow it unboundedly.
+    if (existingInitSql.contains(busyTimeoutPragma)) return existingInitSql
+    return "$existingInitSql; $busyTimeoutPragma"
 }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/LirpKafkaConfig.kt
@@ -24,6 +24,7 @@ import net.transgressoft.lirp.kafka.spi.CloudEventsBinarySerializer
 import net.transgressoft.lirp.kafka.spi.DefaultTopicResolver
 import net.transgressoft.lirp.kafka.spi.LirpEventSerializer
 import net.transgressoft.lirp.kafka.spi.TopicResolver
+import com.zaxxer.hikari.HikariDataSource
 import org.jetbrains.exposed.v1.jdbc.Database
 import javax.sql.DataSource
 
@@ -117,6 +118,16 @@ class LirpKafkaConfig private constructor(val bootstrapServers: String) : AutoCl
         onDeadLetter: LirpErrorHandler? = null
     ) {
         check(relay == null) { "Relay is already running; call stopRelay() first" }
+        // Apply a pool-wide busy_timeout PRAGMA on SQLite deployments before any connection is
+        // borrowed. HikariCP runs connectionInitSql on every connection it opens, so every
+        // pooled connection receives the PRAGMA — not just the one used for schema creation.
+        // This gives concurrent entity-save capture INSERTs a retry window while the relay
+        // holds its write transaction, avoiding immediate SQLITE_BUSY with the 0 ms default.
+        // The guard is scoped to HikariDataSource + jdbc:sqlite URLs so non-SQLite sources
+        // and non-HikariCP pools are unaffected.
+        if (dataSource is HikariDataSource && dataSource.jdbcUrl?.startsWith("jdbc:sqlite") == true) {
+            dataSource.connectionInitSql = "PRAGMA busy_timeout=${config.sqliteBusyTimeoutMs}"
+        }
         val db = Database.connect(dataSource)
         // Always construct a fresh publisher so that any producerConfig or bootstrapServers change
         // supplied on a restart (after stopRelay) reaches a new KafkaProducer.

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelay.kt
@@ -78,7 +78,20 @@ import kotlinx.coroutines.runInterruptible
  * to override routing for specific aggregate types or event-type codes.
  *
  * **Ordering:** records are keyed by [OutboxEvent.aggregateId] so the Kafka producer routes
- * all events for a given aggregate to the same partition, preserving per-aggregate ordering.
+ * all events for a given aggregate to the same partition, preserving per-aggregate ordering
+ * for a **single relay instance in the absence of retries**. Two situations break that ordering:
+ *
+ * - **Retry rescheduling:** when a delivery attempt fails and the row is rescheduled via
+ *   exponential backoff, a newer event for the same aggregate that becomes eligible in the
+ *   interim may be published first — the relay drains globally by creation time with no
+ *   per-aggregate head-of-line blocking.
+ * - **Multiple concurrent relays:** [net.transgressoft.lirp.kafka.outbox.SqlOutboxStore] selects
+ *   rows with `SKIP LOCKED` on dialects that support it, so two relay instances can each claim
+ *   adjacent rows for the same aggregate and publish them out of order even when neither was
+ *   retried. Run a single relay instance if strict per-aggregate ordering is required.
+ *
+ * Consumers that require strict per-aggregate ordering under all conditions must implement
+ * idempotent, sequence-number–aware processing to detect and handle out-of-order delivery.
  *
  * **Dispatcher isolation:** the relay runs on a dedicated [kotlinx.coroutines.Dispatchers.IO] scope
  * (not on the shared single-slot `ReactiveScope.ioScope`) so a slow broker acknowledgement does not

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/SqlOutboxStore.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/outbox/SqlOutboxStore.kt
@@ -91,6 +91,14 @@ internal class SqlOutboxStore(private val db: Database) : OutboxStore {
      * without emitting unsupported syntax. The lock is held for the duration of the enclosing
      * transaction — that same transaction will either commit [markSent] or roll back, leaving the
      * row available for the next poll cycle.
+     *
+     * **Ordering caveat under retry:** the query selects globally by creation time with no
+     * per-aggregate head-of-line blocking. When an older row for a given aggregate is deferred
+     * (its `nextRetryAt` is in the future), a newer row for the same aggregate is still eligible
+     * and will be returned first. This means per-aggregate ordering on the Kafka partition can be
+     * violated when a retried event is rescheduled — the newer event is published before the
+     * older one's retry window expires. Consumers that depend on strict per-aggregate ordering
+     * under all conditions must implement idempotent, sequence-number–aware processing.
      */
     override fun findUnsentForRelay(limit: Int, now: Instant): List<OutboxEvent> {
         val lockOption = selectLockOption(currentDialect, org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager.current().db.version)

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer.kt
@@ -74,6 +74,10 @@ class CloudEventsBinarySerializer : LirpEventSerializer {
         val eventTypeCode =
             ceType.substringAfterLast('.').toIntOrNull()
                 ?: error("ce_type '$ceType' does not end in a numeric event-type code")
+        val ceTypePrefix = ceType.substringBeforeLast('.')
+        require(ceTypePrefix == aggregateType) {
+            "ce_type prefix '$ceTypePrefix' does not match ce_source aggregate type '$aggregateType'; headers may be corrupted"
+        }
         val aggregateId =
             headers["ce_subject"]?.toString(Charsets.UTF_8)?.takeIf { it.isNotBlank() }
                 ?: error("ce_subject header is missing or blank; a non-blank aggregate identifier is required")

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer.kt
@@ -70,6 +70,7 @@ class CloudEventsBinarySerializer : LirpEventSerializer {
         val source = headers["ce_source"]?.toString(Charsets.UTF_8) ?: error("missing required ce_source header")
         require(source.startsWith("lirp/")) { "ce_source '$source' does not use the expected lirp/{aggregateType} format" }
         val aggregateType = source.removePrefix("lirp/")
+        require(aggregateType.isNotBlank()) { "ce_source '$source' has a blank aggregate type; expected lirp/{aggregateType}" }
         val ceType = headers["ce_type"]?.toString(Charsets.UTF_8) ?: error("missing required ce_type header")
         val eventTypeCode =
             ceType.substringAfterLast('.').toIntOrNull()
@@ -85,7 +86,10 @@ class CloudEventsBinarySerializer : LirpEventSerializer {
         try {
             kotlin.time.Instant.parse(createdAt)
         } catch (e: IllegalArgumentException) {
-            error("ce_time '$createdAt' is not a valid ISO-8601 UTC timestamp; expected format: 2026-07-01T10:30:00Z")
+            throw IllegalStateException(
+                "ce_time '$createdAt' is not a valid ISO-8601 instant; expected an RFC 3339 timestamp, e.g. 2026-07-01T10:30:00Z",
+                e
+            )
         }
         val contentType = headers["content-type"]?.toString(Charsets.UTF_8) ?: error("missing required content-type header")
         require(contentType == "application/json") { "unsupported content-type '$contentType'" }

--- a/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer.kt
+++ b/lirp-kafka/src/main/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializer.kt
@@ -38,9 +38,10 @@ package net.transgressoft.lirp.kafka.spi
  * All header values are encoded as UTF-8 bytes. [deserialize] fails fast on any record that does
  * not honour this contract: a missing required header, a blank `ce_id` or `ce_subject` (an empty
  * `ByteArray` is non-null but decodes to an empty string — still rejected), an unsupported
- * `ce_specversion` or `content-type`, or a `ce_source` that is not in the `lirp/{aggregateType}`
- * form all raise an exception rather than yield a bogus envelope (bug detector — do not downgrade
- * to logging).
+ * `ce_specversion` or `content-type`, a `ce_time` that is not a valid ISO-8601 UTC timestamp,
+ * a `ce_type` prefix that does not match the `ce_source` aggregate type, or a `ce_source` that
+ * is not in the `lirp/{aggregateType}` form all raise an exception rather than yield a bogus
+ * envelope (bug detector — do not downgrade to logging).
  *
  * No external CloudEvents SDK is required. Hand-rolled with kotlinx-serialization only.
  */
@@ -77,6 +78,11 @@ class CloudEventsBinarySerializer : LirpEventSerializer {
             headers["ce_subject"]?.toString(Charsets.UTF_8)?.takeIf { it.isNotBlank() }
                 ?: error("ce_subject header is missing or blank; a non-blank aggregate identifier is required")
         val createdAt = headers["ce_time"]?.toString(Charsets.UTF_8) ?: error("missing required ce_time header")
+        try {
+            kotlin.time.Instant.parse(createdAt)
+        } catch (e: IllegalArgumentException) {
+            error("ce_time '$createdAt' is not a valid ISO-8601 UTC timestamp; expected format: 2026-07-01T10:30:00Z")
+        }
         val contentType = headers["content-type"]?.toString(Charsets.UTF_8) ?: error("missing required content-type header")
         require(contentType == "application/json") { "unsupported content-type '$contentType'" }
         return LirpEventEnvelope(eventId, aggregateType, aggregateId, eventTypeCode, payload, createdAt)

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
@@ -26,6 +26,7 @@ import net.transgressoft.lirp.kafka.KafkaOutboxSqlRepository
 import net.transgressoft.lirp.kafka.spi.LirpEventEnvelope
 import net.transgressoft.lirp.kafka.spi.LirpEventSerializer
 import net.transgressoft.lirp.kafka.spi.SerializedEvent
+import net.transgressoft.lirp.kafka.sqliteBusyTimeoutInitSql
 import net.transgressoft.lirp.persistence.AudioItem
 import net.transgressoft.lirp.persistence.MutableAudioItem
 import net.transgressoft.lirp.persistence.RegistryBase
@@ -424,6 +425,23 @@ internal class OutboxRelayTest : StringSpec() {
                     firstConn.close()
                 }
             }
+        }
+
+        "LirpKafkaConfig sqliteBusyTimeoutInitSql sets the PRAGMA when no init SQL is pre-configured" {
+            sqliteBusyTimeoutInitSql(null, 3_000L) shouldBe "PRAGMA busy_timeout=3000"
+            sqliteBusyTimeoutInitSql("   ", 3_000L) shouldBe "PRAGMA busy_timeout=3000"
+        }
+
+        "LirpKafkaConfig sqliteBusyTimeoutInitSql preserves a caller-supplied init SQL by appending the PRAGMA" {
+            sqliteBusyTimeoutInitSql("PRAGMA journal_mode=WAL", 5_000L) shouldBe
+                "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000"
+        }
+
+        "LirpKafkaConfig sqliteBusyTimeoutInitSql is idempotent across relay restarts" {
+            // A relay restarted on the same HikariDataSource already carries the PRAGMA — re-applying
+            // must not duplicate it and grow connectionInitSql unboundedly.
+            val afterFirstStart = sqliteBusyTimeoutInitSql(null, 3_000L)
+            sqliteBusyTimeoutInitSql(afterFirstStart, 3_000L) shouldBe afterFirstStart
         }
 
         // #331 — PM-10: relay stop() must return promptly even when a publish is blocking.

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/outbox/OutboxRelayTest.kt
@@ -32,6 +32,7 @@ import net.transgressoft.lirp.persistence.RegistryBase
 import net.transgressoft.lirp.persistence.sql.AudioItemSqlTableDef
 import net.transgressoft.lirp.persistence.sql.H2ContainerSupport
 import net.transgressoft.lirp.persistence.transaction
+import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
@@ -56,6 +57,7 @@ import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.nio.file.Files
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.time.Clock
@@ -390,6 +392,40 @@ internal class OutboxRelayTest : StringSpec() {
             }
         }
 
+        // #340 — SQLite busy_timeout PRAGMA is applied pool-wide via connectionInitSql.
+        // This test drives the mechanism directly (mirroring what LirpKafkaConfig.startRelay does)
+        // and proves both: (a) the pool config object carries the expected connectionInitSql, and
+        // (b) a second, freshly-borrowed pool connection reports the configured busy_timeout value,
+        // confirming pool-wide delivery and not just a single-connection side effect.
+        "LirpKafkaConfig startRelay applies SQLite busy_timeout PRAGMA pool-wide via connectionInitSql" {
+            withSqliteOutboxDb { dataSource ->
+                val configuredTimeoutMs = 5_000L
+                val outboxConfig = KafkaOutboxConfig(sqliteBusyTimeoutMs = configuredTimeoutMs)
+
+                // (a) Pool config carries the expected PRAGMA — same assignment LirpKafkaConfig.startRelay makes.
+                val expectedInitSql = "PRAGMA busy_timeout=${outboxConfig.sqliteBusyTimeoutMs}"
+                dataSource.connectionInitSql shouldBe expectedInitSql
+
+                // (b) Prove pool-wide delivery: hold a first connection open, then borrow a SECOND
+                // distinct connection from the pool and assert its effective busy_timeout matches.
+                val firstConn = dataSource.connection
+                try {
+                    val secondConnTimeout =
+                        dataSource.connection.use { secondConn ->
+                            secondConn.createStatement().use { stmt ->
+                                stmt.executeQuery("PRAGMA busy_timeout").use { rs ->
+                                    rs.next()
+                                    rs.getLong(1)
+                                }
+                            }
+                        }
+                    secondConnTimeout shouldBe configuredTimeoutMs
+                } finally {
+                    firstConn.close()
+                }
+            }
+        }
+
         // #331 — PM-10: relay stop() must return promptly even when a publish is blocking.
         // Before the fix, the relay ran on the single-slot ioScope and stop() used runBlocking
         // against a non-cancellable producer.send().get(), stalling shutdown for delivery.timeout.ms.
@@ -428,6 +464,39 @@ internal class OutboxRelayTest : StringSpec() {
 // -------------------------------------------------------------------------------------------------
 // Fixtures & helpers
 // -------------------------------------------------------------------------------------------------
+
+/**
+ * Runs [block] with a SQLite [HikariDataSource] backed by a temporary file, pre-configured with
+ * `PRAGMA busy_timeout=5000` as [com.zaxxer.hikari.HikariDataSource.connectionInitSql] — exactly
+ * the PRAGMA [LirpKafkaConfig.startRelay] sets before calling `Database.connect`. The pool has
+ * [maximumPoolSize] = 2 so a second connection can be borrowed independently of the first, enabling
+ * pool-wide PRAGMA assertions. Closes the datasource and deletes the file afterwards.
+ */
+private inline fun withSqliteOutboxDb(block: (HikariDataSource) -> Unit) {
+    val dbFile = Files.createTempFile("lirp-outbox-sqlite-test-", ".db").toFile()
+    try {
+        val config =
+            HikariConfig().apply {
+                jdbcUrl = "jdbc:sqlite:${dbFile.absolutePath}"
+                driverClassName = "org.sqlite.JDBC"
+                maximumPoolSize = 2
+                // Mirror what LirpKafkaConfig.startRelay sets on a jdbc:sqlite HikariDataSource —
+                // this is what guarantees every pool connection gets the PRAGMA, not just the first one.
+                connectionInitSql = "PRAGMA busy_timeout=5000"
+            }
+        val dataSource = HikariDataSource(config)
+        try {
+            block(dataSource)
+        } finally {
+            dataSource.close()
+        }
+    } finally {
+        dbFile.delete()
+        // Remove SQLite's WAL sidecar files if present.
+        java.io.File("${dbFile.absolutePath}-wal").delete()
+        java.io.File("${dbFile.absolutePath}-shm").delete()
+    }
+}
 
 /**
  * Runs [block] with a fresh H2 [Database] whose outbox and dead-letter tables already exist, closing

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializerTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializerTest.kt
@@ -141,5 +141,13 @@ internal class CloudEventsBinarySerializerTest : StringSpec() {
                     ("ce_type" to "album.300".toByteArray(Charsets.UTF_8))
             shouldThrow<IllegalArgumentException> { serializer.deserialize(serialized.value, headers) }
         }
+
+        "CloudEventsBinarySerializerTest deserialize rejects a ce_source with a blank aggregate type" {
+            // "lirp/" strips to an empty aggregateType; without a guard it would pass the
+            // ce_type/ce_source cross-check whenever ce_type has no dot prefix, yielding a
+            // blank aggregateType that corrupts downstream topic routing.
+            val headers = serialized.headers + ("ce_source" to "lirp/".toByteArray(Charsets.UTF_8))
+            shouldThrow<IllegalArgumentException> { serializer.deserialize(serialized.value, headers) }
+        }
     }
 }

--- a/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializerTest.kt
+++ b/lirp-kafka/src/test/kotlin/net/transgressoft/lirp/kafka/spi/CloudEventsBinarySerializerTest.kt
@@ -128,5 +128,18 @@ internal class CloudEventsBinarySerializerTest : StringSpec() {
             val headers = serialized.headers + ("ce_subject" to "   ".toByteArray(Charsets.UTF_8))
             shouldThrow<IllegalStateException> { serializer.deserialize(serialized.value, headers) }
         }
+
+        "CloudEventsBinarySerializerTest deserialize rejects a garbage ce_time header" {
+            val headers = serialized.headers + ("ce_time" to "not-a-date".toByteArray(Charsets.UTF_8))
+            shouldThrow<IllegalStateException> { serializer.deserialize(serialized.value, headers) }
+        }
+
+        "CloudEventsBinarySerializerTest deserialize rejects a ce_type prefix that does not match the ce_source aggregate type" {
+            val headers =
+                serialized.headers +
+                    ("ce_source" to "lirp/track".toByteArray(Charsets.UTF_8)) +
+                    ("ce_type" to "album.300".toByteArray(Charsets.UTF_8))
+            shouldThrow<IllegalArgumentException> { serializer.deserialize(serialized.value, headers) }
+        }
     }
 }

--- a/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/FxScalarAccessorProcessor.kt
+++ b/lirp-ksp/src/main/kotlin/net/transgressoft/lirp/ksp/FxScalarAccessorProcessor.kt
@@ -31,6 +31,7 @@ import com.google.devtools.ksp.validate
 
 private const val NULLABLE_STRING_SERIALIZER = "@Suppress(\"UNCHECKED_CAST\") serializer<String?>() as KSerializer<Any?>"
 private const val NULLABLE_STRING_CAST_TYPE = "String?"
+private const val JAVAFX_PROPERTY_PACKAGE = "javafx.beans.property."
 
 /**
  * KSP processor that generates [LirpFxScalarAccessor][net.transgressoft.lirp.persistence.LirpFxScalarAccessor]
@@ -161,13 +162,24 @@ class FxScalarAccessorProcessor(
         logger.info("Generated $packageName.$accessorName for $kotlinName")
     }
 
+    /**
+     * Returns true when the property type FQN belongs to the official `javafx.beans.property` package.
+     *
+     * This guards the suffix-based dispatch in [resolveSerializerAndCastType] so consumer types whose
+     * names happen to end with `StringProperty`, `IntegerProperty`, etc. are not mis-classified as
+     * JavaFX primitives and given a wrong serializer.
+     */
+    private fun isJavaFxProperty(propTypeFqn: String): Boolean = propTypeFqn.startsWith(JAVAFX_PROPERTY_PACKAGE)
+
     private fun resolveSerializerAndCastType(
         prop: KSPropertyDeclaration,
         propTypeFqn: String
-    ): Pair<String, String> =
-        when {
-            propTypeFqn.endsWith("StringProperty") ->
-                NULLABLE_STRING_SERIALIZER to NULLABLE_STRING_CAST_TYPE
+    ): Pair<String, String> {
+        // Non-JavaFX types always fall through to the String default regardless of their name suffix,
+        // so short-circuit here and let the suffix dispatch below read cleanly.
+        if (!isJavaFxProperty(propTypeFqn)) return NULLABLE_STRING_SERIALIZER to NULLABLE_STRING_CAST_TYPE
+        return when {
+            propTypeFqn.endsWith("StringProperty") -> NULLABLE_STRING_SERIALIZER to NULLABLE_STRING_CAST_TYPE
             propTypeFqn.endsWith("IntegerProperty") ->
                 "@Suppress(\"UNCHECKED_CAST\") serializer<Int>() as KSerializer<Any?>" to "Int"
             propTypeFqn.endsWith("DoubleProperty") ->
@@ -181,23 +193,20 @@ class FxScalarAccessorProcessor(
             propTypeFqn.endsWith("ObjectProperty") -> resolveObjectPropertySerializer(prop)
             else -> NULLABLE_STRING_SERIALIZER to NULLABLE_STRING_CAST_TYPE
         }
+    }
 
     private fun resolveObjectPropertySerializer(prop: KSPropertyDeclaration): Pair<String, String> {
         val typeArg = prop.type.resolve().arguments.getOrNull(0)?.type?.resolve()
         return if (typeArg != null) {
+            // Use the shared renderer — it correctly handles isMarkedNullable at all levels.
             val rendered = renderKsType(typeArg)
-            "@Suppress(\"UNCHECKED_CAST\") serializer<$rendered?>() as KSerializer<Any?>" to "$rendered?"
+            // ObjectProperty payloads are always nullable in the serialized form (get() can return
+            // null even for non-nullable declared types), so ensure the type ends with exactly one ?.
+            val renderedNullable = if (rendered.endsWith("?")) rendered else "$rendered?"
+            "@Suppress(\"UNCHECKED_CAST\") serializer<$renderedNullable>() as KSerializer<Any?>" to renderedNullable
         } else {
             NULLABLE_STRING_SERIALIZER to NULLABLE_STRING_CAST_TYPE
         }
-    }
-
-    private fun renderKsType(type: KSType): String {
-        val baseName = type.declaration.qualifiedName?.asString() ?: return "String"
-        val args = type.arguments
-        if (args.isEmpty()) return baseName
-        val renderedArgs = args.joinToString(", ") { arg -> renderKsTypeArgument(arg) }
-        return "$baseName<$renderedArgs>"
     }
 }
 

--- a/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/FxScalarAccessorProcessorTest.kt
+++ b/lirp-ksp/src/test/kotlin/net/transgressoft/lirp/ksp/FxScalarAccessorProcessorTest.kt
@@ -29,8 +29,9 @@ import org.junit.jupiter.api.DisplayName
  * correct `_LirpFxScalarAccessor` implementations for entities with FxScalar delegate properties.
  *
  * Each test compiles a source entity in-process using kctfork and asserts on the generated file content.
- * FxScalar property stubs are defined inline in the `net.transgressoft.lirp.persistence` package
- * to satisfy the processor's FQN-based `FxScalarPropertyDelegate` detection without importing JavaFX.
+ * Positive-case stubs are defined in `javafx.beans.property` so the JavaFX-FQN guard in the processor
+ * passes for the six primitive types and `ObjectProperty`. A separate negative stub in a non-JavaFX
+ * package verifies that custom `*Property`-suffixed types fall through to the `else` default.
  */
 @OptIn(ExperimentalCompilerApi::class)
 @DisplayName("FxScalarAccessorProcessor")
@@ -38,14 +39,15 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
 
     // Stubs for JavaFX property types that implement FxScalarPropertyDelegate.
     // Each stub class name ends with the expected suffix (e.g. "StringProperty", "IntegerProperty")
-    // so the processor's FQN-suffix-based serializer mapping resolves correctly.
-    // Stubs live in net.transgressoft.lirp.persistence so the processor's FQN detection works.
+    // and lives in javafx.beans.property so the processor's JavaFX-FQN guard passes and the correct
+    // primitive serializer is selected.
     val fxPropertyStubs =
         SourceFile.kotlin(
             "FxPropertyStubs.kt",
             """
-            package net.transgressoft.lirp.persistence
+            package javafx.beans.property
 
+            import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
             import kotlin.reflect.KProperty
 
             class StubStringProperty(private var value: String? = null) : FxScalarPropertyDelegate {
@@ -109,7 +111,7 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                     """
                     package test
                     import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.StubStringProperty
+                    import javafx.beans.property.StubStringProperty
 
                     data class ProductEntity(override val id: Int) : ReactiveEntityBase<Int, ProductEntity>() {
                         override val uniqueId: String get() = "${'$'}id"
@@ -141,12 +143,12 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                     """
                     package test
                     import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.StubStringProperty
-                    import net.transgressoft.lirp.persistence.StubIntegerProperty
-                    import net.transgressoft.lirp.persistence.StubDoubleProperty
-                    import net.transgressoft.lirp.persistence.StubFloatProperty
-                    import net.transgressoft.lirp.persistence.StubLongProperty
-                    import net.transgressoft.lirp.persistence.StubBooleanProperty
+                    import javafx.beans.property.StubStringProperty
+                    import javafx.beans.property.StubIntegerProperty
+                    import javafx.beans.property.StubDoubleProperty
+                    import javafx.beans.property.StubFloatProperty
+                    import javafx.beans.property.StubLongProperty
+                    import javafx.beans.property.StubBooleanProperty
 
                     data class AllScalarsEntity(override val id: Int) : ReactiveEntityBase<Int, AllScalarsEntity>() {
                         override val uniqueId: String get() = "${'$'}id"
@@ -189,7 +191,7 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                     """
                     package test
                     import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.StubObjectProperty
+                    import javafx.beans.property.StubObjectProperty
                     import kotlinx.serialization.Serializable
 
                     @Serializable
@@ -246,7 +248,7 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                     """
                     package test
                     import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.StubStringProperty
+                    import javafx.beans.property.StubStringProperty
 
                     internal data class InternalFxEntity(override val id: Int) : ReactiveEntityBase<Int, InternalFxEntity>() {
                         override val uniqueId: String get() = "${'$'}id"
@@ -271,7 +273,7 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                     """
                     package test
                     import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.StubStringProperty
+                    import javafx.beans.property.StubStringProperty
 
                     internal class InternalOuterFx {
                         data class InnerFx(override val id: Int) : ReactiveEntityBase<Int, InnerFx>() {
@@ -298,7 +300,7 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                     """
                     package test
                     import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.StubStringProperty
+                    import javafx.beans.property.StubStringProperty
 
                     private class PrivateOuterFx {
                         data class HiddenFx(override val id: Int) : ReactiveEntityBase<Int, HiddenFx>() {
@@ -327,7 +329,7 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
                     """
                     package test
                     import net.transgressoft.lirp.entity.ReactiveEntityBase
-                    import net.transgressoft.lirp.persistence.StubStringProperty
+                    import javafx.beans.property.StubStringProperty
 
                     class OuterContainer {
                         data class InnerEntity(override val id: Int) : ReactiveEntityBase<Int, InnerEntity>() {
@@ -348,5 +350,93 @@ internal class FxScalarAccessorProcessorTest : StringSpec({
             "class `OuterContainer\$InnerEntity_LirpFxScalarAccessor` : LirpFxScalarAccessor<OuterContainer.InnerEntity>",
             "name = \"label\""
         )
+    }
+
+    // #346: a custom type whose name ends with "StringProperty" but lives outside javafx.beans.property
+    // must fall through to the else default, not be mis-classified as a String property.
+    "FxScalarAccessorProcessor generates else-default serializer for custom *StringProperty type not in javafx.beans.property" {
+        val customStringPropertyStub =
+            SourceFile.kotlin(
+                "CustomStringPropertyStub.kt",
+                """
+                package net.transgressoft.lirp.persistence.fx
+
+                import net.transgressoft.lirp.persistence.FxScalarPropertyDelegate
+                import kotlin.reflect.KProperty
+
+                // Custom type whose name ends with "StringProperty" but is not in javafx.beans.property.
+                // The generated accessor falls through to the else default (String? serializer/cast).
+                // The set() signature accepts Any? so the generated "value as String?" cast compiles,
+                // but the serializer emitted is the wrong String? fallback — not a domain-correct one.
+                class LocalizedStringProperty(private var value: Any? = null) : FxScalarPropertyDelegate {
+                    override fun bindMutationCallback(callback: (Any?, Any?, () -> Unit) -> Unit) {}
+                    fun get(): Any? = value
+                    fun set(v: Any?) { value = v }
+                    operator fun getValue(thisRef: Any?, property: KProperty<*>): LocalizedStringProperty = this
+                }
+                """
+            )
+
+        val result =
+            KspTestSupport.compile(
+                FxScalarAccessorProcessorProvider(),
+                customStringPropertyStub,
+                SourceFile.kotlin(
+                    "LocalizedEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import net.transgressoft.lirp.persistence.fx.LocalizedStringProperty
+
+                    data class LocalizedEntity(override val id: Int) : ReactiveEntityBase<Int, LocalizedEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                        val label by LocalizedStringProperty()
+                    }
+                    """
+                )
+            )
+
+        val content = result.shouldSucceed().generatedFileContent("LocalizedEntity_LirpFxScalarAccessor.kt")
+        // Must use the else-default String? serializer, not serializer<Int>() or any non-String specialist
+        content.shouldContainEach(
+            "serializer<String?>()",
+            "value as String?"
+        )
+    }
+
+    // #347: a nullable-payload ObjectProperty must generate a single-? type, not Foo??.
+    "FxScalarAccessorProcessor generates single-? serializer for nullable-payload ObjectProperty" {
+        val result =
+            KspTestSupport.compile(
+                FxScalarAccessorProcessorProvider(),
+                fxPropertyStubs,
+                SourceFile.kotlin(
+                    "NullableTaggedEntity.kt",
+                    """
+                    package test
+                    import net.transgressoft.lirp.entity.ReactiveEntityBase
+                    import javafx.beans.property.StubObjectProperty
+                    import kotlinx.serialization.Serializable
+
+                    @Serializable
+                    data class Tag(val value: String)
+
+                    data class NullableTaggedEntity(override val id: Int) : ReactiveEntityBase<Int, NullableTaggedEntity>() {
+                        override val uniqueId: String get() = "${'$'}id"
+                        override fun clone() = copy()
+                        val tag by StubObjectProperty<Tag?>()
+                    }
+                    """
+                )
+            )
+
+        val content = result.shouldSucceed().generatedFileContent("NullableTaggedEntity_LirpFxScalarAccessor.kt")
+        content.shouldContainEach(
+            "serializer<test.Tag?>()",
+            "value as test.Tag?"
+        )
+        // Verify no double-? is emitted
+        (content.contains("test.Tag??")) shouldBe false
     }
 })


### PR DESCRIPTION
## Summary

Resolves the twelve deferred tech-debt issues carried over from prior work, restoring the correctness and fail-fast invariants each one documents. The fixes span three subsystems: the lirp-core JSON serializer (6), lirp-ksp / FxScalar code generation (2), and the lirp-kafka outbox (4). Every fix ships with a regression test using the canonical music-domain fixtures.

## ⚠ Breaking change

**Loading persisted JSON now fails fast when a required reactive-property field is missing** (#343). Previously a `by reactiveProperty(...)` field absent from stored JSON was silently loaded at its constructor default, producing a partially-migrated entity with no diagnostic. It now throws, listing the missing field names — consistent with how a missing constructor parameter already behaves.

This warrants a **minor** version bump (not a patch). See `CHANGELOG.md` → *Breaking Changes* and the *Upgrading* note in `README.md` for the two migration paths (migrate the JSON, or declare the field as a constructor parameter with a default).

## Changes

### lirp-core — JSON serializer
- **#338 / #342** — The aggregate-ID serializer is resolved from the declared key type rather than the runtime class of the first live reference ID. Fixes lossy round-trips for polymorphic/boxed keys and a construction crash when the aggregate collection sample is empty (typical first run).
- **#339** — The reactive-property accessor loader no longer swallows a genuine code-generation regression at DEBUG; the expected contextual-serializer case stays a DEBUG fallback, an unexpected reflective failure now surfaces at WARN.
- **#341** — The FxScalar value serializer is resolved from the declared payload type instead of defaulting to `String?` when the reflection sample value is null.
- **#343** — Consistent fail-fast schema-migration contract (see breaking change above).
- **#344** — Two `JsonFileRepository` instances over the same file now use an instance-unique temp-file suffix, eliminating last-writer-wins clobbering and temp-file races.

### lirp-ksp — FxScalar code generation
- **#346** — Property-type detection is guarded on the JavaFX property FQN, so a custom `*Property`-suffixed type in another package is no longer mis-generated with a String serializer/cast.
- **#347** — Nullable-payload `ObjectProperty` generation uses the shared type renderer with a single, conditional nullability marker — no more uncompilable `serializer<Foo??>()`.

### lirp-kafka — outbox
- **#340** — The SQLite `busy_timeout` PRAGMA is applied pool-wide via HikariCP `connectionInitSql` (preserving any caller-supplied init SQL), so concurrent entity-save capture INSERTs get a retry window instead of an immediate `SQLITE_BUSY` while the relay is publishing. Adds `KafkaOutboxConfig.sqliteBusyTimeoutMs` (default 3000 ms).
- **#345** — Documents the per-aggregate ordering caveat under retry in the relay/store KDoc.
- **#348** — `ce_time` is validated as an ISO-8601 instant at the SPI boundary (fail-fast) rather than only null-checked.
- **#349** — The `ce_type` prefix is cross-checked against the `ce_source` aggregate type, and a blank aggregate type is rejected, closing a silent-inconsistency surface.

## Verification

- All three module test suites pass (including concurrency Stress tests): `gradle :lirp-core:test :lirp-ksp:test :lirp-kafka:test`
- Lint clean: `gradle ktlintCheck`
- Public API baseline intact: `gradle apiCheck` (new `sqliteBusyTimeoutMs` config field rebaselined)
- Each of the 12 issues verified present in source with a locking regression test.

## Public API

- New: `KafkaOutboxConfig.sqliteBusyTimeoutMs` (`Long`, default `3000`).
- Behavioral break: JSON load throws on missing required reactive-property fields (#343) — documented in CHANGELOG/README.

Closes #338
Closes #339
Closes #340
Closes #341
Closes #342
Closes #343
Closes #344
Closes #345
Closes #346
Closes #347
Closes #348
Closes #349
